### PR TITLE
feat(mcp): Plan tab Node side — hayba_request_input + hayba_get_user_response (#11)

### DIFF
--- a/packages/hayba/src/tools/index.ts
+++ b/packages/hayba/src/tools/index.ts
@@ -20,6 +20,16 @@ import { sceneValidatePhysicsHandler, meta as scenePhysicsMeta } from './scene/s
 import { editorCaptureViewportHandler, meta as captureMeta } from './editor/editor-capture-viewport.js';
 import { editorStartPieHandler, meta as pieMeta } from './editor/editor-start-pie.js';
 import { editorStreamLogHandler, meta as streamLogMeta } from './editor/editor-stream-log.js';
+import {
+  haybaRequestInputHandler,
+  meta as requestInputMeta,
+  requestInputSchema,
+} from './prompts/hayba-request-input.js';
+import {
+  haybaGetUserResponseHandler,
+  meta as getUserResponseMeta,
+  getUserResponseSchema,
+} from './prompts/hayba-get-user-response.js';
 
 // ── PCGEx tool handlers ───────────────────────────────────────────────────────
 import { searchNodeCatalog } from './search-node-catalog.js';
@@ -131,6 +141,32 @@ export function registerTools(server: McpServer, session: SessionManagerStub): v
           isError: true,
         };
       }
+    },
+  );
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Generic input-request system (Plan tab AI monitor, issue #11).
+  // hayba_request_input pushes a prompt to UE; hayba_get_user_response polls
+  // for the user's answer. UE handlers maintain the prompt/response queues.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  server.tool(
+    'hayba_request_input',
+    appendMeta('Push a prompt to the UE Plan tab — approve / choose_one / choose_many / text / form / progress kinds. Returns prompt_id; poll hayba_get_user_response to retrieve the answer.', requestInputMeta),
+    requestInputSchema.shape,
+    async (params) => {
+      const r = await haybaRequestInputHandler(params as Record<string, unknown>, session);
+      return { content: r.content, isError: r.isError };
+    },
+  );
+
+  server.tool(
+    'hayba_get_user_response',
+    appendMeta('Poll for the user response to a prompt previously pushed via hayba_request_input. Returns {prompt_id, status: pending|answered|rejected|timeout|unknown, value?}.', getUserResponseMeta),
+    getUserResponseSchema.shape,
+    async (params) => {
+      const r = await haybaGetUserResponseHandler(params as Record<string, unknown>, session);
+      return { content: r.content, isError: r.isError };
     },
   );
 
@@ -1004,6 +1040,10 @@ function recordEagerSchemas(
     if (typeof v === 'string') { try { return JSON.parse(v); } catch { return v; } }
     return v;
   }, vec3);
+
+  // ── Plan tab prompts (issue #11) ──────────────────────────────────────────
+  reg('hayba_request_input', requestInputSchema.shape, 'low', '{prompt_id, status:"pushed"|"push_failed", error?}');
+  reg('hayba_get_user_response', getUserResponseSchema.shape, 'low', '{prompt_id, status, value?, error?}');
 
   // ── Code Mode meta ────────────────────────────────────────────────────────
   reg('list_tool_categories', {}, 'low', '{categories:[{domain,commands:[string]}]}');

