### PR TITLE
feat(mcp): perf telemetry tools — editor_get_perf_stats / texture_audit / mesh_audit (#5)

### DIFF
--- a/packages/hayba/src/tools/index.ts
+++ b/packages/hayba/src/tools/index.ts
@@ -20,6 +20,9 @@ import { sceneValidatePhysicsHandler, meta as scenePhysicsMeta } from './scene/s
 import { editorCaptureViewportHandler, meta as captureMeta } from './editor/editor-capture-viewport.js';
 import { editorStartPieHandler, meta as pieMeta } from './editor/editor-start-pie.js';
 import { editorStreamLogHandler, meta as streamLogMeta } from './editor/editor-stream-log.js';
+import { editorGetPerfStatsHandler, meta as perfStatsMeta, schema as perfStatsSchema } from './perf/editor-get-perf-stats.js';
+import { textureAuditHandler, meta as textureAuditMeta, schema as textureAuditSchema } from './perf/texture-audit.js';
+import { meshAuditHandler, meta as meshAuditMeta, schema as meshAuditSchema } from './perf/mesh-audit.js';
 
 // ── PCGEx tool handlers ───────────────────────────────────────────────────────
 import { searchNodeCatalog } from './search-node-catalog.js';
@@ -317,6 +320,37 @@ export function registerTools(server: McpServer, session: SessionManagerStub): v
       const r = await editorStreamLogHandler(params as Record<string, unknown>, session);
       return { content: r.content, isError: r.isError };
     }
+  );
+
+  // ── Perf telemetry (issue #5) ───────────────────────────────────────────────
+  server.tool(
+    'editor_get_perf_stats',
+    appendMeta('Sample frame ms / draw calls / triangles / memory from FStatManager. Use this before suggesting scene optimizations.', perfStatsMeta),
+    perfStatsSchema.shape,
+    async (params) => {
+      const r = await editorGetPerfStatsHandler(params as Record<string, unknown>, session);
+      return { content: r.content, isError: r.isError };
+    },
+  );
+
+  server.tool(
+    'texture_audit',
+    appendMeta('Surface largest textures by memory + compression-format outliers, ordered descending. Use for technical-artist passes.', textureAuditMeta),
+    textureAuditSchema.shape,
+    async (params) => {
+      const r = await textureAuditHandler(params as Record<string, unknown>, session);
+      return { content: r.content, isError: r.isError };
+    },
+  );
+
+  server.tool(
+    'mesh_audit',
+    appendMeta('Surface highest-poly meshes, LOD-chain gaps, and instance-count hotspots. Pairs with texture_audit for full scene perf passes.', meshAuditMeta),
+    meshAuditSchema.shape,
+    async (params) => {
+      const r = await meshAuditHandler(params as Record<string, unknown>, session);
+      return { content: r.content, isError: r.isError };
+    },
   );
 
   // ── PCGEx tools ─────────────────────────────────────────────────────────────
@@ -1059,6 +1093,11 @@ function recordEagerSchemas(
     format: z.enum(['raw', 'structured']).optional().describe('"structured" emits {line, category, severity, msg, raw} objects'),
     since_line: z.coerce.number().int().min(0).optional(),
   }, 'low', '{lines:[string|object], next_line:int, format}');
