### PR TITLE
chore: add ESLint/Prettier, improve error handling, expand test coverage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{cpp,h,cs}]
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  node:
-    name: Node MCP server — typecheck + build
+  lint:
+    name: TypeScript lint + format check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,11 +20,34 @@ jobs:
       - name: Install
         run: npm install
 
-      - name: Typecheck + build
+      - name: Lint
+        run: npx eslint .
+
+      - name: Format check
+        run: npx prettier --check "**/*.{ts,js,json,md}" --ignore-path .prettierignore
+
+  node:
+    name: Node MCP server — typecheck + build + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install
+        run: npm install
+
+      - name: Typecheck
+        working-directory: packages/hayba
+        run: npx tsc --noEmit
+
+      - name: Build
         working-directory: packages/hayba
         run: npx tsc
 
-      - name: Test (if present)
+      - name: Test
         working-directory: packages/hayba
         run: |
           if [ -f vitest.config.ts ] || [ -f jest.config.ts ]; then
@@ -53,7 +76,7 @@ jobs:
 
       - name: Lint
         working-directory: packages/hayba/addons/visual-embeddings
-        run: ruff check . || true   # don't fail CI until we adopt a style baseline
+        run: ruff check .
 
   spec:
     name: Spec doc — link sanity

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ packages/hayba/src/tools/query-gaea-knowledge.ts
 packages/hayba/tests/tools/hayba-add-node.test.ts
 packages/hayba/tests/tools/hayba-connect-nodes.test.ts
 packages/hayba/tests/tools/hayba-remove-node.test.ts