--- a/packages/hayba/src/tools/prompts/hayba-get-user-response.test.ts
+++ b/packages/hayba/src/tools/prompts/hayba-get-user-response.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const sendMock = vi.fn();
+
+vi.mock('../../tcp-client.js', () => ({
+  ensureConnected: vi.fn(async () => ({ send: sendMock })),
+}));
+
+import { haybaGetUserResponseHandler } from './hayba-get-user-response.js';
+
+describe('hayba_get_user_response', () => {
+  beforeEach(() => sendMock.mockReset());
+  afterEach(() => sendMock.mockReset());
+
+  it('forwards prompt_id and wait_ms to UE, returns UE payload verbatim on success', async () => {
+    sendMock.mockResolvedValueOnce({ ok: true, data: { prompt_id: 'p1', status: 'answered', value: 'hello' } });
+    const r = await haybaGetUserResponseHandler({ prompt_id: 'p1', wait_ms: 1000 }, {});
+    expect(r.isError).toBeFalsy();
+    expect(JSON.parse(r.content[0].text)).toEqual({ prompt_id: 'p1', status: 'answered', value: 'hello' });
+    expect(sendMock).toHaveBeenCalledWith('hayba_get_user_response', { prompt_id: 'p1', wait_ms: 1000 }, 5000);
+  });
+
+  it('uses TCP timeout > wait_ms so UE-side blocking finishes inside the request window', async () => {
+    sendMock.mockResolvedValueOnce({ ok: true, data: { prompt_id: 'p1', status: 'pending' } });
+    await haybaGetUserResponseHandler({ prompt_id: 'p1', wait_ms: 30_000 }, {});
+    expect(sendMock).toHaveBeenCalledWith(
+      'hayba_get_user_response',
+      { prompt_id: 'p1', wait_ms: 30_000 },
+      32_000,
+    );
+  });
+
+  it('defaults wait_ms to 0 (non-blocking poll)', async () => {
+    sendMock.mockResolvedValueOnce({ ok: true, data: { prompt_id: 'p1', status: 'pending' } });
+    await haybaGetUserResponseHandler({ prompt_id: 'p1' }, {});
+    expect(sendMock).toHaveBeenCalledWith('hayba_get_user_response', { prompt_id: 'p1', wait_ms: 0 }, 5000);
+  });
+
+  it('maps a TCP failure to status=unknown with error', async () => {
+    sendMock.mockResolvedValueOnce({ ok: false, error: 'queue empty' });
+    const r = await haybaGetUserResponseHandler({ prompt_id: 'p1' }, {});
+    expect(r.isError).toBe(true);
+    const body = JSON.parse(r.content[0].text);
+    expect(body).toEqual({ prompt_id: 'p1', status: 'unknown', error: 'queue empty' });
+  });
+
+  it('rejects missing prompt_id at validation time', async () => {
+    const r = await haybaGetUserResponseHandler({}, {});
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/Validation error/);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hayba/src/tools/prompts/hayba-get-user-response.ts
+++ b/packages/hayba/src/tools/prompts/hayba-get-user-response.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { ensureConnected } from '../../tcp-client.js';
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'polling for the answer to a prompt previously pushed via hayba_request_input',
+  not_when: 'pushing a new prompt — use hayba_request_input',
+};
+
+export const getUserResponseSchema = z.object({
+  prompt_id: z.string().min(1),
+  wait_ms: z.number().int().min(0).max(300_000).optional()
+    .describe('How long the UE side should block waiting for an answer. Default 0 (non-blocking poll).'),
+});
+
+export type GetUserResponseParams = z.infer<typeof getUserResponseSchema>;
+
+export type UserResponseStatus = 'pending' | 'answered' | 'rejected' | 'timeout' | 'unknown';
+
+export interface UserResponse {
+  prompt_id: string;
+  status: UserResponseStatus;
+  value?: unknown;
+  error?: string;
+}
+
+export const haybaGetUserResponseHandler: ToolHandler = async (args) => {
+  const parsed = getUserResponseSchema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const waitMs = parsed.data.wait_ms ?? 0;
+  // TCP request timeout has to outlive the UE-side wait, plus a margin.
+  const tcpTimeoutMs = Math.max(5000, waitMs + 2000);
+  try {
+    const client = await ensureConnected();
+    const resp = await client.send(
+      'hayba_get_user_response',
+      { prompt_id: parsed.data.prompt_id, wait_ms: waitMs },
+      tcpTimeoutMs,
+    );
+    if (!resp.ok) {
+      const body: UserResponse = { prompt_id: parsed.data.prompt_id, status: 'unknown', error: resp.error };
+      return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }], isError: true };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
+  } catch (e) {
+    const body: UserResponse = { prompt_id: parsed.data.prompt_id, status: 'unknown', error: (e as Error).message };
+    return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }], isError: true };
+  }
+};