+
+  // ── Perf telemetry (issue #5) ─────────────────────────────────────────────
+  reg('editor_get_perf_stats', perfStatsSchema.shape, 'low', '{frame_ms, draw_calls, triangles, memory_mb, sampled_frames}');
+  reg('texture_audit', textureAuditSchema.shape, 'medium', '{items:[{path, width, height, format, on_disk_kb, group, compression}], total_count}');
+  reg('mesh_audit', meshAuditSchema.shape, 'medium', '{items:[{path, triangles, lod_count, instance_count, lod_issue?}], total_count}');
 
   // ── PCGEx domain ──────────────────────────────────────────────────────────
   reg('hayba_search_node_catalog', {

--- a/packages/hayba/src/tools/perf/editor-get-perf-stats.ts
+++ b/packages/hayba/src/tools/perf/editor-get-perf-stats.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { ensureConnected } from '../../tcp-client.js';
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['gpu_load'],
+  when: 'auditing scene perf — frame time, draw calls, triangle count, memory',
+  not_when: 'asking about specific assets — use texture_audit or mesh_audit',
+};
+
+export const schema = z.object({
+  sample_frames: z.number().int().min(1).max(120).optional()
+    .describe('How many frames to average. Default 30.'),
+});
+
+export const editorGetPerfStatsHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  try {
+    const client = await ensureConnected();
+    const resp = await client.send('editor_get_perf_stats', parsed.data as Record<string, unknown>, 10_000);
+    if (!resp.ok) {
+      return { content: [{ type: 'text', text: `editor_get_perf_stats failed: ${resp.error ?? 'unknown'}` }], isError: true };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
+  } catch (e) {
+    return { content: [{ type: 'text', text: `editor_get_perf_stats error: ${(e as Error).message}` }], isError: true };
+  }
+};

--- a/packages/hayba/src/tools/perf/mesh-audit.ts
+++ b/packages/hayba/src/tools/perf/mesh-audit.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { ensureConnected } from '../../tcp-client.js';
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'finding high-poly meshes, LOD-chain gaps, or instance-count hotspots',
+  not_when: 'auditing textures — use texture_audit',
+};
+
+export const schema = z.object({
+  top_n: z.number().int().min(1).max(200).optional().describe('Top entries to return. Default 25.'),
+  min_triangles: z.number().int().min(0).optional().describe('Minimum triangle count to include.'),
+  path_prefix: z.string().optional().describe('Only audit assets whose path starts with this prefix.'),
+  include_lod_issues: z.boolean().optional().describe('Flag meshes with sparse/missing LOD chains.'),
+});
+
+export const meshAuditHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  try {
+    const client = await ensureConnected();
+    const resp = await client.send('mesh_audit', parsed.data as Record<string, unknown>, 30_000);
+    if (!resp.ok) {
+      return { content: [{ type: 'text', text: `mesh_audit failed: ${resp.error ?? 'unknown'}` }], isError: true };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
+  } catch (e) {
+    return { content: [{ type: 'text', text: `mesh_audit error: ${(e as Error).message}` }], isError: true };
+  }
+};

--- a/packages/hayba/src/tools/perf/perf-tools.test.ts
+++ b/packages/hayba/src/tools/perf/perf-tools.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const sendMock = vi.fn();
+
+vi.mock('../../tcp-client.js', () => ({
+  ensureConnected: vi.fn(async () => ({ send: sendMock })),
+}));
+
+import { editorGetPerfStatsHandler } from './editor-get-perf-stats.js';
+import { textureAuditHandler } from './texture-audit.js';
+import { meshAuditHandler } from './mesh-audit.js';
+
+describe('perf telemetry tools', () => {
+  beforeEach(() => sendMock.mockReset());
+  afterEach(() => sendMock.mockReset());
+
+  it('editor_get_perf_stats forwards sample_frames and returns UE payload', async () => {
+    sendMock.mockResolvedValueOnce({ ok: true, data: { frame_ms: 12.3, draw_calls: 1500, triangles: 3_000_000, memory_mb: 2200 } });
+    const r = await editorGetPerfStatsHandler({ sample_frames: 60 }, {});
+    expect(r.isError).toBeFalsy();
+    expect(sendMock).toHaveBeenCalledWith('editor_get_perf_stats', { sample_frames: 60 }, 10_000);
+    expect(JSON.parse(r.content[0].text).frame_ms).toBe(12.3);
+  });
+
+  it('editor_get_perf_stats clamps sample_frames > 120 via validation', async () => {
+    const r = await editorGetPerfStatsHandler({ sample_frames: 999 }, {});
+    expect(r.isError).toBe(true);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('texture_audit forwards all filters', async () => {
+    sendMock.mockResolvedValueOnce({ ok: true, data: { items: [] } });
+    await textureAuditHandler({ top_n: 10, min_kb: 500, path_prefix: '/Game/Env/' }, {});
+    expect(sendMock).toHaveBeenCalledWith(
+      'texture_audit',
+      { top_n: 10, min_kb: 500, path_prefix: '/Game/Env/' },
+      30_000,
+    );
+  });
+
+  it('texture_audit surfaces TCP failure as isError', async () => {
+    sendMock.mockResolvedValueOnce({ ok: false, error: 'not connected' });
+    const r = await textureAuditHandler({}, {});
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/texture_audit failed: not connected/);
+  });
+
+  it('mesh_audit forwards include_lod_issues', async () => {
+    sendMock.mockResolvedValueOnce({ ok: true, data: { items: [{ path: '/Game/A', triangles: 200_000, lod_count: 1 }] } });
+    const r = await meshAuditHandler({ top_n: 5, include_lod_issues: true }, {});
+    expect(r.isError).toBeFalsy();
+    expect(sendMock).toHaveBeenCalledWith(
+      'mesh_audit',
+      { top_n: 5, include_lod_issues: true },
+      30_000,
+    );
+  });
+
+  it('mesh_audit maps thrown exception to isError', async () => {
+    sendMock.mockRejectedValueOnce(new Error('socket closed'));
+    const r = await meshAuditHandler({}, {});
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/mesh_audit error: socket closed/);
+  });
+});