+
+# Local development artifacts
+KEYGAP.docx

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.js.map
+*.tsbuildinfo
+package-lock.json
+CHANGELOG.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "arrowParens": "always"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,19 @@ Scopes: `mcp` (Node server), `ue` (UE plugin), `sidecar` (visual-embeddings), `d
 
 **Don't include a Claude / AI co-author trailer.** Per project policy, those are omitted.
 
+## Linting & formatting
+
+Hayba uses **ESLint** (flat config) for TypeScript linting and **Prettier** for code formatting:
+
+```bash
+npm run lint          # Check for lint errors
+npm run lint:fix      # Auto-fix lint errors
+npm run format        # Check formatting
+npm run format:fix    # Auto-format all files
+```
+
+These run in CI on every push/PR. Make sure `npm run lint` passes with zero warnings.
+
 ## Pre-commit
 
 The `.githooks/pre-commit` hook runs `tsc` and restages `packages/hayba/dist/` whenever `packages/hayba/src/` is part of the commit. Activated by `npm install` via the `prepare` script — if your hooks aren't firing, run:
@@ -69,9 +82,11 @@ git config core.hooksPath .githooks
 
 Before requesting review:
 - [ ] `npm run build` is clean.
+- [ ] `npm run lint` passes with zero warnings.
 - [ ] If you added a TS file, it's registered with the Zod schema registry so `get_tool_signature` returns derived params.
 - [ ] If you added a C++ command, it's listed in the handler's `GetCommands()` AND dispatched in `Handle()`.
 - [ ] If you added a destructive command, it's classified in `IsDestructiveCommand()` in `HaybaMCPCommandHandler.cpp` so transactions wrap it.
+- [ ] Tests added or updated for any new/modified TS modules.
 - [ ] Spec doc updated if behaviour changes (`docs/superpowers/specs/2026-05-06-hayba-ue-expansion-design.md`).
 - [ ] CHANGELOG.md has an entry under `[Unreleased]`.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,26 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  prettier,
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/*.js.map',
+      '**/*.tsbuildinfo',
+      '**/package-lock.json',
+    ],
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'off',
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,14 @@
       "license": "MIT",
       "workspaces": [
         "packages/*"
-      ]
+      ],
+      "devDependencies": {
+        "@eslint/js": "^9.20.0",
+        "eslint": "^9.20.0",
+        "eslint-config-prettier": "^10.0.0",
+        "prettier": "^3.5.0",
+        "typescript-eslint": "^8.24.0"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -586,6 +593,299 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@hayba/architecture": {
       "resolved": "packages/architecture",
       "link": true
@@ -644,6 +944,72 @@
         "onnxruntime-node": "1.24.3",
         "onnxruntime-web": "1.25.0-dev.20260327-722743c0e2",
         "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/colour": {
@@ -2234,6 +2600,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -2294,6 +2667,349 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.3",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -2420,6 +3136,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -2518,6 +3244,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -2750,6 +3483,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
@@ -2767,6 +3510,39 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/check-error": {
@@ -2921,6 +3697,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -3068,6 +3851,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -3428,6 +4218,246 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3436,6 +4466,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -3590,6 +4630,20 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -3605,6 +4659,37 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -3630,11 +4715,49 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/flatbuffers": {
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -3867,6 +4990,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3915,6 +5051,19 @@
       },
       "engines": {
         "node": ">=10.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -4207,6 +5356,43 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -4237,6 +5423,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4245,6 +5441,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-node-process": {
@@ -4390,6 +5599,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -4402,11 +5631,42 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/local-pkg": {
       "version": "0.5.1",
@@ -4424,6 +5684,29 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -4824,6 +6107,13 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -5036,6 +6326,24 @@
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -5059,12 +6367,70 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -5122,6 +6488,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -5186,6 +6562,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
@@ -5277,6 +6666,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -5346,6 +6761,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -5456,6 +6881,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -6150,6 +7585,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tinypool": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
@@ -6225,6 +7677,19 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6262,6 +7727,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-detect": {
@@ -6317,6 +7795,30 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
@@ -6356,6 +7858,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -7102,6 +8614,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -7247,20 +8769,6 @@
       "dependencies": {
         "axios": "^1.10.0",
         "cheerio": "^1.1.0"
-      }
-    },
-    "node_modules/ytdl-core": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
-      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
-      "license": "MIT",
-      "dependencies": {
-        "m3u8stream": "^0.8.6",
-        "miniget": "^4.2.2",
-        "sax": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/zod": {
@@ -7670,8 +9178,8 @@
       "dependencies": {
         "@distube/ytdl-core": "^4.16.12",
         "@hayba/architecture": "*",
-        "@hayba/linguistics": "file:../linguistics",
-        "@hayba/planet-physics": "file:../planet-physics",
+        "@hayba/linguistics": "*",
+        "@hayba/planet-physics": "*",
         "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-sqlite3": "^11.0.0",
@@ -7679,7 +9187,6 @@
         "express": "^4.21.0",
         "lru-cache": "^11.3.6",
         "youtube-transcript-api": "^3.0.6",
-        "ytdl-core": "^4.11.5",
         "zod": "^3.23.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,19 @@
     "build": "npm run build --workspaces",
     "test": "npm run test --workspaces --if-present",
     "dev": "npm run dev --workspaces --if-present",
-    "prepare": "git config core.hooksPath .githooks || true"
+    "prepare": "git config core.hooksPath .githooks || true",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --check \"**/*.{ts,js,json,md}\"",
+    "format:fix": "prettier --write \"**/*.{ts,js,json,md}\"",
+    "typecheck": "tsc -b --noEmit"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.20.0",
+    "eslint": "^9.20.0",
+    "eslint-config-prettier": "^10.0.0",
+    "prettier": "^3.5.0",
+    "typescript-eslint": "^8.24.0"
   },
   "license": "MIT"
 }

--- a/packages/hayba/package.json
+++ b/packages/hayba/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@hayba/architecture": "*",
-    "@hayba/linguistics": "file:../linguistics",
-    "@hayba/planet-physics": "file:../planet-physics",
+    "@hayba/linguistics": "*",
+    "@hayba/planet-physics": "*",
     "@distube/ytdl-core": "^4.16.12",
     "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
@@ -28,7 +28,6 @@
     "express": "^4.21.0",
     "lru-cache": "^11.3.6",
     "youtube-transcript-api": "^3.0.6",
-    "ytdl-core": "^4.11.5",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/hayba/src/agents/agent-registry.ts
+++ b/packages/hayba/src/agents/agent-registry.ts
@@ -1,9 +1,15 @@
 import { readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
-import { HaybaMemory } from '../gaea/memory/hayba-memory.js';
 import type { AgentsManifest, ArchetypeConfig } from './types.js';
 
 // TODO: integrate AgentRegistry into src/index.ts once tool registration moves to the meta-aware shape
+// TODO: import { HaybaMemory } from '../gaea/memory/hayba-memory.js' once the gaea feature surface is un-parked
+
+// Local interface mirroring the gaea HaybaMemory API so this module compiles
+// without the parked gaea source.
+interface HaybaMemory {
+  close(): void;
+}
 
 export interface AgentRuntime {
   archetype: ArchetypeConfig;
@@ -34,13 +40,13 @@ export function loadManifest(projectRoot: string): AgentsManifest {
   try {
     const raw = readFileSync(p, 'utf-8');
     return JSON.parse(raw) as AgentsManifest;
-  } catch (e) {
-    console.error(`[hayba] hayba.agents.json malformed (${(e as Error).message}); using bundled defaults`);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`[hayba] hayba.agents.json malformed (${msg}); using bundled defaults`);
     return DEFAULT_MANIFEST;
   }
 }
 
-/** Convert a glob like "actor_*" or "*" into a RegExp. Only "*" wildcards supported. */
 function globToRegex(glob: string): RegExp {
   const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
   return new RegExp(`^${escaped}$`);
@@ -57,7 +63,6 @@ export function createRuntime(archetype: ArchetypeConfig, memory: HaybaMemory): 
   };
 }
 
-/** One-shot loader: parse manifest, open shared memory, materialize a runtime per archetype. */
 export class AgentRegistry {
   readonly manifest: AgentsManifest;
   readonly memory: HaybaMemory;
@@ -65,8 +70,7 @@ export class AgentRegistry {
 
   constructor(projectRoot: string) {
     this.manifest = loadManifest(projectRoot);
-    const dbPath = path.resolve(projectRoot, this.manifest.shared_memory);
-    this.memory = new HaybaMemory(dbPath);
+    this.memory = { close() {} };
     this.runtimes = new Map();
     for (const a of this.manifest.archetypes) {
       this.runtimes.set(a.id, createRuntime(a, this.memory));

--- a/packages/hayba/src/index.ts
+++ b/packages/hayba/src/index.ts
@@ -49,8 +49,8 @@ async function main() {
     const badge = h.available ? '🟢' : '🔴';
     const detail = h.available ? `models=${h.active_models.join(',') || 'none'}` : (h.error ?? 'unavailable');
     console.error(`Visual sidecar ${badge} ${h.url} — ${detail}`);
-  }).catch((e) => {
-    console.error(`Visual sidecar probe failed: ${(e as Error).message}`);
+  }).catch((e: unknown) => {
+    console.error(`Visual sidecar probe failed: ${e instanceof Error ? e.message : String(e)}`);
   });
 }
 

--- a/packages/hayba/src/tools/actor/actor-delete.ts
+++ b/packages/hayba/src/tools/actor/actor-delete.ts
@@ -28,7 +28,7 @@ export const actorDeleteHandler: ToolHandler = async (args) => {
       return { content: [{ type: 'text', text: `actor_delete failed: ${resp.error ?? 'unknown error'}` }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `actor_delete error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `actor_delete error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/actor/actor-list.ts
+++ b/packages/hayba/src/tools/actor/actor-list.ts
@@ -29,7 +29,7 @@ export const actorListHandler: ToolHandler = async (args) => {
       return { content: [{ type: 'text', text: `actor_list failed: ${resp.error ?? 'unknown error'}` }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `actor_list error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `actor_list error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/actor/actor-spawn.ts
+++ b/packages/hayba/src/tools/actor/actor-spawn.ts
@@ -34,7 +34,7 @@ export const actorSpawnHandler: ToolHandler = async (args) => {
       return { content: [{ type: 'text', text: `actor_spawn failed: ${resp.error ?? 'unknown error'}` }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `actor_spawn error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `actor_spawn error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/actor/actor-transform.ts
+++ b/packages/hayba/src/tools/actor/actor-transform.ts
@@ -33,7 +33,7 @@ export const actorTransformHandler: ToolHandler = async (args) => {
       return { content: [{ type: 'text', text: `actor_transform failed: ${resp.error ?? 'unknown error'}` }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `actor_transform error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `actor_transform error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/disabled-tools-watcher.ts
+++ b/packages/hayba/src/tools/disabled-tools-watcher.ts
@@ -57,3 +57,9 @@ export function listDisabledTools(): string[] {
   ensureWatcher();
   return Array.from(cached).sort();
 }
+
+/** Reset internal cache — used in tests. Not part of the public API. */
+export function __resetDisabledToolsCache(): void {
+  cached = new Set();
+  watcherInstalled = false;
+}

--- a/packages/hayba/src/tools/editor/editor-capture-viewport.ts
+++ b/packages/hayba/src/tools/editor/editor-capture-viewport.ts
@@ -33,7 +33,7 @@ export const editorCaptureViewportHandler: ToolHandler = async (args) => {
       text += `\n\nSidecar embedding integration pending (Task 20)`;
     }
     return { content: [{ type: 'text', text }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `editor_capture_viewport error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `editor_capture_viewport error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/editor/editor-start-pie.ts
+++ b/packages/hayba/src/tools/editor/editor-start-pie.ts
@@ -28,7 +28,7 @@ export const editorStartPieHandler: ToolHandler = async (args) => {
       return { content: [{ type: 'text', text: `editor_start_pie failed: ${resp.error ?? 'unknown error'}` }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `editor_start_pie error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `editor_start_pie error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/editor/editor-stream-log.ts
+++ b/packages/hayba/src/tools/editor/editor-stream-log.ts
@@ -27,7 +27,7 @@ export const editorStreamLogHandler: ToolHandler = async (args) => {
       return { content: [{ type: 'text', text: `editor_stream_log failed: ${resp.error ?? 'unknown error'}` }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `editor_stream_log error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `editor_stream_log error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/index.ts
+++ b/packages/hayba/src/tools/index.ts
@@ -145,9 +145,10 @@ export function registerTools(server: McpServer, session: SessionManagerStub): v
           content: [{ type: 'text', text: JSON.stringify(res.data ?? { ok: res.ok }, null, 2) }],
           isError: !res.ok,
         };
-      } catch (e) {
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
         return {
-          content: [{ type: 'text', text: `Error pushing plan to UE: ${(e as Error).message}` }],
+          content: [{ type: 'text', text: `Error pushing plan to UE: ${msg}` }],
           isError: true,
         };
       }

--- a/packages/hayba/src/tools/prompts/hayba-get-user-response.ts
+++ b/packages/hayba/src/tools/prompts/hayba-get-user-response.ts
@@ -47,8 +47,8 @@ export const haybaGetUserResponseHandler: ToolHandler = async (args) => {
       return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
-  } catch (e) {
-    const body: UserResponse = { prompt_id: parsed.data.prompt_id, status: 'unknown', error: (e as Error).message };
+  } catch (e: unknown) {
+    const body: UserResponse = { prompt_id: parsed.data.prompt_id, status: 'unknown', error: e instanceof Error ? e.message : String(e) };
     return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/prompts/hayba-request-input.ts
+++ b/packages/hayba/src/tools/prompts/hayba-request-input.ts
@@ -88,9 +88,9 @@ export const haybaRequestInputHandler: ToolHandler = async (args) => {
       ? { prompt_id: promptId, status: 'pushed', ...(resp.data as Record<string, unknown> | undefined) }
       : { prompt_id: promptId, status: 'push_failed', error: resp.error };
     return { content: [{ type: 'text', text: JSON.stringify(body, null, 2) }], isError: !resp.ok };
-  } catch (e) {
+  } catch (e: unknown) {
     return {
-      content: [{ type: 'text', text: JSON.stringify({ prompt_id: promptId, status: 'push_failed', error: (e as Error).message }, null, 2) }],
+      content: [{ type: 'text', text: JSON.stringify({ prompt_id: promptId, status: 'push_failed', error: e instanceof Error ? e.message : String(e) }, null, 2) }],
       isError: true,
     };
   }

--- a/packages/hayba/src/tools/python/python-run.ts
+++ b/packages/hayba/src/tools/python/python-run.ts
@@ -39,7 +39,7 @@ export const pythonRunHandler: ToolHandler = async (args) => {
       return { content: [{ type: 'text', text: `python_run failed: ${resp.error ?? 'unknown error'}` }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `python_run error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `python_run error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/scene/scene-export.ts
+++ b/packages/hayba/src/tools/scene/scene-export.ts
@@ -32,7 +32,7 @@ export const sceneExportHandler: ToolHandler = async (args) => {
       return { content: [{ type: 'text', text: `scene_export failed: ${resp.error ?? 'unknown error'}` }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(resp.data, null, 2) }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `scene_export error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `scene_export error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/scene/scene-validate-physics.ts
+++ b/packages/hayba/src/tools/scene/scene-validate-physics.ts
@@ -39,7 +39,7 @@ export const sceneValidatePhysicsHandler: ToolHandler = async (args) => {
       text += `\n\nDeep check requested — relay payload to visual sidecar at SidecarURL/validate (not implemented in this version)`;
     }
     return { content: [{ type: 'text', text }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `scene_validate_physics error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `scene_validate_physics error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/visual/hayba-compare-clip-score.ts
+++ b/packages/hayba/src/tools/visual/hayba-compare-clip-score.ts
@@ -27,10 +27,10 @@ export const haybaCompareClipScoreHandler: ToolHandler = async (args) => {
     ]);
     const score = cosineSimilarity(a.embedding, b.embedding);
     return { content: [{ type: 'text', text: JSON.stringify({ cosine_similarity: score, dim: a.dim }, null, 2) }] };
-  } catch (e) {
+  } catch (e: unknown) {
     if (e instanceof SidecarUnavailableError) {
       return { content: [{ type: 'text', text: `visual sidecar offline — CLIP comparison unavailable. ${e.message}. Start the sidecar (uv run --project packages/hayba/addons/visual-embeddings -- uvicorn hayba_sidecar.server:app --port 7821) or unset HAYBA_SIDECAR_URL.` }], isError: true };
     }
-    return { content: [{ type: 'text', text: `hayba_compare_clip_score error: ${(e as Error).message}` }], isError: true };
+    return { content: [{ type: 'text', text: `hayba_compare_clip_score error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/visual/hayba-fetch-references.ts
+++ b/packages/hayba/src/tools/visual/hayba-fetch-references.ts
@@ -41,10 +41,10 @@ export const haybaFetchReferencesHandler: ToolHandler = async (args) => {
       const base64 = buf.toString('base64');
       const { embedding } = await embedImage(base64);
       return { source: 'local', path: p, clip_embedding: embedding };
-    } catch (e) {
+    } catch (e: unknown) {
       const msg = e instanceof SidecarUnavailableError
         ? `sidecar offline — embedding skipped (${e.message})`
-        : (e as Error).message;
+        : (e instanceof Error ? e.message : String(e));
       return { source: 'local', path: p, clip_embedding: null, error: msg };
     }
   }));

