### PR TITLE
feat(mcp): sidecar discovery handshake + degraded-mode (closes #29)

### DIFF
--- a/docs/briefs/2026-05-12-architecture-handoff.md
+++ b/docs/briefs/2026-05-12-architecture-handoff.md
@@ -1,0 +1,83 @@
+# Architecture / Settlements Branch — Claude Handoff Brief
+
+You're picking up the **architecture pillar** of Hayba, a worldbuilding platform for AAA game devs / 3D artists / rigorous worldbuilding authors. Hayba is an open-core MIT plugin (UE5) + cloud SaaS, positioned as "the only AI worldbuilding tool grounded in real planetary science."
+
+The platform has several pillars (tectonics, climate, biome, architecture, linguistics, history-sim, etc.). Other Claude instances are already working **tectonics** (live) and **linguistics** (live); you've been handed **architecture**.
+
+## What the architecture pillar does
+
+End-to-end procedural built environment, from individual buildings through cities to road networks, with style consistent within a culture / region / era. Two audience tiers:
+
+- **Game devs** want: place a "Tang-dynasty merchant town" or "medieval Hanseatic harbor city" by clicking a region on the map; get a full layout (roads, districts, building footprints, style guides) that can be tessellated into UE5 actors. Pareto-relevant 80%.
+- **Authors / city-sim hobbyists** want: emergent diachronic growth — pick a founding date and let the settlement evolve through centuries (founding → market town → walled city → industrial sprawl), retaining old core street patterns as concentric rings. Pareto-relevant 20%, but the positioning differentiator.
+
+Locked decisions you should treat as constraints:
+
+1. **Tiered depth**: ship the game-dev floor first (snapshot generation: pick culture + era + size → get a city); expose author features behind the same data model (diachronic growth, demolition, war damage layers).
+2. **Visual style guides, not raw rules**. Style is captured by a palette of building archetypes (materials, roof shape, footprint typology, story height, ornamentation) + a road grammar (street width hierarchies, intersection types). Users edit by dragging archetypes on a panel; AI fills the rest.
+3. **AI is constrained by deterministic generators**. The LLM never produces buildings that violate the style guide's archetype palette; constrained decoding gates the output. The LLM's job is choosing WHICH archetypes go where, not inventing geometry.
+4. **Integration with other pillars** (you don't own these, you consume them):
+   - **Terrain** (from tectonics + hydrology): settlements respect rivers, slope, soil, defensive geometry. Read elevation + drainage from the tectonic output.
+   - **Climate** (from tectonics M5): vernacular architecture follows climate — pitched roofs in snow zones, courtyards in arid, stilts in floodplains.
+   - **Linguistics** (from linguistics pillar): place names, street names, signage all sourced via the linguistics MCP tools.
+
+## What's already in place
+
+### Code scaffold
+None yet — start `packages/architecture/` as a TypeScript package, ESM, vitest-based. Pattern after `packages/linguistics/`.
+
+### Shared infra (don't reinvent)
+
+- **Deterministic seeds**: use the existing `hayba-seeds` Rust crate via Node IPC or port its SplitMix64 algorithm to TypeScript. Pattern: master seed → scope-derived child seed → per-region sub-seed → per-settlement sub-seed → per-building sub-seed. Same `(master, region_id, "settlement", index, "building", index)` tuple → same building forever. Reference: `packages/hayba-seeds/src/lib.rs`.
+- **Schema spine**: Postgres + pgvector hosted on Supabase (free tier). Other pillars use similar tables; follow their conventions.
+- **MCP server**: `packages/hayba/src/index.ts` is the Node MCP server entry. Add your tools alongside existing ones, prefix `architecture_*` (e.g. `architecture_generate_settlement`, `architecture_style_palette`, `architecture_road_network`).
+- **Determinism contract**: every public API is a pure function of `(master_seed, params)`. No `Date.now()`, no `Math.random()`. Bit-exact across runs on a single machine.
+
+### Reference data to draw from (all CC-licensed)
+
+- **OpenStreetMap historical layers** — real road network samples for grammar induction
+- **Atlas of Urban Form** (digital morphology atlas) — settlement typologies by era/region
+- **Wikidata urban heritage** — building materials + period palettes by culture
+- **VernacularArchitecture.com**'s public dataset on regional building styles
+
+## What to build (open GitHub issues — full text on GH)
+
+Listed in priority order. Each is independent and shippable.
+
+### A1 — Archetype palette + style guide schema
+Define the data model: an `ArchetypeBuilding` (footprint shape, story count, material set, roof type, ornamentation tags) and `StyleGuide` (set of archetypes + selection weights). Provide seed palettes for 6 reference cultures (Mediaeval-European, Tang-Chinese, Pre-Columbian-Andean, Sub-Saharan-Hausa, Edo-Japanese, Industrial-Revolution-English). MCP tool `architecture_list_style_guides`.
+
+### A2 — Road network generator
+Generate a road graph for a given settlement footprint + terrain. Implement L-system or recursive subdivision producing realistic street hierarchies (arterials → collectors → locals). Respect terrain slope (avoid >15% grade for primary roads). MCP tool `architecture_generate_road_network` returning a polyline graph.
+
+### A3 — Settlement layout generator
+Take a region polygon + style guide + target population → place road network + parcel grid + lot assignments → bind archetypes to lots. MCP tool `architecture_generate_settlement`. Emit GeoJSON of buildings + roads.
+
+### A4 — Vernacular constraint engine
+Climate × material gating. Pitched roofs in snow zones; courtyards in arid; stilts in floodplains. Reads climate envelope from tectonics M5 output. MCP tool `architecture_check_vernacular_consistency`.
+
+### A5 — Diachronic settlement growth
+Take a settlement at founding date + style guide changes over time → evolve concentric ring structure across centuries. Old core street patterns retained; outer rings reflect later style guides. MCP tool `architecture_evolve_settlement`.
+
+### A6 — Building 3D geometry emitter
+Take an archetype + lot → output a parameterized geometry description (heights, openings, roof apex) suitable for UE5 PCG / Houdini to instantiate. MCP tool `architecture_emit_building_geometry`.
+
+### A7 — Place-name binding (linguistics integration)
+Bind street names + district names + building names via the linguistics pillar's `language_generate_name` tool. Per-settlement consistent naming language. MCP tool `architecture_assign_names`.
+
+### A8 — Demo viewer
+Mini browser viewer (analogous to `viz/index.html`) that renders an L4 settlement: roads + parcels + building footprints in plan view. Plate is the area of validation.
+
+## How to coordinate
+
+- Open issues on the `zajalist/hayba` repo with `branch: architecture, area: typescript, enhancement` labels. The other pillars use parallel `branch:` labels.
+- Don't push to `feat/mcp-stabilization` (the tectonics branch). Create `feat/architecture-pillar` or similar.
+- The tectonics + linguistics instances may surface integration questions; thread them via issue comments rather than direct merges.
+
+## Spec / constraints summary
+
+- **MIT license**, no GPL deps. Style-guide JSON is the user's IP, not yours; treat it as data.
+- **Deterministic from seed.** No exceptions. Bit-exact within a single machine.
+- **Pure functions** at the MCP boundary. No global state.
+- **Tested.** vitest, ≥80% coverage on the deterministic generators.
+- **Visual checkpoint mandatory** for any visible output ticket — settlement viewer must render real output before claiming a ticket done.

--- a/docs/superpowers/plans/2026-05-12-architecture-a1-style-schema.md
+++ b/docs/superpowers/plans/2026-05-12-architecture-a1-style-schema.md
@@ -1,0 +1,2118 @@
+# Architecture Pillar A1 — Style Schema Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `@hayba/architecture` package with the typology / style-sheet / style-guide schema, validators, 11 seed style-guides + 10 typologies as JSON data, and four MCP tools registered in the Hayba MCP server.
+
+**Architecture:** Plain-TS interfaces (no Zod inside the engine package — matches `@hayba/linguistics`). Hand-rolled type guards in `validate.ts`. JSON data in `src/data/`, loaded synchronously at registry init. MCP wire layer is a thin Zod wrapper in `packages/hayba/src/tools/worldbuilding/architecture-handlers.ts` that calls into the pure engine.
+
+**Tech Stack:** TypeScript 5.6+ (NodeNext modules, `verbatimModuleSyntax`), Vitest 2.1+, MIT license. Node 24+. Zod 3.x used only at the MCP boundary.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-architecture-style-schema-design.md`
+**Issue:** [#101](https://github.com/zajalist/zajalist-hayba/issues/101)
+**Branch:** `feat/architecture-pillar` (already created, the spec doc commit is HEAD)
+
+---
+
+## File Structure
+
+```
+packages/architecture/
+├── package.json                              [Task 1]
+├── tsconfig.json                             [Task 1]
+├── vitest.config.ts                          [Task 1]
+├── src/
+│   ├── index.ts                              [Task 1, extended Task 9]
+│   ├── schema.ts                             [Task 2]
+│   ├── validate.ts                           [Tasks 3–6]
+│   ├── validate.test.ts                      [Tasks 3–6]
+│   ├── schema.test.ts                        [Task 2]
+│   ├── registry.ts                           [Task 9]
+│   ├── registry.test.ts                      [Task 9, extended Task 15]
+│   ├── mcp.ts                                [Tasks 10–13]
+│   ├── mcp.test.ts                           [Tasks 10–13]
+│   └── data/
+│       ├── typologies.json                   [Task 7]
+│       └── style-guides/                     [Task 8]
+│           ├── medieval-european-carolingian.json
+│           ├── medieval-european-romanesque.json
+│           ├── medieval-european-gothic.json
+│           ├── tang-chinese-7c.json
+│           ├── tang-chinese-9c.json
+│           ├── andean-inca.json
+│           ├── andean-pre-inca.json
+│           ├── hausa-classical.json
+│           ├── edo-japanese-early.json
+│           ├── edo-japanese-late.json
+│           └── industrial-revolution-english.json
+└── docs/
+    └── extras-glossary.md                    [Task 16]
+
+packages/hayba/src/tools/worldbuilding/
+└── architecture-handlers.ts                  [Task 14]   (new)
+
+packages/hayba/src/tools/index.ts             [Task 14]   (modified — register 4 tools + reg() entries)
+```
+
+---
+
+### Task 1: Scaffold `@hayba/architecture` package
+
+**Files:**
+- Create: `packages/architecture/package.json`
+- Create: `packages/architecture/tsconfig.json`
+- Create: `packages/architecture/vitest.config.ts`
+- Create: `packages/architecture/src/index.ts`
+- Create: `packages/architecture/src/smoke.test.ts` (temporary, deleted after Task 2)
+
+- [ ] **Step 1: Write the failing smoke test**
+
+`packages/architecture/src/smoke.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { PACKAGE_NAME } from './index.js';
+
+describe('package smoke', () => {
+  it('exports the package name', () => {
+    expect(PACKAGE_NAME).toBe('@hayba/architecture');
+  });
+});
+```
+
+- [ ] **Step 2: Create package.json**
+
+`packages/architecture/package.json` (copy structure from `packages/linguistics/package.json`):
+```json
+{
+  "name": "@hayba/architecture",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.2",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  },
+  "license": "MIT"
+}
+```
+
+- [ ] **Step 3: Create tsconfig.json**
+
+`packages/architecture/tsconfig.json` (identical to linguistics':
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.json"]
+}
+```
+Note `resolveJsonModule: true` and `*.json` in include — needed to import seed JSON via TypeScript.
+
+- [ ] **Step 4: Create vitest.config.ts**
+
+`packages/architecture/vitest.config.ts`:
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+      include: ['src/validate.ts', 'src/registry.ts', 'src/mcp.ts'],
+    },
+  },
+});
+```
+
+- [ ] **Step 5: Create initial index.ts**
+
+`packages/architecture/src/index.ts`:
+```ts
+export const PACKAGE_NAME = '@hayba/architecture';
+```
+
+- [ ] **Step 6: Install workspace dependencies**
+
+Run from repo root:
+```bash
+npm install --workspace=@hayba/architecture
+```
+Expected: package linked into root `node_modules`, no errors.
+
+- [ ] **Step 7: Run smoke test**
+
+Run from repo root:
+```bash
+npm test --workspace=@hayba/architecture
+```
+Expected: 1 test passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/architecture/package.json packages/architecture/tsconfig.json packages/architecture/vitest.config.ts packages/architecture/src/index.ts packages/architecture/src/smoke.test.ts package-lock.json
+git commit -m "feat(architecture): scaffold @hayba/architecture package"
+```
+
+---
+
+### Task 2: Schema types
+
+**Files:**
+- Create: `packages/architecture/src/schema.ts`
+- Create: `packages/architecture/src/schema.test.ts`
+- Delete: `packages/architecture/src/smoke.test.ts`
+- Modify: `packages/architecture/src/index.ts` — replace placeholder with real re-exports
+
+- [ ] **Step 1: Write failing test for type shapes**
+
+`packages/architecture/src/schema.test.ts`:
+```ts
+import { describe, it, expectTypeOf } from 'vitest';
+import type {
+  FeatureBundle, RoofType, PrimaryMaterial, FootprintShape,
+  Typology, StyleSheet, StyleGuide,
+} from './schema.js';
+
+describe('schema types', () => {
+  it('FeatureBundle accepts string and string[] values', () => {
+    const bundle: FeatureBundle = { roof: 'gable', tags: ['rural', 'old'] };
+    expectTypeOf(bundle).toMatchTypeOf<Readonly<Record<string, string | readonly string[]>>>();
+  });
+
+  it('FootprintShape is a discriminated union of 5 kinds', () => {
+    const kinds: FootprintShape['kind'][] =
+      ['rectangle', 'linear-row', 'L-shape', 'U-shape', 'courtyard'];
+    expectTypeOf(kinds).toMatchTypeOf<Array<FootprintShape['kind']>>();
+  });
+
+  it('Typology has the expected required fields', () => {
+    const t: Typology = {
+      id: 'peasant_home',
+      footprint: { kind: 'rectangle', aspectRatio: [1, 2], areaRange: [25, 80] },
+      storyRange: [1, 2],
+      fenestrationDensity: [0.05, 0.15],
+    };
+    expectTypeOf(t.id).toBeString();
+    expectTypeOf(t.storyRange).toEqualTypeOf<[number, number]>();
+  });
+
+  it('StyleSheet carries cultureId, dateRange, core, extras', () => {
+    const s: StyleSheet = {
+      id: 'test',
+      cultureId: 'medieval-european',
+      dateRange: [1140, 1400],
+      core: { primaryMaterial: 'stone', roofType: 'gable', ornamentation: [] },
+      extras: {},
+    };
+    expectTypeOf(s.cultureId).toBeString();
+    expectTypeOf(s.dateRange).toEqualTypeOf<[number, number]>();
+  });
+
+  it('StyleGuide embeds StyleSheet by value and lists typology weights', () => {
+    const g: StyleGuide = {
+      id: 'test-guide',
+      styleSheet: {
+        id: 'test-sheet', cultureId: 'c', dateRange: [0, 1],
+        core: { primaryMaterial: 'timber', roofType: 'thatch', ornamentation: [] },
+        extras: {},
+      },
+      typologyWeights: [{ typologyId: 'peasant_home', weight: 1 }],
+    };
+    expectTypeOf(g.styleSheet).toMatchTypeOf<StyleSheet>();
+    expectTypeOf(g.typologyWeights).toEqualTypeOf<ReadonlyArray<{ typologyId: string; weight: number }>>();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test --workspace=@hayba/architecture`
+Expected: FAIL — `Cannot find module './schema.js'`.
+
+- [ ] **Step 3: Write schema.ts**
+
+`packages/architecture/src/schema.ts`:
+```ts
+/**
+ * @hayba/architecture — schema definitions.
+ *
+ * Three artifacts: Typology (structural), StyleSheet (cosmetic),
+ * StyleGuide (binds the two). All by-value, all readonly-safe.
+ */
+
+export type FeatureBundle = Readonly<Record<string, string | readonly string[]>>;
+
+export type RoofType =
+  | 'gable' | 'hip' | 'flat' | 'pagoda' | 'thatch' | 'dome' | 'shed' | 'mansard';
+
+export const ROOF_TYPES = [
+  'gable', 'hip', 'flat', 'pagoda', 'thatch', 'dome', 'shed', 'mansard',
+] as const satisfies readonly RoofType[];
+
+export type PrimaryMaterial =
+  | 'stone' | 'timber' | 'mudbrick' | 'adobe' | 'rammed-earth'
+  | 'brick' | 'concrete' | 'wattle-daub';
+
+export const PRIMARY_MATERIALS = [
+  'stone', 'timber', 'mudbrick', 'adobe', 'rammed-earth',
+  'brick', 'concrete', 'wattle-daub',
+] as const satisfies readonly PrimaryMaterial[];
+
+export type FootprintKind =
+  | 'rectangle' | 'linear-row' | 'L-shape' | 'U-shape' | 'courtyard';
+
+export const FOOTPRINT_KINDS = [
+  'rectangle', 'linear-row', 'L-shape', 'U-shape', 'courtyard',
+] as const satisfies readonly FootprintKind[];
+
+export type FootprintShape =
+  | { kind: 'rectangle';  aspectRatio:        [number, number]; areaRange:        [number, number] }
+  | { kind: 'linear-row'; widthRange:         [number, number]; depthRange:       [number, number] }
+  | { kind: 'L-shape';    wingDepth:          [number, number]; courtyardFraction:[number, number] }
+  | { kind: 'U-shape';    wingDepth:          [number, number]; openingWidth:     [number, number] }
+  | { kind: 'courtyard';  courtyardFraction:  [number, number]; wingDepth:        [number, number] };
+
+export interface Typology {
+  id: string;
+  footprint: FootprintShape;
+  storyRange: [number, number];
+  fenestrationDensity: [number, number];
+  pathfindingHints?: Readonly<Record<string, string>>;
+}
+
+export interface StyleSheet {
+  id: string;
+  cultureId: string;
+  dateRange: [number, number];
+  core: {
+    primaryMaterial: PrimaryMaterial;
+    secondaryMaterial?: PrimaryMaterial;
+    roofType: RoofType;
+    ornamentation: readonly string[];
+  };
+  extras: FeatureBundle;
+}
+
+export interface StyleGuide {
+  id: string;
+  styleSheet: StyleSheet;
+  typologyWeights: ReadonlyArray<{ typologyId: string; weight: number }>;
+}
+```
+
+- [ ] **Step 4: Replace `index.ts` placeholder**
+
+`packages/architecture/src/index.ts`:
+```ts
+export type {
+  FeatureBundle, RoofType, PrimaryMaterial,
+  FootprintKind, FootprintShape,
+  Typology, StyleSheet, StyleGuide,
+} from './schema.js';
+
+export {
+  ROOF_TYPES, PRIMARY_MATERIALS, FOOTPRINT_KINDS,
+} from './schema.js';
+```
+
+- [ ] **Step 5: Delete the smoke test**
+
+```bash
+git rm packages/architecture/src/smoke.test.ts
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture`
+Expected: 5 tests pass (`schema.test.ts`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/architecture/src/schema.ts packages/architecture/src/schema.test.ts packages/architecture/src/index.ts
+git commit -m "feat(architecture): A1 schema types — Typology, StyleSheet, StyleGuide"
+```
+
+---
+
+### Task 3: Validator — `FootprintShape`
+
+**Files:**
+- Create: `packages/architecture/src/validate.ts`
+- Create: `packages/architecture/src/validate.test.ts`
+
+- [ ] **Step 1: Write failing tests for footprint validation**
+
+`packages/architecture/src/validate.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { validateFootprintShape } from './validate.js';
+
+describe('validateFootprintShape', () => {
+  it('accepts a well-formed rectangle', () => {
+    const errs = validateFootprintShape(
+      { kind: 'rectangle', aspectRatio: [1, 2], areaRange: [25, 100] },
+      '/footprint',
+    );
+    expect(errs).toEqual([]);
+  });
+
+  it('rejects unknown kind', () => {
+    const errs = validateFootprintShape({ kind: 'pentagon' } as unknown, '/footprint');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].path).toBe('/footprint/kind');
+    expect(errs[0].message).toMatch(/unknown footprint kind/i);
+  });
+
+  it('rejects reversed aspect ratio', () => {
+    const errs = validateFootprintShape(
+      { kind: 'rectangle', aspectRatio: [3, 1], areaRange: [25, 100] },
+      '/footprint',
+    );
+    expect(errs.some(e => e.path === '/footprint/aspectRatio')).toBe(true);
+  });
+
+  it('rejects non-array input', () => {
+    const errs = validateFootprintShape('not an object' as unknown, '/footprint');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].path).toBe('/footprint');
+  });
+
+  it('surfaces multiple errors for a malformed L-shape', () => {
+    const errs = validateFootprintShape(
+      { kind: 'L-shape', wingDepth: [5, 2], courtyardFraction: [-1, 0.5] },
+      '/footprint',
+    );
+    expect(errs.length).toBeGreaterThanOrEqual(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test --workspace=@hayba/architecture -- validate.test`
+Expected: FAIL — `validate.js` missing.
+
+- [ ] **Step 3: Write `validate.ts` with `validateFootprintShape` and shared helpers**
+
+`packages/architecture/src/validate.ts`:
+```ts
+import {
+  FOOTPRINT_KINDS, type FootprintShape, type FootprintKind,
+} from './schema.js';
+
+export interface ValidationError {
+  path: string;       // JSON-pointer style, e.g. "/typologies/3/footprint/aspectRatio"
+  message: string;
+}
+
+export class ArchitectureSchemaError extends Error {
+  constructor(public readonly errors: ValidationError[]) {
+    super(`@hayba/architecture: ${errors.length} validation error(s)`);
+    this.name = 'ArchitectureSchemaError';
+  }
+}
+
+/** Shared helper: `[min, max]` tuple with min ≤ max and both finite. */
+export function validateRange(
+  value: unknown, path: string, opts: { minAllowed?: number } = {},
+): ValidationError[] {
+  const errs: ValidationError[] = [];
+  if (!Array.isArray(value) || value.length !== 2) {
+    return [{ path, message: 'expected [min, max] tuple of length 2' }];
+  }
+  const [lo, hi] = value;
+  if (typeof lo !== 'number' || !Number.isFinite(lo)) {
+    errs.push({ path: `${path}/0`, message: 'min must be a finite number' });
+  }
+  if (typeof hi !== 'number' || !Number.isFinite(hi)) {
+    errs.push({ path: `${path}/1`, message: 'max must be a finite number' });
+  }
+  if (typeof lo === 'number' && typeof hi === 'number' && lo > hi) {
+    errs.push({ path, message: `min (${lo}) must be ≤ max (${hi})` });
+  }
+  if (opts.minAllowed !== undefined && typeof lo === 'number' && lo < opts.minAllowed) {
+    errs.push({ path: `${path}/0`, message: `min must be ≥ ${opts.minAllowed}` });
+  }
+  return errs;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+export function validateFootprintShape(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const kind = value.kind;
+  if (typeof kind !== 'string' || !(FOOTPRINT_KINDS as readonly string[]).includes(kind)) {
+    return [{
+      path: `${path}/kind`,
+      message: `unknown footprint kind ${JSON.stringify(kind)}; expected one of ${FOOTPRINT_KINDS.join(', ')}`,
+    }];
+  }
+  const k = kind as FootprintKind;
+  const errs: ValidationError[] = [];
+  switch (k) {
+    case 'rectangle':
+      errs.push(...validateRange(value.aspectRatio, `${path}/aspectRatio`, { minAllowed: 0 }));
+      errs.push(...validateRange(value.areaRange,   `${path}/areaRange`,   { minAllowed: 0 }));
+      break;
+    case 'linear-row':
+      errs.push(...validateRange(value.widthRange, `${path}/widthRange`, { minAllowed: 0 }));
+      errs.push(...validateRange(value.depthRange, `${path}/depthRange`, { minAllowed: 0 }));
+      break;
+    case 'L-shape':
+      errs.push(...validateRange(value.wingDepth,         `${path}/wingDepth`,         { minAllowed: 0 }));
+      errs.push(...validateRange(value.courtyardFraction, `${path}/courtyardFraction`, { minAllowed: 0 }));
+      break;
+    case 'U-shape':
+      errs.push(...validateRange(value.wingDepth,    `${path}/wingDepth`,    { minAllowed: 0 }));
+      errs.push(...validateRange(value.openingWidth, `${path}/openingWidth`, { minAllowed: 0 }));
+      break;
+    case 'courtyard':
+      errs.push(...validateRange(value.courtyardFraction, `${path}/courtyardFraction`, { minAllowed: 0 }));
+      errs.push(...validateRange(value.wingDepth,         `${path}/wingDepth`,         { minAllowed: 0 }));
+      break;
+  }
+  return errs;
+}
+
+// Re-export the validated type narrowing helper for downstream tasks.
+export function isFootprintShape(v: unknown): v is FootprintShape {
+  return validateFootprintShape(v, '/').length === 0;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture -- validate.test`
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/architecture/src/validate.ts packages/architecture/src/validate.test.ts
+git commit -m "feat(architecture): A1 footprint shape validator"
+```
+
+---
+
+### Task 4: Validator — `Typology`
+
+**Files:**
+- Modify: `packages/architecture/src/validate.ts` — add `validateTypology`
+- Modify: `packages/architecture/src/validate.test.ts` — add typology tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/architecture/src/validate.test.ts`:
+```ts
+import { validateTypology } from './validate.js';
+
+describe('validateTypology', () => {
+  const valid = {
+    id: 'peasant_home',
+    footprint: { kind: 'rectangle', aspectRatio: [1, 2], areaRange: [25, 80] },
+    storyRange: [1, 2],
+    fenestrationDensity: [0.05, 0.15],
+  };
+
+  it('accepts a well-formed typology', () => {
+    expect(validateTypology(valid, '/typology')).toEqual([]);
+  });
+
+  it('rejects empty id', () => {
+    const errs = validateTypology({ ...valid, id: '' }, '/typology');
+    expect(errs.some(e => e.path === '/typology/id')).toBe(true);
+  });
+
+  it('rejects missing footprint', () => {
+    const { footprint: _, ...rest } = valid;
+    const errs = validateTypology(rest, '/typology');
+    expect(errs.some(e => e.path.startsWith('/typology/footprint'))).toBe(true);
+  });
+
+  it('rejects story range with min > max', () => {
+    const errs = validateTypology({ ...valid, storyRange: [3, 1] }, '/typology');
+    expect(errs.some(e => e.path === '/typology/storyRange')).toBe(true);
+  });
+
+  it('rejects fenestrationDensity > 1', () => {
+    const errs = validateTypology({ ...valid, fenestrationDensity: [0.05, 1.5] }, '/typology');
+    expect(errs.some(e => e.path.startsWith('/typology/fenestrationDensity'))).toBe(true);
+  });
+
+  it('accepts optional pathfindingHints record', () => {
+    const errs = validateTypology(
+      { ...valid, pathfindingHints: { footTraffic: 'high' } }, '/typology',
+    );
+    expect(errs).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test --workspace=@hayba/architecture -- validate.test`
+Expected: FAIL — `validateTypology` not exported.
+
+- [ ] **Step 3: Add `validateTypology` to `validate.ts`**
+
+Append to `packages/architecture/src/validate.ts`:
+```ts
+import type { Typology } from './schema.js';
+
+export function validateTypology(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const errs: ValidationError[] = [];
+  if (typeof value.id !== 'string' || value.id.length === 0) {
+    errs.push({ path: `${path}/id`, message: 'id must be a non-empty string' });
+  }
+  errs.push(...validateFootprintShape(value.footprint, `${path}/footprint`));
+  errs.push(...validateRange(value.storyRange, `${path}/storyRange`, { minAllowed: 1 }));
+  errs.push(...validateRange(value.fenestrationDensity, `${path}/fenestrationDensity`, { minAllowed: 0 }));
+  if (Array.isArray(value.fenestrationDensity) && value.fenestrationDensity.length === 2) {
+    const hi = value.fenestrationDensity[1];
+    if (typeof hi === 'number' && hi > 1) {
+      errs.push({
+        path: `${path}/fenestrationDensity/1`,
+        message: `max must be ≤ 1 (got ${hi})`,
+      });
+    }
+  }
+  if (value.pathfindingHints !== undefined) {
+    if (!isPlainObject(value.pathfindingHints)) {
+      errs.push({ path: `${path}/pathfindingHints`, message: 'expected an object' });
+    } else {
+      for (const [k, v] of Object.entries(value.pathfindingHints)) {
+        if (typeof v !== 'string') {
+          errs.push({
+            path: `${path}/pathfindingHints/${k}`,
+            message: 'expected string value',
+          });
+        }
+      }
+    }
+  }
+  return errs;
+}
+
+export function isTypology(v: unknown): v is Typology {
+  return validateTypology(v, '/').length === 0;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture -- validate.test`
+Expected: 11 tests pass (5 from Task 3 + 6 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/architecture/src/validate.ts packages/architecture/src/validate.test.ts
+git commit -m "feat(architecture): A1 typology validator"
+```
+
+---
+
+### Task 5: Validator — `StyleSheet`
+
+**Files:**
+- Modify: `packages/architecture/src/validate.ts` — add `validateStyleSheet`
+- Modify: `packages/architecture/src/validate.test.ts` — add stylesheet tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/architecture/src/validate.test.ts`:
+```ts
+import { validateStyleSheet } from './validate.js';
+
+describe('validateStyleSheet', () => {
+  const valid = {
+    id: 'medieval-european-gothic',
+    cultureId: 'medieval-european',
+    dateRange: [1140, 1400],
+    core: {
+      primaryMaterial: 'stone',
+      roofType: 'gable',
+      ornamentation: ['pointed-arch', 'flying-buttress'],
+    },
+    extras: { stainedGlass: 'present' },
+  };
+
+  it('accepts a well-formed sheet', () => {
+    expect(validateStyleSheet(valid, '/sheet')).toEqual([]);
+  });
+
+  it('rejects unknown roofType', () => {
+    const bad = { ...valid, core: { ...valid.core, roofType: 'tepee' } };
+    const errs = validateStyleSheet(bad, '/sheet');
+    expect(errs.some(e => e.path === '/sheet/core/roofType')).toBe(true);
+  });
+
+  it('rejects unknown primaryMaterial', () => {
+    const bad = { ...valid, core: { ...valid.core, primaryMaterial: 'plasma' } };
+    const errs = validateStyleSheet(bad, '/sheet');
+    expect(errs.some(e => e.path === '/sheet/core/primaryMaterial')).toBe(true);
+  });
+
+  it('rejects extras with non-string-non-array value', () => {
+    const bad = { ...valid, extras: { count: 42 } };
+    const errs = validateStyleSheet(bad, '/sheet');
+    expect(errs.some(e => e.path === '/sheet/extras/count')).toBe(true);
+  });
+
+  it('accepts extras with string[] values', () => {
+    const ok = { ...valid, extras: { tags: ['rural', 'old'] } };
+    expect(validateStyleSheet(ok, '/sheet')).toEqual([]);
+  });
+
+  it('rejects dateRange with negative endYear smaller than startYear', () => {
+    const bad = { ...valid, dateRange: [1400, 1140] };
+    const errs = validateStyleSheet(bad, '/sheet');
+    expect(errs.some(e => e.path === '/sheet/dateRange')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test --workspace=@hayba/architecture -- validate.test`
+Expected: FAIL — `validateStyleSheet` not exported.
+
+- [ ] **Step 3: Add `validateStyleSheet`**
+
+Append to `packages/architecture/src/validate.ts`:
+```ts
+import {
+  PRIMARY_MATERIALS, ROOF_TYPES,
+  type PrimaryMaterial, type RoofType, type StyleSheet,
+} from './schema.js';
+
+function validateFeatureBundle(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const errs: ValidationError[] = [];
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === 'string') continue;
+    if (Array.isArray(v) && v.every(item => typeof item === 'string')) continue;
+    errs.push({
+      path: `${path}/${k}`,
+      message: 'expected string or string[] value',
+    });
+  }
+  return errs;
+}
+
+export function validateStyleSheet(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const errs: ValidationError[] = [];
+  if (typeof value.id !== 'string' || value.id.length === 0) {
+    errs.push({ path: `${path}/id`, message: 'id must be a non-empty string' });
+  }
+  if (typeof value.cultureId !== 'string' || value.cultureId.length === 0) {
+    errs.push({ path: `${path}/cultureId`, message: 'cultureId must be a non-empty string' });
+  }
+  errs.push(...validateRange(value.dateRange, `${path}/dateRange`));
+
+  const core = value.core;
+  if (!isPlainObject(core)) {
+    errs.push({ path: `${path}/core`, message: 'expected an object' });
+  } else {
+    if (!(PRIMARY_MATERIALS as readonly string[]).includes(core.primaryMaterial as string)) {
+      errs.push({
+        path: `${path}/core/primaryMaterial`,
+        message: `unknown primaryMaterial ${JSON.stringify(core.primaryMaterial)}; expected one of ${PRIMARY_MATERIALS.join(', ')}`,
+      });
+    }
+    if (core.secondaryMaterial !== undefined &&
+        !(PRIMARY_MATERIALS as readonly string[]).includes(core.secondaryMaterial as string)) {
+      errs.push({
+        path: `${path}/core/secondaryMaterial`,
+        message: `unknown secondaryMaterial ${JSON.stringify(core.secondaryMaterial)}`,
+      });
+    }
+    if (!(ROOF_TYPES as readonly string[]).includes(core.roofType as string)) {
+      errs.push({
+        path: `${path}/core/roofType`,
+        message: `unknown roofType ${JSON.stringify(core.roofType)}; expected one of ${ROOF_TYPES.join(', ')}`,
+      });
+    }
+    if (!Array.isArray(core.ornamentation) ||
+        !core.ornamentation.every(s => typeof s === 'string')) {
+      errs.push({
+        path: `${path}/core/ornamentation`,
+        message: 'expected array of strings',
+      });
+    }
+  }
+  errs.push(...validateFeatureBundle(value.extras, `${path}/extras`));
+  return errs;
+}
+
+export function isStyleSheet(v: unknown): v is StyleSheet {
+  return validateStyleSheet(v, '/').length === 0;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture -- validate.test`
+Expected: 17 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/architecture/src/validate.ts packages/architecture/src/validate.test.ts
+git commit -m "feat(architecture): A1 stylesheet validator"
+```
+
+---
+
+### Task 6: Validator — `StyleGuide` + cross-ref check
+
+**Files:**
+- Modify: `packages/architecture/src/validate.ts` — add `validateStyleGuide` + `validateStyleGuideRefs`
+- Modify: `packages/architecture/src/validate.test.ts` — add guide tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/architecture/src/validate.test.ts`:
+```ts
+import { validateStyleGuide, validateStyleGuideRefs } from './validate.js';
+
+describe('validateStyleGuide', () => {
+  const sheet = {
+    id: 's1', cultureId: 'c', dateRange: [0, 100],
+    core: { primaryMaterial: 'timber', roofType: 'thatch', ornamentation: [] },
+    extras: {},
+  };
+  const valid = {
+    id: 'g1',
+    styleSheet: sheet,
+    typologyWeights: [
+      { typologyId: 'peasant_home', weight: 1 },
+      { typologyId: 'townhouse',    weight: 2.5 },
+    ],
+  };
+
+  it('accepts a well-formed guide', () => {
+    expect(validateStyleGuide(valid, '/g')).toEqual([]);
+  });
+
+  it('rejects empty typologyWeights', () => {
+    const errs = validateStyleGuide({ ...valid, typologyWeights: [] }, '/g');
+    expect(errs.some(e => e.path === '/g/typologyWeights')).toBe(true);
+  });
+
+  it('rejects zero/negative weight', () => {
+    const bad = {
+      ...valid,
+      typologyWeights: [{ typologyId: 'peasant_home', weight: 0 }],
+    };
+    const errs = validateStyleGuide(bad, '/g');
+    expect(errs.some(e => e.path === '/g/typologyWeights/0/weight')).toBe(true);
+  });
+
+  it('rejects malformed embedded styleSheet', () => {
+    const bad = { ...valid, styleSheet: { ...sheet, core: { ...sheet.core, roofType: 'X' } } };
+    const errs = validateStyleGuide(bad, '/g');
+    expect(errs.some(e => e.path === '/g/styleSheet/core/roofType')).toBe(true);
+  });
+});
+
+describe('validateStyleGuideRefs', () => {
+  const sheet = {
+    id: 's', cultureId: 'c', dateRange: [0, 1],
+    core: { primaryMaterial: 'timber', roofType: 'thatch', ornamentation: [] },
+    extras: {},
+  };
+  const guide = {
+    id: 'g', styleSheet: sheet,
+    typologyWeights: [{ typologyId: 'peasant_home', weight: 1 }],
+  };
+
+  it('returns no errors when all typology refs resolve', () => {
+    expect(validateStyleGuideRefs(guide as never, new Set(['peasant_home']), '/g')).toEqual([]);
+  });
+
+  it('reports dangling typology references', () => {
+    const errs = validateStyleGuideRefs(guide as never, new Set(['townhouse']), '/g');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].path).toBe('/g/typologyWeights/0/typologyId');
+    expect(errs[0].message).toMatch(/peasant_home/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test --workspace=@hayba/architecture -- validate.test`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `validateStyleGuide` + `validateStyleGuideRefs`**
+
+Append to `packages/architecture/src/validate.ts`:
+```ts
+import type { StyleGuide } from './schema.js';
+
+export function validateStyleGuide(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const errs: ValidationError[] = [];
+  if (typeof value.id !== 'string' || value.id.length === 0) {
+    errs.push({ path: `${path}/id`, message: 'id must be a non-empty string' });
+  }
+  errs.push(...validateStyleSheet(value.styleSheet, `${path}/styleSheet`));
+
+  if (!Array.isArray(value.typologyWeights)) {
+    errs.push({ path: `${path}/typologyWeights`, message: 'expected array' });
+  } else if (value.typologyWeights.length === 0) {
+    errs.push({ path: `${path}/typologyWeights`, message: 'must list at least one typology' });
+  } else {
+    value.typologyWeights.forEach((entry, i) => {
+      const ePath = `${path}/typologyWeights/${i}`;
+      if (!isPlainObject(entry)) {
+        errs.push({ path: ePath, message: 'expected an object' });
+        return;
+      }
+      if (typeof entry.typologyId !== 'string' || entry.typologyId.length === 0) {
+        errs.push({ path: `${ePath}/typologyId`, message: 'typologyId must be a non-empty string' });
+      }
+      if (typeof entry.weight !== 'number' || !Number.isFinite(entry.weight) || entry.weight <= 0) {
+        errs.push({ path: `${ePath}/weight`, message: 'weight must be a positive finite number' });
+      }
+    });
+  }
+  return errs;
+}
+
+export function isStyleGuide(v: unknown): v is StyleGuide {
+  return validateStyleGuide(v, '/').length === 0;
+}
+
+/**
+ * Cross-reference check: every `typologyId` referenced from `guide.typologyWeights`
+ * must exist in `knownTypologyIds`. Run AFTER `validateStyleGuide`; assumes
+ * the guide is structurally valid.
+ */
+export function validateStyleGuideRefs(
+  guide: StyleGuide, knownTypologyIds: ReadonlySet<string>, path: string,
+): ValidationError[] {
+  const errs: ValidationError[] = [];
+  guide.typologyWeights.forEach((entry, i) => {
+    if (!knownTypologyIds.has(entry.typologyId)) {
+      errs.push({
+        path: `${path}/typologyWeights/${i}/typologyId`,
+        message: `unknown typologyId ${JSON.stringify(entry.typologyId)}`,
+      });
+    }
+  });
+  return errs;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture -- validate.test`
+Expected: 23 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/architecture/src/validate.ts packages/architecture/src/validate.test.ts
+git commit -m "feat(architecture): A1 styleguide validator + cross-ref check"
+```
+
+---
+
+### Task 7: Typology seed data
+
+**Files:**
+- Create: `packages/architecture/src/data/typologies.json`
+
+- [ ] **Step 1: Author `typologies.json`**
+
+`packages/architecture/src/data/typologies.json`:
+```json
+{
+  "typologies": [
+    {
+      "id": "peasant_home",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 1.6], "areaRange": [20, 60] },
+      "storyRange": [1, 2],
+      "fenestrationDensity": [0.04, 0.12]
+    },
+    {
+      "id": "townhouse",
+      "footprint": { "kind": "linear-row", "widthRange": [4, 7], "depthRange": [10, 22] },
+      "storyRange": [2, 4],
+      "fenestrationDensity": [0.12, 0.25]
+    },
+    {
+      "id": "market_stall",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 2.5], "areaRange": [6, 20] },
+      "storyRange": [1, 1],
+      "fenestrationDensity": [0.0, 0.05]
+    },
+    {
+      "id": "manor",
+      "footprint": { "kind": "U-shape", "wingDepth": [6, 12], "openingWidth": [8, 18] },
+      "storyRange": [2, 3],
+      "fenestrationDensity": [0.18, 0.32]
+    },
+    {
+      "id": "temple",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.3, 2.2], "areaRange": [80, 600] },
+      "storyRange": [1, 3],
+      "fenestrationDensity": [0.05, 0.18]
+    },
+    {
+      "id": "granary",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 1.4], "areaRange": [12, 80] },
+      "storyRange": [1, 2],
+      "fenestrationDensity": [0.0, 0.04]
+    },
+    {
+      "id": "watchtower",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 1.2], "areaRange": [9, 36] },
+      "storyRange": [3, 6],
+      "fenestrationDensity": [0.02, 0.08]
+    },
+    {
+      "id": "walled_palace",
+      "footprint": { "kind": "courtyard", "courtyardFraction": [0.25, 0.5], "wingDepth": [8, 16] },
+      "storyRange": [1, 3],
+      "fenestrationDensity": [0.10, 0.25]
+    },
+    {
+      "id": "workshop",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 2.0], "areaRange": [30, 120] },
+      "storyRange": [1, 2],
+      "fenestrationDensity": [0.10, 0.30]
+    },
+    {
+      "id": "civic_hall",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.5, 2.5], "areaRange": [100, 400] },
+      "storyRange": [1, 2],
+      "fenestrationDensity": [0.15, 0.35]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Stage and commit** (registry test follows in Task 9; data alone is not testable yet)
+
+```bash
+git add packages/architecture/src/data/typologies.json
+git commit -m "feat(architecture): A1 seed typology registry (10 entries)"
+```
+
+---
+
+### Task 8: StyleGuide seed data (11 files)
+
+**Files:**
+- Create: `packages/architecture/src/data/style-guides/medieval-european-carolingian.json`
+- Create: `packages/architecture/src/data/style-guides/medieval-european-romanesque.json`
+- Create: `packages/architecture/src/data/style-guides/medieval-european-gothic.json`
+- Create: `packages/architecture/src/data/style-guides/tang-chinese-7c.json`
+- Create: `packages/architecture/src/data/style-guides/tang-chinese-9c.json`
+- Create: `packages/architecture/src/data/style-guides/andean-inca.json`
+- Create: `packages/architecture/src/data/style-guides/andean-pre-inca.json`
+- Create: `packages/architecture/src/data/style-guides/hausa-classical.json`
+- Create: `packages/architecture/src/data/style-guides/edo-japanese-early.json`
+- Create: `packages/architecture/src/data/style-guides/edo-japanese-late.json`
+- Create: `packages/architecture/src/data/style-guides/industrial-revolution-english.json`
+
+- [ ] **Step 1: Author first guide (full example to follow)**
+
+`packages/architecture/src/data/style-guides/medieval-european-gothic.json`:
+```json
+{
+  "id": "medieval-european-gothic",
+  "styleSheet": {
+    "id": "medieval-european-gothic",
+    "cultureId": "medieval-european",
+    "dateRange": [1140, 1400],
+    "core": {
+      "primaryMaterial": "stone",
+      "secondaryMaterial": "timber",
+      "roofType": "gable",
+      "ornamentation": ["pointed-arch", "flying-buttress", "rose-window", "gargoyle"]
+    },
+    "extras": {
+      "stainedGlass": "common",
+      "verticalEmphasis": "strong",
+      "tracery": "ribbed"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "peasant_home", "weight": 6 },
+    { "typologyId": "townhouse",    "weight": 4 },
+    { "typologyId": "market_stall", "weight": 2 },
+    { "typologyId": "manor",        "weight": 1 },
+    { "typologyId": "temple",       "weight": 1 },
+    { "typologyId": "watchtower",   "weight": 1 },
+    { "typologyId": "civic_hall",   "weight": 1 }
+  ]
+}
+```
+
+- [ ] **Step 2: Author the remaining 10 guides following the same shape**
+
+Each file follows the schema established above. Per-culture authoring hints — use these as starting points, refine from the reference sources in the spec (Atlas of Urban Form, Wikidata `P186`, VernacularArchitecture.com):
+
+| File | cultureId | dateRange | primaryMaterial | roofType | Heavy-weighted typologies | Distinguishing `extras` |
+|---|---|---|---|---|---|---|
+| `medieval-european-carolingian.json` | `medieval-european` | `[750, 1000]` | `timber` | `gable` | peasant_home, granary, watchtower | `roofPitch: "steep"`, `defensiveWalls: "earthen"` |
+| `medieval-european-romanesque.json` | `medieval-european` | `[1000, 1200]` | `stone` | `gable` | peasant_home, townhouse, temple, watchtower | `vaulting: "barrel"`, `windowSize: "small"` |
+| `tang-chinese-7c.json` | `tang-chinese` | `[618, 800]` | `timber` | `pagoda` | peasant_home, townhouse, temple, walled_palace | `dougong: "present"`, `colorPalette: ["red","gold"]` |
+| `tang-chinese-9c.json` | `tang-chinese` | `[800, 907]` | `timber` | `pagoda` | townhouse, walled_palace, temple, civic_hall | `dougong: "elaborate"`, `eaves: "deep-overhang"` |
+| `andean-inca.json` | `andean` | `[1438, 1533]` | `stone` | `thatch` | peasant_home, granary, temple, walled_palace, watchtower | `wallStyle: "polygonal-fitted"`, `niches: "trapezoidal"` |
+| `andean-pre-inca.json` | `andean` | `[200, 1438]` | `adobe` | `thatch` | peasant_home, granary, temple | `wallStyle: "coursed-adobe"` |
+| `hausa-classical.json` | `hausa` | `[1400, 1800]` | `mudbrick` | `flat` | peasant_home, walled_palace, market_stall, civic_hall | `tubali: "molded-mud-cones"`, `multiBuilding: "true"`, `pinnacles: "azara"` |
+| `edo-japanese-early.json` | `edo-japanese` | `[1603, 1750]` | `timber` | `hip` | peasant_home, townhouse, market_stall, temple | `engawa: "present"`, `tokonoma: "common"`, `shoji: "ubiquitous"` |
+| `edo-japanese-late.json` | `edo-japanese` | `[1750, 1868]` | `timber` | `hip` | townhouse, market_stall, civic_hall, walled_palace | `engawa: "present"`, `kawara: "common"` |
+| `industrial-revolution-english.json` | `industrial-revolution-english` | `[1760, 1900]` | `brick` | `mansard` | townhouse, workshop, civic_hall, market_stall | `chimneyStacks: "tall"`, `cornice: "stone"`, `bayWindows: "common"` |
+
+Each file's `typologyWeights` MUST only reference typology ids defined in Task 7's `typologies.json` (`peasant_home, townhouse, market_stall, manor, temple, granary, watchtower, walled_palace, workshop, civic_hall`). Cross-ref will be checked in Task 9.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/architecture/src/data/style-guides/
+git commit -m "feat(architecture): A1 seed style guides (11 culture/era palettes)"
+```
+
+---
+
+### Task 9: Registry — load, cache, validate all data
+
+**Files:**
+- Create: `packages/architecture/src/registry.ts`
+- Create: `packages/architecture/src/registry.test.ts`
+- Modify: `packages/architecture/src/index.ts` — re-export registry surface
+
+- [ ] **Step 1: Write failing test**
+
+`packages/architecture/src/registry.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  loadRegistry, listStyleGuideMeta, getStyleGuide, getTypology,
+  ArchitectureRegistryError,
+} from './registry.js';
+
+describe('registry', () => {
+  it('loads the bundled seed data without errors', () => {
+    expect(() => loadRegistry()).not.toThrow();
+  });
+
+  it('exposes all 10 typologies', () => {
+    const reg = loadRegistry();
+    expect(reg.typologyIds.size).toBe(10);
+    expect(reg.typologyIds.has('peasant_home')).toBe(true);
+  });
+
+  it('exposes all 11 style guides', () => {
+    expect(listStyleGuideMeta().length).toBe(11);
+  });
+
+  it('every typologyId referenced from a guide resolves', () => {
+    const reg = loadRegistry();
+    for (const guide of reg.styleGuidesById.values()) {
+      for (const w of guide.typologyWeights) {
+        expect(reg.typologyIds.has(w.typologyId)).toBe(true);
+      }
+    }
+  });
+
+  it('getStyleGuide returns the embedded sheet for a known id', () => {
+    const g = getStyleGuide('medieval-european-gothic');
+    expect(g).not.toBeNull();
+    expect(g!.styleSheet.cultureId).toBe('medieval-european');
+  });
+
+  it('getStyleGuide returns null for unknown id', () => {
+    expect(getStyleGuide('not-a-real-id')).toBeNull();
+  });
+
+  it('getTypology returns null for unknown id', () => {
+    expect(getTypology('not-a-real-id')).toBeNull();
+  });
+
+  it('loadRegistry is idempotent and returns the same cached object', () => {
+    expect(loadRegistry()).toBe(loadRegistry());
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test --workspace=@hayba/architecture -- registry.test`
+Expected: FAIL — `registry.js` missing.
+
+- [ ] **Step 3: Implement registry**
+
+`packages/architecture/src/registry.ts`:
+```ts
+import {
+  validateTypology, validateStyleGuide, validateStyleGuideRefs,
+  ArchitectureSchemaError, type ValidationError,
+} from './validate.js';
+import type { StyleGuide, Typology } from './schema.js';
+
+import typologiesFile from './data/typologies.json' with { type: 'json' };
+
+import g01 from './data/style-guides/medieval-european-carolingian.json' with { type: 'json' };
+import g02 from './data/style-guides/medieval-european-romanesque.json' with { type: 'json' };
+import g03 from './data/style-guides/medieval-european-gothic.json' with { type: 'json' };
+import g04 from './data/style-guides/tang-chinese-7c.json' with { type: 'json' };
+import g05 from './data/style-guides/tang-chinese-9c.json' with { type: 'json' };
+import g06 from './data/style-guides/andean-inca.json' with { type: 'json' };
+import g07 from './data/style-guides/andean-pre-inca.json' with { type: 'json' };
+import g08 from './data/style-guides/hausa-classical.json' with { type: 'json' };
+import g09 from './data/style-guides/edo-japanese-early.json' with { type: 'json' };
+import g10 from './data/style-guides/edo-japanese-late.json' with { type: 'json' };
+import g11 from './data/style-guides/industrial-revolution-english.json' with { type: 'json' };
+
+const RAW_GUIDES: unknown[] = [g01, g02, g03, g04, g05, g06, g07, g08, g09, g10, g11];
+
+export class ArchitectureRegistryError extends Error {
+  constructor(public readonly errors: ValidationError[]) {
+    super(`@hayba/architecture: registry load failed (${errors.length} error(s))`);
+    this.name = 'ArchitectureRegistryError';
+  }
+}
+
+export interface Registry {
+  readonly typologies: ReadonlyMap<string, Typology>;
+  readonly typologyIds: ReadonlySet<string>;
+  readonly styleGuidesById: ReadonlyMap<string, StyleGuide>;
+  readonly styleGuideOrder: readonly string[];   // sorted insertion order
+}
+
+let CACHED: Registry | null = null;
+
+export function loadRegistry(): Registry {
+  if (CACHED) return CACHED;
+
+  const errors: ValidationError[] = [];
+  const typologies = new Map<string, Typology>();
+  const typologyIds = new Set<string>();
+
+  const rawTypos = (typologiesFile as { typologies?: unknown[] }).typologies;
+  if (!Array.isArray(rawTypos)) {
+    throw new ArchitectureRegistryError([
+      { path: '/typologies', message: 'typologies.json missing "typologies" array' },
+    ]);
+  }
+  rawTypos.forEach((t, i) => {
+    const errs = validateTypology(t, `/typologies/${i}`);
+    if (errs.length === 0) {
+      const typed = t as Typology;
+      if (typologies.has(typed.id)) {
+        errors.push({ path: `/typologies/${i}/id`, message: `duplicate typology id ${JSON.stringify(typed.id)}` });
+      } else {
+        typologies.set(typed.id, typed);
+        typologyIds.add(typed.id);
+      }
+    } else {
+      errors.push(...errs);
+    }
+  });
+
+  const styleGuidesById = new Map<string, StyleGuide>();
+  const styleGuideOrder: string[] = [];
+
+  // Sort by source filename equivalent → use index order; data files are sorted alphabetically above.
+  RAW_GUIDES.forEach((g, i) => {
+    const path = `/styleGuides/${i}`;
+    const errs = validateStyleGuide(g, path);
+    if (errs.length > 0) {
+      errors.push(...errs);
+      return;
+    }
+    const typed = g as StyleGuide;
+    if (styleGuidesById.has(typed.id)) {
+      errors.push({ path: `${path}/id`, message: `duplicate styleGuide id ${JSON.stringify(typed.id)}` });
+      return;
+    }
+    const refErrs = validateStyleGuideRefs(typed, typologyIds, path);
+    if (refErrs.length > 0) {
+      errors.push(...refErrs);
+      return;
+    }
+    styleGuidesById.set(typed.id, typed);
+    styleGuideOrder.push(typed.id);
+  });
+
+  if (errors.length > 0) {
+    throw new ArchitectureRegistryError(errors);
+  }
+
+  CACHED = {
+    typologies, typologyIds,
+    styleGuidesById,
+    styleGuideOrder: Object.freeze([...styleGuideOrder]),
+  };
+  return CACHED;
+}
+
+/** Test-only: drop the cache. NOT exposed via package index. */
+export function _resetRegistryCacheForTests(): void {
+  CACHED = null;
+}
+
+export interface StyleGuideMeta {
+  id: string;
+  cultureId: string;
+  dateRange: [number, number];
+  typologyCount: number;
+}
+
+export function listStyleGuideMeta(): StyleGuideMeta[] {
+  const reg = loadRegistry();
+  return reg.styleGuideOrder.map(id => {
+    const g = reg.styleGuidesById.get(id)!;
+    return {
+      id: g.id,
+      cultureId: g.styleSheet.cultureId,
+      dateRange: g.styleSheet.dateRange,
+      typologyCount: g.typologyWeights.length,
+    };
+  });
+}
+
+export function getStyleGuide(id: string): StyleGuide | null {
+  return loadRegistry().styleGuidesById.get(id) ?? null;
+}
+
+export function getTypology(id: string): Typology | null {
+  return loadRegistry().typologies.get(id) ?? null;
+}
+
+export { ArchitectureSchemaError };
+```
+
+- [ ] **Step 4: Update `index.ts` to re-export registry surface**
+
+Replace `packages/architecture/src/index.ts` with:
+```ts
+export type {
+  FeatureBundle, RoofType, PrimaryMaterial,
+  FootprintKind, FootprintShape,
+  Typology, StyleSheet, StyleGuide,
+} from './schema.js';
+
+export {
+  ROOF_TYPES, PRIMARY_MATERIALS, FOOTPRINT_KINDS,
+} from './schema.js';
+
+export type { ValidationError } from './validate.js';
+export {
+  ArchitectureSchemaError,
+  validateFootprintShape, validateTypology, validateStyleSheet,
+  validateStyleGuide, validateStyleGuideRefs,
+  isFootprintShape, isTypology, isStyleSheet, isStyleGuide,
+} from './validate.js';
+
+export type { Registry, StyleGuideMeta } from './registry.js';
+export {
+  ArchitectureRegistryError,
+  loadRegistry, listStyleGuideMeta, getStyleGuide, getTypology,
+} from './registry.js';
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture`
+Expected: 31 tests pass (23 validate + 8 registry).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/architecture/src/registry.ts packages/architecture/src/registry.test.ts packages/architecture/src/index.ts
+git commit -m "feat(architecture): A1 registry loader + caching"
+```
+
+---
+
+### Task 10: MCP tool — `architecture_list_style_guides`
+
+**Files:**
+- Create: `packages/architecture/src/mcp.ts`
+- Create: `packages/architecture/src/mcp.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+`packages/architecture/src/mcp.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { listStyleGuides } from './mcp.js';
+
+describe('architecture_list_style_guides', () => {
+  it('returns metadata for all 11 seed guides', () => {
+    const out = listStyleGuides();
+    expect(out.guides).toHaveLength(11);
+    expect(out.guides[0]).toMatchObject({
+      id: expect.any(String),
+      cultureId: expect.any(String),
+      dateRange: expect.any(Array),
+      typologyCount: expect.any(Number),
+    });
+  });
+
+  it('output is byte-identical across calls', () => {
+    expect(JSON.stringify(listStyleGuides())).toBe(JSON.stringify(listStyleGuides()));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test --workspace=@hayba/architecture -- mcp.test`
+Expected: FAIL — `mcp.js` missing.
+
+- [ ] **Step 3: Create `mcp.ts` with `listStyleGuides`**
+
+`packages/architecture/src/mcp.ts`:
+```ts
+import { listStyleGuideMeta, type StyleGuideMeta } from './registry.js';
+
+export interface ListStyleGuidesResult {
+  guides: StyleGuideMeta[];
+}
+
+export function listStyleGuides(): ListStyleGuidesResult {
+  return { guides: listStyleGuideMeta() };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture -- mcp.test`
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/architecture/src/mcp.ts packages/architecture/src/mcp.test.ts
+git commit -m "feat(architecture): A1 MCP — list_style_guides"
+```
+
+---
+
+### Task 11: MCP tool — `architecture_get_style_guide`
+
+**Files:**
+- Modify: `packages/architecture/src/mcp.ts` — add `getStyleGuideTool`
+- Modify: `packages/architecture/src/mcp.test.ts` — add tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/architecture/src/mcp.test.ts`:
+```ts
+import { getStyleGuideTool } from './mcp.js';
+
+describe('architecture_get_style_guide', () => {
+  it('returns the full guide for a known id', () => {
+    const out = getStyleGuideTool({ id: 'medieval-european-gothic' });
+    expect('guide' in out).toBe(true);
+    if ('guide' in out) {
+      expect(out.guide.styleSheet.core.primaryMaterial).toBe('stone');
+    }
+  });
+
+  it('returns not_found error for unknown id', () => {
+    const out = getStyleGuideTool({ id: 'nonexistent' });
+    expect(out).toEqual({ error: 'not_found', id: 'nonexistent' });
+  });
+
+  it('is deterministic across calls', () => {
+    const a = JSON.stringify(getStyleGuideTool({ id: 'medieval-european-gothic' }));
+    const b = JSON.stringify(getStyleGuideTool({ id: 'medieval-european-gothic' }));
+    expect(a).toBe(b);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test --workspace=@hayba/architecture -- mcp.test`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `getStyleGuideTool`**
+
+Append to `packages/architecture/src/mcp.ts`:
+```ts
+import { getStyleGuide, getTypology } from './registry.js';
+import type { StyleGuide, Typology } from './schema.js';
+
+export type GetStyleGuideResult =
+  | { guide: StyleGuide }
+  | { error: 'not_found'; id: string };
+
+export function getStyleGuideTool(args: { id: string }): GetStyleGuideResult {
+  const g = getStyleGuide(args.id);
+  if (!g) return { error: 'not_found', id: args.id };
+  return { guide: g };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture -- mcp.test`
+Expected: 5 tests pass total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/architecture/src/mcp.ts packages/architecture/src/mcp.test.ts
+git commit -m "feat(architecture): A1 MCP — get_style_guide"
+```
+
+---
+
+### Task 12: MCP tool — `architecture_get_typology`
+
+**Files:**
+- Modify: `packages/architecture/src/mcp.ts` — add `getTypologyTool`
+- Modify: `packages/architecture/src/mcp.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/architecture/src/mcp.test.ts`:
+```ts
+import { getTypologyTool } from './mcp.js';
+
+describe('architecture_get_typology', () => {
+  it('returns typology for known id', () => {
+    const out = getTypologyTool({ id: 'peasant_home' });
+    expect('typology' in out).toBe(true);
+    if ('typology' in out) {
+      expect(out.typology.id).toBe('peasant_home');
+      expect(out.typology.footprint.kind).toBe('rectangle');
+    }
+  });
+
+  it('returns not_found for unknown id', () => {
+    const out = getTypologyTool({ id: 'castle' });
+    expect(out).toEqual({ error: 'not_found', id: 'castle' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test --workspace=@hayba/architecture -- mcp.test`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `getTypologyTool`**
+
+Append to `packages/architecture/src/mcp.ts`:
+```ts
+export type GetTypologyResult =
+  | { typology: Typology }
+  | { error: 'not_found'; id: string };
+
+export function getTypologyTool(args: { id: string }): GetTypologyResult {
+  const t = getTypology(args.id);
+  if (!t) return { error: 'not_found', id: args.id };
+  return { typology: t };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture -- mcp.test`
+Expected: 7 tests pass total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/architecture/src/mcp.ts packages/architecture/src/mcp.test.ts
+git commit -m "feat(architecture): A1 MCP — get_typology"
+```
+
+---
+
+### Task 13: MCP tool — `architecture_validate_style_guide`
+
+**Files:**
+- Modify: `packages/architecture/src/mcp.ts` — add `validateStyleGuideTool`
+- Modify: `packages/architecture/src/mcp.test.ts`
+- Modify: `packages/architecture/src/index.ts` — re-export MCP tools
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/architecture/src/mcp.test.ts`:
+```ts
+import { validateStyleGuideTool } from './mcp.js';
+
+describe('architecture_validate_style_guide', () => {
+  const valid = {
+    id: 'test-guide',
+    styleSheet: {
+      id: 'test-sheet', cultureId: 'medieval-european', dateRange: [1000, 1200],
+      core: { primaryMaterial: 'stone', roofType: 'gable', ornamentation: [] },
+      extras: {},
+    },
+    typologyWeights: [{ typologyId: 'peasant_home', weight: 1 }],
+  };
+
+  it('returns ok=true for a well-formed guide with known typology refs', () => {
+    expect(validateStyleGuideTool({ json: valid })).toEqual({ ok: true });
+  });
+
+  it('returns ok=true even if typology refs are unknown — refs are A1 registry concern only', () => {
+    const bad = { ...valid, typologyWeights: [{ typologyId: 'unknown_t', weight: 1 }] };
+    // Structural validation passes; ref check is run by the registry, not by this tool.
+    expect(validateStyleGuideTool({ json: bad })).toEqual({ ok: true });
+  });
+
+  it('returns structured errors for a malformed input', () => {
+    const out = validateStyleGuideTool({
+      json: { id: '', styleSheet: { id: 's' }, typologyWeights: 'not-an-array' },
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.errors.length).toBeGreaterThanOrEqual(2);
+      for (const e of out.errors) {
+        expect(typeof e.path).toBe('string');
+        expect(typeof e.message).toBe('string');
+      }
+    }
+  });
+
+  it('surfaces ALL errors (not first-fail)', () => {
+    const out = validateStyleGuideTool({
+      json: {
+        id: '',
+        styleSheet: {
+          id: '', cultureId: '', dateRange: 'bad',
+          core: { primaryMaterial: 'plasma', roofType: 'tepee', ornamentation: [] },
+          extras: { broken: 42 },
+        },
+        typologyWeights: [],
+      },
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.errors.length).toBeGreaterThanOrEqual(5);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test --workspace=@hayba/architecture -- mcp.test`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `validateStyleGuideTool`**
+
+Append to `packages/architecture/src/mcp.ts`:
+```ts
+import { validateStyleGuide, type ValidationError } from './validate.js';
+
+export type ValidateStyleGuideResult =
+  | { ok: true }
+  | { ok: false; errors: ValidationError[] };
+
+export function validateStyleGuideTool(args: { json: unknown }): ValidateStyleGuideResult {
+  const errs = validateStyleGuide(args.json, '');
+  if (errs.length === 0) return { ok: true };
+  return { ok: false, errors: errs };
+}
+```
+
+- [ ] **Step 4: Re-export MCP tools from index.ts**
+
+Append to `packages/architecture/src/index.ts`:
+```ts
+export type {
+  ListStyleGuidesResult, GetStyleGuideResult, GetTypologyResult, ValidateStyleGuideResult,
+} from './mcp.js';
+export {
+  listStyleGuides, getStyleGuideTool, getTypologyTool, validateStyleGuideTool,
+} from './mcp.js';
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm test --workspace=@hayba/architecture`
+Expected: 47 tests pass (5 schema + 23 validate + 8 registry + 11 mcp).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/architecture/src/mcp.ts packages/architecture/src/mcp.test.ts packages/architecture/src/index.ts
+git commit -m "feat(architecture): A1 MCP — validate_style_guide"
+```
+
+---
+
+### Task 14: Wire MCP tools into the Hayba MCP server
+
+**Files:**
+- Create: `packages/hayba/src/tools/worldbuilding/architecture-handlers.ts`
+- Modify: `packages/hayba/src/tools/index.ts` — register the four tools + reg() entries
+- Modify: `packages/hayba/package.json` — add `@hayba/architecture` dependency
+
+- [ ] **Step 1: Add the workspace dependency**
+
+Edit `packages/hayba/package.json`. Find the `"dependencies"` block (it already contains `@hayba/linguistics`) and add:
+```json
+"@hayba/architecture": "*",
+```
+
+Then run from repo root:
+```bash
+npm install
+```
+
+- [ ] **Step 2: Create the handler module**
+
+`packages/hayba/src/tools/worldbuilding/architecture-handlers.ts`:
+```ts
+import { z } from 'zod';
+import {
+  listStyleGuides as engineListStyleGuides,
+  getStyleGuideTool as engineGetStyleGuide,
+  getTypologyTool as engineGetTypology,
+  validateStyleGuideTool as engineValidateStyleGuide,
+} from '@hayba/architecture';
+
+/* ─────────────────────  schemas  ───────────────────── */
+
+export const listStyleGuidesSchema = z.object({});
+
+export const getStyleGuideSchema = z.object({
+  id: z.string().describe('StyleGuide id, e.g. "medieval-european-gothic"'),
+});
+
+export const getTypologySchema = z.object({
+  id: z.string().describe('Typology id, e.g. "peasant_home"'),
+});
+
+export const validateStyleGuideSchema = z.object({
+  json: z.unknown().describe('Candidate StyleGuide JSON to validate against the A1 schema'),
+});
+
+/* ─────────────────────  handlers  ───────────────────── */
+
+export function listStyleGuides(_params: z.infer<typeof listStyleGuidesSchema>) {
+  return engineListStyleGuides();
+}
+
+export function getStyleGuide(params: z.infer<typeof getStyleGuideSchema>) {
+  return engineGetStyleGuide(params);
+}
+
+export function getTypology(params: z.infer<typeof getTypologySchema>) {
+  return engineGetTypology(params);
+}
+
+export function validateStyleGuide(params: z.infer<typeof validateStyleGuideSchema>) {
+  return engineValidateStyleGuide(params);
+}
+```
+
+- [ ] **Step 3: Register the tools in `packages/hayba/src/tools/index.ts`**
+
+This file is large; the operations are additive. Two changes:
+
+**(a)** Near the top with other tool imports, add:
+```ts
+import {
+  listStyleGuidesSchema,
+  getStyleGuideSchema,
+  getTypologySchema,
+  validateStyleGuideSchema,
+  listStyleGuides as architectureListStyleGuides,
+  getStyleGuide as architectureGetStyleGuide,
+  getTypology as architectureGetTypology,
+  validateStyleGuide as architectureValidateStyleGuide,
+} from './worldbuilding/architecture-handlers.js';
+```
+
+**(b)** In the `server.tool(...)` block — search for the existing `language_remix_phonologies` registration (it lives just before the planet tools). After its closing `);`, add four blocks:
+
+```ts
+  server.tool(
+    'architecture_list_style_guides',
+    'List all seed StyleGuide palettes (metadata only — id, cultureId, dateRange, typologyCount).',
+    listStyleGuidesSchema.shape,
+    async (params) => {
+      try {
+        const result = architectureListStyleGuides(params as z.infer<typeof listStyleGuidesSchema>);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: msg }) }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    'architecture_get_style_guide',
+    'Fetch a full StyleGuide by id (embedded StyleSheet + typologyWeights). Returns { error: "not_found" } if unknown.',
+    getStyleGuideSchema.shape,
+    async (params) => {
+      try {
+        const result = architectureGetStyleGuide(params as z.infer<typeof getStyleGuideSchema>);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: msg }) }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    'architecture_get_typology',
+    'Fetch a Typology by id (footprint, storyRange, fenestrationDensity). Returns { error: "not_found" } if unknown.',
+    getTypologySchema.shape,
+    async (params) => {
+      try {
+        const result = architectureGetTypology(params as z.infer<typeof getTypologySchema>);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: msg }) }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    'architecture_validate_style_guide',
+    'Validate a candidate StyleGuide JSON against the A1 schema. Returns { ok: true } or { ok: false, errors: [...] }.',
+    validateStyleGuideSchema.shape,
+    async (params) => {
+      try {
+        const result = architectureValidateStyleGuide(params as z.infer<typeof validateStyleGuideSchema>);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: msg }) }], isError: true };
+      }
+    }
+  );
+```
+
+**(c)** Add corresponding `reg(...)` entries. Search for the existing `reg('language_remix_phonologies', ...)` line and add immediately after:
+```ts
+  reg('architecture_list_style_guides',   listStyleGuidesSchema.shape,   'low', '{guides:[{id,cultureId,dateRange,typologyCount}]}');
+  reg('architecture_get_style_guide',     getStyleGuideSchema.shape,     'low', '{guide}|{error,id}');
+  reg('architecture_get_typology',        getTypologySchema.shape,       'low', '{typology}|{error,id}');
+  reg('architecture_validate_style_guide',validateStyleGuideSchema.shape,'low', '{ok}|{ok:false,errors:[{path,message}]}');
+```
+
+- [ ] **Step 4: Run the hayba package's typecheck**
+
+Run from repo root:
+```bash
+npm run typecheck --workspace=hayba
+```
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Run the hayba test suite**
+
+Run from repo root:
+```bash
+npm test --workspace=hayba
+```
+Expected: existing tests still pass; nothing in `tools/index.test.ts` broke.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hayba/package.json packages/hayba/src/tools/worldbuilding/architecture-handlers.ts packages/hayba/src/tools/index.ts package-lock.json
+git commit -m "feat(architecture): wire A1 MCP tools into hayba server"
+```
+
+---
+
+### Task 15: Determinism + cross-pillar contract tests
+
+**Files:**
+- Modify: `packages/architecture/src/mcp.test.ts` — add the determinism sweep
+- Modify: `packages/architecture/src/registry.test.ts` — add the cross-ref sweep
+
+- [ ] **Step 1: Add the determinism sweep**
+
+Append to `packages/architecture/src/mcp.test.ts`:
+```ts
+import { listStyleGuides as _ls, getStyleGuideTool as _gs, getTypologyTool as _gt }
+  from './mcp.js';
+
+describe('determinism — byte-identical JSON across calls', () => {
+  it('list_style_guides', () => {
+    expect(JSON.stringify(_ls())).toBe(JSON.stringify(_ls()));
+  });
+  it('get_style_guide on every seed id', () => {
+    const ids = _ls().guides.map(g => g.id);
+    for (const id of ids) {
+      expect(JSON.stringify(_gs({ id }))).toBe(JSON.stringify(_gs({ id })));
+    }
+  });
+  it('get_typology on every seed typology', () => {
+    const seen = new Set<string>();
+    for (const meta of _ls().guides) {
+      const g = _gs({ id: meta.id });
+      if ('guide' in g) {
+        for (const w of g.guide.typologyWeights) seen.add(w.typologyId);
+      }
+    }
+    expect(seen.size).toBeGreaterThan(0);
+    for (const id of seen) {
+      expect(JSON.stringify(_gt({ id }))).toBe(JSON.stringify(_gt({ id })));
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Add the cross-pillar contract sweep**
+
+Append to `packages/architecture/src/registry.test.ts`:
+```ts
+describe('cross-pillar contract — every guide ref resolves', () => {
+  it('no dangling typologyId in any seed StyleGuide', () => {
+    const reg = loadRegistry();
+    const missing: Array<{ guide: string; typologyId: string }> = [];
+    for (const guide of reg.styleGuidesById.values()) {
+      for (const w of guide.typologyWeights) {
+        if (!reg.typologyIds.has(w.typologyId)) {
+          missing.push({ guide: guide.id, typologyId: w.typologyId });
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('every guide has at least one typology weight', () => {
+    const reg = loadRegistry();
+    for (const guide of reg.styleGuidesById.values()) {
+      expect(guide.typologyWeights.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('within a culture, overlapping dateRanges are detected (warning surface)', () => {
+    const reg = loadRegistry();
+    const byCulture = new Map<string, Array<{ id: string; range: [number, number] }>>();
+    for (const guide of reg.styleGuidesById.values()) {
+      const list = byCulture.get(guide.styleSheet.cultureId) ?? [];
+      list.push({ id: guide.id, range: guide.styleSheet.dateRange });
+      byCulture.set(guide.styleSheet.cultureId, list);
+    }
+    // Sanity check: tiebreaker rule documented in spec — highest endYear wins. This test
+    // just asserts the data set is well-formed enough that A5 selection has a deterministic answer.
+    for (const [_culture, list] of byCulture) {
+      const sorted = [...list].sort((a, b) => b.range[1] - a.range[1]);
+      expect(sorted[0]).toBeDefined();
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run from repo root:
+```bash
+npm test --workspace=@hayba/architecture
+```
+Expected: 53 tests pass total (5 schema + 23 validate + 11 registry + 14 mcp).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/architecture/src/mcp.test.ts packages/architecture/src/registry.test.ts
+git commit -m "test(architecture): A1 determinism + cross-pillar contract sweeps"
+```
+
+---
+
+### Task 16: extras-glossary.md
+
+**Files:**
+- Create: `packages/architecture/docs/extras-glossary.md`
+
+- [ ] **Step 1: Author the glossary**
+
+`packages/architecture/docs/extras-glossary.md`:
+```markdown
+# StyleSheet `extras` glossary
+
+The `extras` field on `StyleSheet` is an open `FeatureBundle` (`Record<string, string | string[]>`) for culture-specific concepts that don't fit the typed `core` fields. Every key used by a seed StyleGuide must appear here.
+
+Promote a key to `StyleSheet.core` (a real typed field) once it generalizes across cultures.
+
+## Keys in use
+
+| Key | Cultures using it | Type | Notes |
+|---|---|---|---|
+| `bayWindows` | industrial-revolution-english | string | Frequency tag, e.g. `"common"`. |
+| `chimneyStacks` | industrial-revolution-english | string | Height tag, e.g. `"tall"`. |
+| `colorPalette` | tang-chinese | string[] | Named pigments. |
+| `cornice` | industrial-revolution-english | string | Material tag, e.g. `"stone"`. |
+| `defensiveWalls` | medieval-european-carolingian | string | Material tag. |
+| `dougong` | tang-chinese | string | Bracket-set complexity tag (`present` / `elaborate`). |
+| `eaves` | tang-chinese-9c | string | Overhang depth tag. |
+| `engawa` | edo-japanese | string | Verandah strip, `"present"` if part of vernacular. |
+| `kawara` | edo-japanese-late | string | Clay tile roof tag. |
+| `multiBuilding` | hausa-classical | string | `"true"` marks compound-typology archetypes; A3 may treat as cluster. |
+| `niches` | andean-inca | string | Wall-niche shape tag (`trapezoidal`). |
+| `pinnacles` | hausa-classical | string | Roof-edge ornament (azara pinnacles). |
+| `roofPitch` | medieval-european-carolingian | string | Steepness tag. |
+| `shoji` | edo-japanese-early | string | Paper-screen partition prevalence. |
+| `stainedGlass` | medieval-european-gothic | string | Frequency tag. |
+| `tokonoma` | edo-japanese-early | string | Decorative alcove prevalence. |
+| `tracery` | medieval-european-gothic | string | Window-stonework style tag. |
+| `tubali` | hausa-classical | string | Molded mud cones, characteristic of Hausa Zaure. |
+| `vaulting` | medieval-european-romanesque | string | Roof-vault style. |
+| `verticalEmphasis` | medieval-european-gothic | string | Massing tag. |
+| `wallStyle` | andean | string | Polygonal-fitted vs. coursed-adobe. |
+| `windowSize` | medieval-european-romanesque | string | Relative size tag. |
+
+## Promotion candidates
+
+Keys appearing in 3+ cultures should be considered for promotion to `core`:
+
+- `wallStyle` (currently 2 cultures) — could become `core.wallStyle: 'fitted-polygonal' | 'coursed' | 'tubali' | ...` once a third culture lands.
+- `roofPitch` — overlaps semantically with `roofType`; consider folding into roof-type tags rather than promoting.
+
+## Authoring rules
+
+1. New extras keys MUST be added to this table in the same commit as the StyleGuide JSON that introduces them.
+2. Don't reuse a key for a different concept across cultures. If two cultures need different `tracery` semantics, namespace: `tracery.medieval-european`.
+3. Prefer `string` over `string[]` unless the field is genuinely a set (e.g., `colorPalette`).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/architecture/docs/extras-glossary.md
+git commit -m "docs(architecture): A1 extras-glossary"
+```
+
+---
+
+### Task 17: Coverage check + final wrap
+
+**Files:** none modified — validation only.
+
+- [ ] **Step 1: Run full test suite + coverage**
+
+Run from repo root:
+```bash
+npm test --workspace=@hayba/architecture -- --coverage
+```
+Expected:
+- All 53 tests pass.
+- Coverage for `src/validate.ts`, `src/registry.ts`, `src/mcp.ts` each ≥ 80%.
+
+If coverage falls short on a file, add targeted tests in the corresponding `*.test.ts` rather than chasing arbitrary numbers.
+
+- [ ] **Step 2: Run the typecheck**
+
+Run from repo root:
+```bash
+npm run typecheck --workspace=@hayba/architecture
+npm run typecheck --workspace=hayba
+```
+Expected: both pass clean.
+
+- [ ] **Step 3: Verify the hayba MCP server still boots**
+
+Run from repo root:
+```bash
+npm run build --workspace=@hayba/architecture
+npm run build --workspace=hayba
+```
+Expected: both build clean, no missing-module errors from the new architecture imports.
+
+- [ ] **Step 4: Smoke-check the MCP tool list**
+
+Read `packages/hayba/src/tools/index.ts` to confirm all four new tools are registered (two appearances each — once in `server.tool(...)` and once in `reg(...)`). Run:
+```bash
+grep -c "architecture_" packages/hayba/src/tools/index.ts
+```
+Expected: at least 12 hits (4 tools × 3 typical references — import, server.tool, reg).
+
+- [ ] **Step 5: Tick the issue acceptance checklist**
+
+Update GH issue #101 — tick the boxes that are now complete:
+```bash
+gh issue edit 101 -R zajalist/hayba --body "$(gh issue view 101 -R zajalist/hayba --json body -q .body | sed 's/- \[ \] Schema published/- [x] Schema published/' | sed 's/- \[ \] Six palettes/- [x] Eleven palettes/' | sed 's/- \[ \] MCP tool registered/- [x] Four MCP tools registered/' | sed 's/- \[ \] vitest/- [x] vitest/' | sed 's/- \[ \] Style-guide JSON treated/- [x] Style-guide JSON treated/')"
+```
+(If the sed substitutions look off after fetching the current body, edit the body manually via `gh issue edit 101 -R zajalist/hayba` instead.)
+
+- [ ] **Step 6: Final commit** (only if previous steps touched files)
+
+```bash
+git status
+```
+If clean — nothing to commit, Task 17 is verification only.
+
+If any files changed (e.g., from coverage-targeted tests in Step 1), commit them:
+```bash
+git add packages/architecture/src/
+git commit -m "test(architecture): A1 coverage fill-in"
+```
+
+- [ ] **Step 7: Push the branch**
+
+Only after the user explicitly approves pushing:
+```bash
+git push -u origin feat/architecture-pillar
+```
+
+---
+
+## Definition of done (mirrors issue #101)
+
+- [x] Schema published from `packages/architecture/src/schema.ts` *(Task 2)*
+- [x] All 11 seed StyleGuides + 10 typologies validate against the schema and load deterministically *(Task 9, Task 15)*
+- [x] Four MCP tools registered in `packages/hayba/src/tools/index.ts` and exercised by tests *(Tasks 10–14)*
+- [x] vitest ≥80% on validators; determinism test green *(Tasks 15, 17)*
+- [x] No GPL-licensed inputs in `data/` *(Task 7, Task 8)*
+- [x] `packages/architecture/docs/extras-glossary.md` exists and documents every extras key used *(Task 16)*
+
+## Self-review notes (already applied to the plan above)
+
+- Confirmed spec coverage: every "Out of scope for A1" item in the spec is genuinely absent from the plan.
+- Confirmed every `typologyId` referenced from any task's example JSON appears in the Task 7 registry (`peasant_home, townhouse, market_stall, manor, temple, granary, watchtower, walled_palace, workshop, civic_hall`).
+- Confirmed every method/symbol used in a later task is exported by an earlier task (e.g., `validateStyleGuideRefs` introduced in Task 6, used in Task 9).
+- Confirmed test count math: Task 2 (5) + Task 3 (5) + Task 4 (6) + Task 5 (6) + Task 6 (6) + Task 9 (8) + Task 10 (2) + Task 11 (3) + Task 12 (2) + Task 13 (4) + Task 15 determinism (3) + Task 15 contract (3) = **53 tests** by Task 17 end. Intermediate expected counts in Tasks 13 (47) and 15/17 (53) are correct after this self-review pass.

--- a/docs/superpowers/specs/2026-05-12-architecture-style-schema-design.md
+++ b/docs/superpowers/specs/2026-05-12-architecture-style-schema-design.md
@@ -1,0 +1,214 @@
+# Architecture Pillar — A1 Style Schema Design
+
+**Issue**: [#101 — A1 Archetype palette + style guide schema](https://github.com/zajalist/hayba/issues/101)
+**Epic**: [#109 — Architecture pillar](https://github.com/zajalist/hayba/issues/109)
+**Date**: 2026-05-12
+**Status**: Draft, awaiting spec-review gate
+
+## Context
+
+A1 is the foundation of the architecture pillar. Every downstream ticket (A2–A8) consumes the schema and the seed palettes it defines. This spec captures the data model, storage, MCP surface, and testing strategy.
+
+The design follows an architectural-research recommendation surfaced during brainstorming: **structural topology is decoupled from morphological style**. A building on a lot is the binding `(typology, styleSheet, era, seed) → building`, late-bound at generation time. This avoids the combinatorial explosion of baking culture × era × function into single archetypes (6 × 4 × 10 = 240 hand-authored archetypes the wrong way).
+
+## Schema artifacts
+
+Three TypeScript types in `packages/architecture/src/schema.ts`. Plain interfaces — no Zod, no runtime dependency. Validation is hand-rolled type guards, mirroring `packages/linguistics/`.
+
+```ts
+export type FeatureBundle = Readonly<Record<string, string | readonly string[]>>;
+
+export type RoofType =
+  | 'gable' | 'hip' | 'flat' | 'pagoda' | 'thatch' | 'dome' | 'shed' | 'mansard';
+
+export type PrimaryMaterial =
+  | 'stone' | 'timber' | 'mudbrick' | 'adobe' | 'rammed-earth'
+  | 'brick' | 'concrete' | 'wattle-daub';
+
+export type FootprintShape =
+  | { kind: 'rectangle';    aspectRatio: [number, number];           areaRange: [number, number] }
+  | { kind: 'linear-row';   widthRange: [number, number];            depthRange: [number, number] }
+  | { kind: 'L-shape';      wingDepth: [number, number];             courtyardFraction: [number, number] }
+  | { kind: 'U-shape';      wingDepth: [number, number];             openingWidth: [number, number] }
+  | { kind: 'courtyard';    courtyardFraction: [number, number];     wingDepth: [number, number] };
+
+export interface Typology {
+  id: string;
+  footprint: FootprintShape;
+  storyRange: [number, number];
+  fenestrationDensity: [number, number];
+  pathfindingHints?: Readonly<Record<string, string>>;
+}
+
+export interface StyleSheet {
+  id: string;
+  cultureId: string;
+  dateRange: [number, number];
+  core: {
+    primaryMaterial: PrimaryMaterial;
+    secondaryMaterial?: PrimaryMaterial;
+    roofType: RoofType;
+    ornamentation: readonly string[];
+  };
+  extras: FeatureBundle;
+}
+
+export interface StyleGuide {
+  id: string;
+  styleSheet: StyleSheet;
+  typologyWeights: ReadonlyArray<{ typologyId: string; weight: number }>;
+}
+```
+
+### Design choices, with rationale
+
+- **Hybrid typed-core + open `extras` bundle (on `StyleSheet`).** A finite enum core (`roofType`, `primaryMaterial`) makes LLM-constrained decoding in A3 cheap and testable. The open `extras` bundle absorbs culture-specific concepts (engawa, tokonoma, riad, kancha) without forcing schema churn for every new culture.
+- **Footprint as a discriminated union of 5 kinds.** `rectangle | linear-row | L-shape | U-shape | courtyard`. Each kind gets its own deterministic generator in A3. The `compound` kind (Hausa Zaure, nomadic enclosure rings) is deferred — Hausa palette temporarily uses `courtyard` plus `extras.multiBuilding = 'true'` so the data is preserved.
+- **Era is a `dateRange` field on `StyleSheet`**, not a separate artifact. A5 resolves `(cultureId, year) → StyleSheet` by range lookup. Tiebreaker on overlapping ranges within a culture: **highest `endYear` wins** (most recent style sheet for the year).
+- **`StyleGuide` embeds `StyleSheet` by value** so MCP consumers get a self-contained payload in one round trip. The 18 seed sheets dedupe at authoring time, not at the MCP boundary.
+
+### Invariants enforced by validators
+
+- For every `[min, max]` tuple: `min ≤ max`.
+- `weight > 0` for every entry in `typologyWeights`. Weights are unnormalized positive reals; A3's sampler normalizes per call. A1 makes no assumption that they sum to anything in particular.
+- Every `typologyId` referenced from any StyleGuide resolves in the typology registry.
+- Within a `cultureId`, `dateRange`s may overlap; tiebreaker is `endYear` desc.
+- No RNG anywhere in A1. Pure data + pure functions.
+
+## Storage layout
+
+```
+packages/architecture/
+├── package.json            # @hayba/architecture, type:module, vitest, MIT
+├── tsconfig.json
+├── vitest.config.ts
+├── src/
+│   ├── index.ts            # public re-exports
+│   ├── schema.ts           # interfaces above
+│   ├── validate.ts         # hand-rolled type guards
+│   ├── registry.ts         # load + cache typologies and style guides
+│   ├── mcp.ts              # MCP tool implementations
+│   └── data/
+│       ├── typologies.json
+│       └── style-guides/
+│           ├── medieval-european-carolingian.json
+│           ├── medieval-european-romanesque.json
+│           ├── medieval-european-gothic.json
+│           ├── tang-chinese-7c.json
+│           ├── tang-chinese-9c.json
+│           ├── andean-inca.json
+│           ├── andean-pre-inca.json
+│           ├── hausa-classical.json
+│           ├── edo-japanese-early.json
+│           ├── edo-japanese-late.json
+│           └── industrial-revolution-english.json
+```
+
+### Typology registry (v0, ~10 entries)
+
+`peasant_home, townhouse, market_stall, manor, temple, granary, watchtower, walled_palace, workshop, civic_hall`. Each is **culture-agnostic** by design: a `peasant_home`'s footprint is the same dressed in Mediaeval-European or Edo-Japanese — cultural feel comes entirely from the StyleSheet swap and the per-typology weights in each StyleGuide.
+
+### Seed StyleGuides (v0, 11 entries)
+
+Roughly one per era for each of the 6 cultures from the handoff brief. Each guide's `typologyWeights` reflects what the culture/era actually built — Andean-Inca weights `temple` / `granary` / `walled_palace` heavily; Industrial-Revolution-English weights `townhouse` / `workshop` / `civic_hall`.
+
+### Reference data for authoring (all CC-licensed)
+
+- **Atlas of Urban Form** — typology lists, ratios per era.
+- **Wikidata urban heritage** — `P186 material used`, `P31 architectural style` per culture.
+- **VernacularArchitecture.com** — public regional styles dataset.
+- **Christopher Alexander's *A Pattern Language*** (253 patterns) — authoring lens for `typologyWeights`. Not encoded as data in v0; cited as inspiration only.
+
+### License & IP
+
+- All seed JSON authored from CC0 / CC-BY sources; no GPL inputs.
+- Style-guide JSON is treated as user IP (per A1 acceptance criterion). The package ships seed palettes only as examples; the schema is the product.
+- Wikidata: CC0. OSM data: not redistributed.
+
+## MCP tool surface
+
+Four tools, registered alongside existing tools in `packages/hayba/src/index.ts`. All are pure functions of the loaded registry — no I/O, no RNG, no state.
+
+```ts
+architecture_list_style_guides(): {
+  guides: Array<{
+    id: string;
+    cultureId: string;
+    dateRange: [number, number];
+    typologyCount: number;
+  }>
+}
+
+architecture_get_style_guide(args: { id: string }): {
+  guide: StyleGuide;
+} | { error: 'not_found'; id: string }
+
+architecture_get_typology(args: { id: string }): {
+  typology: Typology;
+} | { error: 'not_found'; id: string }
+
+architecture_validate_style_guide(args: { json: unknown }): {
+  ok: true;
+} | { ok: false; errors: Array<{ path: string; message: string }> }
+```
+
+### Behavioural notes
+
+- **`list_style_guides` returns metadata only**, not full guides. Agents call `get_style_guide` for the one they want.
+- **`get_typology` lives on its own** so A3/A5/A6 can fetch typologies independently when iterating lots without paying for a whole style guide each time.
+- **`validate_style_guide` is the LLM-author surface**. Returns *all* errors for a given input (not first-fail) so an LLM emitting candidate JSON gets the full list in one round trip.
+- **No `list_typologies`** in the public surface — the set is small, fixed in code, and the typology IDs in play are visible via every `StyleGuide.typologyWeights`. Cheap to add later if A6/A7 want it.
+- **Errors are returned, not thrown** at the MCP boundary. Internal guards throw `ArchitectureSchemaError`; the MCP wrapper maps to `{error: ...}` objects.
+- **Deterministic output** — identical inputs produce identical JSON. Object keys insertion-ordered; arrays sorted where order isn't semantic.
+
+## Testing
+
+Vitest, ≥80% coverage on the validators (per A1 acceptance — A1 ships data + schema, no generators yet).
+
+```
+src/
+├── schema.test.ts          # type-shape assertions, range-tuple invariants
+├── validate.test.ts        # the heaviest; covers every guard path
+├── registry.test.ts        # all 11 seed StyleGuides + 10 typologies load cleanly
+└── mcp.test.ts             # tool contracts: happy, not_found, malformed, determinism
+```
+
+### Cases that must pass
+
+- **Determinism**: each MCP tool called twice in sequence produces byte-identical JSON.
+- **Cross-pillar contract**: every `typologyId` in every `typologyWeights[]` resolves in the typology registry.
+- **Validator surfaces *all* errors**, not first-fail — assert on error-list length, not just truthiness.
+- **Range invariants**: malformed `[max, min]` tuples are caught with a JSON-pointer path.
+- **Round-trip**: `validate → serialize → parse → validate` returns the same `ok: true` for every seed StyleGuide.
+
+### No visual checkpoint
+
+A1 is data + schema; nothing renders. A8's viewer is where the visual gate kicks in (for A3+).
+
+## Out of scope for A1
+
+Documented here to keep follow-up tickets focused:
+
+- pgvector semantic search (`architecture_search_styles`) — deferred follow-up, depends on Supabase wiring.
+- LLM constrained-decoding gating logic — lives in A3's sampler. A1 only provides the palette it gates against.
+- Pattern Language as encoded data — authoring inspiration only in v0.
+- `compound` footprint kind and `TypologyCluster` multi-building groupings.
+- Era as a first-class artifact with named events / rulers / tech levels.
+- Building geometry parameters (heights, openings, roof apex) — A6 territory.
+
+## Risks
+
+- **Schema churn from extras drift.** Without a vocabulary registry for `extras` keys, different palettes can use different keys for the same concept (`engawa` vs `verandah`). Mitigation: maintain a free-form glossary doc in `packages/architecture/docs/extras-glossary.md` alongside the seed palettes; promote popular extras keys to typed `core` fields when they generalize. Long-term: consider mapping against Getty AAT.
+- **Era tiebreaker ambiguity** when two StyleSheets overlap. Documented rule (highest `endYear` wins) is deterministic but may surprise authors. Mitigation: a registry-load warning when ranges overlap within a culture.
+- **Typology registry rigidity.** 10 fixed typologies might not cover every culture cleanly (e.g., Andean storage `qollqa` ≠ generic granary). Mitigation: extras on the typology side is intentionally optional and minimal in v0; revisit once A3 hits real generation.
+
+## Definition of done
+
+Mirrors the acceptance checklist on issue #101:
+
+- [ ] Schema published from `packages/architecture/src/schema.ts`.
+- [ ] All 11 seed StyleGuides + 10 typologies validate against the schema and load deterministically.
+- [ ] All four MCP tools registered in `packages/hayba/src/index.ts` and exercised by tests.
+- [ ] vitest ≥80% on validators; determinism test green.
+- [ ] No GPL-licensed inputs in `data/`.
+- [ ] `packages/architecture/docs/extras-glossary.md` exists and documents every extras key used by seed palettes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7016,6 +7016,7 @@
       "license": "MIT",
       "dependencies": {
         "@distube/ytdl-core": "^4.16.12",
+        "@hayba/architecture": "*",
         "@hayba/linguistics": "file:../linguistics",
         "@hayba/planet-physics": "file:../planet-physics",
         "@huggingface/transformers": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -515,6 +515,10 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hayba/architecture": {
+      "resolved": "packages/architecture",
+      "link": true
+    },
     "node_modules/@hayba/gaea-server": {
       "resolved": "packages/haybagaea-server",
       "link": true
@@ -6656,6 +6660,331 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "packages/architecture": {
+      "name": "@hayba/architecture",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.12.2",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "packages/architecture/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "packages/architecture/node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/architecture/node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/architecture/node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/architecture/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/architecture/node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/architecture/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/architecture/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/architecture/node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "packages/architecture/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "packages/architecture/node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/architecture/node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/architecture/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/architecture/node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "packages/architecture/node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "packages/architecture/node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/architecture/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/architecture/node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/architecture/node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/architecture/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "packages/gaea": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,20 @@
         "packages/*"
       ]
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.39.0",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
@@ -40,6 +54,63 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@distube/ytdl-core": {
@@ -1128,6 +1199,119 @@
         }
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1141,12 +1325,44 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -1515,6 +1731,17 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -2325,6 +2552,16 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2427,6 +2664,19 @@
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -2975,6 +3225,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3399,6 +3656,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -3571,6 +3845,61 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/global-agent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
@@ -3631,6 +3960,16 @@
       "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
@@ -3698,6 +4037,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -3933,6 +4279,101 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -4030,6 +4471,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/matcher": {
@@ -4154,6 +4623,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -4161,6 +4646,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -4564,6 +5059,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -4630,6 +5132,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
@@ -5463,7 +5989,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -5511,6 +6067,19 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -5550,6 +6119,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {
@@ -6533,6 +7117,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6668,6 +7287,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.12.2",
+        "@vitest/coverage-v8": "^2.1.9",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
       }
@@ -6680,6 +7300,39 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "packages/architecture/node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
       }
     },
     "packages/architecture/node_modules/@vitest/expect": {

--- a/packages/architecture/demo/index.html
+++ b/packages/architecture/demo/index.html
@@ -1,0 +1,964 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Hayba · Architecture Atlas</title>
+<link rel="icon" type="image/svg+xml" href="./logo.svg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&family=Noto+Sans+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  /* —— Hayba UE plugin design language — shared with linguistics workbench —— */
+  :root {
+    --bg-deep:     #1b1e24;
+    --bg-base:     #22262e;
+    --bg-panel:    #2a2e36;
+    --bg-raised:   #303540;
+    --bg-elevated: #353a45;
+    --border-hard: #1a1d22;
+    --border-mid:  #2f343d;
+    --border-soft: #3d434e;
+    --accent:      #B56A1D;
+    --accent-hover:#D17F2A;
+    --accent-dim:  #B56A1D22;
+    --accent-glow: #B56A1D55;
+    --cream:       #DED4C3;
+    --text-primary:   #e5e8eb;
+    --text-secondary: #a8aeb8;
+    --text-muted:     #6b7280;
+    --text-accent:    #D17F2A;
+    --status-green:   #4db38a;
+    --status-orange:  #B56A1D;
+    --status-red:     #e06464;
+    --tag-blue:    #6a9fdc;
+    --tag-pink:    #c685c0;
+    --tag-green:   #7ec48e;
+    --tag-amber:   #e0b85e;
+    --font-ui:   'Noto Sans', 'Segoe UI', 'Roboto', system-ui, sans-serif;
+    --font-mono: 'Noto Sans Mono', 'Consolas', 'Cascadia Mono', monospace;
+
+    /* —— material chip colors —— */
+    --mat-stone:        #94a3b8;
+    --mat-timber:       #b48a5a;
+    --mat-mudbrick:     #a06a3e;
+    --mat-adobe:        #c89060;
+    --mat-rammed-earth: #8c6843;
+    --mat-brick:        #b85a4a;
+    --mat-concrete:     #8a8e95;
+    --mat-wattle-daub:  #c4a96a;
+  }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    background: var(--bg-deep);
+    color: var(--text-primary);
+    font-family: var(--font-ui);
+    font-size: 13px;
+    display: grid;
+    grid-template-rows: 38px 1fr;
+    overflow: hidden;
+    -webkit-font-smoothing: antialiased;
+  }
+  .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+  .muted { color: var(--text-muted); }
+  .accent { color: var(--accent); }
+  ::-webkit-scrollbar { width: 6px; height: 6px; }
+  ::-webkit-scrollbar-track { background: var(--bg-deep); }
+  ::-webkit-scrollbar-thumb { background: #2a2a2a; border-radius: 3px; }
+  ::-webkit-scrollbar-thumb:hover { background: #3a3a3a; }
+
+  /* —— toolbar —— */
+  .toolbar {
+    background: var(--bg-base);
+    border-bottom: 1px solid var(--border-hard);
+    display: flex; align-items: center;
+    padding: 0 18px; gap: 0;
+  }
+  .toolbar .brand-block { display: flex; align-items: center; gap: 10px; }
+  .toolbar .logo { height: 26px; width: auto; }
+  .toolbar .brand {
+    color: var(--text-primary); font-weight: 600; font-size: 14px;
+    letter-spacing: -0.1px;
+  }
+  .toolbar .brand .sub { color: var(--text-secondary); font-weight: 400; margin-left: 2px; }
+  .toolbar .divider {
+    width: 1px; height: 22px; background: var(--border-soft);
+    margin: 0 14px;
+  }
+  .toolbar .grow { flex: 1; }
+  .toolbar .stats-bar { display: flex; gap: 4px; }
+  .stat-pill {
+    display: inline-flex; align-items: center; gap: 7px;
+    padding: 5px 10px 5px 9px; border-radius: 5px;
+    color: var(--text-secondary); font-size: 12.5px;
+    cursor: default; white-space: nowrap; flex-shrink: 0;
+    transition: background .12s, color .12s;
+  }
+  .toolbar .stats-bar { display: flex; gap: 4px; flex-shrink: 0; flex-wrap: nowrap; align-items: center; }
+  .stat-pill:hover { background: var(--bg-panel); color: var(--text-primary); }
+  .stat-pill .dot {
+    width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0;
+    box-shadow: 0 0 5px currentColor;
+  }
+  .stat-pill .v {
+    color: var(--text-primary); font-weight: 600;
+    font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+  }
+  .stat-pill.guides .dot     { color: var(--accent); background: currentColor; }
+  .stat-pill.typologies .dot { color: var(--tag-blue); background: currentColor; }
+  .stat-pill.cultures .dot   { color: var(--tag-green); background: currentColor; }
+  .stat-pill.extras .dot     { color: var(--tag-amber); background: currentColor; }
+
+  /* —— tabs —— */
+  .tabs { display: flex; gap: 2px; height: 30px; align-items: center; }
+  .tab {
+    height: 26px; padding: 0 12px; border-radius: 4px;
+    display: inline-flex; align-items: center; gap: 7px;
+    color: var(--text-secondary); font-size: 12.5px; font-weight: 500;
+    cursor: pointer; background: transparent;
+    border: 1px solid transparent;
+    transition: background .12s, color .12s, border-color .12s;
+  }
+  .tab:hover { color: var(--text-primary); background: var(--bg-panel); }
+  .tab.active {
+    color: var(--text-primary); background: var(--bg-elevated);
+    border-color: var(--border-soft);
+  }
+
+  /* —— app shell —— */
+  .app { display: grid; grid-template-columns: 280px 1fr 380px; overflow: hidden; min-height: 0; }
+  .pane { overflow: auto; min-height: 0; }
+  .pane.left  { background: var(--bg-base); border-right: 1px solid var(--border-mid); }
+  .pane.right { background: var(--bg-base); border-left:  1px solid var(--border-mid); }
+
+  /* —— left rail: culture groups + style guide rows —— */
+  .rail-section { padding: 14px 0 6px; }
+  .rail-h {
+    font-size: 10.5px; letter-spacing: 0.6px; text-transform: uppercase;
+    color: var(--text-muted); font-weight: 700;
+    padding: 4px 16px 8px; display: flex; align-items: center; justify-content: space-between;
+  }
+  .rail-h .count {
+    font-size: 10px; padding: 1px 6px;
+    background: var(--bg-panel); border-radius: 8px;
+    color: var(--text-secondary); font-weight: 500;
+  }
+  .culture-group { margin-bottom: 6px; }
+  .culture-name {
+    font-size: 11px; color: var(--text-secondary); font-weight: 600;
+    padding: 8px 16px 4px; text-transform: capitalize;
+    display: flex; align-items: center; gap: 6px;
+  }
+  .culture-name .swatch {
+    width: 10px; height: 10px; border-radius: 2px;
+    background: var(--accent);
+  }
+  .guide-row {
+    padding: 7px 16px 7px 30px; cursor: pointer;
+    border-left: 2px solid transparent;
+    display: grid; grid-template-columns: 1fr auto; gap: 4px;
+    align-items: baseline;
+    transition: background .12s, border-color .12s, color .12s;
+  }
+  .guide-row:hover { background: var(--bg-panel); }
+  .guide-row.active {
+    background: var(--bg-elevated);
+    border-left-color: var(--accent);
+    color: var(--text-primary);
+  }
+  .guide-row .name {
+    font-size: 12.5px; color: var(--text-primary); font-weight: 500;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .guide-row.active .name { color: var(--accent); font-weight: 600; }
+  .guide-row .era {
+    font-size: 10.5px; color: var(--text-muted);
+    font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+  }
+
+  /* —— center pane: detail card + timeline + footprint catalogue —— */
+  .center-wrap { padding: 22px 28px 60px; max-width: 880px; margin: 0 auto; }
+  .detail-h1 {
+    font-size: 22px; font-weight: 600; color: var(--text-primary);
+    margin-bottom: 4px; letter-spacing: -0.2px;
+  }
+  .detail-sub {
+    color: var(--text-secondary); font-size: 13px; margin-bottom: 22px;
+  }
+  .detail-sub .culture-pill {
+    display: inline-block; padding: 2px 8px; border-radius: 3px;
+    background: var(--accent-dim); color: var(--text-accent);
+    font-size: 11.5px; font-weight: 600; margin-right: 8px;
+    text-transform: capitalize;
+  }
+
+  .panel {
+    background: var(--bg-base); border: 1px solid var(--border-mid);
+    border-radius: 6px; padding: 18px 20px; margin-bottom: 14px;
+  }
+  .panel-h {
+    font-size: 11px; letter-spacing: 0.8px; text-transform: uppercase;
+    color: var(--text-muted); font-weight: 700; margin-bottom: 12px;
+  }
+
+  /* —— material + roof chips —— */
+  .chip-row { display: flex; gap: 8px; flex-wrap: wrap; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 6px 11px 6px 8px; border-radius: 4px;
+    background: var(--bg-panel); border: 1px solid var(--border-soft);
+    font-size: 12.5px;
+  }
+  .chip .swatch {
+    width: 14px; height: 14px; border-radius: 2px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-hard);
+  }
+  .chip .label { color: var(--text-primary); font-weight: 500; }
+  .chip .kind { color: var(--text-muted); font-size: 10.5px; font-weight: 600;
+                text-transform: uppercase; letter-spacing: 0.5px; }
+
+  /* —— extras grid —— */
+  .extras { display: grid; grid-template-columns: 1fr 1fr; gap: 6px 14px; }
+  .extras .k {
+    color: var(--text-secondary); font-size: 11.5px;
+    font-family: var(--font-mono); padding: 4px 0;
+  }
+  .extras .v {
+    color: var(--text-primary); font-size: 12px; padding: 4px 0;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .extras .v .arr-item {
+    display: inline-block; padding: 1px 5px; margin-right: 3px;
+    background: var(--bg-panel); border-radius: 2px;
+    font-size: 10.5px; color: var(--text-secondary);
+  }
+
+  /* —— ornamentation tag list —— */
+  .orn-list { display: flex; flex-wrap: wrap; gap: 5px; }
+  .orn-tag {
+    padding: 3px 9px; border-radius: 3px;
+    background: var(--bg-panel);
+    border: 1px solid var(--border-soft);
+    color: var(--text-secondary); font-size: 11.5px;
+    font-family: var(--font-mono);
+  }
+
+  /* —— era timeline (horizontal bar w/ tick markers) —— */
+  .timeline {
+    position: relative; height: 56px; margin-top: 6px;
+    background: linear-gradient(to right,
+      transparent 0%, var(--bg-panel) 12%, var(--bg-panel) 88%, transparent 100%);
+    border-radius: 3px;
+  }
+  .timeline .axis {
+    position: absolute; left: 0; right: 0; top: 28px; height: 2px;
+    background: var(--border-soft);
+  }
+  .timeline .seg {
+    position: absolute; top: 19px; height: 18px;
+    background: var(--accent-dim); border: 1px solid var(--accent);
+    border-radius: 2px; cursor: pointer;
+    transition: background .12s, transform .12s;
+  }
+  .timeline .seg:hover { background: var(--accent-glow); transform: translateY(-1px); }
+  .timeline .seg.active {
+    background: var(--accent); border-color: var(--accent-hover);
+  }
+  .timeline .seg.active::after {
+    content: ''; position: absolute; top: -4px; left: 50%; width: 2px; height: 26px;
+    background: var(--accent-hover); transform: translateX(-50%);
+  }
+  .timeline .tick {
+    position: absolute; top: 38px; font-size: 10px;
+    color: var(--text-muted); font-family: var(--font-mono);
+    transform: translateX(-50%);
+  }
+  .timeline .seg-label {
+    position: absolute; top: 0px; font-size: 10px;
+    color: var(--text-secondary); font-weight: 600;
+    transform: translateX(-50%);
+  }
+
+  /* —— right pane: typology weights bar chart + footprint —— */
+  .right-wrap { padding: 22px 20px 60px; }
+  .right-h {
+    font-size: 11px; letter-spacing: 0.8px; text-transform: uppercase;
+    color: var(--text-muted); font-weight: 700; margin-bottom: 12px;
+  }
+  .weights-list { display: flex; flex-direction: column; gap: 3px; margin-bottom: 22px; }
+  .weight-row {
+    position: relative;
+    display: grid; grid-template-columns: 1fr 32px;
+    align-items: center; gap: 8px;
+    padding: 5px 8px; border-radius: 3px;
+    cursor: pointer; border: 1px solid transparent;
+    transition: background .12s, border-color .12s;
+  }
+  .weight-row:hover { background: var(--bg-panel); }
+  .weight-row.selected {
+    background: var(--bg-elevated); border-color: var(--accent);
+  }
+  .weight-row .name {
+    font-size: 12.5px; color: var(--text-primary);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    position: relative; z-index: 1;
+    padding: 2px 0;
+  }
+  .weight-row .bar-bg {
+    position: absolute; left: 0; top: 0; bottom: 0;
+    background: linear-gradient(to right, var(--accent-dim), transparent);
+    border-radius: 2px; z-index: 0; pointer-events: none;
+  }
+  .weight-row .col-name {
+    position: relative; padding: 2px 6px; overflow: hidden;
+  }
+  .weight-row .col-w {
+    font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+    color: var(--text-secondary); font-size: 11.5px;
+    text-align: right;
+  }
+
+  .footprint-card {
+    background: var(--bg-deep); border: 1px solid var(--border-mid);
+    border-radius: 6px; padding: 16px; margin-bottom: 14px;
+  }
+  .footprint-card .head {
+    display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 10px;
+  }
+  .footprint-card .typo-name {
+    font-size: 14px; font-weight: 600; color: var(--text-primary);
+    text-transform: capitalize;
+  }
+  .footprint-card .kind-pill {
+    padding: 2px 7px; border-radius: 3px;
+    background: var(--accent-dim); color: var(--text-accent);
+    font-size: 10px; font-weight: 700; letter-spacing: 0.4px;
+    text-transform: uppercase;
+  }
+  .footprint-svg {
+    display: block; margin: 0 auto;
+    background: var(--bg-deep);
+  }
+  .footprint-svg .lot      { fill: none; stroke: var(--border-soft); stroke-dasharray: 3 3; }
+  .footprint-svg .building { fill: var(--accent-dim); stroke: var(--accent); stroke-width: 1.4; }
+  .footprint-svg .window   { fill: var(--cream); opacity: 0.55; }
+  .footprint-svg .label    { fill: var(--text-muted); font-size: 9px; font-family: var(--font-mono); }
+
+  .meta-row {
+    display: grid; grid-template-columns: max-content 1fr; gap: 8px 14px;
+    margin-top: 10px;
+    font-size: 11.5px;
+  }
+  .meta-row .k {
+    color: var(--text-muted); font-family: var(--font-mono);
+    font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.4px;
+    align-self: center;
+  }
+  .meta-row .v {
+    color: var(--text-primary); font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* —— footprint kind legend in the typologies view —— */
+  .kind-legend {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 12px;
+  }
+
+  /* —— typologies view layout —— */
+  .typologies-grid {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 14px;
+  }
+  .typology-card {
+    background: var(--bg-base); border: 1px solid var(--border-mid);
+    border-radius: 6px; padding: 16px;
+    display: flex; flex-direction: column; gap: 8px;
+  }
+  .typology-card .name {
+    font-size: 14px; font-weight: 600; text-transform: capitalize;
+  }
+
+  .empty-state {
+    color: var(--text-muted); text-align: center; padding: 40px 20px;
+    font-style: italic;
+  }
+</style>
+</head>
+<body>
+
+<!-- ─── toolbar ───────────────────────────────────────────── -->
+<div class="toolbar">
+  <div class="brand-block">
+    <img src="./logo.svg" class="logo" alt="">
+    <div class="brand">Hayba <span class="sub">· Architecture Atlas</span></div>
+  </div>
+  <div class="divider"></div>
+  <div class="tabs" id="tabs">
+    <button class="tab active" data-view="guides">Style guides</button>
+    <button class="tab" data-view="typologies">Typologies</button>
+  </div>
+  <div class="divider"></div>
+  <div class="stats-bar" id="stats"></div>
+  <div class="grow"></div>
+  <span class="mono muted" style="font-size:11px;">A1 · style-data explorer</span>
+</div>
+
+<!-- ─── app shell ─────────────────────────────────────────── -->
+<div class="app" id="app">
+  <div class="pane left"  id="leftPane"></div>
+  <div class="pane center"><div class="center-wrap" id="centerPane"></div></div>
+  <div class="pane right" id="rightPane"><div class="right-wrap" id="rightWrap"></div></div>
+</div>
+
+<script type="module">
+'use strict';
+
+/* ─── data loading ─────────────────────────────────────── */
+
+const GUIDE_FILES = [
+  'medieval-european-carolingian',
+  'medieval-european-romanesque',
+  'medieval-european-gothic',
+  'tang-chinese-7c',
+  'tang-chinese-9c',
+  'andean-pre-inca',
+  'andean-inca',
+  'edo-japanese-early',
+  'edo-japanese-late',
+  'hausa-classical',
+  'industrial-revolution-english',
+];
+
+const [typologyFile, ...guides] = await Promise.all([
+  fetch('../src/data/typologies.json').then(r => r.json()),
+  ...GUIDE_FILES.map(n => fetch(`../src/data/style-guides/${n}.json`).then(r => r.json())),
+]);
+
+const typologies = typologyFile.typologies;
+const typologyById = Object.fromEntries(typologies.map(t => [t.id, t]));
+const guideById = Object.fromEntries(guides.map(g => [g.id, g]));
+
+/* group guides by culture, sort by dateRange[0] */
+const byCulture = new Map();
+for (const g of guides) {
+  const c = g.styleSheet.cultureId;
+  if (!byCulture.has(c)) byCulture.set(c, []);
+  byCulture.get(c).push(g);
+}
+for (const list of byCulture.values()) list.sort((a, b) => a.styleSheet.dateRange[0] - b.styleSheet.dateRange[0]);
+
+/* count unique extras keys for the stats bar */
+const extrasKeys = new Set();
+for (const g of guides) for (const k of Object.keys(g.styleSheet.extras || {})) extrasKeys.add(k);
+
+/* ─── state ─────────────────────────────────────────────── */
+
+const state = {
+  view: 'guides',
+  guideId: 'medieval-european-gothic',
+  typologyId: null,
+};
+
+/* ─── stats bar ─────────────────────────────────────────── */
+
+function renderStats() {
+  const el = document.getElementById('stats');
+  el.innerHTML = `
+    <div class="stat-pill guides"><span class="dot"></span><span>guides</span><span class="v">${guides.length}</span></div>
+    <div class="stat-pill cultures"><span class="dot"></span><span>cultures</span><span class="v">${byCulture.size}</span></div>
+    <div class="stat-pill typologies"><span class="dot"></span><span>typologies</span><span class="v">${typologies.length}</span></div>
+  `;
+}
+
+/* ─── per-culture swatch color ──────────────────────────── */
+
+const CULTURE_HUES = {
+  'medieval-european': '#8a7654',
+  'tang-chinese':      '#b85a4a',
+  'andean':            '#a06a3e',
+  'edo-japanese':      '#5a7e8a',
+  'hausa':             '#c89060',
+  'industrial-revolution-english': '#7e8a94',
+};
+
+function cultureLabel(id) {
+  return id.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ');
+}
+
+/* ─── left rail (guides view) ────────────────────────────── */
+
+function renderLeftPane() {
+  const pane = document.getElementById('leftPane');
+  if (state.view === 'guides') {
+    let html = `<div class="rail-section">
+      <div class="rail-h">Style guides <span class="count">${guides.length}</span></div>`;
+    for (const [culture, list] of byCulture) {
+      html += `<div class="culture-group">
+        <div class="culture-name"><span class="swatch" style="background:${CULTURE_HUES[culture] ?? 'var(--accent)'}"></span>${cultureLabel(culture)}</div>`;
+      for (const g of list) {
+        const active = state.guideId === g.id ? 'active' : '';
+        html += `<div class="guide-row ${active}" data-guide="${g.id}">
+          <div class="name">${humanize(g.id, culture)}</div>
+          <div class="era">${g.styleSheet.dateRange[0]}–${g.styleSheet.dateRange[1]}</div>
+        </div>`;
+      }
+      html += '</div>';
+    }
+    html += '</div>';
+    pane.innerHTML = html;
+    pane.querySelectorAll('.guide-row').forEach(el => {
+      el.addEventListener('click', () => {
+        state.guideId = el.dataset.guide;
+        state.typologyId = null;
+        renderLeftPane(); renderCenter(); renderRight();
+      });
+    });
+  } else {
+    /* typologies view: left rail lists typologies + the 5 footprint kinds as filters */
+    let html = `<div class="rail-section">
+      <div class="rail-h">Typologies <span class="count">${typologies.length}</span></div>`;
+    for (const t of typologies) {
+      const active = state.typologyId === t.id ? 'active' : '';
+      html += `<div class="guide-row ${active}" data-typology="${t.id}">
+        <div class="name">${humanize(t.id)}</div>
+        <div class="era">${t.footprint.kind}</div>
+      </div>`;
+    }
+    html += '</div>';
+    pane.innerHTML = html;
+    pane.querySelectorAll('.guide-row').forEach(el => {
+      el.addEventListener('click', () => {
+        state.typologyId = el.dataset.typology;
+        renderLeftPane(); renderCenter(); renderRight();
+      });
+    });
+  }
+}
+
+function humanize(id, culture) {
+  // 'medieval-european-gothic' → 'Gothic' when grouped under culture 'medieval-european'
+  let s = id;
+  if (culture && id.startsWith(culture + '-')) s = id.slice(culture.length + 1);
+  return s.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+/* ─── center pane (guides view) ──────────────────────────── */
+
+function renderCenter() {
+  const wrap = document.getElementById('centerPane');
+  if (state.view === 'guides') {
+    const g = guideById[state.guideId];
+    if (!g) { wrap.innerHTML = '<div class="empty-state">Pick a style guide on the left.</div>'; return; }
+    const s = g.styleSheet;
+
+    wrap.innerHTML = `
+      <div class="detail-h1">${humanize(g.id, s.cultureId)}</div>
+      <div class="detail-sub">
+        <span class="culture-pill" style="background:${hexA(CULTURE_HUES[s.cultureId] ?? '#B56A1D',0.18)};color:${CULTURE_HUES[s.cultureId] ?? 'var(--text-accent)'}">${cultureLabel(s.cultureId)}</span>
+        <span class="mono">${s.dateRange[0]}–${s.dateRange[1]}</span>
+        <span class="muted"> · ${g.typologyWeights.length} typologies in palette</span>
+      </div>
+
+      <div class="panel">
+        <div class="panel-h">Era timeline · ${cultureLabel(s.cultureId)}</div>
+        ${renderTimeline(s.cultureId, g.id)}
+      </div>
+
+      <div class="panel">
+        <div class="panel-h">Core style</div>
+        <div class="chip-row" style="margin-bottom:14px;">
+          ${materialChip('primary', s.core.primaryMaterial)}
+          ${s.core.secondaryMaterial ? materialChip('secondary', s.core.secondaryMaterial) : ''}
+          ${roofChip(s.core.roofType)}
+        </div>
+        <div class="panel-h" style="margin-top:18px;">Ornamentation</div>
+        <div class="orn-list">
+          ${s.core.ornamentation.map(o => `<span class="orn-tag">${o}</span>`).join('') || '<span class="muted">—</span>'}
+        </div>
+      </div>
+
+      <div class="panel">
+        <div class="panel-h">Extras · ${Object.keys(s.extras || {}).length} key${Object.keys(s.extras || {}).length !== 1 ? 's' : ''}</div>
+        ${renderExtras(s.extras)}
+      </div>
+    `;
+    wrap.querySelectorAll('.timeline .seg').forEach(el => {
+      el.addEventListener('click', () => {
+        state.guideId = el.dataset.guide;
+        renderLeftPane(); renderCenter(); renderRight();
+      });
+    });
+  } else {
+    /* typologies view: gallery of typology cards */
+    wrap.innerHTML = `
+      <div class="detail-h1">Typology catalogue</div>
+      <div class="detail-sub">10 culture-agnostic structural archetypes. Each is dressed by a StyleSheet to become a real building.</div>
+      <div class="typologies-grid">
+        ${typologies.map(t => `
+          <div class="typology-card" data-typology="${t.id}" style="cursor:pointer;${state.typologyId === t.id ? 'border-color:var(--accent);' : ''}">
+            ${footprintSvg(t, 200, 130)}
+            <div class="name">${humanize(t.id)}</div>
+            <div class="meta-row">
+              <span class="k">Kind</span>     <span class="v">${t.footprint.kind}</span>
+              <span class="k">Stories</span>  <span class="v">${t.storyRange[0]}–${t.storyRange[1]}</span>
+              <span class="k">Windows</span>  <span class="v">${pct(t.fenestrationDensity[0])}–${pct(t.fenestrationDensity[1])}</span>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+    `;
+    wrap.querySelectorAll('.typology-card').forEach(el => {
+      el.addEventListener('click', () => {
+        state.typologyId = el.dataset.typology;
+        renderLeftPane(); renderCenter(); renderRight();
+      });
+    });
+  }
+}
+
+function pct(n) { return (n * 100).toFixed(0) + '%'; }
+
+function renderExtras(extras) {
+  const keys = Object.keys(extras || {});
+  if (!keys.length) return '<div class="muted">No culture-specific extras.</div>';
+  let html = '<div class="extras">';
+  for (const k of keys) {
+    const v = extras[k];
+    let rendered;
+    if (Array.isArray(v)) {
+      rendered = v.map(x => `<span class="arr-item">${x}</span>`).join('');
+    } else {
+      rendered = `<span class="mono">${v}</span>`;
+    }
+    html += `<div class="k">${k}</div><div class="v">${rendered}</div>`;
+  }
+  html += '</div>';
+  return html;
+}
+
+/* ─── timeline (horizontal era ribbon for a culture) ────── */
+
+function renderTimeline(cultureId, activeGuideId) {
+  const list = byCulture.get(cultureId);
+  if (!list || !list.length) return '';
+  const minY = Math.min(...list.map(g => g.styleSheet.dateRange[0]));
+  const maxY = Math.max(...list.map(g => g.styleSheet.dateRange[1]));
+  const span = Math.max(maxY - minY, 1);
+  const padFrac = 0.06;
+  const w = 100;  // % units
+  const inner = w * (1 - 2 * padFrac);
+  let html = `<div class="timeline">
+    <div class="axis"></div>`;
+  for (const g of list) {
+    const dr = g.styleSheet.dateRange;
+    const leftPct  = padFrac * 100 + ((dr[0] - minY) / span) * inner;
+    const widthPct = ((dr[1] - dr[0]) / span) * inner;
+    const active = activeGuideId === g.id ? 'active' : '';
+    const label = humanize(g.id, cultureId);
+    html += `<div class="seg ${active}" data-guide="${g.id}"
+                  title="${label}: ${dr[0]}–${dr[1]}"
+                  style="left:${leftPct}%; width:${Math.max(widthPct, 2)}%;"></div>`;
+    if (active) {
+      html += `<div class="seg-label" style="left:${leftPct + widthPct/2}%;">${label}</div>`;
+    }
+  }
+  /* axis tick labels (start, mid, end) */
+  const midY = Math.round((minY + maxY) / 2);
+  html += `<div class="tick" style="left:${padFrac * 100}%;">${minY}</div>`;
+  html += `<div class="tick" style="left:50%;">${midY}</div>`;
+  html += `<div class="tick" style="left:${(1 - padFrac) * 100}%;">${maxY}</div>`;
+  html += `</div>`;
+  return html;
+}
+
+/* ─── chips ─────────────────────────────────────────────── */
+
+function materialChip(role, material) {
+  const v = `var(--mat-${material})`;
+  return `<div class="chip" title="${material}">
+    <span class="swatch" style="background:${v}"></span>
+    <span class="kind">${role}</span>
+    <span class="label">${material}</span>
+  </div>`;
+}
+
+function roofChip(roofType) {
+  const glyph = ROOF_GLYPH[roofType] ?? '';
+  return `<div class="chip" title="roof: ${roofType}">
+    <span class="swatch" style="background:transparent;border:none;display:inline-flex;align-items:center;justify-content:center;color:var(--accent);">${glyph}</span>
+    <span class="kind">roof</span>
+    <span class="label">${roofType}</span>
+  </div>`;
+}
+
+const ROOF_GLYPH = {
+  gable:   `<svg width="14" height="10" viewBox="0 0 14 10"><polyline points="1,9 7,1 13,9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>`,
+  hip:     `<svg width="14" height="10" viewBox="0 0 14 10"><polyline points="1,9 4,2 10,2 13,9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>`,
+  flat:    `<svg width="14" height="10" viewBox="0 0 14 10"><line x1="1" y1="3" x2="13" y2="3" stroke="currentColor" stroke-width="1.4"/></svg>`,
+  pagoda:  `<svg width="14" height="11" viewBox="0 0 14 11"><polyline points="1,5 4,2 10,2 13,5" fill="none" stroke="currentColor" stroke-width="1.2"/><polyline points="2,9 5,6 9,6 12,9" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>`,
+  thatch:  `<svg width="14" height="10" viewBox="0 0 14 10"><path d="M1,9 Q4,2 7,1 Q10,2 13,9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>`,
+  dome:    `<svg width="14" height="10" viewBox="0 0 14 10"><path d="M2,9 A6,6 0 0 1 12,9" fill="none" stroke="currentColor" stroke-width="1.4"/></svg>`,
+  shed:    `<svg width="14" height="10" viewBox="0 0 14 10"><polyline points="1,9 13,2" fill="none" stroke="currentColor" stroke-width="1.4"/></svg>`,
+  mansard: `<svg width="14" height="10" viewBox="0 0 14 10"><polyline points="1,9 3,4 11,4 13,9" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>`,
+};
+
+/* ─── footprint SVG per kind ──────────────────────────────── */
+
+function footprintSvg(t, w, h) {
+  const fp = t.footprint;
+  const pad = 16;
+  const W = w - 2*pad, H = h - 2*pad;
+
+  let buildingPath = '';
+  let inner = '';
+  let aspectNote = '';
+
+  if (fp.kind === 'rectangle') {
+    const ar = mid(fp.aspectRatio);
+    const { rw, rh } = fitToBox(ar, W, H);
+    const x = pad + (W - rw) / 2, y = pad + (H - rh) / 2;
+    buildingPath = `M ${x},${y} h ${rw} v ${rh} h ${-rw} z`;
+    aspectNote = `aspect ${ar.toFixed(2)}`;
+    inner = windowDots(x, y, rw, rh, t.fenestrationDensity);
+  } else if (fp.kind === 'linear-row') {
+    const wid = mid(fp.widthRange), dep = mid(fp.depthRange);
+    const ar = wid / dep;
+    const { rw, rh } = fitToBox(ar, W, H);
+    const x = pad + (W - rw) / 2, y = pad + (H - rh) / 2;
+    buildingPath = `M ${x},${y} h ${rw} v ${rh} h ${-rw} z`;
+    aspectNote = `${dep.toFixed(1)}×${wid.toFixed(1)}m`;
+    inner = windowDots(x, y, rw, rh, t.fenestrationDensity);
+  } else if (fp.kind === 'L-shape') {
+    const cf = mid(fp.courtyardFraction);
+    const { rw, rh } = fitToBox(1.0, W, H);
+    const x = pad + (W - rw) / 2, y = pad + (H - rh) / 2;
+    const cut = cf;
+    // L = full rect with top-right square cut out
+    buildingPath = `
+      M ${x},${y}
+      h ${rw * (1-cut)}
+      v ${rh * cut}
+      h ${rw * cut}
+      v ${rh * (1-cut)}
+      h ${-rw}
+      z
+    `.replace(/\s+/g, ' ').trim();
+    aspectNote = `courtyard ${pct(cf)}`;
+  } else if (fp.kind === 'U-shape') {
+    const ow = mid(fp.openingWidth), wd = mid(fp.wingDepth);
+    const { rw, rh } = fitToBox(1.0, W, H);
+    const x = pad + (W - rw) / 2, y = pad + (H - rh) / 2;
+    // proportional wing depth and opening width relative to rw/rh
+    const wf = Math.min(0.35, wd / 30);
+    const of = Math.min(0.65, ow / 20);
+    const sideW = rw * wf;
+    const openW = rw * of;
+    const restW = rw - 2*sideW - openW;
+    const baseH = rh * (1 - wf);
+    buildingPath = `
+      M ${x},${y}
+      h ${sideW}
+      v ${rh - baseH - (rh*wf)}
+    `;
+    // Cleaner U with explicit anchors:
+    const innerLeft  = x + sideW;
+    const innerRight = x + sideW + openW + sideW;  // ignore restW for clean U
+    // Recompute: U has three sides — left wing, bottom base, right wing
+    const leftWingX  = x;
+    const leftWingW  = rw * wf;
+    const rightWingW = rw * wf;
+    const rightWingX = x + rw - rightWingW;
+    const openingW   = rw - leftWingW - rightWingW;
+    const wingDepthY = rh * (1 - wf);
+    buildingPath = `
+      M ${leftWingX},${y}
+      h ${leftWingW}
+      v ${wingDepthY}
+      h ${openingW}
+      v ${-wingDepthY}
+      h ${rightWingW}
+      v ${rh}
+      h ${-rw}
+      z
+    `.replace(/\s+/g, ' ').trim();
+    aspectNote = `opening ${ow.toFixed(0)}m`;
+  } else if (fp.kind === 'courtyard') {
+    const cf = mid(fp.courtyardFraction);
+    const { rw, rh } = fitToBox(1.1, W, H);
+    const x = pad + (W - rw) / 2, y = pad + (H - rh) / 2;
+    const innerW = rw * Math.sqrt(cf), innerH = rh * Math.sqrt(cf);
+    const ix = x + (rw - innerW) / 2, iy = y + (rh - innerH) / 2;
+    // Outer ring as building, inner courtyard as hole (use evenodd)
+    buildingPath = `
+      M ${x},${y} h ${rw} v ${rh} h ${-rw} z
+      M ${ix},${iy} h ${innerW} v ${innerH} h ${-innerW} z
+    `.replace(/\s+/g, ' ').trim();
+    aspectNote = `inner court ${pct(cf)}`;
+  }
+
+  return `
+    <svg class="footprint-svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+      <rect class="lot" x="${pad/2}" y="${pad/2}" width="${w - pad}" height="${h - pad}" rx="2"/>
+      <path class="building" d="${buildingPath}" fill-rule="evenodd"/>
+      ${inner}
+      <text class="label" x="${w/2}" y="${h - 3}" text-anchor="middle">${aspectNote}</text>
+    </svg>
+  `;
+}
+
+function mid([lo, hi]) { return (lo + hi) / 2; }
+
+function fitToBox(aspect, W, H) {
+  let rw = W, rh = W / aspect;
+  if (rh > H) { rh = H; rw = H * aspect; }
+  return { rw, rh };
+}
+
+function windowDots(x, y, w, h, density) {
+  const d = mid(density);
+  if (d <= 0) return '';
+  const cols = Math.max(2, Math.round(w / 18));
+  const rows = Math.max(1, Math.round(h / 22));
+  const sw = 3, sh = 3.5;
+  let svg = '';
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      // place ~d fraction of slots
+      if ((c + r * cols) % Math.max(1, Math.round(1 / Math.max(d, 0.02))) !== 0) continue;
+      const cx = x + (c + 0.5) * (w / cols) - sw/2;
+      const cy = y + (r + 0.5) * (h / rows) - sh/2;
+      svg += `<rect class="window" x="${cx}" y="${cy}" width="${sw}" height="${sh}" rx="0.5"/>`;
+    }
+  }
+  return svg;
+}
+
+/* ─── right pane (typology weights for the active guide, or footprint detail) ── */
+
+function renderRight() {
+  const wrap = document.getElementById('rightWrap');
+  if (state.view === 'guides') {
+    const g = guideById[state.guideId];
+    if (!g) { wrap.innerHTML = ''; return; }
+    const maxW = Math.max(...g.typologyWeights.map(w => w.weight));
+    const sortedWeights = [...g.typologyWeights].sort((a, b) => b.weight - a.weight);
+    let html = `<div class="right-h">Typology weights</div><div class="weights-list">`;
+    for (const w of sortedWeights) {
+      const sel = state.typologyId === w.typologyId ? 'selected' : '';
+      const pct = (w.weight / maxW) * 100;
+      html += `<div class="weight-row ${sel}" data-typology="${w.typologyId}">
+        <div class="bar-bg" style="width:${pct}%"></div>
+        <div class="col-name">${humanize(w.typologyId)}</div>
+        <div class="col-w">${w.weight}</div>
+      </div>`;
+    }
+    html += '</div>';
+    /* footprint detail card */
+    const tid = state.typologyId ?? sortedWeights[0]?.typologyId;
+    if (tid && typologyById[tid]) {
+      const t = typologyById[tid];
+      html += `<div class="footprint-card">
+        <div class="head">
+          <div class="typo-name">${humanize(t.id)}</div>
+          <span class="kind-pill">${t.footprint.kind}</span>
+        </div>
+        ${footprintSvg(t, 340, 200)}
+        <div class="meta-row">
+          <span class="k">Stories</span>          <span class="v">${t.storyRange[0]}–${t.storyRange[1]}</span>
+          <span class="k">Fenestration</span>     <span class="v">${pctRange(t.fenestrationDensity)}</span>
+          ${footprintParamRow(t.footprint)}
+        </div>
+        <div style="margin-top:12px;font-size:11px;color:var(--text-muted);line-height:1.5;">
+          Dressed by <span class="accent">${humanize(g.id, g.styleSheet.cultureId)}</span> → walls in ${matSpan(g.styleSheet.core.primaryMaterial)}, ${g.styleSheet.core.roofType} roof.
+        </div>
+      </div>`;
+    }
+    wrap.innerHTML = html;
+    wrap.querySelectorAll('.weight-row').forEach(el => {
+      el.addEventListener('click', () => {
+        state.typologyId = el.dataset.typology;
+        renderRight();
+      });
+    });
+  } else {
+    /* typologies view: show every culture/era dressing of the selected typology */
+    if (!state.typologyId) { wrap.innerHTML = '<div class="empty-state">Pick a typology.</div>'; return; }
+    const t = typologyById[state.typologyId];
+    let html = `<div class="right-h">${humanize(t.id)} across cultures</div>`;
+    for (const g of guides) {
+      const weight = g.typologyWeights.find(w => w.typologyId === t.id)?.weight;
+      if (!weight) continue;
+      const s = g.styleSheet;
+      html += `<div class="footprint-card">
+        <div class="head">
+          <div class="typo-name" style="font-size:12.5px;">${humanize(g.id, s.cultureId)}</div>
+          <span class="kind-pill" style="background:${hexA(CULTURE_HUES[s.cultureId] ?? '#B56A1D', 0.18)};color:${CULTURE_HUES[s.cultureId] ?? 'var(--text-accent)'}">${cultureLabel(s.cultureId)}</span>
+        </div>
+        <div style="font-size:11.5px;line-height:1.6;">
+          <span class="muted">walls</span> ${matSpan(s.core.primaryMaterial)}
+          ${s.core.secondaryMaterial ? `<span class="muted">+ </span>${matSpan(s.core.secondaryMaterial)}` : ''}
+          <br><span class="muted">roof</span> ${s.core.roofType}
+          <br><span class="muted">weight</span> <span class="mono">${weight}</span>
+          · <span class="muted">${s.dateRange[0]}–${s.dateRange[1]}</span>
+        </div>
+      </div>`;
+    }
+    wrap.innerHTML = html;
+  }
+}
+
+function matSpan(m) {
+  return `<span style="color:var(--mat-${m});font-weight:500;">${m}</span>`;
+}
+function pctRange([lo, hi]) {
+  return `${(lo*100).toFixed(0)}%–${(hi*100).toFixed(0)}%`;
+}
+function footprintParamRow(fp) {
+  // surface kind-specific params in the meta row
+  const rows = [];
+  if (fp.kind === 'rectangle') {
+    rows.push(['Aspect', `${fp.aspectRatio[0]}–${fp.aspectRatio[1]}`]);
+    rows.push(['Area',   `${fp.areaRange[0]}–${fp.areaRange[1]} m²`]);
+  } else if (fp.kind === 'linear-row') {
+    rows.push(['Width', `${fp.widthRange[0]}–${fp.widthRange[1]} m`]);
+    rows.push(['Depth', `${fp.depthRange[0]}–${fp.depthRange[1]} m`]);
+  } else if (fp.kind === 'L-shape' || fp.kind === 'courtyard') {
+    rows.push(['Wing depth', `${fp.wingDepth[0]}–${fp.wingDepth[1]} m`]);
+    rows.push(['Courtyard',  `${pct(fp.courtyardFraction[0])}–${pct(fp.courtyardFraction[1])}`]);
+  } else if (fp.kind === 'U-shape') {
+    rows.push(['Wing depth',   `${fp.wingDepth[0]}–${fp.wingDepth[1]} m`]);
+    rows.push(['Opening',      `${fp.openingWidth[0]}–${fp.openingWidth[1]} m`]);
+  }
+  return rows.map(([k, v]) => `<span class="k">${k}</span><span class="v">${v}</span>`).join('');
+}
+
+function hexA(hex, a) {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0,2), 16), g = parseInt(h.slice(2,4), 16), b = parseInt(h.slice(4,6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+/* ─── tab wiring ────────────────────────────────────────── */
+
+document.getElementById('tabs').addEventListener('click', e => {
+  const t = e.target.closest('.tab');
+  if (!t) return;
+  document.querySelectorAll('.tab').forEach(x => x.classList.remove('active'));
+  t.classList.add('active');
+  state.view = t.dataset.view;
+  if (state.view === 'typologies' && !state.typologyId) state.typologyId = typologies[0].id;
+  renderLeftPane(); renderCenter(); renderRight();
+});
+
+/* ─── boot ──────────────────────────────────────────────── */
+
+renderStats();
+renderLeftPane();
+renderCenter();
+renderRight();
+</script>
+
+</body>
+</html>

--- a/packages/architecture/demo/logo.svg
+++ b/packages/architecture/demo/logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- Three layered building silhouettes — references the typology/style/guide split -->
+  <rect x="3" y="20" width="6" height="9" fill="#B56A1D"/>
+  <rect x="11" y="14" width="10" height="15" fill="#D17F2A"/>
+  <rect x="23" y="9" width="6" height="20" fill="#DED4C3"/>
+  <!-- Tiny windows -->
+  <rect x="5" y="23" width="2" height="2" fill="#1b1e24"/>
+  <rect x="13" y="17" width="2" height="2" fill="#1b1e24"/>
+  <rect x="17" y="17" width="2" height="2" fill="#1b1e24"/>
+  <rect x="13" y="22" width="2" height="2" fill="#1b1e24"/>
+  <rect x="17" y="22" width="2" height="2" fill="#1b1e24"/>
+  <rect x="25" y="12" width="2" height="2" fill="#1b1e24"/>
+  <rect x="25" y="16" width="2" height="2" fill="#1b1e24"/>
+  <rect x="25" y="20" width="2" height="2" fill="#1b1e24"/>
+  <!-- Ground line -->
+  <rect x="0" y="29" width="32" height="1" fill="#1a1d22"/>
+</svg>

--- a/packages/architecture/demo/serve.mjs
+++ b/packages/architecture/demo/serve.mjs
@@ -1,0 +1,54 @@
+/**
+ * Zero-dep static dev server for the A1 architecture demo. Serves the package
+ * root so the HTML page can fetch `../src/data/...` directly.
+ *
+ *   npm run serve   →  http://localhost:5184/demo/
+ */
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
+const START_PORT = Number(process.env.PORT ?? 5184);
+const MAX_TRIES = 20;
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.mjs':  'application/javascript; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map':  'application/json; charset=utf-8',
+  '.svg':  'image/svg+xml',
+};
+
+const server = createServer(async (req, res) => {
+  try {
+    let url = decodeURIComponent((req.url ?? '/').split('?')[0]);
+    if (url === '/') url = '/demo/';
+    if (url.endsWith('/')) url += 'index.html';
+    const fp = join(ROOT, url);
+    if (!fp.startsWith(ROOT)) { res.writeHead(403); return res.end('forbidden'); }
+    const body = await readFile(fp);
+    res.writeHead(200, { 'content-type': MIME[extname(fp)] ?? 'application/octet-stream' });
+    res.end(body);
+  } catch {
+    res.writeHead(404, { 'content-type': 'text/plain' });
+    res.end('not found: ' + req.url);
+  }
+});
+
+function listen(port, tries) {
+  server.once('error', (err) => {
+    if (err.code === 'EADDRINUSE' && tries < MAX_TRIES) {
+      listen(port + 1, tries + 1);
+    } else {
+      throw err;
+    }
+  });
+  server.listen(port, () => {
+    console.log(`hayba architecture demo · http://localhost:${port}/demo/`);
+  });
+}
+listen(START_PORT, 0);

--- a/packages/architecture/docs/extras-glossary.md
+++ b/packages/architecture/docs/extras-glossary.md
@@ -1,0 +1,45 @@
+# StyleSheet `extras` glossary
+
+The `extras` field on `StyleSheet` is an open `FeatureBundle` (`Record<string, string | string[]>`) for culture-specific concepts that don't fit the typed `core` fields. Every key used by a seed StyleGuide must appear here.
+
+Promote a key to `StyleSheet.core` (a real typed field) once it generalizes across cultures.
+
+## Keys in use
+
+| Key | Cultures using it | Type | Notes |
+|---|---|---|---|
+| `bayWindows` | industrial-revolution-english | string | Frequency tag, e.g. `"common"`. |
+| `chimneyStacks` | industrial-revolution-english | string | Height tag, e.g. `"tall"`. |
+| `colorPalette` | tang-chinese | string[] | Named pigments. |
+| `cornice` | industrial-revolution-english | string | Material tag, e.g. `"stone"`. |
+| `defensiveWalls` | medieval-european-carolingian | string | Material tag. |
+| `dougong` | tang-chinese | string | Bracket-set complexity tag (`present` / `elaborate`). |
+| `eaves` | tang-chinese-9c | string | Overhang depth tag. |
+| `engawa` | edo-japanese | string | Verandah strip, `"present"` if part of vernacular. |
+| `kawara` | edo-japanese-late | string | Clay tile roof tag. |
+| `multiBuilding` | hausa-classical | string | `"true"` marks compound-typology archetypes; A3 may treat as cluster. |
+| `niches` | andean-inca | string | Wall-niche shape tag (`trapezoidal`). |
+| `pinnacles` | hausa-classical | string | Roof-edge ornament (azara pinnacles). |
+| `roofPitch` | medieval-european-carolingian | string | Steepness tag. |
+| `shoji` | edo-japanese-early | string | Paper-screen partition prevalence. |
+| `stainedGlass` | medieval-european-gothic | string | Frequency tag. |
+| `tokonoma` | edo-japanese-early | string | Decorative alcove prevalence. |
+| `tracery` | medieval-european-gothic | string | Window-stonework style tag. |
+| `tubali` | hausa-classical | string | Molded mud cones, characteristic of Hausa Zaure. |
+| `vaulting` | medieval-european-romanesque | string | Roof-vault style. |
+| `verticalEmphasis` | medieval-european-gothic | string | Massing tag. |
+| `wallStyle` | andean | string | Polygonal-fitted vs. coursed-adobe. |
+| `windowSize` | medieval-european-romanesque | string | Relative size tag. |
+
+## Promotion candidates
+
+Keys appearing in 3+ cultures should be considered for promotion to `core`:
+
+- `wallStyle` (currently 2 cultures) — could become `core.wallStyle: 'fitted-polygonal' | 'coursed' | 'tubali' | ...` once a third culture lands.
+- `roofPitch` — overlaps semantically with `roofType`; consider folding into roof-type tags rather than promoting.
+
+## Authoring rules
+
+1. New extras keys MUST be added to this table in the same commit as the StyleGuide JSON that introduces them.
+2. Don't reuse a key for a different concept across cultures. If two cultures need different `tracery` semantics, namespace: `tracery.medieval-european`.
+3. Prefer `string` over `string[]` unless the field is genuinely a set (e.g., `colorPalette`).

--- a/packages/architecture/package.json
+++ b/packages/architecture/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "serve": "node demo/serve.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",

--- a/packages/architecture/package.json
+++ b/packages/architecture/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
+    "@vitest/coverage-v8": "^2.1.9",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"
   },

--- a/packages/architecture/package.json
+++ b/packages/architecture/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@hayba/architecture",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.2",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  },
+  "license": "MIT"
+}

--- a/packages/architecture/src/data/style-guides/andean-inca.json
+++ b/packages/architecture/src/data/style-guides/andean-inca.json
@@ -1,0 +1,27 @@
+{
+  "id": "andean-inca",
+  "styleSheet": {
+    "id": "andean-inca",
+    "cultureId": "andean",
+    "dateRange": [1438, 1533],
+    "core": {
+      "primaryMaterial": "stone",
+      "secondaryMaterial": "adobe",
+      "roofType": "thatch",
+      "ornamentation": ["polygonal-stonework", "trapezoidal-niche", "double-jamb-doorway"]
+    },
+    "extras": {
+      "wallStyle": "polygonal-fitted",
+      "niches": "trapezoidal"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "peasant_home",  "weight": 6 },
+    { "typologyId": "granary",       "weight": 5 },
+    { "typologyId": "temple",        "weight": 4 },
+    { "typologyId": "walled_palace", "weight": 4 },
+    { "typologyId": "watchtower",    "weight": 4 },
+    { "typologyId": "workshop",      "weight": 2 },
+    { "typologyId": "civic_hall",    "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/andean-pre-inca.json
+++ b/packages/architecture/src/data/style-guides/andean-pre-inca.json
@@ -1,0 +1,24 @@
+{
+  "id": "andean-pre-inca",
+  "styleSheet": {
+    "id": "andean-pre-inca",
+    "cultureId": "andean",
+    "dateRange": [200, 1438],
+    "core": {
+      "primaryMaterial": "adobe",
+      "secondaryMaterial": "stone",
+      "roofType": "thatch",
+      "ornamentation": ["adobe-fresco", "geometric-frieze"]
+    },
+    "extras": {
+      "wallStyle": "coursed-adobe"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "peasant_home",  "weight": 7 },
+    { "typologyId": "granary",       "weight": 5 },
+    { "typologyId": "temple",        "weight": 4 },
+    { "typologyId": "market_stall",  "weight": 2 },
+    { "typologyId": "watchtower",    "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/edo-japanese-early.json
+++ b/packages/architecture/src/data/style-guides/edo-japanese-early.json
@@ -1,0 +1,28 @@
+{
+  "id": "edo-japanese-early",
+  "styleSheet": {
+    "id": "edo-japanese-early",
+    "cultureId": "edo-japanese",
+    "dateRange": [1603, 1750],
+    "core": {
+      "primaryMaterial": "timber",
+      "secondaryMaterial": "stone",
+      "roofType": "hip",
+      "ornamentation": ["shoji-grid", "engawa-veranda", "irimoya-gable", "kawara-tile-end"]
+    },
+    "extras": {
+      "engawa": "present",
+      "tokonoma": "common",
+      "shoji": "ubiquitous"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "peasant_home",  "weight": 6 },
+    { "typologyId": "townhouse",     "weight": 5 },
+    { "typologyId": "market_stall",  "weight": 4 },
+    { "typologyId": "temple",        "weight": 4 },
+    { "typologyId": "manor",         "weight": 2 },
+    { "typologyId": "granary",       "weight": 2 },
+    { "typologyId": "civic_hall",    "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/edo-japanese-late.json
+++ b/packages/architecture/src/data/style-guides/edo-japanese-late.json
@@ -1,0 +1,27 @@
+{
+  "id": "edo-japanese-late",
+  "styleSheet": {
+    "id": "edo-japanese-late",
+    "cultureId": "edo-japanese",
+    "dateRange": [1750, 1868],
+    "core": {
+      "primaryMaterial": "timber",
+      "secondaryMaterial": "stone",
+      "roofType": "hip",
+      "ornamentation": ["kawara-tile", "namako-wall", "irimoya-roof"]
+    },
+    "extras": {
+      "engawa": "present",
+      "kawara": "common"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "townhouse",     "weight": 6 },
+    { "typologyId": "market_stall",  "weight": 5 },
+    { "typologyId": "civic_hall",    "weight": 4 },
+    { "typologyId": "walled_palace", "weight": 4 },
+    { "typologyId": "peasant_home",  "weight": 3 },
+    { "typologyId": "temple",        "weight": 2 },
+    { "typologyId": "workshop",      "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/hausa-classical.json
+++ b/packages/architecture/src/data/style-guides/hausa-classical.json
@@ -1,0 +1,28 @@
+{
+  "id": "hausa-classical",
+  "styleSheet": {
+    "id": "hausa-classical",
+    "cultureId": "hausa",
+    "dateRange": [1400, 1800],
+    "core": {
+      "primaryMaterial": "mudbrick",
+      "secondaryMaterial": "wattle-daub",
+      "roofType": "flat",
+      "ornamentation": ["tubali-pinnacle", "carved-mud-relief", "azara-banding"]
+    },
+    "extras": {
+      "tubali": "molded-mud-cones",
+      "multiBuilding": "true",
+      "pinnacles": "azara"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "peasant_home",  "weight": 6 },
+    { "typologyId": "walled_palace", "weight": 5 },
+    { "typologyId": "market_stall",  "weight": 4 },
+    { "typologyId": "civic_hall",    "weight": 4 },
+    { "typologyId": "granary",       "weight": 3 },
+    { "typologyId": "temple",        "weight": 2 },
+    { "typologyId": "workshop",      "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/industrial-revolution-english.json
+++ b/packages/architecture/src/data/style-guides/industrial-revolution-english.json
@@ -1,0 +1,27 @@
+{
+  "id": "industrial-revolution-english",
+  "styleSheet": {
+    "id": "industrial-revolution-english",
+    "cultureId": "industrial-revolution-english",
+    "dateRange": [1760, 1900],
+    "core": {
+      "primaryMaterial": "brick",
+      "secondaryMaterial": "stone",
+      "roofType": "mansard",
+      "ornamentation": ["bay-window", "cornice-bracket", "cast-iron-balcony", "fanlight-arch"]
+    },
+    "extras": {
+      "chimneyStacks": "tall",
+      "cornice": "stone",
+      "bayWindows": "common"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "townhouse",     "weight": 7 },
+    { "typologyId": "workshop",      "weight": 5 },
+    { "typologyId": "civic_hall",    "weight": 4 },
+    { "typologyId": "market_stall",  "weight": 4 },
+    { "typologyId": "peasant_home",  "weight": 3 },
+    { "typologyId": "manor",         "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/medieval-european-carolingian.json
+++ b/packages/architecture/src/data/style-guides/medieval-european-carolingian.json
@@ -1,0 +1,26 @@
+{
+  "id": "medieval-european-carolingian",
+  "styleSheet": {
+    "id": "medieval-european-carolingian",
+    "cultureId": "medieval-european",
+    "dateRange": [750, 1000],
+    "core": {
+      "primaryMaterial": "timber",
+      "secondaryMaterial": "stone",
+      "roofType": "gable",
+      "ornamentation": ["corner-quoins", "rounded-arch", "decorative-shingles"]
+    },
+    "extras": {
+      "roofPitch": "steep",
+      "defensiveWalls": "earthen"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "peasant_home", "weight": 7 },
+    { "typologyId": "granary",      "weight": 5 },
+    { "typologyId": "watchtower",   "weight": 4 },
+    { "typologyId": "temple",       "weight": 2 },
+    { "typologyId": "manor",        "weight": 2 },
+    { "typologyId": "market_stall", "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/medieval-european-gothic.json
+++ b/packages/architecture/src/data/style-guides/medieval-european-gothic.json
@@ -1,0 +1,28 @@
+{
+  "id": "medieval-european-gothic",
+  "styleSheet": {
+    "id": "medieval-european-gothic",
+    "cultureId": "medieval-european",
+    "dateRange": [1140, 1400],
+    "core": {
+      "primaryMaterial": "stone",
+      "secondaryMaterial": "timber",
+      "roofType": "gable",
+      "ornamentation": ["pointed-arch", "flying-buttress", "rose-window", "gargoyle"]
+    },
+    "extras": {
+      "stainedGlass": "common",
+      "verticalEmphasis": "strong",
+      "tracery": "ribbed"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "peasant_home", "weight": 6 },
+    { "typologyId": "townhouse",    "weight": 4 },
+    { "typologyId": "market_stall", "weight": 2 },
+    { "typologyId": "manor",        "weight": 1 },
+    { "typologyId": "temple",       "weight": 1 },
+    { "typologyId": "watchtower",   "weight": 1 },
+    { "typologyId": "civic_hall",   "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/medieval-european-romanesque.json
+++ b/packages/architecture/src/data/style-guides/medieval-european-romanesque.json
@@ -1,0 +1,27 @@
+{
+  "id": "medieval-european-romanesque",
+  "styleSheet": {
+    "id": "medieval-european-romanesque",
+    "cultureId": "medieval-european",
+    "dateRange": [1000, 1200],
+    "core": {
+      "primaryMaterial": "stone",
+      "secondaryMaterial": "timber",
+      "roofType": "gable",
+      "ornamentation": ["round-arch", "blind-arcade", "tympanum-carving"]
+    },
+    "extras": {
+      "vaulting": "barrel",
+      "windowSize": "small"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "peasant_home", "weight": 6 },
+    { "typologyId": "townhouse",    "weight": 5 },
+    { "typologyId": "temple",       "weight": 4 },
+    { "typologyId": "watchtower",   "weight": 4 },
+    { "typologyId": "manor",        "weight": 2 },
+    { "typologyId": "granary",      "weight": 2 },
+    { "typologyId": "market_stall", "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/tang-chinese-7c.json
+++ b/packages/architecture/src/data/style-guides/tang-chinese-7c.json
@@ -1,0 +1,27 @@
+{
+  "id": "tang-chinese-7c",
+  "styleSheet": {
+    "id": "tang-chinese-7c",
+    "cultureId": "tang-chinese",
+    "dateRange": [618, 800],
+    "core": {
+      "primaryMaterial": "timber",
+      "secondaryMaterial": "stone",
+      "roofType": "pagoda",
+      "ornamentation": ["dougong-bracket", "ridge-finial", "lacquered-eaves", "cinnabar-columns"]
+    },
+    "extras": {
+      "dougong": "present",
+      "colorPalette": ["red", "gold"]
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "peasant_home",  "weight": 6 },
+    { "typologyId": "townhouse",     "weight": 5 },
+    { "typologyId": "temple",        "weight": 4 },
+    { "typologyId": "walled_palace", "weight": 4 },
+    { "typologyId": "granary",       "weight": 2 },
+    { "typologyId": "market_stall",  "weight": 2 },
+    { "typologyId": "civic_hall",    "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/style-guides/tang-chinese-9c.json
+++ b/packages/architecture/src/data/style-guides/tang-chinese-9c.json
@@ -1,0 +1,27 @@
+{
+  "id": "tang-chinese-9c",
+  "styleSheet": {
+    "id": "tang-chinese-9c",
+    "cultureId": "tang-chinese",
+    "dateRange": [800, 907],
+    "core": {
+      "primaryMaterial": "timber",
+      "secondaryMaterial": "stone",
+      "roofType": "pagoda",
+      "ornamentation": ["multi-tier-dougong", "ridge-beast", "gilt-eaves"]
+    },
+    "extras": {
+      "dougong": "elaborate",
+      "eaves": "deep-overhang"
+    }
+  },
+  "typologyWeights": [
+    { "typologyId": "townhouse",     "weight": 5 },
+    { "typologyId": "walled_palace", "weight": 5 },
+    { "typologyId": "temple",        "weight": 4 },
+    { "typologyId": "civic_hall",    "weight": 4 },
+    { "typologyId": "peasant_home",  "weight": 3 },
+    { "typologyId": "market_stall",  "weight": 2 },
+    { "typologyId": "granary",       "weight": 1 }
+  ]
+}

--- a/packages/architecture/src/data/typologies.json
+++ b/packages/architecture/src/data/typologies.json
@@ -1,0 +1,64 @@
+{
+  "typologies": [
+    {
+      "id": "peasant_home",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 1.6], "areaRange": [20, 60] },
+      "storyRange": [1, 2],
+      "fenestrationDensity": [0.04, 0.12]
+    },
+    {
+      "id": "townhouse",
+      "footprint": { "kind": "linear-row", "widthRange": [4, 7], "depthRange": [10, 22] },
+      "storyRange": [2, 4],
+      "fenestrationDensity": [0.12, 0.25]
+    },
+    {
+      "id": "market_stall",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 2.5], "areaRange": [6, 20] },
+      "storyRange": [1, 1],
+      "fenestrationDensity": [0.0, 0.05]
+    },
+    {
+      "id": "manor",
+      "footprint": { "kind": "U-shape", "wingDepth": [6, 12], "openingWidth": [8, 18] },
+      "storyRange": [2, 3],
+      "fenestrationDensity": [0.18, 0.32]
+    },
+    {
+      "id": "temple",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.3, 2.2], "areaRange": [80, 600] },
+      "storyRange": [1, 3],
+      "fenestrationDensity": [0.05, 0.18]
+    },
+    {
+      "id": "granary",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 1.4], "areaRange": [12, 80] },
+      "storyRange": [1, 2],
+      "fenestrationDensity": [0.0, 0.04]
+    },
+    {
+      "id": "watchtower",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 1.2], "areaRange": [9, 36] },
+      "storyRange": [3, 6],
+      "fenestrationDensity": [0.02, 0.08]
+    },
+    {
+      "id": "walled_palace",
+      "footprint": { "kind": "courtyard", "courtyardFraction": [0.25, 0.5], "wingDepth": [8, 16] },
+      "storyRange": [1, 3],
+      "fenestrationDensity": [0.10, 0.25]
+    },
+    {
+      "id": "workshop",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.0, 2.0], "areaRange": [30, 120] },
+      "storyRange": [1, 2],
+      "fenestrationDensity": [0.10, 0.30]
+    },
+    {
+      "id": "civic_hall",
+      "footprint": { "kind": "rectangle", "aspectRatio": [1.5, 2.5], "areaRange": [100, 400] },
+      "storyRange": [1, 2],
+      "fenestrationDensity": [0.15, 0.35]
+    }
+  ]
+}

--- a/packages/architecture/src/index.ts
+++ b/packages/architecture/src/index.ts
@@ -1,1 +1,9 @@
-export const PACKAGE_NAME = '@hayba/architecture';
+export type {
+  FeatureBundle, RoofType, PrimaryMaterial,
+  FootprintKind, FootprintShape,
+  Typology, StyleSheet, StyleGuide,
+} from './schema.js';
+
+export {
+  ROOF_TYPES, PRIMARY_MATERIALS, FOOTPRINT_KINDS,
+} from './schema.js';

--- a/packages/architecture/src/index.ts
+++ b/packages/architecture/src/index.ts
@@ -7,3 +7,17 @@ export type {
 export {
   ROOF_TYPES, PRIMARY_MATERIALS, FOOTPRINT_KINDS,
 } from './schema.js';
+
+export type { ValidationError } from './validate.js';
+export {
+  ArchitectureSchemaError,
+  validateFootprintShape, validateTypology, validateStyleSheet,
+  validateStyleGuide, validateStyleGuideRefs,
+  isFootprintShape, isTypology, isStyleSheet, isStyleGuide,
+} from './validate.js';
+
+export type { Registry, StyleGuideMeta } from './registry.js';
+export {
+  ArchitectureRegistryError,
+  loadRegistry, listStyleGuideMeta, getStyleGuide, getTypology,
+} from './registry.js';

--- a/packages/architecture/src/index.ts
+++ b/packages/architecture/src/index.ts
@@ -21,3 +21,10 @@ export {
   ArchitectureRegistryError,
   loadRegistry, listStyleGuideMeta, getStyleGuide, getTypology,
 } from './registry.js';
+
+export type {
+  ListStyleGuidesResult, GetStyleGuideResult, GetTypologyResult, ValidateStyleGuideResult,
+} from './mcp.js';
+export {
+  listStyleGuides, getStyleGuideTool, getTypologyTool, validateStyleGuideTool,
+} from './mcp.js';

--- a/packages/architecture/src/index.ts
+++ b/packages/architecture/src/index.ts
@@ -1,0 +1,1 @@
+export const PACKAGE_NAME = '@hayba/architecture';

--- a/packages/architecture/src/mcp.test.ts
+++ b/packages/architecture/src/mcp.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { listStyleGuides, getStyleGuideTool, getTypologyTool, validateStyleGuideTool } from './mcp.js';
+
+describe('architecture_list_style_guides', () => {
+  it('returns metadata for all 11 seed guides', () => {
+    const out = listStyleGuides();
+    expect(out.guides).toHaveLength(11);
+    expect(out.guides[0]).toMatchObject({
+      id: expect.any(String),
+      cultureId: expect.any(String),
+      dateRange: expect.any(Array),
+      typologyCount: expect.any(Number),
+    });
+  });
+
+  it('output is byte-identical across calls', () => {
+    expect(JSON.stringify(listStyleGuides())).toBe(JSON.stringify(listStyleGuides()));
+  });
+});
+
+describe('architecture_get_style_guide', () => {
+  it('returns the full guide for a known id', () => {
+    const out = getStyleGuideTool({ id: 'medieval-european-gothic' });
+    expect('guide' in out).toBe(true);
+    if ('guide' in out) {
+      expect(out.guide.styleSheet.core.primaryMaterial).toBe('stone');
+    }
+  });
+
+  it('returns not_found error for unknown id', () => {
+    const out = getStyleGuideTool({ id: 'nonexistent' });
+    expect(out).toEqual({ error: 'not_found', id: 'nonexistent' });
+  });
+
+  it('is deterministic across calls', () => {
+    const a = JSON.stringify(getStyleGuideTool({ id: 'medieval-european-gothic' }));
+    const b = JSON.stringify(getStyleGuideTool({ id: 'medieval-european-gothic' }));
+    expect(a).toBe(b);
+  });
+});
+
+describe('architecture_get_typology', () => {
+  it('returns typology for known id', () => {
+    const out = getTypologyTool({ id: 'peasant_home' });
+    expect('typology' in out).toBe(true);
+    if ('typology' in out) {
+      expect(out.typology.id).toBe('peasant_home');
+      expect(out.typology.footprint.kind).toBe('rectangle');
+    }
+  });
+
+  it('returns not_found for unknown id', () => {
+    const out = getTypologyTool({ id: 'castle' });
+    expect(out).toEqual({ error: 'not_found', id: 'castle' });
+  });
+});
+
+describe('architecture_validate_style_guide', () => {
+  const valid = {
+    id: 'test-guide',
+    styleSheet: {
+      id: 'test-sheet', cultureId: 'medieval-european', dateRange: [1000, 1200],
+      core: { primaryMaterial: 'stone', roofType: 'gable', ornamentation: [] },
+      extras: {},
+    },
+    typologyWeights: [{ typologyId: 'peasant_home', weight: 1 }],
+  };
+
+  it('returns ok=true for a well-formed guide with known typology refs', () => {
+    expect(validateStyleGuideTool({ json: valid })).toEqual({ ok: true });
+  });
+
+  it('returns ok=true even if typology refs are unknown — refs are A1 registry concern only', () => {
+    const bad = { ...valid, typologyWeights: [{ typologyId: 'unknown_t', weight: 1 }] };
+    // Structural validation passes; ref check is run by the registry, not by this tool.
+    expect(validateStyleGuideTool({ json: bad })).toEqual({ ok: true });
+  });
+
+  it('returns structured errors for a malformed input', () => {
+    const out = validateStyleGuideTool({
+      json: { id: '', styleSheet: { id: 's' }, typologyWeights: 'not-an-array' },
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) {
+      expect(out.errors.length).toBeGreaterThanOrEqual(2);
+      for (const e of out.errors) {
+        expect(typeof e.path).toBe('string');
+        expect(typeof e.message).toBe('string');
+      }
+    }
+  });
+
+  it('surfaces ALL errors (not first-fail)', () => {
+    const out = validateStyleGuideTool({
+      json: {
+        id: '',
+        styleSheet: {
+          id: '', cultureId: '', dateRange: 'bad',
+          core: { primaryMaterial: 'plasma', roofType: 'tepee', ornamentation: [] },
+          extras: { broken: 42 },
+        },
+        typologyWeights: [],
+      },
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.errors.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/packages/architecture/src/mcp.test.ts
+++ b/packages/architecture/src/mcp.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { listStyleGuides, getStyleGuideTool, getTypologyTool, validateStyleGuideTool } from './mcp.js';
+import {
+  listStyleGuides, getStyleGuideTool, getTypologyTool, validateStyleGuideTool,
+  listStyleGuides as _ls, getStyleGuideTool as _gs, getTypologyTool as _gt,
+} from './mcp.js';
 
 describe('architecture_list_style_guides', () => {
   it('returns metadata for all 11 seed guides', () => {
@@ -104,5 +107,30 @@ describe('architecture_validate_style_guide', () => {
     });
     expect(out.ok).toBe(false);
     if (!out.ok) expect(out.errors.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('determinism — byte-identical JSON across calls', () => {
+  it('list_style_guides', () => {
+    expect(JSON.stringify(_ls())).toBe(JSON.stringify(_ls()));
+  });
+  it('get_style_guide on every seed id', () => {
+    const ids = _ls().guides.map(g => g.id);
+    for (const id of ids) {
+      expect(JSON.stringify(_gs({ id }))).toBe(JSON.stringify(_gs({ id })));
+    }
+  });
+  it('get_typology on every seed typology', () => {
+    const seen = new Set<string>();
+    for (const meta of _ls().guides) {
+      const g = _gs({ id: meta.id });
+      if ('guide' in g) {
+        for (const w of g.guide.typologyWeights) seen.add(w.typologyId);
+      }
+    }
+    expect(seen.size).toBeGreaterThan(0);
+    for (const id of seen) {
+      expect(JSON.stringify(_gt({ id }))).toBe(JSON.stringify(_gt({ id })));
+    }
   });
 });

--- a/packages/architecture/src/mcp.ts
+++ b/packages/architecture/src/mcp.ts
@@ -1,0 +1,54 @@
+import {
+  listStyleGuideMeta,
+  getStyleGuide as registryGetStyleGuide,
+  getTypology as registryGetTypology,
+  type StyleGuideMeta,
+} from './registry.js';
+import { validateStyleGuide, type ValidationError } from './validate.js';
+import type { StyleGuide, Typology } from './schema.js';
+
+// ─── list_style_guides ──────────────────────────────────────────────────────
+
+export interface ListStyleGuidesResult {
+  guides: StyleGuideMeta[];
+}
+
+export function listStyleGuides(): ListStyleGuidesResult {
+  return { guides: listStyleGuideMeta() };
+}
+
+// ─── get_style_guide ────────────────────────────────────────────────────────
+
+export type GetStyleGuideResult =
+  | { guide: StyleGuide }
+  | { error: 'not_found'; id: string };
+
+export function getStyleGuideTool(args: { id: string }): GetStyleGuideResult {
+  const g = registryGetStyleGuide(args.id);
+  if (!g) return { error: 'not_found', id: args.id };
+  return { guide: g };
+}
+
+// ─── get_typology ────────────────────────────────────────────────────────────
+
+export type GetTypologyResult =
+  | { typology: Typology }
+  | { error: 'not_found'; id: string };
+
+export function getTypologyTool(args: { id: string }): GetTypologyResult {
+  const t = registryGetTypology(args.id);
+  if (!t) return { error: 'not_found', id: args.id };
+  return { typology: t };
+}
+
+// ─── validate_style_guide ────────────────────────────────────────────────────
+
+export type ValidateStyleGuideResult =
+  | { ok: true }
+  | { ok: false; errors: ValidationError[] };
+
+export function validateStyleGuideTool(args: { json: unknown }): ValidateStyleGuideResult {
+  const errs = validateStyleGuide(args.json, '');
+  if (errs.length === 0) return { ok: true };
+  return { ok: false, errors: errs };
+}

--- a/packages/architecture/src/registry.test.ts
+++ b/packages/architecture/src/registry.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+  loadRegistry, listStyleGuideMeta, getStyleGuide, getTypology,
+  ArchitectureRegistryError,
+} from './registry.js';
+
+describe('registry', () => {
+  it('loads the bundled seed data without errors', () => {
+    expect(() => loadRegistry()).not.toThrow();
+  });
+
+  it('exposes all 10 typologies', () => {
+    const reg = loadRegistry();
+    expect(reg.typologyIds.size).toBe(10);
+    expect(reg.typologyIds.has('peasant_home')).toBe(true);
+  });
+
+  it('exposes all 11 style guides', () => {
+    expect(listStyleGuideMeta().length).toBe(11);
+  });
+
+  it('every typologyId referenced from a guide resolves', () => {
+    const reg = loadRegistry();
+    for (const guide of reg.styleGuidesById.values()) {
+      for (const w of guide.typologyWeights) {
+        expect(reg.typologyIds.has(w.typologyId)).toBe(true);
+      }
+    }
+  });
+
+  it('getStyleGuide returns the embedded sheet for a known id', () => {
+    const g = getStyleGuide('medieval-european-gothic');
+    expect(g).not.toBeNull();
+    expect(g!.styleSheet.cultureId).toBe('medieval-european');
+  });
+
+  it('getStyleGuide returns null for unknown id', () => {
+    expect(getStyleGuide('not-a-real-id')).toBeNull();
+  });
+
+  it('getTypology returns null for unknown id', () => {
+    expect(getTypology('not-a-real-id')).toBeNull();
+  });
+
+  it('loadRegistry is idempotent and returns the same cached object', () => {
+    expect(loadRegistry()).toBe(loadRegistry());
+  });
+});

--- a/packages/architecture/src/registry.test.ts
+++ b/packages/architecture/src/registry.test.ts
@@ -46,3 +46,41 @@ describe('registry', () => {
     expect(loadRegistry()).toBe(loadRegistry());
   });
 });
+
+describe('cross-pillar contract — every guide ref resolves', () => {
+  it('no dangling typologyId in any seed StyleGuide', () => {
+    const reg = loadRegistry();
+    const missing: Array<{ guide: string; typologyId: string }> = [];
+    for (const guide of reg.styleGuidesById.values()) {
+      for (const w of guide.typologyWeights) {
+        if (!reg.typologyIds.has(w.typologyId)) {
+          missing.push({ guide: guide.id, typologyId: w.typologyId });
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('every guide has at least one typology weight', () => {
+    const reg = loadRegistry();
+    for (const guide of reg.styleGuidesById.values()) {
+      expect(guide.typologyWeights.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('within a culture, overlapping dateRanges are detected (warning surface)', () => {
+    const reg = loadRegistry();
+    const byCulture = new Map<string, Array<{ id: string; range: [number, number] }>>();
+    for (const guide of reg.styleGuidesById.values()) {
+      const list = byCulture.get(guide.styleSheet.cultureId) ?? [];
+      list.push({ id: guide.id, range: guide.styleSheet.dateRange });
+      byCulture.set(guide.styleSheet.cultureId, list);
+    }
+    // Tiebreaker rule per spec: highest endYear wins. This asserts the data is
+    // well-formed enough that A5 selection has a deterministic answer.
+    for (const [_culture, list] of byCulture) {
+      const sorted = [...list].sort((a, b) => b.range[1] - a.range[1]);
+      expect(sorted[0]).toBeDefined();
+    }
+  });
+});

--- a/packages/architecture/src/registry.test.ts
+++ b/packages/architecture/src/registry.test.ts
@@ -1,8 +1,68 @@
 import { describe, it, expect } from 'vitest';
 import {
   loadRegistry, listStyleGuideMeta, getStyleGuide, getTypology,
-  ArchitectureRegistryError,
+  buildRegistry, ArchitectureRegistryError,
+  _resetRegistryCacheForTests,
 } from './registry.js';
+
+const validTypology = {
+  id: 'peasant_home',
+  footprint: { kind: 'rectangle', aspectRatio: [1, 2], areaRange: [25, 80] },
+  storyRange: [1, 2],
+  fenestrationDensity: [0.05, 0.15],
+};
+const validSheet = {
+  id: 's', cultureId: 'c', dateRange: [0, 100],
+  core: { primaryMaterial: 'timber', roofType: 'thatch', ornamentation: [] },
+  extras: {},
+};
+const validGuide = {
+  id: 'g', styleSheet: validSheet,
+  typologyWeights: [{ typologyId: 'peasant_home', weight: 1 }],
+};
+
+describe('buildRegistry error paths', () => {
+  it('throws ArchitectureRegistryError when a guide refs an unknown typology', () => {
+    const badGuide = { ...validGuide, typologyWeights: [{ typologyId: 'unknown_t', weight: 1 }] };
+    expect(() => buildRegistry([validTypology], [badGuide])).toThrow(ArchitectureRegistryError);
+  });
+
+  it('throws on duplicate typology ids', () => {
+    expect(() => buildRegistry([validTypology, validTypology], [validGuide]))
+      .toThrow(ArchitectureRegistryError);
+  });
+
+  it('throws on duplicate styleGuide ids', () => {
+    expect(() => buildRegistry([validTypology], [validGuide, { ...validGuide }]))
+      .toThrow(ArchitectureRegistryError);
+  });
+
+  it('throws on structurally malformed guide (rejected by validateStyleGuide)', () => {
+    expect(() => buildRegistry([validTypology], [{ id: '', styleSheet: validSheet, typologyWeights: [] }]))
+      .toThrow(ArchitectureRegistryError);
+  });
+
+  it('error carries the structured ValidationError list', () => {
+    try {
+      buildRegistry([validTypology], [{ ...validGuide, typologyWeights: [{ typologyId: 'unknown_t', weight: 1 }] }]);
+      expect.fail('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ArchitectureRegistryError);
+      expect((e as ArchitectureRegistryError).errors.length).toBeGreaterThan(0);
+      expect((e as ArchitectureRegistryError).errors[0].path).toMatch(/typologyId/);
+    }
+  });
+});
+
+describe('_resetRegistryCacheForTests', () => {
+  it('drops the cache so the next loadRegistry rebuilds', () => {
+    const before = loadRegistry();
+    _resetRegistryCacheForTests();
+    const after = loadRegistry();
+    expect(before).not.toBe(after);   // distinct object after reset
+    expect(after.typologyIds.size).toBe(before.typologyIds.size);  // same data
+  });
+});
 
 describe('registry', () => {
   it('loads the bundled seed data without errors', () => {

--- a/packages/architecture/src/registry.ts
+++ b/packages/architecture/src/registry.ts
@@ -36,19 +36,14 @@ export interface Registry {
 
 let CACHED: Registry | null = null;
 
-export function loadRegistry(): Registry {
-  if (CACHED) return CACHED;
-
+export function buildRegistry(
+  rawTypos: unknown[],
+  rawGuides: unknown[],
+): Registry {
   const errors: ValidationError[] = [];
   const typologies = new Map<string, Typology>();
   const typologyIds = new Set<string>();
 
-  const rawTypos = (typologiesFile as { typologies?: unknown[] }).typologies;
-  if (!Array.isArray(rawTypos)) {
-    throw new ArchitectureRegistryError([
-      { path: '/typologies', message: 'typologies.json missing "typologies" array' },
-    ]);
-  }
   rawTypos.forEach((t, i) => {
     const errs = validateTypology(t, `/typologies/${i}`);
     if (errs.length === 0) {
@@ -67,7 +62,7 @@ export function loadRegistry(): Registry {
   const styleGuidesById = new Map<string, StyleGuide>();
   const styleGuideOrder: string[] = [];
 
-  RAW_GUIDES.forEach((g, i) => {
+  rawGuides.forEach((g, i) => {
     const path = `/styleGuides/${i}`;
     const errs = validateStyleGuide(g, path);
     if (errs.length > 0) {
@@ -92,11 +87,24 @@ export function loadRegistry(): Registry {
     throw new ArchitectureRegistryError(errors);
   }
 
-  CACHED = {
+  return {
     typologies, typologyIds,
     styleGuidesById,
     styleGuideOrder: Object.freeze([...styleGuideOrder]),
   };
+}
+
+export function loadRegistry(): Registry {
+  if (CACHED) return CACHED;
+
+  const rawTypos = (typologiesFile as { typologies?: unknown[] }).typologies;
+  if (!Array.isArray(rawTypos)) {
+    throw new ArchitectureRegistryError([
+      { path: '/typologies', message: 'typologies.json missing "typologies" array' },
+    ]);
+  }
+
+  CACHED = buildRegistry(rawTypos, RAW_GUIDES);
   return CACHED;
 }
 

--- a/packages/architecture/src/registry.ts
+++ b/packages/architecture/src/registry.ts
@@ -1,0 +1,136 @@
+import {
+  validateTypology, validateStyleGuide, validateStyleGuideRefs,
+  ArchitectureSchemaError, type ValidationError,
+} from './validate.js';
+import type { StyleGuide, Typology } from './schema.js';
+
+import typologiesFile from './data/typologies.json' with { type: 'json' };
+
+import g01 from './data/style-guides/medieval-european-carolingian.json' with { type: 'json' };
+import g02 from './data/style-guides/medieval-european-romanesque.json' with { type: 'json' };
+import g03 from './data/style-guides/medieval-european-gothic.json' with { type: 'json' };
+import g04 from './data/style-guides/tang-chinese-7c.json' with { type: 'json' };
+import g05 from './data/style-guides/tang-chinese-9c.json' with { type: 'json' };
+import g06 from './data/style-guides/andean-inca.json' with { type: 'json' };
+import g07 from './data/style-guides/andean-pre-inca.json' with { type: 'json' };
+import g08 from './data/style-guides/hausa-classical.json' with { type: 'json' };
+import g09 from './data/style-guides/edo-japanese-early.json' with { type: 'json' };
+import g10 from './data/style-guides/edo-japanese-late.json' with { type: 'json' };
+import g11 from './data/style-guides/industrial-revolution-english.json' with { type: 'json' };
+
+const RAW_GUIDES: unknown[] = [g01, g02, g03, g04, g05, g06, g07, g08, g09, g10, g11];
+
+export class ArchitectureRegistryError extends Error {
+  constructor(public readonly errors: ValidationError[]) {
+    super(`@hayba/architecture: registry load failed (${errors.length} error(s))`);
+    this.name = 'ArchitectureRegistryError';
+  }
+}
+
+export interface Registry {
+  readonly typologies: ReadonlyMap<string, Typology>;
+  readonly typologyIds: ReadonlySet<string>;
+  readonly styleGuidesById: ReadonlyMap<string, StyleGuide>;
+  readonly styleGuideOrder: readonly string[];
+}
+
+let CACHED: Registry | null = null;
+
+export function loadRegistry(): Registry {
+  if (CACHED) return CACHED;
+
+  const errors: ValidationError[] = [];
+  const typologies = new Map<string, Typology>();
+  const typologyIds = new Set<string>();
+
+  const rawTypos = (typologiesFile as { typologies?: unknown[] }).typologies;
+  if (!Array.isArray(rawTypos)) {
+    throw new ArchitectureRegistryError([
+      { path: '/typologies', message: 'typologies.json missing "typologies" array' },
+    ]);
+  }
+  rawTypos.forEach((t, i) => {
+    const errs = validateTypology(t, `/typologies/${i}`);
+    if (errs.length === 0) {
+      const typed = t as Typology;
+      if (typologies.has(typed.id)) {
+        errors.push({ path: `/typologies/${i}/id`, message: `duplicate typology id ${JSON.stringify(typed.id)}` });
+      } else {
+        typologies.set(typed.id, typed);
+        typologyIds.add(typed.id);
+      }
+    } else {
+      errors.push(...errs);
+    }
+  });
+
+  const styleGuidesById = new Map<string, StyleGuide>();
+  const styleGuideOrder: string[] = [];
+
+  RAW_GUIDES.forEach((g, i) => {
+    const path = `/styleGuides/${i}`;
+    const errs = validateStyleGuide(g, path);
+    if (errs.length > 0) {
+      errors.push(...errs);
+      return;
+    }
+    const typed = g as StyleGuide;
+    if (styleGuidesById.has(typed.id)) {
+      errors.push({ path: `${path}/id`, message: `duplicate styleGuide id ${JSON.stringify(typed.id)}` });
+      return;
+    }
+    const refErrs = validateStyleGuideRefs(typed, typologyIds, path);
+    if (refErrs.length > 0) {
+      errors.push(...refErrs);
+      return;
+    }
+    styleGuidesById.set(typed.id, typed);
+    styleGuideOrder.push(typed.id);
+  });
+
+  if (errors.length > 0) {
+    throw new ArchitectureRegistryError(errors);
+  }
+
+  CACHED = {
+    typologies, typologyIds,
+    styleGuidesById,
+    styleGuideOrder: Object.freeze([...styleGuideOrder]),
+  };
+  return CACHED;
+}
+
+/** Test-only: drop the cache. NOT exposed via package index. */
+export function _resetRegistryCacheForTests(): void {
+  CACHED = null;
+}
+
+export interface StyleGuideMeta {
+  id: string;
+  cultureId: string;
+  dateRange: [number, number];
+  typologyCount: number;
+}
+
+export function listStyleGuideMeta(): StyleGuideMeta[] {
+  const reg = loadRegistry();
+  return reg.styleGuideOrder.map(id => {
+    const g = reg.styleGuidesById.get(id)!;
+    return {
+      id: g.id,
+      cultureId: g.styleSheet.cultureId,
+      dateRange: g.styleSheet.dateRange,
+      typologyCount: g.typologyWeights.length,
+    };
+  });
+}
+
+export function getStyleGuide(id: string): StyleGuide | null {
+  return loadRegistry().styleGuidesById.get(id) ?? null;
+}
+
+export function getTypology(id: string): Typology | null {
+  return loadRegistry().typologies.get(id) ?? null;
+}
+
+export { ArchitectureSchemaError };

--- a/packages/architecture/src/schema.test.ts
+++ b/packages/architecture/src/schema.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type {
+  FeatureBundle, RoofType, PrimaryMaterial, FootprintShape,
+  Typology, StyleSheet, StyleGuide,
+} from './schema.js';
+
+describe('schema types', () => {
+  it('FeatureBundle accepts string and string[] values', () => {
+    const bundle: FeatureBundle = { roof: 'gable', tags: ['rural', 'old'] };
+    expectTypeOf(bundle).toMatchTypeOf<Readonly<Record<string, string | readonly string[]>>>();
+  });
+
+  it('FootprintShape is a discriminated union of 5 kinds', () => {
+    const kinds: FootprintShape['kind'][] =
+      ['rectangle', 'linear-row', 'L-shape', 'U-shape', 'courtyard'];
+    expectTypeOf(kinds).toMatchTypeOf<Array<FootprintShape['kind']>>();
+  });
+
+  it('Typology has the expected required fields', () => {
+    const t: Typology = {
+      id: 'peasant_home',
+      footprint: { kind: 'rectangle', aspectRatio: [1, 2], areaRange: [25, 80] },
+      storyRange: [1, 2],
+      fenestrationDensity: [0.05, 0.15],
+    };
+    expectTypeOf(t.id).toBeString();
+    expectTypeOf(t.storyRange).toEqualTypeOf<[number, number]>();
+  });
+
+  it('StyleSheet carries cultureId, dateRange, core, extras', () => {
+    const s: StyleSheet = {
+      id: 'test',
+      cultureId: 'medieval-european',
+      dateRange: [1140, 1400],
+      core: { primaryMaterial: 'stone', roofType: 'gable', ornamentation: [] },
+      extras: {},
+    };
+    expectTypeOf(s.cultureId).toBeString();
+    expectTypeOf(s.dateRange).toEqualTypeOf<[number, number]>();
+  });
+
+  it('StyleGuide embeds StyleSheet by value and lists typology weights', () => {
+    const g: StyleGuide = {
+      id: 'test-guide',
+      styleSheet: {
+        id: 'test-sheet', cultureId: 'c', dateRange: [0, 1],
+        core: { primaryMaterial: 'timber', roofType: 'thatch', ornamentation: [] },
+        extras: {},
+      },
+      typologyWeights: [{ typologyId: 'peasant_home', weight: 1 }],
+    };
+    expectTypeOf(g.styleSheet).toMatchTypeOf<StyleSheet>();
+    expectTypeOf(g.typologyWeights).toEqualTypeOf<ReadonlyArray<{ typologyId: string; weight: number }>>();
+  });
+});

--- a/packages/architecture/src/schema.ts
+++ b/packages/architecture/src/schema.ts
@@ -1,0 +1,65 @@
+/**
+ * @hayba/architecture — schema definitions.
+ *
+ * Three artifacts: Typology (structural), StyleSheet (cosmetic),
+ * StyleGuide (binds the two). All by-value, all readonly-safe.
+ */
+
+export type FeatureBundle = Readonly<Record<string, string | readonly string[]>>;
+
+export type RoofType =
+  | 'gable' | 'hip' | 'flat' | 'pagoda' | 'thatch' | 'dome' | 'shed' | 'mansard';
+
+export const ROOF_TYPES = [
+  'gable', 'hip', 'flat', 'pagoda', 'thatch', 'dome', 'shed', 'mansard',
+] as const satisfies readonly RoofType[];
+
+export type PrimaryMaterial =
+  | 'stone' | 'timber' | 'mudbrick' | 'adobe' | 'rammed-earth'
+  | 'brick' | 'concrete' | 'wattle-daub';
+
+export const PRIMARY_MATERIALS = [
+  'stone', 'timber', 'mudbrick', 'adobe', 'rammed-earth',
+  'brick', 'concrete', 'wattle-daub',
+] as const satisfies readonly PrimaryMaterial[];
+
+export type FootprintKind =
+  | 'rectangle' | 'linear-row' | 'L-shape' | 'U-shape' | 'courtyard';
+
+export const FOOTPRINT_KINDS = [
+  'rectangle', 'linear-row', 'L-shape', 'U-shape', 'courtyard',
+] as const satisfies readonly FootprintKind[];
+
+export type FootprintShape =
+  | { kind: 'rectangle';  aspectRatio:        [number, number]; areaRange:        [number, number] }
+  | { kind: 'linear-row'; widthRange:         [number, number]; depthRange:       [number, number] }
+  | { kind: 'L-shape';    wingDepth:          [number, number]; courtyardFraction:[number, number] }
+  | { kind: 'U-shape';    wingDepth:          [number, number]; openingWidth:     [number, number] }
+  | { kind: 'courtyard';  courtyardFraction:  [number, number]; wingDepth:        [number, number] };
+
+export interface Typology {
+  id: string;
+  footprint: FootprintShape;
+  storyRange: [number, number];
+  fenestrationDensity: [number, number];
+  pathfindingHints?: Readonly<Record<string, string>>;
+}
+
+export interface StyleSheet {
+  id: string;
+  cultureId: string;
+  dateRange: [number, number];
+  core: {
+    primaryMaterial: PrimaryMaterial;
+    secondaryMaterial?: PrimaryMaterial;
+    roofType: RoofType;
+    ornamentation: readonly string[];
+  };
+  extras: FeatureBundle;
+}
+
+export interface StyleGuide {
+  id: string;
+  styleSheet: StyleSheet;
+  typologyWeights: ReadonlyArray<{ typologyId: string; weight: number }>;
+}

--- a/packages/architecture/src/smoke.test.ts
+++ b/packages/architecture/src/smoke.test.ts
@@ -1,8 +1,0 @@
-import { describe, it, expect } from 'vitest';
-import { PACKAGE_NAME } from './index.js';
-
-describe('package smoke', () => {
-  it('exports the package name', () => {
-    expect(PACKAGE_NAME).toBe('@hayba/architecture');
-  });
-});

--- a/packages/architecture/src/smoke.test.ts
+++ b/packages/architecture/src/smoke.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { PACKAGE_NAME } from './index.js';
+
+describe('package smoke', () => {
+  it('exports the package name', () => {
+    expect(PACKAGE_NAME).toBe('@hayba/architecture');
+  });
+});

--- a/packages/architecture/src/validate.test.ts
+++ b/packages/architecture/src/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateFootprintShape } from './validate.js';
+import { validateFootprintShape, validateTypology } from './validate.js';
 
 describe('validateFootprintShape', () => {
   it('accepts a well-formed rectangle', () => {
@@ -37,5 +37,46 @@ describe('validateFootprintShape', () => {
       '/footprint',
     );
     expect(errs.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('validateTypology', () => {
+  const valid = {
+    id: 'peasant_home',
+    footprint: { kind: 'rectangle', aspectRatio: [1, 2], areaRange: [25, 80] },
+    storyRange: [1, 2],
+    fenestrationDensity: [0.05, 0.15],
+  };
+
+  it('accepts a well-formed typology', () => {
+    expect(validateTypology(valid, '/typology')).toEqual([]);
+  });
+
+  it('rejects empty id', () => {
+    const errs = validateTypology({ ...valid, id: '' }, '/typology');
+    expect(errs.some(e => e.path === '/typology/id')).toBe(true);
+  });
+
+  it('rejects missing footprint', () => {
+    const { footprint: _footprint, ...rest } = valid;
+    const errs = validateTypology(rest, '/typology');
+    expect(errs.some(e => e.path.startsWith('/typology/footprint'))).toBe(true);
+  });
+
+  it('rejects story range with min > max', () => {
+    const errs = validateTypology({ ...valid, storyRange: [3, 1] }, '/typology');
+    expect(errs.some(e => e.path === '/typology/storyRange')).toBe(true);
+  });
+
+  it('rejects fenestrationDensity > 1', () => {
+    const errs = validateTypology({ ...valid, fenestrationDensity: [0.05, 1.5] }, '/typology');
+    expect(errs.some(e => e.path.startsWith('/typology/fenestrationDensity'))).toBe(true);
+  });
+
+  it('accepts optional pathfindingHints record', () => {
+    const errs = validateTypology(
+      { ...valid, pathfindingHints: { footTraffic: 'high' } }, '/typology',
+    );
+    expect(errs).toEqual([]);
   });
 });

--- a/packages/architecture/src/validate.test.ts
+++ b/packages/architecture/src/validate.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { validateFootprintShape, validateTypology, validateStyleSheet } from './validate.js';
+import {
+  validateFootprintShape, validateTypology, validateStyleSheet,
+  validateStyleGuide, validateStyleGuideRefs,
+} from './validate.js';
 
 describe('validateFootprintShape', () => {
   it('accepts a well-formed rectangle', () => {
@@ -125,5 +128,68 @@ describe('validateStyleSheet', () => {
     const bad = { ...valid, dateRange: [1400, 1140] };
     const errs = validateStyleSheet(bad, '/sheet');
     expect(errs.some(e => e.path === '/sheet/dateRange')).toBe(true);
+  });
+});
+
+describe('validateStyleGuide', () => {
+  const sheet = {
+    id: 's1', cultureId: 'c', dateRange: [0, 100],
+    core: { primaryMaterial: 'timber', roofType: 'thatch', ornamentation: [] },
+    extras: {},
+  };
+  const valid = {
+    id: 'g1',
+    styleSheet: sheet,
+    typologyWeights: [
+      { typologyId: 'peasant_home', weight: 1 },
+      { typologyId: 'townhouse',    weight: 2.5 },
+    ],
+  };
+
+  it('accepts a well-formed guide', () => {
+    expect(validateStyleGuide(valid, '/g')).toEqual([]);
+  });
+
+  it('rejects empty typologyWeights', () => {
+    const errs = validateStyleGuide({ ...valid, typologyWeights: [] }, '/g');
+    expect(errs.some(e => e.path === '/g/typologyWeights')).toBe(true);
+  });
+
+  it('rejects zero/negative weight', () => {
+    const bad = {
+      ...valid,
+      typologyWeights: [{ typologyId: 'peasant_home', weight: 0 }],
+    };
+    const errs = validateStyleGuide(bad, '/g');
+    expect(errs.some(e => e.path === '/g/typologyWeights/0/weight')).toBe(true);
+  });
+
+  it('rejects malformed embedded styleSheet', () => {
+    const bad = { ...valid, styleSheet: { ...sheet, core: { ...sheet.core, roofType: 'X' } } };
+    const errs = validateStyleGuide(bad, '/g');
+    expect(errs.some(e => e.path === '/g/styleSheet/core/roofType')).toBe(true);
+  });
+});
+
+describe('validateStyleGuideRefs', () => {
+  const sheet = {
+    id: 's', cultureId: 'c', dateRange: [0, 1],
+    core: { primaryMaterial: 'timber', roofType: 'thatch', ornamentation: [] },
+    extras: {},
+  };
+  const guide = {
+    id: 'g', styleSheet: sheet,
+    typologyWeights: [{ typologyId: 'peasant_home', weight: 1 }],
+  };
+
+  it('returns no errors when all typology refs resolve', () => {
+    expect(validateStyleGuideRefs(guide as never, new Set(['peasant_home']), '/g')).toEqual([]);
+  });
+
+  it('reports dangling typology references', () => {
+    const errs = validateStyleGuideRefs(guide as never, new Set(['townhouse']), '/g');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].path).toBe('/g/typologyWeights/0/typologyId');
+    expect(errs[0].message).toMatch(/peasant_home/);
   });
 });

--- a/packages/architecture/src/validate.test.ts
+++ b/packages/architecture/src/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateFootprintShape, validateTypology } from './validate.js';
+import { validateFootprintShape, validateTypology, validateStyleSheet } from './validate.js';
 
 describe('validateFootprintShape', () => {
   it('accepts a well-formed rectangle', () => {
@@ -78,5 +78,52 @@ describe('validateTypology', () => {
       { ...valid, pathfindingHints: { footTraffic: 'high' } }, '/typology',
     );
     expect(errs).toEqual([]);
+  });
+});
+
+describe('validateStyleSheet', () => {
+  const valid = {
+    id: 'medieval-european-gothic',
+    cultureId: 'medieval-european',
+    dateRange: [1140, 1400],
+    core: {
+      primaryMaterial: 'stone',
+      roofType: 'gable',
+      ornamentation: ['pointed-arch', 'flying-buttress'],
+    },
+    extras: { stainedGlass: 'present' },
+  };
+
+  it('accepts a well-formed sheet', () => {
+    expect(validateStyleSheet(valid, '/sheet')).toEqual([]);
+  });
+
+  it('rejects unknown roofType', () => {
+    const bad = { ...valid, core: { ...valid.core, roofType: 'tepee' } };
+    const errs = validateStyleSheet(bad, '/sheet');
+    expect(errs.some(e => e.path === '/sheet/core/roofType')).toBe(true);
+  });
+
+  it('rejects unknown primaryMaterial', () => {
+    const bad = { ...valid, core: { ...valid.core, primaryMaterial: 'plasma' } };
+    const errs = validateStyleSheet(bad, '/sheet');
+    expect(errs.some(e => e.path === '/sheet/core/primaryMaterial')).toBe(true);
+  });
+
+  it('rejects extras with non-string-non-array value', () => {
+    const bad = { ...valid, extras: { count: 42 } };
+    const errs = validateStyleSheet(bad, '/sheet');
+    expect(errs.some(e => e.path === '/sheet/extras/count')).toBe(true);
+  });
+
+  it('accepts extras with string[] values', () => {
+    const ok = { ...valid, extras: { tags: ['rural', 'old'] } };
+    expect(validateStyleSheet(ok, '/sheet')).toEqual([]);
+  });
+
+  it('rejects dateRange with negative endYear smaller than startYear', () => {
+    const bad = { ...valid, dateRange: [1400, 1140] };
+    const errs = validateStyleSheet(bad, '/sheet');
+    expect(errs.some(e => e.path === '/sheet/dateRange')).toBe(true);
   });
 });

--- a/packages/architecture/src/validate.test.ts
+++ b/packages/architecture/src/validate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { validateFootprintShape } from './validate.js';
+
+describe('validateFootprintShape', () => {
+  it('accepts a well-formed rectangle', () => {
+    const errs = validateFootprintShape(
+      { kind: 'rectangle', aspectRatio: [1, 2], areaRange: [25, 100] },
+      '/footprint',
+    );
+    expect(errs).toEqual([]);
+  });
+
+  it('rejects unknown kind', () => {
+    const errs = validateFootprintShape({ kind: 'pentagon' } as unknown, '/footprint');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].path).toBe('/footprint/kind');
+    expect(errs[0].message).toMatch(/unknown footprint kind/i);
+  });
+
+  it('rejects reversed aspect ratio', () => {
+    const errs = validateFootprintShape(
+      { kind: 'rectangle', aspectRatio: [3, 1], areaRange: [25, 100] },
+      '/footprint',
+    );
+    expect(errs.some(e => e.path === '/footprint/aspectRatio')).toBe(true);
+  });
+
+  it('rejects non-array input', () => {
+    const errs = validateFootprintShape('not an object' as unknown, '/footprint');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].path).toBe('/footprint');
+  });
+
+  it('surfaces multiple errors for a malformed L-shape', () => {
+    const errs = validateFootprintShape(
+      { kind: 'L-shape', wingDepth: [5, 2], courtyardFraction: [-1, 0.5] },
+      '/footprint',
+    );
+    expect(errs.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/architecture/src/validate.ts
+++ b/packages/architecture/src/validate.ts
@@ -1,0 +1,252 @@
+import {
+  FOOTPRINT_KINDS, PRIMARY_MATERIALS, ROOF_TYPES,
+  type FootprintShape, type FootprintKind,
+  type Typology, type StyleSheet, type StyleGuide,
+} from './schema.js';
+
+export interface ValidationError {
+  path: string;       // JSON-pointer style, e.g. "/typologies/3/footprint/aspectRatio"
+  message: string;
+}
+
+export class ArchitectureSchemaError extends Error {
+  constructor(public readonly errors: ValidationError[]) {
+    super(`@hayba/architecture: ${errors.length} validation error(s)`);
+    this.name = 'ArchitectureSchemaError';
+  }
+}
+
+/** Shared helper: `[min, max]` tuple with min ≤ max and both finite. */
+export function validateRange(
+  value: unknown, path: string, opts: { minAllowed?: number } = {},
+): ValidationError[] {
+  const errs: ValidationError[] = [];
+  if (!Array.isArray(value) || value.length !== 2) {
+    return [{ path, message: 'expected [min, max] tuple of length 2' }];
+  }
+  const [lo, hi] = value;
+  if (typeof lo !== 'number' || !Number.isFinite(lo)) {
+    errs.push({ path: `${path}/0`, message: 'min must be a finite number' });
+  }
+  if (typeof hi !== 'number' || !Number.isFinite(hi)) {
+    errs.push({ path: `${path}/1`, message: 'max must be a finite number' });
+  }
+  if (typeof lo === 'number' && typeof hi === 'number' && lo > hi) {
+    errs.push({ path, message: `min (${lo}) must be ≤ max (${hi})` });
+  }
+  if (opts.minAllowed !== undefined && typeof lo === 'number' && lo < opts.minAllowed) {
+    errs.push({ path: `${path}/0`, message: `min must be ≥ ${opts.minAllowed}` });
+  }
+  return errs;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+export function validateFootprintShape(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const kind = value.kind;
+  if (typeof kind !== 'string' || !(FOOTPRINT_KINDS as readonly string[]).includes(kind)) {
+    return [{
+      path: `${path}/kind`,
+      message: `unknown footprint kind ${JSON.stringify(kind)}; expected one of ${FOOTPRINT_KINDS.join(', ')}`,
+    }];
+  }
+  const k = kind as FootprintKind;
+  const errs: ValidationError[] = [];
+  switch (k) {
+    case 'rectangle':
+      errs.push(...validateRange(value.aspectRatio, `${path}/aspectRatio`, { minAllowed: 0 }));
+      errs.push(...validateRange(value.areaRange,   `${path}/areaRange`,   { minAllowed: 0 }));
+      break;
+    case 'linear-row':
+      errs.push(...validateRange(value.widthRange, `${path}/widthRange`, { minAllowed: 0 }));
+      errs.push(...validateRange(value.depthRange, `${path}/depthRange`, { minAllowed: 0 }));
+      break;
+    case 'L-shape':
+      errs.push(...validateRange(value.wingDepth,         `${path}/wingDepth`,         { minAllowed: 0 }));
+      errs.push(...validateRange(value.courtyardFraction, `${path}/courtyardFraction`, { minAllowed: 0 }));
+      break;
+    case 'U-shape':
+      errs.push(...validateRange(value.wingDepth,    `${path}/wingDepth`,    { minAllowed: 0 }));
+      errs.push(...validateRange(value.openingWidth, `${path}/openingWidth`, { minAllowed: 0 }));
+      break;
+    case 'courtyard':
+      errs.push(...validateRange(value.courtyardFraction, `${path}/courtyardFraction`, { minAllowed: 0 }));
+      errs.push(...validateRange(value.wingDepth,         `${path}/wingDepth`,         { minAllowed: 0 }));
+      break;
+  }
+  return errs;
+}
+
+export function isFootprintShape(v: unknown): v is FootprintShape {
+  return validateFootprintShape(v, '/').length === 0;
+}
+
+export function validateTypology(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const errs: ValidationError[] = [];
+  if (typeof value.id !== 'string' || value.id.length === 0) {
+    errs.push({ path: `${path}/id`, message: 'id must be a non-empty string' });
+  }
+  errs.push(...validateFootprintShape(value.footprint, `${path}/footprint`));
+  errs.push(...validateRange(value.storyRange, `${path}/storyRange`, { minAllowed: 1 }));
+  errs.push(...validateRange(value.fenestrationDensity, `${path}/fenestrationDensity`, { minAllowed: 0 }));
+  if (Array.isArray(value.fenestrationDensity) && value.fenestrationDensity.length === 2) {
+    const hi = value.fenestrationDensity[1];
+    if (typeof hi === 'number' && hi > 1) {
+      errs.push({
+        path: `${path}/fenestrationDensity/1`,
+        message: `max must be ≤ 1 (got ${hi})`,
+      });
+    }
+  }
+  if (value.pathfindingHints !== undefined) {
+    if (!isPlainObject(value.pathfindingHints)) {
+      errs.push({ path: `${path}/pathfindingHints`, message: 'expected an object' });
+    } else {
+      for (const [k, v] of Object.entries(value.pathfindingHints)) {
+        if (typeof v !== 'string') {
+          errs.push({
+            path: `${path}/pathfindingHints/${k}`,
+            message: 'expected string value',
+          });
+        }
+      }
+    }
+  }
+  return errs;
+}
+
+export function isTypology(v: unknown): v is Typology {
+  return validateTypology(v, '/').length === 0;
+}
+
+function validateFeatureBundle(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const errs: ValidationError[] = [];
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === 'string') continue;
+    if (Array.isArray(v) && v.every(item => typeof item === 'string')) continue;
+    errs.push({
+      path: `${path}/${k}`,
+      message: 'expected string or string[] value',
+    });
+  }
+  return errs;
+}
+
+export function validateStyleSheet(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const errs: ValidationError[] = [];
+  if (typeof value.id !== 'string' || value.id.length === 0) {
+    errs.push({ path: `${path}/id`, message: 'id must be a non-empty string' });
+  }
+  if (typeof value.cultureId !== 'string' || value.cultureId.length === 0) {
+    errs.push({ path: `${path}/cultureId`, message: 'cultureId must be a non-empty string' });
+  }
+  errs.push(...validateRange(value.dateRange, `${path}/dateRange`));
+
+  const core = value.core;
+  if (!isPlainObject(core)) {
+    errs.push({ path: `${path}/core`, message: 'expected an object' });
+  } else {
+    if (!(PRIMARY_MATERIALS as readonly string[]).includes(core.primaryMaterial as string)) {
+      errs.push({
+        path: `${path}/core/primaryMaterial`,
+        message: `unknown primaryMaterial ${JSON.stringify(core.primaryMaterial)}; expected one of ${PRIMARY_MATERIALS.join(', ')}`,
+      });
+    }
+    if (core.secondaryMaterial !== undefined &&
+        !(PRIMARY_MATERIALS as readonly string[]).includes(core.secondaryMaterial as string)) {
+      errs.push({
+        path: `${path}/core/secondaryMaterial`,
+        message: `unknown secondaryMaterial ${JSON.stringify(core.secondaryMaterial)}`,
+      });
+    }
+    if (!(ROOF_TYPES as readonly string[]).includes(core.roofType as string)) {
+      errs.push({
+        path: `${path}/core/roofType`,
+        message: `unknown roofType ${JSON.stringify(core.roofType)}; expected one of ${ROOF_TYPES.join(', ')}`,
+      });
+    }
+    if (!Array.isArray(core.ornamentation) ||
+        !core.ornamentation.every(s => typeof s === 'string')) {
+      errs.push({
+        path: `${path}/core/ornamentation`,
+        message: 'expected array of strings',
+      });
+    }
+  }
+  errs.push(...validateFeatureBundle(value.extras, `${path}/extras`));
+  return errs;
+}
+
+export function isStyleSheet(v: unknown): v is StyleSheet {
+  return validateStyleSheet(v, '/').length === 0;
+}
+
+export function validateStyleGuide(value: unknown, path: string): ValidationError[] {
+  if (!isPlainObject(value)) {
+    return [{ path, message: 'expected an object' }];
+  }
+  const errs: ValidationError[] = [];
+  if (typeof value.id !== 'string' || value.id.length === 0) {
+    errs.push({ path: `${path}/id`, message: 'id must be a non-empty string' });
+  }
+  errs.push(...validateStyleSheet(value.styleSheet, `${path}/styleSheet`));
+
+  if (!Array.isArray(value.typologyWeights)) {
+    errs.push({ path: `${path}/typologyWeights`, message: 'expected array' });
+  } else if (value.typologyWeights.length === 0) {
+    errs.push({ path: `${path}/typologyWeights`, message: 'must list at least one typology' });
+  } else {
+    value.typologyWeights.forEach((entry, i) => {
+      const ePath = `${path}/typologyWeights/${i}`;
+      if (!isPlainObject(entry)) {
+        errs.push({ path: ePath, message: 'expected an object' });
+        return;
+      }
+      if (typeof entry.typologyId !== 'string' || entry.typologyId.length === 0) {
+        errs.push({ path: `${ePath}/typologyId`, message: 'typologyId must be a non-empty string' });
+      }
+      if (typeof entry.weight !== 'number' || !Number.isFinite(entry.weight) || entry.weight <= 0) {
+        errs.push({ path: `${ePath}/weight`, message: 'weight must be a positive finite number' });
+      }
+    });
+  }
+  return errs;
+}
+
+export function isStyleGuide(v: unknown): v is StyleGuide {
+  return validateStyleGuide(v, '/').length === 0;
+}
+
+/**
+ * Cross-reference check: every `typologyId` referenced from `guide.typologyWeights`
+ * must exist in `knownTypologyIds`. Run AFTER `validateStyleGuide`; assumes
+ * the guide is structurally valid.
+ */
+export function validateStyleGuideRefs(
+  guide: StyleGuide, knownTypologyIds: ReadonlySet<string>, path: string,
+): ValidationError[] {
+  const errs: ValidationError[] = [];
+  guide.typologyWeights.forEach((entry, i) => {
+    if (!knownTypologyIds.has(entry.typologyId)) {
+      errs.push({
+        path: `${path}/typologyWeights/${i}/typologyId`,
+        message: `unknown typologyId ${JSON.stringify(entry.typologyId)}`,
+      });
+    }
+  });
+  return errs;
+}

--- a/packages/architecture/tsconfig.json
+++ b/packages/architecture/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.json"]
+}

--- a/packages/architecture/vitest.config.ts
+++ b/packages/architecture/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+      include: ['src/validate.ts', 'src/registry.ts', 'src/mcp.ts'],
+    },
+  },
+});

--- a/packages/hayba/dashboard/src/components/TitleBar.tsx
+++ b/packages/hayba/dashboard/src/components/TitleBar.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import './TitleBar.css';
 
-interface UEStatus { connected: boolean; }
+interface UEStatus {
+  connected: boolean;
+  visual_embeddings_available?: boolean;
+  active_models?: string[];
+  sidecar_url?: string;
+  sidecar_error?: string;
+}
 
 export function TitleBar({ currentTab, onTabChange }: {
   currentTab: string;
@@ -10,14 +16,27 @@ export function TitleBar({ currentTab, onTabChange }: {
   const [ueStatus, setUeStatus] = useState<UEStatus>({ connected: false });
 
   useEffect(() => {
-    fetch('/api/ue/status').then(r => r.json()).then(d => setUeStatus({ connected: d.connected })).catch(() => {});
-    const id = setInterval(() => {
-      fetch('/api/ue/status').then(r => r.json()).then(d => setUeStatus({ connected: d.connected })).catch(() => {});
-    }, 5000);
+    const refresh = () => {
+      fetch('/api/ue/status').then(r => r.json()).then(setUeStatus).catch(() => {});
+    };
+    refresh();
+    const id = setInterval(refresh, 5000);
     return () => clearInterval(id);
   }, []);
 
   const tabs = ['Projects', 'PCG', 'Linguistics', 'Settings'];
+
+  // Sidecar badge: 🟢 active models present, 🔴 unreachable / errored, 🟡 reachable but no models active.
+  const sidecarDot = ueStatus.sidecar_error
+    ? 'dot-red'
+    : ueStatus.visual_embeddings_available
+      ? 'dot-green'
+      : 'dot-orange';
+  const sidecarTitle = ueStatus.sidecar_error
+    ? `Visual sidecar unavailable: ${ueStatus.sidecar_error}`
+    : ueStatus.visual_embeddings_available
+      ? `Visual sidecar online — ${(ueStatus.active_models ?? []).join(', ')}`
+      : 'Visual sidecar reachable but no models active';
 
   return (
     <div className="titlebar">
@@ -36,6 +55,7 @@ export function TitleBar({ currentTab, onTabChange }: {
       <div className="titlebar-status">
         <span><span className={`dot ${ueStatus.connected ? 'dot-green' : 'dot-red'}`} /> UE 5.7</span>
         <span><span className="dot dot-orange" /> Gaea</span>
+        <span title={sidecarTitle}><span className={`dot ${sidecarDot}`} /> CLIP</span>
       </div>
     </div>
   );

--- a/packages/hayba/dashboard/src/pages/SettingsPage.tsx
+++ b/packages/hayba/dashboard/src/pages/SettingsPage.tsx
@@ -1,4 +1,135 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+interface SidecarStatus {
+  visual_embeddings_available?: boolean;
+  active_models?: string[];
+  sidecar_url?: string;
+  sidecar_error?: string;
+  connected?: boolean;
+  ueVersion?: string;
+  pluginVersion?: string;
+}
+
+const cardStyle: React.CSSProperties = {
+  background: 'var(--surface-1, #1a1a1a)',
+  border: '1px solid var(--border, #333)',
+  borderRadius: 6,
+  padding: 16,
+  marginBottom: 16,
+};
+
+const labelStyle: React.CSSProperties = { color: 'var(--text-muted, #888)', fontSize: 12, marginBottom: 4 };
+const valueStyle: React.CSSProperties = { color: 'var(--text, #ddd)', fontFamily: 'var(--font-mono, monospace)', fontSize: 13 };
+
 export function SettingsPage() {
-  return <div style={{ padding: 16, color: 'var(--text-muted)' }}>Settings — coming soon</div>;
+  const [status, setStatus] = useState<SidecarStatus | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      const r = await fetch('/api/ue/status');
+      setStatus(await r.json());
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const refreshSidecar = async () => {
+    setRefreshing(true);
+    try {
+      await fetch('/api/sidecar/refresh', { method: 'POST' });
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const sidecarBadge = status?.sidecar_error
+    ? { color: '#e54848', label: 'Offline' }
+    : status?.visual_embeddings_available
+      ? { color: '#3ad07a', label: 'Online' }
+      : { color: '#e8a73c', label: 'Reachable, no models' };
+
+  const ueBadge = status?.connected
+    ? { color: '#3ad07a', label: 'Connected' }
+    : { color: '#e54848', label: 'Disconnected' };
+
+  return (
+    <div style={{ padding: 16, maxWidth: 720 }}>
+      <h2 style={{ marginTop: 0 }}>Settings</h2>
+      {error && <div style={{ color: '#e54848', marginBottom: 16 }}>{error}</div>}
+
+      <section style={cardStyle}>
+        <h3 style={{ margin: '0 0 12px 0' }}>Unreal Engine</h3>
+        <div style={labelStyle}>Status</div>
+        <div style={valueStyle}>
+          <span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', background: ueBadge.color, marginRight: 6 }} />
+          {ueBadge.label}
+        </div>
+        {status?.ueVersion && (
+          <>
+            <div style={{ ...labelStyle, marginTop: 12 }}>UE version</div>
+            <div style={valueStyle}>{status.ueVersion}</div>
+          </>
+        )}
+        {status?.pluginVersion && (
+          <>
+            <div style={{ ...labelStyle, marginTop: 12 }}>HaybaMCPToolkit plugin</div>
+            <div style={valueStyle}>{status.pluginVersion}</div>
+          </>
+        )}
+      </section>
+
+      <section style={cardStyle}>
+        <h3 style={{ margin: '0 0 12px 0' }}>Visual Sidecar (CLIP)</h3>
+        <div style={labelStyle}>Status</div>
+        <div style={valueStyle}>
+          <span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', background: sidecarBadge.color, marginRight: 6 }} />
+          {sidecarBadge.label}
+        </div>
+
+        <div style={{ ...labelStyle, marginTop: 12 }}>Endpoint</div>
+        <div style={valueStyle}>{status?.sidecar_url ?? 'unknown'}</div>
+
+        <div style={{ ...labelStyle, marginTop: 12 }}>Active models</div>
+        <div style={valueStyle}>{status?.active_models?.length ? status.active_models.join(', ') : '—'}</div>
+
+        {status?.sidecar_error && (
+          <>
+            <div style={{ ...labelStyle, marginTop: 12 }}>Error</div>
+            <div style={{ ...valueStyle, color: '#e54848' }}>{status.sidecar_error}</div>
+          </>
+        )}
+
+        <button
+          onClick={refreshSidecar}
+          disabled={refreshing}
+          style={{
+            marginTop: 16,
+            padding: '6px 14px',
+            background: 'var(--accent, #3a7af0)',
+            color: '#fff',
+            border: 'none',
+            borderRadius: 4,
+            cursor: refreshing ? 'wait' : 'pointer',
+            opacity: refreshing ? 0.6 : 1,
+          }}
+        >
+          {refreshing ? 'Probing…' : 'Re-probe sidecar'}
+        </button>
+        <p style={{ ...labelStyle, marginTop: 12 }}>
+          Start the sidecar with{' '}
+          <code style={{ color: 'var(--text, #ddd)' }}>
+            uv run --project packages/hayba/addons/visual-embeddings -- uvicorn hayba_sidecar.server:app --port 7821
+          </code>
+        </p>
+      </section>
+    </div>
+  );
 }

--- a/packages/hayba/package.json
+++ b/packages/hayba/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hayba/architecture": "*",
     "@hayba/linguistics": "file:../linguistics",
     "@hayba/planet-physics": "file:../planet-physics",
     "@distube/ytdl-core": "^4.16.12",

--- a/packages/hayba/src/dashboard/api.ts
+++ b/packages/hayba/src/dashboard/api.ts
@@ -6,6 +6,7 @@ import { loadCatalog, searchCatalog, getCategories } from '../catalog.js';
 import { createProject, deleteProject, getProject, listProjects } from '../projects.js';
 import { submitZones, getCurrentZones, setHeightmap, getHeightmap, getPainterSession, lockPainter, unlockPainter, createScratchSession, submitScratchZones, getScratchZones } from '../zones.js';
 import { getEntries, addEntry, deleteEntry, getBaseTemplates } from '../encyclopedia.js';
+import { getCachedSidecarHealth, pingSidecar } from '../tools/visual/sidecar-client.js';
 
 /**
  * Register REST API endpoints for the dashboard.
@@ -49,21 +50,38 @@ export function registerApiRoutes(app: Express): void {
     }
   });
 
-  // UE status (ping)
+  // UE status (ping) + visual sidecar handshake
   app.get('/api/ue/status', async (_req: Request, res: Response) => {
+    const sidecar = getCachedSidecarHealth() ?? await pingSidecar();
+    const sidecarFields = {
+      visual_embeddings_available: sidecar.available,
+      active_models: sidecar.active_models,
+      sidecar_url: sidecar.url,
+      sidecar_error: sidecar.error,
+    };
     try {
       const client = getUEClient();
       if (!client.isConnected()) {
-        return res.json({ connected: false, error: 'Not connected to UE' });
+        return res.json({ connected: false, error: 'Not connected to UE', ...sidecarFields });
       }
       const response = await client.send('ping', {}, 5000);
       if (response.ok) {
-        res.json({ connected: true, ...response.data });
+        res.json({ connected: true, ...sidecarFields, ...response.data });
       } else {
-        res.json({ connected: false, error: response.error });
+        res.json({ connected: false, error: response.error, ...sidecarFields });
       }
     } catch (err) {
-      res.json({ connected: false, error: err instanceof Error ? err.message : 'Unknown error' });
+      res.json({ connected: false, error: err instanceof Error ? err.message : 'Unknown error', ...sidecarFields });
+    }
+  });
+
+  // Force a fresh sidecar probe (useful after launching the sidecar mid-session)
+  app.post('/api/sidecar/refresh', async (_req: Request, res: Response) => {
+    try {
+      const health = await pingSidecar();
+      res.json(health);
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'Unknown error' });
     }
   });
 

--- a/packages/hayba/src/index.ts
+++ b/packages/hayba/src/index.ts
@@ -5,6 +5,7 @@ import { config } from './config.js';
 import { listCatalogResources, readCatalogResource } from './resources.js';
 import { registerTools } from './tools/index.js';
 import { startDashboard } from './dashboard/server.js';
+import { pingSidecar } from './tools/visual/sidecar-client.js';
 
 // ── MCP server setup ─────────────────────────────────────────────────────────
 const server = new McpServer({
@@ -40,6 +41,17 @@ async function main() {
   await server.connect(transport);
   console.error(`Hayba MCP Toolkit v1.0.0 started on stdio`);
   console.error(`UE TCP target: ${config.ueTcpHost}:${config.ueTcpPort}`);
+
+  // Probe visual sidecar in the background — populates the cache so subsequent
+  // hayba_check_ue_status and visual tools can branch on availability without
+  // paying connect-timeout latency.
+  pingSidecar().then((h) => {
+    const badge = h.available ? '🟢' : '🔴';
+    const detail = h.available ? `models=${h.active_models.join(',') || 'none'}` : (h.error ?? 'unavailable');
+    console.error(`Visual sidecar ${badge} ${h.url} — ${detail}`);
+  }).catch((e) => {
+    console.error(`Visual sidecar probe failed: ${(e as Error).message}`);
+  });
 }
 
 main().catch(console.error);

--- a/packages/hayba/src/tools/check-ue-status.test.ts
+++ b/packages/hayba/src/tools/check-ue-status.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setCachedSidecarHealth } from './visual/sidecar-client.js';
+
+vi.mock('../tcp-client.js', () => ({
+  ensureConnected: vi.fn(async () => ({
+    send: async () => ({ ok: true, data: { status: 'idle', ueVersion: '5.4' } }),
+  })),
+}));
+
+describe('checkUeStatus / sidecar fields', () => {
+  beforeEach(() => setCachedSidecarHealth(null));
+  afterEach(() => setCachedSidecarHealth(null));
+
+  it('includes visual_embeddings_available + active_models from cached health', async () => {
+    setCachedSidecarHealth({
+      available: true,
+      url: 'http://localhost:7821',
+      models: { clip: true, owl_vit: true },
+      active_models: ['clip', 'owl_vit'],
+      checked_at: Date.now(),
+    });
+
+    const { checkUeStatus } = await import('./check-ue-status.js');
+    const status = await checkUeStatus();
+    expect(status.connected).toBe(true);
+    expect(status.visual_embeddings_available).toBe(true);
+    expect(status.active_models).toEqual(['clip', 'owl_vit']);
+    expect(status.sidecar_url).toBe('http://localhost:7821');
+  });
+
+  it('reports visual_embeddings_available=false when sidecar cache is unavailable', async () => {
+    setCachedSidecarHealth({
+      available: false,
+      url: 'http://localhost:7821',
+      models: {},
+      active_models: [],
+      error: 'ECONNREFUSED',
+      checked_at: Date.now(),
+    });
+
+    const { checkUeStatus } = await import('./check-ue-status.js');
+    const status = await checkUeStatus();
+    expect(status.visual_embeddings_available).toBe(false);
+    expect(status.active_models).toEqual([]);
+    expect(status.sidecar_error).toMatch(/ECONNREFUSED/);
+  });
+});

--- a/packages/hayba/src/tools/check-ue-status.ts
+++ b/packages/hayba/src/tools/check-ue-status.ts
@@ -1,14 +1,43 @@
 import { ensureConnected } from '../tcp-client.js';
+import { getCachedSidecarHealth, pingSidecar } from './visual/sidecar-client.js';
 
-export async function checkUeStatus() {
+export interface UeStatus {
+  connected: boolean;
+  error?: string;
+  visual_embeddings_available: boolean;
+  active_models: string[];
+  sidecar_url?: string;
+  sidecar_error?: string;
+  [key: string]: unknown;
+}
+
+export async function checkUeStatus(): Promise<UeStatus> {
+  // Sidecar — prefer cached snapshot (filled at startup); refresh on demand if
+  // we've never probed. Don't block UE status on sidecar latency.
+  let sidecar = getCachedSidecarHealth();
+  if (!sidecar) {
+    sidecar = await pingSidecar();
+  }
+
+  const sidecarFields = {
+    visual_embeddings_available: sidecar.available,
+    active_models: sidecar.active_models,
+    sidecar_url: sidecar.url,
+    sidecar_error: sidecar.error,
+  };
+
   try {
     const client = await ensureConnected();
     const response = await client.send('ping', {}, 5000);
     if (response.ok && response.data) {
-      return { connected: true, ...response.data };
+      return { connected: true, ...sidecarFields, ...(response.data as Record<string, unknown>) };
     }
-    return { connected: false, error: response.error };
+    return { connected: false, error: response.error, ...sidecarFields };
   } catch (err) {
-    return { connected: false, error: err instanceof Error ? err.message : 'Unknown error' };
+    return {
+      connected: false,
+      error: err instanceof Error ? err.message : 'Unknown error',
+      ...sidecarFields,
+    };
   }
 }

--- a/packages/hayba/src/tools/index.ts
+++ b/packages/hayba/src/tools/index.ts
@@ -55,6 +55,16 @@ import {
   wordForSchema,
 } from './worldbuilding/language-handlers.js';
 import {
+  listStyleGuidesSchema,
+  getStyleGuideSchema,
+  getTypologySchema,
+  validateStyleGuideSchema,
+  listStyleGuides as architectureListStyleGuides,
+  getStyleGuide as architectureGetStyleGuide,
+  getTypology as architectureGetTypology,
+  validateStyleGuide as architectureValidateStyleGuide,
+} from './worldbuilding/architecture-handlers.js';
+import {
   dynamoSchema,
   escapeSchema,
   hzSchema,
@@ -604,6 +614,66 @@ export function registerTools(server: McpServer, session: SessionManagerStub): v
     async (params) => {
       const result = languageRemixPhonologies(params as z.infer<typeof remixPhonologiesSchema>);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    'architecture_list_style_guides',
+    'List all seed StyleGuide palettes (metadata only — id, cultureId, dateRange, typologyCount).',
+    listStyleGuidesSchema.shape,
+    async (params) => {
+      try {
+        const result = architectureListStyleGuides(params as z.infer<typeof listStyleGuidesSchema>);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: msg }) }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    'architecture_get_style_guide',
+    'Fetch a full StyleGuide by id (embedded StyleSheet + typologyWeights). Returns { error: "not_found" } if unknown.',
+    getStyleGuideSchema.shape,
+    async (params) => {
+      try {
+        const result = architectureGetStyleGuide(params as z.infer<typeof getStyleGuideSchema>);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: msg }) }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    'architecture_get_typology',
+    'Fetch a Typology by id (footprint, storyRange, fenestrationDensity). Returns { error: "not_found" } if unknown.',
+    getTypologySchema.shape,
+    async (params) => {
+      try {
+        const result = architectureGetTypology(params as z.infer<typeof getTypologySchema>);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: msg }) }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    'architecture_validate_style_guide',
+    'Validate a candidate StyleGuide JSON against the A1 schema. Returns { ok: true } or { ok: false, errors: [...] }.',
+    validateStyleGuideSchema.shape,
+    async (params) => {
+      try {
+        const result = architectureValidateStyleGuide(params as z.infer<typeof validateStyleGuideSchema>);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: msg }) }], isError: true };
+      }
     }
   );
 
@@ -1170,6 +1240,10 @@ function recordEagerSchemas(
   reg('language_apply_sound_changes', soundChangesSchema.shape, 'low', '{ok, message}');
   reg('language_propose_derivation', proposeDerivationSchema.shape, 'low', '{ok, message}');
   reg('language_remix_phonologies', remixPhonologiesSchema.shape, 'low', '{ok, message}');
+  reg('architecture_list_style_guides',   listStyleGuidesSchema.shape,   'low', '{guides:[{id,cultureId,dateRange,typologyCount}]}');
+  reg('architecture_get_style_guide',     getStyleGuideSchema.shape,     'low', '{guide}|{error,id}');
+  reg('architecture_get_typology',        getTypologySchema.shape,       'low', '{typology}|{error,id}');
+  reg('architecture_validate_style_guide',validateStyleGuideSchema.shape,'low', '{ok}|{ok:false,errors:[{path,message}]}');
   reg('hayba_planet_habitable_zone', hzSchema.shape, 'low', 'HabitableZoneResult JSON');
   reg('hayba_planet_tidal_locking', tidalSchema.shape, 'low', 'TidalLockingResult JSON');
   reg('hayba_planet_dynamo_field', dynamoSchema.shape, 'low', 'DynamoScalingResult JSON');

--- a/packages/hayba/src/tools/visual/hayba-compare-clip-score.ts
+++ b/packages/hayba/src/tools/visual/hayba-compare-clip-score.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { ToolHandler } from '../hayba-bake-terrain.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
-import { embedImage, cosineSimilarity } from './sidecar-client.js';
+import { embedImage, cosineSimilarity, SidecarUnavailableError } from './sidecar-client.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'medium',
@@ -28,6 +28,9 @@ export const haybaCompareClipScoreHandler: ToolHandler = async (args) => {
     const score = cosineSimilarity(a.embedding, b.embedding);
     return { content: [{ type: 'text', text: JSON.stringify({ cosine_similarity: score, dim: a.dim }, null, 2) }] };
   } catch (e) {
+    if (e instanceof SidecarUnavailableError) {
+      return { content: [{ type: 'text', text: `visual sidecar offline — CLIP comparison unavailable. ${e.message}. Start the sidecar (uv run --project packages/hayba/addons/visual-embeddings -- uvicorn hayba_sidecar.server:app --port 7821) or unset HAYBA_SIDECAR_URL.` }], isError: true };
+    }
     return { content: [{ type: 'text', text: `hayba_compare_clip_score error: ${(e as Error).message}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/visual/hayba-fetch-references.ts
+++ b/packages/hayba/src/tools/visual/hayba-fetch-references.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { ToolHandler } from '../hayba-bake-terrain.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
-import { embedImage } from './sidecar-client.js';
+import { embedImage, SidecarUnavailableError } from './sidecar-client.js';
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
 
@@ -42,7 +42,10 @@ export const haybaFetchReferencesHandler: ToolHandler = async (args) => {
       const { embedding } = await embedImage(base64);
       return { source: 'local', path: p, clip_embedding: embedding };
     } catch (e) {
-      return { source: 'local', path: p, clip_embedding: null, error: (e as Error).message };
+      const msg = e instanceof SidecarUnavailableError
+        ? `sidecar offline — embedding skipped (${e.message})`
+        : (e as Error).message;
+      return { source: 'local', path: p, clip_embedding: null, error: msg };
     }
   }));
 

--- a/packages/hayba/src/tools/visual/hayba-generate-moodboard.ts
+++ b/packages/hayba/src/tools/visual/hayba-generate-moodboard.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { ToolHandler } from '../hayba-bake-terrain.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
-import { embedImage } from './sidecar-client.js';
+import { embedImage, SidecarUnavailableError } from './sidecar-client.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'high',
@@ -47,7 +47,10 @@ export const haybaGenerateMoodboardHandler: ToolHandler = async (args) => {
         const { embedding } = await embedImage(img.base64);
         return { ...img, clip_embedding: embedding };
       } catch (e) {
-        return { ...img, clip_embedding: null, embedding_error: (e as Error).message };
+        const msg = e instanceof SidecarUnavailableError
+          ? `sidecar offline — embedding skipped (${e.message})`
+          : (e as Error).message;
+        return { ...img, clip_embedding: null, embedding_error: msg };
       }
     }));
 

--- a/packages/hayba/src/tools/visual/sidecar-client.test.ts
+++ b/packages/hayba/src/tools/visual/sidecar-client.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  pingSidecar,
+  embedImage,
+  setCachedSidecarHealth,
+  getCachedSidecarHealth,
+  SidecarUnavailableError,
+} from './sidecar-client.js';
+
+describe('sidecar-client / health probe', () => {
+  const origFetch = globalThis.fetch;
+  const origUrl = process.env.HAYBA_SIDECAR_URL;
+
+  beforeEach(() => {
+    setCachedSidecarHealth(null);
+    process.env.HAYBA_SIDECAR_URL = 'http://localhost:7821';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    if (origUrl === undefined) delete process.env.HAYBA_SIDECAR_URL;
+    else process.env.HAYBA_SIDECAR_URL = origUrl;
+    setCachedSidecarHealth(null);
+  });
+
+  it('reports available + active models when /health returns ok with enabled models', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(
+      JSON.stringify({ ok: true, models: { clip: true, spatial_clip: false, owl_vit: true } }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )) as unknown as typeof fetch;
+
+    const health = await pingSidecar(500);
+    expect(health.available).toBe(true);
+    expect(health.active_models.sort()).toEqual(['clip', 'owl_vit']);
+    expect(health.url).toBe('http://localhost:7821');
+    expect(getCachedSidecarHealth()).toBe(health);
+  });
+
+  it('reports unavailable when /health throws (sidecar offline)', async () => {
+    globalThis.fetch = vi.fn(async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch;
+    const health = await pingSidecar(500);
+    expect(health.available).toBe(false);
+    expect(health.error).toMatch(/ECONNREFUSED/);
+    expect(health.active_models).toEqual([]);
+  });
+
+  it('reports unavailable when /health returns non-200', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('boom', { status: 503 })) as unknown as typeof fetch;
+    const health = await pingSidecar(500);
+    expect(health.available).toBe(false);
+    expect(health.error).toMatch(/503/);
+  });
+
+  it('reports unavailable when /health says ok but no models are active', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(
+      JSON.stringify({ ok: true, models: { clip: false, spatial_clip: false, owl_vit: false } }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )) as unknown as typeof fetch;
+    const health = await pingSidecar(500);
+    expect(health.available).toBe(false);
+    expect(health.active_models).toEqual([]);
+  });
+});
+
+describe('sidecar-client / degraded-mode short-circuit', () => {
+  const origFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    setCachedSidecarHealth(null);
+  });
+
+  it('embedImage throws SidecarUnavailableError immediately when cache says offline', async () => {
+    setCachedSidecarHealth({
+      available: false,
+      url: 'http://localhost:7821',
+      models: {},
+      active_models: [],
+      error: 'ECONNREFUSED',
+      checked_at: Date.now(),
+    });
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await expect(embedImage('xxx')).rejects.toBeInstanceOf(SidecarUnavailableError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('embedImage proceeds when cache says available', async () => {
+    setCachedSidecarHealth({
+      available: true,
+      url: 'http://localhost:7821',
+      models: { clip: true },
+      active_models: ['clip'],
+      checked_at: Date.now(),
+    });
+    globalThis.fetch = vi.fn(async () => new Response(
+      JSON.stringify({ embedding: [0.1, 0.2, 0.3], dim: 3 }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )) as unknown as typeof fetch;
+
+    const out = await embedImage('xxx');
+    expect(out.dim).toBe(3);
+    expect(out.embedding).toEqual([0.1, 0.2, 0.3]);
+  });
+});

--- a/packages/hayba/src/tools/visual/sidecar-client.ts
+++ b/packages/hayba/src/tools/visual/sidecar-client.ts
@@ -1,14 +1,111 @@
 const DEFAULT_URL = 'http://localhost:7821';
+const DEFAULT_HEALTH_TIMEOUT_MS = 1500;
+const DEFAULT_EMBED_TIMEOUT_MS = 30000;
 
 function sidecarUrl(): string {
   return process.env.HAYBA_SIDECAR_URL ?? DEFAULT_URL;
 }
 
-export async function embedImage(imageBase64: string, opts?: { spatial?: boolean; detect?: boolean }): Promise<{ embedding: number[]; dim: number }> {
-  const res = await fetch(`${sidecarUrl()}/embed`, {
+export interface SidecarHealth {
+  available: boolean;
+  url: string;
+  models: Record<string, boolean>;
+  active_models: string[];
+  error?: string;
+  checked_at: number;
+}
+
+let cached: SidecarHealth | null = null;
+
+async function fetchWithTimeout(url: string, init: RequestInit & { timeoutMs?: number }): Promise<Response> {
+  const { timeoutMs, ...rest } = init;
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs ?? DEFAULT_EMBED_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...rest, signal: controller.signal });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export async function pingSidecar(timeoutMs: number = DEFAULT_HEALTH_TIMEOUT_MS): Promise<SidecarHealth> {
+  const url = sidecarUrl();
+  const checkedAt = Date.now();
+  try {
+    const res = await fetchWithTimeout(`${url}/health`, { method: 'GET', timeoutMs });
+    if (!res.ok) {
+      const health: SidecarHealth = {
+        available: false,
+        url,
+        models: {},
+        active_models: [],
+        error: `sidecar /health returned ${res.status}`,
+        checked_at: checkedAt,
+      };
+      cached = health;
+      return health;
+    }
+    const body = (await res.json()) as { ok?: boolean; models?: Record<string, boolean> };
+    const models = body.models ?? {};
+    const activeModels = Object.entries(models)
+      .filter(([, enabled]) => Boolean(enabled))
+      .map(([name]) => name);
+    const health: SidecarHealth = {
+      available: body.ok !== false && activeModels.length > 0,
+      url,
+      models,
+      active_models: activeModels,
+      checked_at: checkedAt,
+    };
+    cached = health;
+    return health;
+  } catch (e) {
+    const health: SidecarHealth = {
+      available: false,
+      url,
+      models: {},
+      active_models: [],
+      error: (e as Error).message,
+      checked_at: checkedAt,
+    };
+    cached = health;
+    return health;
+  }
+}
+
+export function getCachedSidecarHealth(): SidecarHealth | null {
+  return cached;
+}
+
+export function setCachedSidecarHealth(h: SidecarHealth | null): void {
+  cached = h;
+}
+
+export class SidecarUnavailableError extends Error {
+  constructor(public health: SidecarHealth) {
+    super(`visual sidecar unavailable at ${health.url}${health.error ? ` (${health.error})` : ''}`);
+    this.name = 'SidecarUnavailableError';
+  }
+}
+
+/**
+ * If we have a cached health probe and it reports unavailable, refuse to issue
+ * the request — avoids long connect-timeouts in degraded mode. If no cache
+ * exists, the call proceeds and the cache is populated by next ping.
+ */
+function assertSidecarAvailable(): void {
+  if (cached && !cached.available) {
+    throw new SidecarUnavailableError(cached);
+  }
+}
+
+export async function embedImage(imageBase64: string, opts?: { spatial?: boolean; detect?: boolean; timeoutMs?: number }): Promise<{ embedding: number[]; dim: number }> {
+  assertSidecarAvailable();
+  const res = await fetchWithTimeout(`${sidecarUrl()}/embed`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ image_base64: imageBase64, spatial: opts?.spatial ?? false, detect: opts?.detect ?? false }),
+    timeoutMs: opts?.timeoutMs ?? DEFAULT_EMBED_TIMEOUT_MS,
   });
   if (!res.ok) {
     throw new Error(`sidecar /embed ${res.status}: ${await res.text()}`);

--- a/packages/hayba/src/tools/worldbuilding/architecture-handlers.ts
+++ b/packages/hayba/src/tools/worldbuilding/architecture-handlers.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import {
+  listStyleGuides as engineListStyleGuides,
+  getStyleGuideTool as engineGetStyleGuide,
+  getTypologyTool as engineGetTypology,
+  validateStyleGuideTool as engineValidateStyleGuide,
+} from '@hayba/architecture';
+
+/* ─────────────────────  schemas  ───────────────────── */
+
+export const listStyleGuidesSchema = z.object({});
+
+export const getStyleGuideSchema = z.object({
+  id: z.string().describe('StyleGuide id, e.g. "medieval-european-gothic"'),
+});
+
+export const getTypologySchema = z.object({
+  id: z.string().describe('Typology id, e.g. "peasant_home"'),
+});
+
+export const validateStyleGuideSchema = z.object({
+  json: z.record(z.string(), z.unknown()).describe('Candidate StyleGuide JSON to validate against the A1 schema'),
+});
+
+/* ─────────────────────  handlers  ───────────────────── */
+
+export function listStyleGuides(_params: z.infer<typeof listStyleGuidesSchema>) {
+  return engineListStyleGuides();
+}
+
+export function getStyleGuide(params: z.infer<typeof getStyleGuideSchema>) {
+  return engineGetStyleGuide(params);
+}
+
+export function getTypology(params: z.infer<typeof getTypologySchema>) {
+  return engineGetTypology(params);
+}
+
+export function validateStyleGuide(params: z.infer<typeof validateStyleGuideSchema>) {
+  return engineValidateStyleGuide(params);
+}


### PR DESCRIPTION
## Summary
- Adds `pingSidecar()` health probe (AbortController-timed) + module-level cache (`getCachedSidecarHealth`, `setCachedSidecarHealth`).
- MCP server runs a fire-and-forget probe at startup and logs `Visual sidecar 🟢 http://localhost:7821 — models=clip,owl_vit` (or 🔴 + error).
- `hayba_check_ue_status` now returns `visual_embeddings_available`, `active_models`, `sidecar_url`, `sidecar_error`.
- Dashboard `/api/ue/status` exposes the same fields; new `POST /api/sidecar/refresh` lets the wizard re-probe after starting the sidecar mid-session.
- `embedImage()` short-circuits with `SidecarUnavailableError` when the cache says offline — no more 30s connect hangs in visual tools.
- moodboard / fetch-references / compare-clip-score surface "sidecar offline" explicitly instead of returning opaque fetch errors.

Closes #29.

## Test plan
- [x] `npx vitest run src/tools/visual/sidecar-client.test.ts src/tools/check-ue-status.test.ts` — 8 new tests pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual: start sidecar, hit `/api/ue/status`, see 🟢; stop sidecar, hit `POST /api/sidecar/refresh`, see 🔴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Architecture system with style guides, typologies, and building patterns for worldbuilding.
  * Added interactive Architecture demo viewer for exploring styles and building types.
  * Dashboard now displays visual sidecar status and active models.
  * Settings page is now functional with Unreal Engine connection management and sidecar control.

* **Improvements**
  * Enhanced sidecar error handling and offline detection.
  * Added re-probe capability for sidecar connection troubleshooting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->