--- a/packages/hayba/src/tools/perf/texture-audit.ts
+++ b/packages/hayba/src/tools/perf/texture-audit.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { ensureConnected } from '../../tcp-client.js';
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'finding largest textures by memory or surfacing compression-format outliers',
+  not_when: 'auditing meshes — use mesh_audit',
+};
+
+export const schema = z.object({
+  top_n: z.number().int().min(1).max(200).optional().describe('Top entries to return. Default 25.'),
+  min_kb: z.number().int().min(0).optional().describe('Minimum on-disk size (KB) to include.'),
+  path_prefix: z.string().optional().describe('Only audit assets whose path starts with this prefix (e.g. /Game/).'),
+});
+
+export const textureAuditHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  try {
+    const client = await ensureConnected();
+    const resp = await client.send('texture_audit', parsed.data as Record<string, unknown>, 30_000);
+    if (!resp.ok) {
+      return { content: [{ type: 'text', text: `texture_audit failed: ${resp.error ?? 'unknown'}` }], isError: true };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
+  } catch (e) {
+    return { content: [{ type: 'text', text: `texture_audit error: ${(e as Error).message}` }], isError: true };
+  }
+};


### PR DESCRIPTION
## Summary
Node side of issue #5 (Initiative #5 — Performance telemetry endpoints). Three new MCP tools forward to UE TCP with validated schemas and explicit error mapping. UE-side handlers will land with the HaybaMCPToolkit plugin merge.

- **editor_get_perf_stats({sample_frames?})** — averages FStatManager over N frames (1–120). 10s TCP timeout.
- **texture_audit({top_n?, min_kb?, path_prefix?})** — largest textures by on-disk size + compression-format outliers. 30s timeout.
- **mesh_audit({top_n?, min_triangles?, path_prefix?, include_lod_issues?})** — highest-poly meshes, LOD gaps, instance hotspots. 30s timeout.

All three registered with \`appendMeta\` + \`recordSchema\` so they surface in \`list_tool_categories\` and \`get_tool_signature\`.

Refs #5.

## Test plan
- [x] \`npx vitest run src/tools/perf\` — 6 tests pass
- [x] \`npx tsc --noEmit\` clean
- [ ] End-to-end once UE-side perf handlers land

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced three new diagnostic and audit tools: editor performance statistics collection, texture resource analysis, and mesh resource auditing for enhanced system visibility and optimization

* **Tests**
  * Added comprehensive test coverage for performance and audit tools, including request handling validation, error scenario testing, and parameter constraint verification

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->