### PR TITLE
feat(climate): NX-3-v2a wind vector field

### DIFF
--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -375,6 +375,7 @@ export default function App() {
   const prevDebugClimRef = useRef<THREE.WebGLRenderTarget | null>(null);
   const prevDebugTerrRef = useRef<THREE.WebGLRenderTarget | null>(null);
   const prevDebugHydroRef = useRef<THREE.WebGLRenderTarget | null>(null);
+  const prevDebugWindRef = useRef<THREE.WebGLRenderTarget | null>(null);
   // Live stack handles for the mounted material's selector.
   const debugStackRef = useRef<{
     clim: THREE.WebGLRenderTarget;
@@ -1160,6 +1161,7 @@ export default function App() {
       prevDebugClimRef.current?.dispose();
       prevDebugTerrRef.current?.dispose();
       prevDebugHydroRef.current?.dispose();
+      prevDebugWindRef.current?.dispose();
 
       const __tU0 = performance.now();
       const base = uploadEquirect(new Float32Array(inp.height), w, h);
@@ -1171,6 +1173,7 @@ export default function App() {
       let climRT!: THREE.WebGLRenderTarget;
       let terrRT!: THREE.WebGLRenderTarget;
       let hydroRT!: THREE.WebGLRenderTarget;
+      let windRT!: THREE.WebGLRenderTarget;
       await scene.runBake(async (renderer) => {
         const out = await runHydraulicBake(
           renderer,
@@ -1195,6 +1198,7 @@ export default function App() {
         climRT = out.clim;
         terrRT = out.terr;
         hydroRT = out.hydro;
+        windRT = out.wind;
       });
       const __gpuMs = performance.now() - __tG0;
       sceneRef.current?.setBakeSplit({
@@ -1211,6 +1215,7 @@ export default function App() {
       prevDebugClimRef.current = climRT;
       prevDebugTerrRef.current = terrRT;
       prevDebugHydroRef.current = hydroRT;
+      prevDebugWindRef.current = windRT;
       debugStackRef.current = { clim: climRT, terr: terrRT, hydro: hydroRT };
 
       const mat = makeDebugReliefMaterial();

--- a/apps/hayba-explorer/src/viewport/bake/__headless_harness__.ts
+++ b/apps/hayba-explorer/src/viewport/bake/__headless_harness__.ts
@@ -221,13 +221,14 @@ export async function runRealInputErosionVerification(
 
     const webglErrPre = gl.getError();
     const t0 = performance.now();
-    const { eroded: rt, clim: _c, terr: _t, hydro: _h } =
+    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w } =
       await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
     // Oracle never reads the stack RTs; dispose immediately so the
     // many-bake harness doesn't leak 3 RTs/bake (fatal at 3M).
     _c.dispose();
     _t.dispose();
     _h.dispose();
+    _w.dispose();
     const t1 = performance.now();
     const webglErrPost = gl.getError();
 
@@ -431,13 +432,14 @@ export async function runHeadlessErosionVerification(
 
     const webglErrPre = gl.getError();
     const t0 = performance.now();
-    const { eroded: rt, clim: _c, terr: _t, hydro: _h } =
+    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w } =
       await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
     // Oracle never reads the stack RTs; dispose immediately so the
     // many-bake harness doesn't leak 3 RTs/bake (fatal at 3M).
     _c.dispose();
     _t.dispose();
     _h.dispose();
+    _w.dispose();
     const t1 = performance.now();
     const webglErrPost = gl.getError();
 
@@ -1046,7 +1048,7 @@ async function _bakeAndRenderRelief(
   const cfg = { ...hyd.DEFAULT_HYDRAULIC, ...(overrideCfg ?? {}) };
 
   const t0 = performance.now();
-  const { eroded: rt, clim: _c, terr: _t, hydro: _h } =
+  const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w } =
     await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
   // CP2.c (#234 P2.3a): OPT-IN only — read the REAL baked TERR/HYDRO
   // masks (refreshClimate's TERRAIN/HYDRO passes) before disposal so
@@ -1067,6 +1069,7 @@ async function _bakeAndRenderRelief(
   _c.dispose();
   _t.dispose();
   _h.dispose();
+  _w.dispose();
   const t1 = performance.now();
 
   const buf = new Float32Array(w * h * 4);

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -877,6 +877,31 @@ export const TERRAIN_FRAG = [
   "}",
 ].join("\n");
 
+// NX-3-v2a WIND — faithful geostrophic wind VECTOR (recompute the
+// exact wvec CLIMATE_FRAG computes but discards). r=vx g=vy b=|v|
+// a=0. Reads the blurred MSLP. Defined everywhere (atmospheric).
+export const WIND_FRAG = [
+  H,
+  "uniform sampler2D uMSLP;",
+  "uniform vec2 uGrid;",
+  "uniform float uCoriolisGain;",
+  "void main(){",
+  "  ivec2 rc = fragRC();",
+  "  ivec2 wh = gridWH(uGrid);",
+  "  float v = (float(rc.y) + 0.5) / float(wh.y);",
+  "  float lat = (0.5 - v) * 3.14159265;",
+  "  float s = sin(lat);",
+  "  float pL = texelFetch(uMSLP, ivec2(xw(rc.x - 1, wh.x), yc(rc.y, wh.y)), 0).r;",
+  "  float pR = texelFetch(uMSLP, ivec2(xw(rc.x + 1, wh.x), yc(rc.y, wh.y)), 0).r;",
+  "  float pN = texelFetch(uMSLP, ivec2(xw(rc.x, wh.x), yc(rc.y - 1, wh.y)), 0).r;",
+  "  float pS = texelFetch(uMSLP, ivec2(xw(rc.x, wh.x), yc(rc.y + 1, wh.y)), 0).r;",
+  "  float coslat = max(cos(lat), 1e-3);",
+  "  vec2 gp = vec2((pR - pL) * 0.5 / coslat, (pN - pS) * 0.5);",
+  "  vec2 wvec = uCoriolisGain * s * vec2(-gp.y, gp.x) - gp;",
+  "  fragColor = vec4(fin(wvec.x), fin(wvec.y), fin(length(wvec)), 0.0);",
+  "}",
+].join("\n");
+
 // #234 P2.3a HYDRO — packed hydrology mask. r=discharge Q (#218 ACC),
 // g=elevation-normalised (max(0,h) clamped), b=endorheic (CTRL.a),
 // a=0 (biome-id is P2.3b). Ocean -> all 0.

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.scale.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.scale.test.ts
@@ -12,6 +12,7 @@ import {
   CLIMATE_FRAG,
   TERRAIN_FRAG,
   HYDRO_FRAG,
+  WIND_FRAG,
 } from "./hydraulic.glsl";
 import { BAKE_RES_TIERS, clampBakeRes } from "./bakeResolution";
 
@@ -344,5 +345,22 @@ describe("#234 P2.3a TERRAIN/HYDRO frags", () => {
     expect(HYDRO_FRAG.split("\n").filter(
       (l)=>/^\s*"?uniform /.test(l)&&l.includes("//")).length).toBe(0);
     expect(HYDRO_FRAG).not.toMatch(/`/);
+  });
+});
+
+describe("NX-3-v2a WIND_FRAG", () => {
+  it("packs geostrophic wind vector (vx,vy,|v|) from blurred MSLP", () => {
+    expect(typeof WIND_FRAG).toBe("string");
+    expect(WIND_FRAG).toMatch(/uniform sampler2D uMSLP;/);
+    expect(WIND_FRAG).toMatch(/uniform float uCoriolisGain;/);
+    expect(WIND_FRAG).toMatch(/uCoriolisGain \* s \* vec2\(-gp\.y, gp\.x\) - gp/);
+    expect(WIND_FRAG).toMatch(/length\(wvec\)/);
+    expect(WIND_FRAG).toMatch(/fragColor = vec4\(/);
+    expect(
+      WIND_FRAG.split("\n").filter(
+        (l) => /^\s*"?uniform /.test(l) && l.includes("//"),
+      ).length,
+    ).toBe(0);
+    expect(WIND_FRAG).not.toMatch(/`/);
   });
 });

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -54,6 +54,7 @@ import {
   CLIMATE_FRAG,
   TERRAIN_FRAG,
   HYDRO_FRAG,
+  WIND_FRAG,
   MSLP_FRAG,
   BLUR_H_FRAG,
   BLUR_V_FRAG,
@@ -396,6 +397,7 @@ export interface HydraulicBakeResult {
   clim: THREE.WebGLRenderTarget;
   terr: THREE.WebGLRenderTarget;
   hydro: THREE.WebGLRenderTarget;
+  wind: THREE.WebGLRenderTarget;
 }
 
 export async function runHydraulicBake(
@@ -412,7 +414,7 @@ export async function runHydraulicBake(
   // FAILS if EXT_color_buffer_float is missing. We drive the read/write
   // slots explicitly below (NOT pp.book) so the discipline is local and
   // unambiguous.
-  const pp: PingPongTargets = createPingPong(renderer, w, h, ["A", "F", "M", "ACC", "CTRL", "CLIM", "TERR", "HYDRO", "MSLP"]);
+  const pp: PingPongTargets = createPingPong(renderer, w, h, ["A", "F", "M", "ACC", "CTRL", "CLIM", "TERR", "HYDRO", "MSLP", "WIND"]);
   const A = pp.rt.A; // [slot0, slot1]
   const F = pp.rt.F; // [slot0, slot1]
   // S2.4 detail mask: a ONE-TIME single-channel field (computed pre-loop
@@ -438,6 +440,7 @@ export async function runHydraulicBake(
   // other channel (no per-tick alloc), reused every refreshClimate
   // tick, disposed once at teardown; never escapes, never feeds erosion.
   const MSLP = pp.rt.MSLP;
+  const WIND = pp.rt.WIND;
   let accRead = 0;
   const swapAcc = (): void => {
     accRead ^= 1;
@@ -509,6 +512,16 @@ export async function runHydraulicBake(
         uGlacFullC: u(cfg.glacFullC),
       },
       CLIM[0],
+    );
+    runRawPass(
+      renderer,
+      WIND_FRAG,
+      {
+        uMSLP: u(MSLP[0]),
+        uGrid: u(uGrid),
+        uCoriolisGain: u(cfg.coriolisGain),
+      },
+      WIND[0],
     );
     runRawPass(
       renderer,
@@ -878,5 +891,6 @@ export async function runHydraulicBake(
   HYDRO[1].dispose();
   MSLP[0].dispose();
   MSLP[1].dispose();
-  return { eroded: result, clim: CLIM[0], terr: TERR[0], hydro: HYDRO[0] };
+  WIND[1].dispose();
+  return { eroded: result, clim: CLIM[0], terr: TERR[0], hydro: HYDRO[0], wind: WIND[0] };
 }

--- a/apps/hayba-explorer/src/viewport/bake/stack-mapmode.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/stack-mapmode.test.ts
@@ -8,10 +8,10 @@ const hydraulicSrc = readFileSync(
 );
 
 describe("runHydraulicBake return-shape (Task 1)", () => {
-  it("declares the 4-RT HydraulicBakeResult and returns it", () => {
+  it("declares the 5-RT HydraulicBakeResult and returns it", () => {
     expect(hydraulicSrc).toContain("export interface HydraulicBakeResult");
     expect(hydraulicSrc).toMatch(
-      /return\s*\{\s*eroded:\s*result,\s*clim:\s*CLIM\[0\],\s*terr:\s*TERR\[0\],\s*hydro:\s*HYDRO\[0\]\s*\}/,
+      /return\s*\{\s*eroded:\s*result,\s*clim:\s*CLIM\[0\],\s*terr:\s*TERR\[0\],\s*hydro:\s*HYDRO\[0\],\s*wind:\s*WIND\[0\]\s*\}/,
     );
     expect(hydraulicSrc).toContain(
       "): Promise<HydraulicBakeResult> {",


### PR DESCRIPTION
NX-3-v2a — faithful geostrophic **wind vector** field.

- New `WIND_FRAG`: re-derives the exact `wvec` `CLIMATE_FRAG` already computes but discards (byte-identical pL→wvec transcription), output `(vx, vy, |v|, 0)` into a new `WIND` RGBA32F equirect target.
- `refreshClimate` runs WIND between CLIMATE and TERRAIN; `runHydraulicBake` returns `wind` caller-owned (like clim/terr/hydro); `WIND[1]` teardown-disposed; 3 harness sites + App `prevDebugWindRef` extended.
- Erosion reads `WIND` nowhere ⇒ #218 `8ecba5b` intact by construction.
- Prerequisite for NX-3-v2b (particle-advection flow-map viz). No v2a visual gate (data field).
- Gates: tsc 0 · 8 vitest suites / 78 tests · cargo check --workspace 0 · tectonics-v2 + explorer-lib 58/0 · diff-stat = 6 files (5 + stack-mapmode pin), Rust untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wind simulation output to the hydraulic bake pipeline for enhanced debug rendering capabilities.

* **Bug Fixes**
  * Improved GPU resource management to properly dispose of render targets across repeated bake operations.

* **Tests**
  * Updated test suite to validate wind shader output and new bake result structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->