--- a/packages/hayba/src/tools/prompts/hayba-request-input.test.ts
+++ b/packages/hayba/src/tools/prompts/hayba-request-input.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const sendMock = vi.fn();
+
+vi.mock('../../tcp-client.js', () => ({
+  ensureConnected: vi.fn(async () => ({ send: sendMock })),
+}));
+
+import {
+  haybaRequestInputHandler,
+  requestInputSchema,
+  validateKindPayload,
+  type RequestInputParams,
+} from './hayba-request-input.js';
+
+describe('hayba_request_input / contract validation', () => {
+  it('rejects choose_one without options', () => {
+    expect(validateKindPayload({ kind: 'choose_one', title: 't' } as RequestInputParams)).toMatch(/requires non-empty 'options'/);
+  });
+
+  it('rejects form without fields', () => {
+    expect(validateKindPayload({ kind: 'form', title: 't' } as RequestInputParams)).toMatch(/requires non-empty 'fields'/);
+  });
+
+  it('rejects progress without progress payload', () => {
+    expect(validateKindPayload({ kind: 'progress', title: 't' } as RequestInputParams)).toMatch(/requires 'progress'/);
+  });
+
+  it('accepts approve / text without extra payload', () => {
+    expect(validateKindPayload({ kind: 'approve', title: 't' } as RequestInputParams)).toBeNull();
+    expect(validateKindPayload({ kind: 'text', title: 't' } as RequestInputParams)).toBeNull();
+  });
+
+  it('schema validates a complete form prompt', () => {
+    const out = requestInputSchema.safeParse({
+      kind: 'form',
+      title: 'Pick stack',
+      fields: [{ id: 'lang', label: 'Language', kind: 'enum', options: ['ts', 'rust'] }],
+    });
+    expect(out.success).toBe(true);
+  });
+});
+
+describe('hayba_request_input / TCP push', () => {
+  beforeEach(() => sendMock.mockReset());
+  afterEach(() => sendMock.mockReset());
+
+  it('auto-generates a prompt_id when caller omits one and forwards payload to UE', async () => {
+    sendMock.mockResolvedValueOnce({ ok: true, data: { queued: true } });
+    const result = await haybaRequestInputHandler({
+      kind: 'text',
+      title: 'name?',
+    }, {});
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0].text);
+    expect(body.prompt_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(body.status).toBe('pushed');
+    expect(sendMock).toHaveBeenCalledWith('hayba_request_input', expect.objectContaining({
+      prompt_id: body.prompt_id,
+      kind: 'text',
+      title: 'name?',
+    }), 5000);
+  });
+
+  it('preserves a caller-supplied prompt_id', async () => {
+    sendMock.mockResolvedValueOnce({ ok: true, data: {} });
+    const result = await haybaRequestInputHandler({
+      kind: 'approve',
+      title: 'go?',
+      prompt_id: 'fixed-id-1',
+    }, {});
+    const body = JSON.parse(result.content[0].text);
+    expect(body.prompt_id).toBe('fixed-id-1');
+  });
+
+  it('returns push_failed with prompt_id when TCP send fails', async () => {
+    sendMock.mockResolvedValueOnce({ ok: false, error: 'no UE' });
+    const result = await haybaRequestInputHandler({
+      kind: 'approve',
+      title: 'go?',
+    }, {});
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.status).toBe('push_failed');
+    expect(body.error).toBe('no UE');
+    expect(body.prompt_id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('rejects invalid kind via validation error', async () => {
+    const result = await haybaRequestInputHandler({ kind: 'invalid', title: 'x' }, {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Validation error/);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects choose_one without options before reaching UE', async () => {
+    const result = await haybaRequestInputHandler({ kind: 'choose_one', title: 'pick' }, {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/requires non-empty 'options'/);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hayba/src/tools/prompts/hayba-request-input.ts
+++ b/packages/hayba/src/tools/prompts/hayba-request-input.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
+import { ensureConnected } from '../../tcp-client.js';
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['user_input'],
+  when: 'you need a decision, free-text answer, multi-option choice, or progress display surfaced in the UE Plan tab',
+  not_when: 'requesting approval of a destructive plan — use hayba_propose_plan',
+};
+
+export const optionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  image_base64: z.string().optional(),
+});
+
+export const formFieldSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  kind: z.enum(['text', 'long_text', 'number', 'bool', 'enum']),
+  required: z.boolean().optional(),
+  default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  options: z.array(z.string()).optional(),
+  placeholder: z.string().optional(),
+});
+
+export const requestInputSchema = z.object({
+  kind: z.enum(['approve', 'choose_one', 'choose_many', 'text', 'form', 'progress']),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  options: z.array(optionSchema).optional(),
+  fields: z.array(formFieldSchema).optional(),
+  progress: z.object({
+    value: z.number().min(0).max(1),
+    message: z.string().optional(),
+  }).optional(),
+  prompt_id: z.string().optional().describe('Optional caller-supplied UUID. Auto-generated when absent.'),
+});
+
+export type RequestInputParams = z.infer<typeof requestInputSchema>;
+
+/**
+ * Validates the cross-field contract: every prompt kind has a different
+ * "required payload" — choose_* needs options, form needs fields, etc.
+ * Returns an error message when the contract is violated, or null when ok.
+ */
+export function validateKindPayload(p: RequestInputParams): string | null {
+  switch (p.kind) {
+    case 'approve':
+    case 'text':
+      return null;
+    case 'choose_one':
+    case 'choose_many':
+      if (!p.options || p.options.length === 0) {
+        return `kind=${p.kind} requires non-empty 'options'`;
+      }
+      return null;
+    case 'form':
+      if (!p.fields || p.fields.length === 0) return "kind='form' requires non-empty 'fields'";
+      return null;
+    case 'progress':
+      if (!p.progress) return "kind='progress' requires 'progress'";
+      return null;
+  }
+}
+
+export const haybaRequestInputHandler: ToolHandler = async (args) => {
+  const parsed = requestInputSchema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const contractErr = validateKindPayload(parsed.data);
+  if (contractErr) {
+    return { content: [{ type: 'text', text: `Validation error: ${contractErr}` }], isError: true };
+  }
+
+  const promptId = parsed.data.prompt_id ?? randomUUID();
+  const payload = { ...parsed.data, prompt_id: promptId };
+
+  try {
+    const client = await ensureConnected();
+    const resp = await client.send('hayba_request_input', payload as unknown as Record<string, unknown>, 5000);
+    const body = resp.ok
+      ? { prompt_id: promptId, status: 'pushed', ...(resp.data as Record<string, unknown> | undefined) }
+      : { prompt_id: promptId, status: 'push_failed', error: resp.error };
+    return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }], isError: !resp.ok };
+  } catch (e) {
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ prompt_id: promptId, status: 'push_failed', error: (e as Error).message }, null, 2) }],
+      isError: true,
+    };
+  }
+};