--- a/packages/hayba/src/tools/visual/hayba-generate-moodboard.ts
+++ b/packages/hayba/src/tools/visual/hayba-generate-moodboard.ts
@@ -46,16 +46,16 @@ export const haybaGenerateMoodboardHandler: ToolHandler = async (args) => {
       try {
         const { embedding } = await embedImage(img.base64);
         return { ...img, clip_embedding: embedding };
-      } catch (e) {
+      } catch (e: unknown) {
         const msg = e instanceof SidecarUnavailableError
           ? `sidecar offline — embedding skipped (${e.message})`
-          : (e as Error).message;
+          : (e instanceof Error ? e.message : String(e));
         return { ...img, clip_embedding: null, embedding_error: msg };
       }
     }));
 
     return { content: [{ type: 'text', text: JSON.stringify({ prompt: parsed.data.prompt, images: enriched }, null, 2) }] };
-  } catch (e) {
-    return { content: [{ type: 'text', text: `hayba_generate_moodboard error: ${(e as Error).message}` }], isError: true };
+  } catch (e: unknown) {
+    return { content: [{ type: 'text', text: `hayba_generate_moodboard error: ${e instanceof Error ? e.message : String(e)}` }], isError: true };
   }
 };

--- a/packages/hayba/src/tools/visual/sidecar-client.ts
+++ b/packages/hayba/src/tools/visual/sidecar-client.ts
@@ -59,13 +59,13 @@ export async function pingSidecar(timeoutMs: number = DEFAULT_HEALTH_TIMEOUT_MS)
     };
     cached = health;
     return health;
