### PR TITLE
fix(viewport): NX-3-v2b wind-flow advection (eyeball retune)

### DIFF
--- a/apps/hayba-explorer/src/viewport/windFlow.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/windFlow.glsl.ts
@@ -1,14 +1,17 @@
-// NX-3-v2b WINDFLOW — Eulerian semi-Lagrangian advected-dye flow-map.
-// Back-advect the trail by the geostrophic WIND vector, fade (MdGBWG
-// z=0.9*prev), inject sparse time-seeded births, speed-glow so calm
-// air stays near-black. Display-only; reads WIND read-only.
+// NX-3-v2b WINDFLOW — Eulerian advected-dye flow-map. Back-advect the
+// trail along the NORMALISED wind DIRECTION by a small bounded
+// per-frame step (raw |wvec| is unnormalised/large → advecting by it
+// teleports the dye into a global drift; direction + clamped step is
+// scale-robust). Speed (WIND.b) → glow + a mild streak-length factor,
+// never step distance. Fade MdGBWG z=0.9*prev; sparse phase-offset
+// births. Display-only; reads WIND read-only.
 export const WINDFLOW_FRAG = [
   "uniform sampler2D uPrevTrail;",
   "uniform sampler2D uWind;",
   "uniform vec2 uGrid;",
   "uniform float uDt;",
   "uniform float uTime;",
-  "const float ADV_K = 0.18;",
+  "const float STEP_TEX = 1.5;",
   "const float SPD_REF = 0.55;",
   "const float SEED_THR = 0.992;",
   "out vec4 fragColor;",
@@ -20,12 +23,18 @@ export const WINDFLOW_FRAG = [
   "  vec3 wv = texture(uWind, uv).rgb;",
   "  vec2 v = wv.xy;",
   "  float spd = wv.z;",
-  "  vec2 prevUv = uv - v * uDt * ADV_K;",
+  "  float vlen = length(v);",
+  "  vec2 dir = vlen > 1e-4 ? v / vlen : vec2(0.0);",
+  "  float spdN = clamp(spd / SPD_REF, 0.0, 1.0);",
+  "  float fr = clamp(uDt * 60.0, 0.5, 2.0);",
+  "  float stepUv = (STEP_TEX / max(uGrid.x, uGrid.y)) * (0.15 + 0.85 * spdN) * fr;",
+  "  vec2 prevUv = uv - dir * stepUv;",
   "  prevUv.x = fract(prevUv.x);",
   "  prevUv.y = clamp(prevUv.y, 0.0, 1.0);",
   "  float prev = texture(uPrevTrail, prevUv).r;",
   "  float trail = prev * 0.9;",
-  "  float seed = hash(floor(uv * uGrid) + floor(uTime * 24.0));",
+  "  float ph = hash(floor(uv * uGrid));",
+  "  float seed = hash(floor(uv * uGrid) + floor(uTime * 6.0 + ph * 97.0));",
   "  trail = max(trail, step(SEED_THR, seed));",
   "  float g = trail * smoothstep(0.0, SPD_REF, spd);",
   "  fragColor = vec4(vec3(g), 1.0);",

--- a/apps/hayba-explorer/src/viewport/windFlow.test.ts
+++ b/apps/hayba-explorer/src/viewport/windFlow.test.ts
@@ -10,7 +10,12 @@ describe("NX-3-v2b WINDFLOW_FRAG", () => {
     expect(WINDFLOW_FRAG).toMatch(/uniform vec2 uGrid;/);
     expect(WINDFLOW_FRAG).toMatch(/uniform float uDt;/);
     expect(WINDFLOW_FRAG).toMatch(/uniform float uTime;/);
-    expect(WINDFLOW_FRAG).toMatch(/uv - v \* uDt \* ADV_K/);
+    // Scale-robust advection: normalised direction, bounded per-frame
+    // step (NOT the raw |wvec| — that teleported the dye).
+    expect(WINDFLOW_FRAG).toMatch(/v \/ vlen/);
+    expect(WINDFLOW_FRAG).toMatch(/uv - dir \* stepUv/);
+    expect(WINDFLOW_FRAG).toMatch(/STEP_TEX/);
+    expect(WINDFLOW_FRAG).not.toMatch(/uDt \* ADV_K/);
     expect(WINDFLOW_FRAG).toMatch(/fract\(prevUv\.x\)/);
     expect(WINDFLOW_FRAG).toMatch(/clamp\(prevUv\.y, 0\.0, 1\.0\)/);
     expect(WINDFLOW_FRAG).toMatch(/\* 0\.9/);


### PR DESCRIPTION
NX-3-v2b eyeball retune. The flow advected by the raw geostrophic |wvec| (unnormalised, large) → the dye teleported into a global NE drift instead of flowing along the field.

Fix: advect along the NORMALISED wind direction by a small bounded per-frame step (`STEP_TEX` texels, scaled by clamped speed + a 60fps factor); speed (WIND.b) still drives the glow + a mild streak-length factor, never step distance. Scale-robust regardless of MSLP/coriolis units. Sparse births now phase-offset per texel (less global flicker).

Display-only; zero bake/erosion/Rust change → #218 8ecba5b intact by construction. tsc 0 · 9 vitest / 82 · diff-stat = 7 display files. Note: with the analytic annual-mean MSLP the flow is latitude-banded by design — real eddies/jets need P2.2-oro (continental/orographic MSLP structure), flagged in the spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized wind-flow rendering calculations for improved efficiency and visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->