### PR DESCRIPTION
## Summary
Implements the **Node-side** of issue #11. UE-side queue handlers will land separately when the HaybaMCPToolkit plugin merges into main — these tools fail fast with `status: push_failed` / `unknown` until then.

- `hayba_request_input({kind, title, description?, options?, fields?, progress?, prompt_id?})` — pushes a prompt to the UE Plan tab. Validates the per-kind contract (choose_* needs options, form needs fields, progress needs a progress payload), auto-generates a UUID `prompt_id`, forwards over TCP. Returns `{prompt_id, status: pushed|push_failed, error?}`.
- `hayba_get_user_response({prompt_id, wait_ms?})` — polls the UE response queue. TCP timeout is `wait_ms + 2s` so UE-side blocking returns inside the request window. Maps TCP failure to `status='unknown'`.

Kinds supported by the schema: `approve`, `choose_one`, `choose_many`, `text`, `form`, `progress`. Both tools are registered with `appendMeta` + `recordSchema` so `get_tool_signature` reflects them.

Refs #11.

## Test plan
- [x] `npx vitest run src/tools/prompts` — 15 new tests pass (contract validation, UUID auto-gen, TCP forwarding, timeout math, error mapping)
- [x] `npx tsc --noEmit` clean
- [ ] End-to-end once UE-side queue handlers land

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user input request functionality supporting multiple interaction types: approvals, single/multiple selection, text entry, forms, and progress tracking
  * Added user response retrieval with timeout configuration and automatic fallback timing
  * Implemented comprehensive validation and structured error responses

* **Tests**
  * Added comprehensive test coverage for new user interaction features

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/113)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->