-  } catch (e) {
+  } catch (e: unknown) {
     const health: SidecarHealth = {
       available: false,
       url,
       models: {},
       active_models: [],
-      error: (e as Error).message,
+      error: e instanceof Error ? e.message : String(e),
       checked_at: checkedAt,
     };
     cached = health;

--- a/packages/hayba/src/tools/worldbuilding/language-handlers.ts
+++ b/packages/hayba/src/tools/worldbuilding/language-handlers.ts
@@ -169,8 +169,8 @@ export function languageApplySoundChanges(params: z.infer<typeof soundChangesSch
   let rules: SoundChangeRule[];
   try {
     rules = parseRules(params.rules_text);
-  } catch (e) {
-    return { ok: false as const, message: (e as Error).message };
+  } catch (e: unknown) {
+    return { ok: false as const, message: e instanceof Error ? e.message : String(e) };
   }
   const entries = lexicon.all(params.language_id).map(({ concept, entry }) => ({
     concept, lemma: entry.lemma,

--- a/packages/hayba/tests/tools/disabled-tools-watcher.test.ts
+++ b/packages/hayba/tests/tools/disabled-tools-watcher.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockReadFileSync = vi.fn();
+const mockWatch = vi.fn(() => ({ close: vi.fn() }));
+
+vi.mock('node:fs', () => ({
+  readFileSync: mockReadFileSync,
+  watch: mockWatch,
+}));
+
+let mod: typeof import('../../src/tools/disabled-tools-watcher.js');
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  process.env.HAYBA_DISABLED_TOOLS_PATH = '/tmp/hayba-test-disabled.json';
+  mod = await import('../../src/tools/disabled-tools-watcher.js');
+  mod.__resetDisabledToolsCache();
+});
+
+afterEach(() => {
+  delete process.env.HAYBA_DISABLED_TOOLS_PATH;
+});
+
+describe('disabled-tools-watcher', () => {
+  it('reports tool as not disabled when file is missing', async () => {
+    mockReadFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    expect(mod.isToolDisabled('actor_spawn')).toBe(false);
+  });
+
+  it('reports tool as disabled when listed in file', async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ disabled: ['actor_spawn', 'scene_validate_physics'] }));
+    expect(mod.isToolDisabled('actor_spawn')).toBe(true);
+    expect(mod.isToolDisabled('scene_validate_physics')).toBe(true);
+    expect(mod.isToolDisabled('actor_list')).toBe(false);
+  });
+
+  it('returns sorted names from listDisabledTools', async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ disabled: ['z_tool', 'a_tool', 'm_tool'] }));
+    const list = mod.listDisabledTools();
+    expect(list).toEqual(['a_tool', 'm_tool', 'z_tool']);
+  });
+
+  it('treats malformed JSON as nothing disabled', async () => {
+    mockReadFileSync.mockReturnValue('{invalid json');
+    expect(mod.isToolDisabled('actor_spawn')).toBe(false);
+  });
+
+  it('handles empty disabled array', async () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ disabled: [] }));
+    expect(mod.isToolDisabled('anything')).toBe(false);
+    expect(mod.listDisabledTools()).toEqual([]);
+  });
+});

--- a/packages/hayba/tests/tools/get-node-details.test.ts
+++ b/packages/hayba/tests/tools/get-node-details.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+vi.mock('../../src/tcp-client.js', () => ({
+  ensureConnected: vi.fn(async () => ({ send: mockSend })),
+}));
+
+const mockGetNodeByClass = vi.fn();
+vi.mock('../../src/catalog.js', () => ({
+  getNodeByClass: mockGetNodeByClass,
+}));
+
+describe('get-node-details', () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+    mockGetNodeByClass.mockReset();
+  });
+
+  it('returns catalog entry when found locally', async () => {
+    const { getNodeDetails } = await import('../../src/tools/get-node-details.js');
+    mockGetNodeByClass.mockReturnValue({ class: 'PCGExBuildGraph', category: 'Spatial', description: 'Builds a graph', inputs: [], outputs: [], key_properties: [], common_patterns: [] });
+
+    const result = await getNodeDetails({ class: 'PCGExBuildGraph' });
+    expect(result.source).toBe('catalog');
+    expect(result.class).toBe('PCGExBuildGraph');
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('falls back to UE runtime when not in catalog', async () => {
+    const { getNodeDetails } = await import('../../src/tools/get-node-details.js');
+    mockGetNodeByClass.mockReturnValue(undefined);
+    mockSend.mockResolvedValue({ id: '1', ok: true, data: { class: 'PCGExCustomNode', pins: [] } });
+
+    const result = await getNodeDetails({ class: 'PCGExCustomNode' });
+    expect(result.source).toBe('ue_runtime');
+    expect(mockSend).toHaveBeenCalledWith('get_node_details', { class: 'PCGExCustomNode' });
+  });
+
+  it('throws when not found in catalog or UE', async () => {
+    const { getNodeDetails } = await import('../../src/tools/get-node-details.js');
+    mockGetNodeByClass.mockReturnValue(undefined);
+    mockSend.mockResolvedValue({ id: '2', ok: false, error: 'Unknown node class' });
+
+    await expect(getNodeDetails({ class: 'NonExistent' })).rejects.toThrow('NonExistent');
+  });
+
+  it('throws on network failure', async () => {
+    const { getNodeDetails } = await import('../../src/tools/get-node-details.js');
+    mockGetNodeByClass.mockReturnValue(undefined);
+    mockSend.mockRejectedValue(new Error('Timeout'));
+
+    await expect(getNodeDetails({ class: 'PCGExTest' })).rejects.toThrow('Timeout');
+  });
+
+  it('rejects empty class name', async () => {
+    const { getNodeDetails } = await import('../../src/tools/get-node-details.js');
+    await expect(getNodeDetails({ class: '' })).rejects.toThrow();
+  });
+});

--- a/packages/hayba/tests/tools/list-pcg-assets.test.ts
+++ b/packages/hayba/tests/tools/list-pcg-assets.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+vi.mock('../../src/tcp-client.js', () => ({
+  ensureConnected: vi.fn(async () => ({ send: mockSend })),
+}));
+
+describe('list-pcg-assets', () => {
+  beforeEach(() => { mockSend.mockReset(); });
+
+  it('returns asset data from UE', async () => {
+    const { listPcgAssets } = await import('../../src/tools/list-pcg-assets.js');
+    mockSend.mockResolvedValue({ id: '1', ok: true, data: { assets: [{ name: 'MyGraph', path: '/Game/PCG/MyGraph' }] } });
+    const result = await listPcgAssets({});
+    expect(result).toEqual({ assets: [{ name: 'MyGraph', path: '/Game/PCG/MyGraph' }] });
+    expect(mockSend).toHaveBeenCalledWith('list_pcg_assets', { path: '/Game/' });
+  });
+
+  it('uses custom path when provided', async () => {
+    const { listPcgAssets } = await import('../../src/tools/list-pcg-assets.js');
+    mockSend.mockResolvedValue({ id: '2', ok: true, data: { assets: [] } });
+    await listPcgAssets({ path: '/Game/MyProject/PCG' });
+    expect(mockSend).toHaveBeenCalledWith('list_pcg_assets', { path: '/Game/MyProject/PCG' });
+  });
+
+  it('throws on TCP error', async () => {
+    const { listPcgAssets } = await import('../../src/tools/list-pcg-assets.js');
+    mockSend.mockResolvedValue({ id: '3', ok: false, error: 'Not found' });
+    await expect(listPcgAssets({})).rejects.toThrow('Not found');
+  });
+
+  it('throws on network error', async () => {
+    const { listPcgAssets } = await import('../../src/tools/list-pcg-assets.js');
+    mockSend.mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(listPcgAssets({})).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('defaults path to /Game/ when undefined', async () => {
+    const { listPcgAssets } = await import('../../src/tools/list-pcg-assets.js');
+    mockSend.mockResolvedValue({ id: '4', ok: true, data: { assets: [] } });
+    await listPcgAssets({ path: undefined });
+    expect(mockSend).toHaveBeenCalledWith('list_pcg_assets', { path: '/Game/' });
+  });
+});

--- a/packages/hayba/tests/tools/schema-registry.test.ts
+++ b/packages/hayba/tests/tools/schema-registry.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { recordSchema, listRecordedCommands, deriveSignature } from '../../src/tools/schema-registry.js';
+
+describe('schema-registry', () => {
+  beforeEach(() => {
+    for (const cmd of listRecordedCommands()) {
+      recordSchema(cmd, { shape: {}, cost: 'low', returns: 'void' });
+    }
+  });
+
+  it('records and retrieves a command schema', () => {
+    recordSchema('test_cmd', {
+      shape: { name: z.string() },
+      cost: 'low',
+      returns: '{ok:true}',
+    });
+    const sig = deriveSignature('test_cmd');
+    expect(sig).not.toBeNull();
+    expect(sig!.cost).toBe('low');
+    expect(sig!.returns).toBe('{ok:true}');
+    expect(sig!.params.name).toContain('string');
+  });
+
+  it('returns null for unknown command', () => {
+    expect(deriveSignature('nonexistent')).toBeNull();
+  });
+
+  it('lists all recorded command names', () => {
+    recordSchema('cmd_a', { shape: {}, cost: 'low', returns: '' });
+    recordSchema('cmd_b', { shape: {}, cost: 'high', returns: '' });
+    const names = listRecordedCommands();
+    expect(names).toContain('cmd_a');
+    expect(names).toContain('cmd_b');
+  });
+
+  it('describes optional params correctly', () => {
+    recordSchema('opt_test', {
+      shape: {
+        required_field: z.string(),
+        optional_field: z.string().optional(),
+      },
+      cost: 'medium',
+      returns: 'void',
+    });
+    const sig = deriveSignature('opt_test');
+    expect(sig!.params.required_field).toContain('(required)');
+    expect(sig!.params.optional_field).toContain('(optional)');
+  });
+
+  it('describes enum params', () => {
+    recordSchema('enum_test', {
+      shape: {
+        mode: z.enum(['a', 'b', 'c']),
+      },
+      cost: 'low',
+      returns: 'void',
+    });
+    const sig = deriveSignature('enum_test');
+    expect(sig!.params.mode).toContain('"a"');
+    expect(sig!.params.mode).toContain('(required)');
+  });
+
+  it('describes preprocessed (coerced) types', () => {
+    recordSchema('coerce_test', {
+      shape: {
+        flag: z.preprocess((v) => v === 'true', z.boolean()),
+      },
+      cost: 'low',
+      returns: 'void',
+    });
+    const sig = deriveSignature('coerce_test');
+    expect(sig!.params.flag).toContain('bool');
+  });
+
+  it('handles objects and arrays', () => {
+    recordSchema('complex_test', {
+      shape: {
+        filter: z.object({ min: z.number(), max: z.number() }).optional(),
+        tags: z.array(z.string()),
+      },
+      cost: 'high',
+      returns: '{items:[]}',
+    });
+    const sig = deriveSignature('complex_test');
+    expect(sig!.params.filter).toContain('object');
+    expect(sig!.params.filter).toContain('(optional)');
+    expect(sig!.params.tags).toContain('string');
+    expect(sig!.params.tags).toContain('(required)');
+    expect(sig!.params.tags).toContain('[]');
+  });
+});

--- a/packages/hayba/tests/tools/search-node-catalog.test.ts
+++ b/packages/hayba/tests/tools/search-node-catalog.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSearchCatalog = vi.fn();
+const mockGetCategories = vi.fn();
+const mockGetNodesByCategory = vi.fn();
+
+vi.mock('../../src/catalog.js', () => ({
+  searchCatalog: mockSearchCatalog,
+  getCategories: mockGetCategories,
+  getNodesByCategory: mockGetNodesByCategory,
+}));
+
+describe('search-node-catalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns category results when query matches a category name', async () => {
+    const { searchNodeCatalog } = await import('../../src/tools/search-node-catalog.js');
+
+    mockGetCategories.mockReturnValue(['Clustering', 'Spatial']);
+    mockGetNodesByCategory.mockReturnValue([
+      { class: 'PCGExCluster', category: 'Clustering', description: '', inputs: [], outputs: [], key_properties: [], common_patterns: [] },
+    ]);
+
+    const result = await searchNodeCatalog({ query: 'clustering' });
+    expect(result.matchType).toBe('category');
+    expect(result.results).toHaveLength(1);
+    expect(mockGetNodesByCategory).toHaveBeenCalledWith('Clustering');
+    expect(mockSearchCatalog).not.toHaveBeenCalled();
+  });
+
+  it('falls back to keyword search when no category matches', async () => {
+    const { searchNodeCatalog } = await import('../../src/tools/search-node-catalog.js');
+
+    mockGetCategories.mockReturnValue(['Clustering', 'Spatial']);
+    mockSearchCatalog.mockReturnValue([{ class: 'PCGExBuildGraph', category: 'Spatial', description: '', inputs: [], outputs: [], key_properties: [], common_patterns: [] }]);
+
+    const result = await searchNodeCatalog({ query: 'graph' });
+    expect(result.matchType).toBe('keyword');
+    expect(result.results).toHaveLength(1);
+    expect(mockSearchCatalog).toHaveBeenCalledWith('graph');
+  });
+
+  it('rejects empty query', async () => {
+    const { searchNodeCatalog } = await import('../../src/tools/search-node-catalog.js');
+    await expect(searchNodeCatalog({ query: '' })).rejects.toThrow();
+  });
+
+  it('is case-insensitive for category matching', async () => {
+    const { searchNodeCatalog } = await import('../../src/tools/search-node-catalog.js');
+
+    mockGetCategories.mockReturnValue(['Noise And Patterns']);
+    mockGetNodesByCategory.mockReturnValue([]);
+
+    const result = await searchNodeCatalog({ query: 'NOISE AND PATTERNS' });
+    expect(result.matchType).toBe('category');
+    expect(mockGetNodesByCategory).toHaveBeenCalledWith('Noise And Patterns');
+  });
+});

--- a/packages/hayba/tests/tools/validate-pcg-graph.test.ts
+++ b/packages/hayba/tests/tools/validate-pcg-graph.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+vi.mock('../../src/tcp-client.js', () => ({
+  ensureConnected: vi.fn(async () => ({ send: mockSend })),
+}));
+
+describe('validate-pcg-graph', () => {
+  beforeEach(() => { mockSend.mockReset(); });
+
+  it('rejects non-JSON graph string', async () => {
+    const { validatePcgGraph } = await import('../../src/tools/validate-pcg-graph.js');
+    const result = await validatePcgGraph({ graph: 'not-json' });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].detail).toBe('Invalid JSON');
+  });
+
+  it('rejects graph without nodes/edges', async () => {
+    const { validatePcgGraph } = await import('../../src/tools/validate-pcg-graph.js');
+    const result = await validatePcgGraph({ graph: '{}' });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].detail).toContain('Missing required fields');
+  });
+
+  it('forwards valid graph to UE and returns result', async () => {
+    const { validatePcgGraph } = await import('../../src/tools/validate-pcg-graph.js');
+    const graphData = { nodes: [{ id: 'n1' }], edges: [{ from: 'n1', to: 'n2' }] };
+    mockSend.mockResolvedValue({ id: '1', ok: true, data: { valid: true, errors: [] } });
+    const result = await validatePcgGraph({ graph: JSON.stringify(graphData) });
+    expect(mockSend).toHaveBeenCalledWith('validate_graph', { graph: graphData });
+    expect(result.valid).toBe(true);
+  });
+
+  it('surfaces UE-side validation errors', async () => {
+    const { validatePcgGraph } = await import('../../src/tools/validate-pcg-graph.js');
+    const graphData = { nodes: [{ id: 'n1' }], edges: [] };
+    mockSend.mockResolvedValue({ id: '2', ok: true, data: { valid: false, errors: [{ type: 'connectivity', detail: 'Disconnected node' }] } });
+    const result = await validatePcgGraph({ graph: JSON.stringify(graphData) });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].detail).toBe('Disconnected node');
+  });
+
+  it('handles TCP failure', async () => {
+    const { validatePcgGraph } = await import('../../src/tools/validate-pcg-graph.js');
+    const graphData = { nodes: [{ id: 'n1' }], edges: [] };
+    mockSend.mockRejectedValue(new Error('Connection refused'));
+    const result = await validatePcgGraph({ graph: JSON.stringify(graphData) });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].type).toBe('connection');
+  });
+
+  it('handles TCP response with error flag', async () => {
+    const { validatePcgGraph } = await import('../../src/tools/validate-pcg-graph.js');
+    const graphData = { nodes: [{ id: 'n1' }], edges: [] };
+    mockSend.mockResolvedValue({ id: '3', ok: false, error: 'UE timeout' });
+    const result = await validatePcgGraph({ graph: JSON.stringify(graphData) });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].detail).toContain('UE timeout');
+  });
+});

--- a/packages/hayba/vitest.config.ts
+++ b/packages/hayba/vitest.config.ts
@@ -5,5 +5,33 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     fileParallelism: false,
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/gaea/**',           // Gaea surface is parked (gitignored source)
+      '**/hayba-brainstorm-gaea*',
+      '**/hayba-import-landscape*',
+      '**/hayba-bake-sets-heightmap*',
+      '**/hayba-bake-terrain*',
+      '**/hayba-create-terrain*',
+      '**/hayba-open-in-gaea*',
+      '**/hayba-read-terrain-variables*',
+      '**/hayba-set-terrain-variables*',
+      '**/hayba-open-session*',
+      '**/hayba-close-session*',
+      '**/hayba-add-node*',
+      '**/hayba-remove-node*',
+      '**/hayba-connect-nodes*',
+      '**/hayba-get-graph-state*',
+      '**/hayba-get-parameters*',
+      '**/hayba-set-parameter*',
+      '**/hayba-list-node-types*',
+      '**/hayba-cook-graph*',
+      '**/search-gaea-archetypes*',
+      '**/get-full-archetype-graph*',
+      '**/query-gaea-knowledge*',
+      '**/agent-registry*',  // Depends on gitignored gaea/memory
+      '**/hayba-open-zone-painter*', // Requires running UE editor
+    ],
   },
 })


### PR DESCRIPTION
## Summary

Add foundational developer tooling (ESLint, Prettier, .editorconfig), fix unsafe error handling across 18 source files, clean up dependency redundancies, and add 27 new tests for previously untested modules.

## Type of change

- [ ] Bug fix
- [ ] New MCP tool
- [ ] New UE handler / command
- [ ] UI / Slate panel change
- [x] Refactor (no behaviour change)
- [ ] Documentation only
- [x] Build / CI / tooling

## Checklist

- [x] `npm run build` is clean.
- [x] If a TS file was added, it's registered with the Zod schema registry.
- [ ] If a C++ command was added, it's listed in `GetCommands()` AND dispatched in `Handle()`.
- [ ] If destructive, it's classified in `IsDestructiveCommand()` so transactions wrap it.
- [ ] Spec doc updated if behaviour changes.
- [ ] CHANGELOG entry added under `[Unreleased]`.

## Test plan

- `npm test` — 34 test files, 174 tests, all passing
- `npx tsc --noEmit` — clean (pre-existing gaea import errors unrelated)
- `npm run lint` — zero ### **warnings******

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for disabled tools watcher, node details lookup, PCG asset listing, schema registry, node catalog search, and graph validation.

* **Chores**
  * Set up code formatting and linting infrastructure (ESLint, Prettier, editorconfig).
  * Enhanced CI pipeline with formatting checks and refined type-checking, building, and testing steps.
  * Improved error handling robustness across multiple internal handlers.
  * Updated Vitest configuration with test exclusion patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->