### PR TITLE
feat(viewport): NX-3-v2c Lagrangian particle wind viz (MdGBWG Buffer C)

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/glPass.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/glPass.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { __parseUniformTypesForTest } from "./glPass";
+
+describe("glPass parseUniformTypes — runPointPass enablement", () => {
+  it("parses uniforms from a vert source using gl_VertexID + sampler2D", () => {
+    const src = [
+      "uniform sampler2D uPart;",
+      "uniform vec2 uPartDim;",
+      "uniform sampler2D uWind;",
+      "out float v_intensity;",
+      "void main(){",
+      "  int id = gl_VertexID;",
+      "  int w = int(uPartDim.x);",
+      "  ivec2 rc = ivec2(id - (id / w) * w, id / w);",
+      "  vec4 s = texelFetch(uPart, rc, 0);",
+      "  gl_Position = vec4(s.xy * 2.0 - 1.0, 0.0, 1.0);",
+      "  gl_PointSize = 2.0;",
+      "  v_intensity = texture(uWind, s.xy).z;",
+      "}",
+    ].join("\n");
+    const m = __parseUniformTypesForTest(src);
+    expect(m.get("uPart")).toBe("sampler2D");
+    expect(m.get("uPartDim")).toBe("vec2");
+    expect(m.get("uWind")).toBe("sampler2D");
+  });
+});

--- a/apps/hayba-explorer/src/viewport/bake/glPass.ts
+++ b/apps/hayba-explorer/src/viewport/bake/glPass.ts
@@ -106,6 +106,15 @@ function buildFragmentSource(frag: string): string {
   );
 }
 
+function buildVertexSource(vert: string): string {
+  return (
+    "#version 300 es\n" +
+    "precision highp float;\n" +
+    "precision highp int;\n" +
+    vert
+  );
+}
+
 type Gl = WebGL2RenderingContext;
 
 /** Per-program compiled+linked state + caches. */
@@ -135,6 +144,7 @@ type UniformGlType =
 let _gl: Gl | null = null;
 let _fbo: WebGLFramebuffer | null = null;
 let _vao: WebGLVertexArrayObject | null = null;
+let _pointVao: WebGLVertexArrayObject | null = null;
 let _vbo: WebGLBuffer | null = null;
 const _programs = new Map<string, ProgramEntry>();
 /* Resolved GL texture handle per three Texture/RT, keyed by the three
@@ -193,6 +203,9 @@ function parseUniformTypes(src: string): Map<string, UniformGlType> {
   }
   return out;
 }
+
+/** Test-only re-export. Do not depend on this from production code. */
+export const __parseUniformTypesForTest = parseUniformTypes;
 
 function compileShader(
   gl: Gl,
@@ -284,6 +297,49 @@ function ensureProgram(gl: Gl, frag: string): ProgramEntry {
     type: parseUniformTypes(frag),
   };
   _programs.set(frag, entry);
+  return entry;
+}
+
+/** Compile+link (once) and cache the program for a vertex+fragment source pair. */
+function ensureProgramVF(gl: Gl, vert: string, frag: string): ProgramEntry {
+  const key = "P|" + vert + "\n" + frag;
+  let entry = _programs.get(key);
+  if (entry) return entry;
+
+  const vs = compileShader(gl, gl.VERTEX_SHADER, buildVertexSource(vert), "vertex");
+  const fsSrc = buildFragmentSource(frag);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, fsSrc, "fragment");
+
+  const program = gl.createProgram();
+  if (!program) throw new Error("glPass: createProgram failed");
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  // Bind the VS `position` attribute to location 0 (matches the VAO).
+  gl.bindAttribLocation(program, 0, "position");
+  gl.linkProgram(program);
+  // Shaders can be detached/deleted after a successful link.
+  gl.detachShader(program, vs);
+  gl.detachShader(program, fs);
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(program);
+    gl.deleteProgram(program);
+    // Loud — a shader-prefix mismatch must NOT be silent. Name the frag
+    // by its first signature-ish token so the failing pass is clear.
+    const idMatch = frag.match(/[A-Za-z_]\w*\s*\(/);
+    const fid = idMatch ? idMatch[0].replace(/\s+/g, "") : frag.slice(0, 32);
+    throw new Error(
+      `glPass: program link failed for frag "${fid}":\n${log ?? "(no log)"}`,
+    );
+  }
+
+  entry = {
+    program,
+    loc: new Map(),
+    type: parseUniformTypes(vert + "\n" + frag),
+  };
+  _programs.set(key, entry);
   return entry;
 }
 
@@ -576,6 +632,238 @@ export function runRawPass(
 }
 
 /**
+ * Run ONE POINTS-primitive pass on the raw WebGL2 context into `dstRT`,
+ * using a caller-supplied vertex shader (typically gl_VertexID-driven) and
+ * `count` point sprites. Mirrors runRawPass's discipline byte-for-byte
+ * (same two-phase sampler bind, same explicit cleanup) and differs only in
+ * the 7 named ways: vert param, ensureProgramVF, _pointVao, optional
+ * additive blend, POINTS draw call, blend restore, and count param.
+ */
+export function runPointPass(
+  renderer: THREE.WebGLRenderer,
+  vert: string,
+  frag: string,
+  count: number,
+  uniforms: Record<string, THREE.IUniform>,
+  dstRT: THREE.WebGLRenderTarget,
+  opts?: { additive?: boolean },
+): void {
+  const gl = ensureGl(renderer);
+  const entry = ensureProgramVF(gl, vert, frag);
+  const fbo = _fbo as WebGLFramebuffer;
+  if (_pointVao === null) _pointVao = gl.createVertexArray();
+  const vao = _pointVao as WebGLVertexArrayObject;
+
+  const dstGlTex = resolveRtGlTexture(renderer, dstRT);
+
+  // 1-2. Bind our own FBO and (re)attach the dst's GL texture each pass.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+  gl.framebufferTexture2D(
+    gl.FRAMEBUFFER,
+    gl.COLOR_ATTACHMENT0,
+    gl.TEXTURE_2D,
+    dstGlTex,
+    0,
+  );
+
+  // 3. (dev-gated) framebuffer completeness assert — a misconfigured
+  // attachment should be loud, not a silently black pass.
+  if (
+    (import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV === true
+  ) {
+    const fbStatus = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    if (fbStatus !== gl.FRAMEBUFFER_COMPLETE) {
+      throw new Error(
+        `glPass: framebuffer incomplete (0x${fbStatus.toString(16)})`,
+      );
+    }
+  }
+
+  // 4. Fixed-function state for an offscreen compute pass.
+  gl.viewport(0, 0, dstRT.width, dstRT.height);
+  gl.disable(gl.DEPTH_TEST);
+  gl.disable(gl.BLEND);
+  gl.disable(gl.SCISSOR_TEST);
+  gl.disable(gl.CULL_FACE);
+  gl.colorMask(true, true, true, true);
+  if (opts?.additive) {
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE);
+  }
+
+  // 5. Program + geometry.
+  gl.useProgram(entry.program);
+  gl.bindVertexArray(vao);
+
+  // 6. Upload uniforms by parsed GLSL type. Track sampler units bound so
+  //    they can be explicitly unbound after the draw.
+  //
+  // SAMPLERS ARE TWO-PHASE (load-bearing — do NOT inline phase 2 into
+  // phase 1). resolveRtGlTexture/resolveTexGlHandle call three's
+  // renderer.initRenderTarget / renderer.initTexture, which on a
+  // texture/RT's FIRST use run textures.setupRenderTarget /
+  // textures.setTexture2D. Those go through three's WebGLState and issue
+  // REAL gl.activeTexture(TEXTURE0+slot)/gl.bindTexture (slot defaults to
+  // 0) plus a state.texImage2D upload. If we resolved+raw-bound samplers
+  // one-by-one, the resolve of sampler N (e.g. uPrecip, a DataTexture's
+  // first upload) would clobber the raw bind we already did for sampler
+  // N-1 on its unit (e.g. uA on unit 0) — three's setTexture2D rebinds
+  // unit 0. The shader then samples the wrong texture for the earlier unit
+  // (uA reads zeros while only the later sampler is correct → the exact
+  // "terrain/ocean collapse, water-only updates" failure). So: PHASE 1
+  // resolves EVERY sampler handle (all three-state touches happen here,
+  // before any raw unit bind); PHASE 2 raw-binds the resolved handles to
+  // units with NO three call interleaved, so nothing can clobber a unit
+  // after it is bound.
+  let unit = 0;
+  const boundUnits: number[] = [];
+  // Phase 1: resolve all sampler GL handles + assign units (three's lazy
+  // init/upload may bind textures on its own units here — harmless now,
+  // because no raw unit binds have happened yet).
+  const samplerBinds: {
+    loc: WebGLUniformLocation;
+    handle: WebGLTexture;
+    unit: number;
+  }[] = [];
+  for (const name of Object.keys(uniforms)) {
+    const u = uniforms[name];
+    if (!u) continue;
+    const value = u.value as unknown;
+    const loc = uniformLoc(gl, entry, name);
+    if (loc == null) continue; // not present / optimized out
+    const rt = asRenderTarget(value);
+    if (rt != null) {
+      // CRITICAL: resolve an RT *source* via initRenderTarget (the same
+      // path the dst uses), NOT initTexture(rt.texture). An RT's color
+      // texture is GL-created exclusively by textures.setupRenderTarget
+      // (three.module.js:25842), which sets `__webglTexture` + `__version`
+      // but NOT `__cacheKey` and never registers the texture in three's
+      // `_sources` map. Routing rt.texture through initTexture →
+      // setTexture2D → initTexture(props,tex) (three.module.js:24784) then
+      // sees `textureCacheKey !== props.__cacheKey` (undefined), so it
+      // CREATES A FRESH EMPTY gl.createTexture() and OVERWRITES
+      // props.__webglTexture (three.module.js:24821/24856) — binding an
+      // empty never-rendered texture → the shader samples all zeros.
+      // initRenderTarget is idempotent and returns the RT's real
+      // color-attachment handle.
+      samplerBinds.push({
+        loc,
+        handle: resolveRtGlTexture(renderer, rt),
+        unit,
+      });
+      boundUnits.push(unit);
+      unit++;
+      continue;
+    }
+    if (value instanceof THREE.Texture) {
+      samplerBinds.push({
+        loc,
+        handle: resolveTexGlHandle(renderer, value),
+        unit,
+      });
+      boundUnits.push(unit);
+      unit++;
+      continue;
+    }
+  }
+  // Phase 2: raw-bind every resolved sampler handle to its unit. No three
+  // call runs between these binds, so a unit, once bound, stays bound
+  // through the draw.
+  for (const sb of samplerBinds) {
+    gl.activeTexture(gl.TEXTURE0 + sb.unit);
+    gl.bindTexture(gl.TEXTURE_2D, sb.handle);
+    gl.uniform1i(sb.loc, sb.unit);
+  }
+  // Non-sampler uniforms (no three-state interaction — order-independent).
+  for (const name of Object.keys(uniforms)) {
+    const u = uniforms[name];
+    if (!u) continue;
+    const value = u.value as unknown;
+    const loc = uniformLoc(gl, entry, name);
+    if (loc == null) continue; // not present / optimized out
+    const gType = entry.type.get(name) ?? "unknown";
+
+    // Samplers were handled in the two-phase block above.
+    if (asRenderTarget(value) != null || value instanceof THREE.Texture) {
+      continue;
+    }
+
+    // Vectors.
+    if (value instanceof THREE.Vector2) {
+      if (gType === "uvec2") {
+        // The u64 hash seed: .x = lo32, .y = hi32 as uint bit-patterns.
+        // MUST be uniform2ui — uniform2f would silently corrupt the bake.
+        gl.uniform2ui(loc, value.x >>> 0, value.y >>> 0);
+      } else if (gType === "ivec2") {
+        gl.uniform2i(loc, value.x | 0, value.y | 0);
+      } else {
+        gl.uniform2f(loc, value.x, value.y);
+      }
+      continue;
+    }
+    if (value instanceof THREE.Vector3) {
+      gl.uniform3f(loc, value.x, value.y, value.z);
+      continue;
+    }
+    if (value instanceof THREE.Vector4) {
+      gl.uniform4f(loc, value.x, value.y, value.z, value.w);
+      continue;
+    }
+
+    // Scalars: int/uint vs float driven by the PARSED GLSL type.
+    if (typeof value === "number") {
+      if (gType === "int") {
+        gl.uniform1i(loc, value | 0);
+      } else if (gType === "uint") {
+        gl.uniform1ui(loc, value >>> 0);
+      } else {
+        // float (default) — uFaceRes, uErodibility, …
+        gl.uniform1f(loc, value);
+      }
+      continue;
+    }
+    if (typeof value === "boolean") {
+      gl.uniform1i(loc, value ? 1 : 0);
+      continue;
+    }
+    // Any other type is unexpected for the bake frags — skip silently
+    // (a real type error would surface as a wrong-looking field, and the
+    // parsed-type path above covers every uniform the bake actually uses).
+  }
+
+  // 7. Draw the point sprites.
+  gl.drawArrays(gl.POINTS, 0, count);
+
+  // 8. EXPLICIT cleanup — the whole point. Unbind every sampler unit we
+  //    bound, then the FBO. dst was only ever a COLOR_ATTACHMENT0, never a
+  //    sampler (GL-ALIAS proved no uniform == dst). With all sampler units
+  //    null and the FBO unbound, no texture can be simultaneously a
+  //    sampler source and the active framebuffer attachment on any
+  //    subsequent pass → the "Feedback loop formed between Framebuffer and
+  //    active Texture" condition cannot arise. Structurally impossible.
+  for (const bu of boundUnits) {
+    gl.activeTexture(gl.TEXTURE0 + bu);
+    gl.bindTexture(gl.TEXTURE_2D, null);
+  }
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindVertexArray(null);
+  // Detach the dst texture from the FBO before unbinding (so the dst GL
+  // texture is not even referenced by our FBO between passes).
+  gl.framebufferTexture2D(
+    gl.FRAMEBUFFER,
+    gl.COLOR_ATTACHMENT0,
+    gl.TEXTURE_2D,
+    null,
+    0,
+  );
+  if (opts?.additive) {
+    gl.disable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ZERO);
+  }
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+}
+
+/**
  * Read RGBA32F pixels from a three RenderTarget on the raw WebGL2 context,
  * via OUR own FBO — NOT three's `readRenderTargetPixels`.
  *
@@ -639,10 +927,12 @@ export function disposeGlPassCache(): void {
     if (_fbo) gl.deleteFramebuffer(_fbo);
     if (_vbo) gl.deleteBuffer(_vbo);
     if (_vao) gl.deleteVertexArray(_vao);
+    if (_pointVao) gl.deleteVertexArray(_pointVao);
   }
   _programs.clear();
   _fbo = null;
   _vbo = null;
   _vao = null;
+  _pointVao = null;
   _gl = null;
 }

--- a/apps/hayba-explorer/src/viewport/windFlow.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/windFlow.glsl.ts
@@ -1,42 +1,115 @@
-// NX-3-v2b WINDFLOW — Eulerian advected-dye flow-map. Back-advect the
-// trail along the NORMALISED wind DIRECTION by a small bounded
-// per-frame step (raw |wvec| is unnormalised/large → advecting by it
-// teleports the dye into a global drift; direction + clamped step is
-// scale-robust). Speed (WIND.b) → glow + a mild streak-length factor,
-// never step distance. Fade MdGBWG z=0.9*prev; sparse phase-offset
-// births. Display-only; reads WIND read-only.
-export const WINDFLOW_FRAG = [
-  "uniform sampler2D uPrevTrail;",
+// NX-3-v2c WINDFLOW shaders — MdGBWG Buffer C-faithful Lagrangian
+// particles. INIT seeds the 64x64 particle state; ADVECT integrates
+// position along the normalised wind direction + ages + respawns
+// (deterministic per-particle hash); FADE multiplies the trail by
+// 0.9; SPLAT_VERT positions each point by `gl_VertexID` indexing
+// into the particle state texture; SPLAT_FRAG emits a soft round
+// dot whose brightness is gated by |wind| and fades with age.
+// Display-only; reads WIND read-only; trail RT is engine-private.
+
+const HASH = [
+  "float hash(vec2 p){",
+  "  return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);",
+  "}",
+  "float hash(float p){",
+  "  return fract(sin(p * 78.233) * 43758.5453);",
+  "}",
+].join("\n");
+
+const LIFE_DECL = "const float LIFE = 1.5;";
+const STEP_K_DECL = "const float STEP_K = 0.06;";
+const SPD_REF_DECL = "const float SPD_REF = 0.55;";
+
+export const INIT_FRAG = [
+  "uniform vec2 uGrid;",
+  LIFE_DECL,
+  "out vec4 fragColor;",
+  HASH,
+  "void main(){",
+  "  vec2 fc = gl_FragCoord.xy;",
+  "  float h1 = hash(fc);",
+  "  float h2 = hash(fc + vec2(13.7, 91.3));",
+  "  float h3 = hash(fc + vec2(57.1, 4.6));",
+  "  float h4 = hash(fc + vec2(31.2, 22.9));",
+  "  fragColor = vec4(h1, h2, LIFE * h3, h4);",
+  "}",
+].join("\n");
+
+export const ADVECT_FRAG = [
+  "uniform sampler2D uPrev;",
   "uniform sampler2D uWind;",
   "uniform vec2 uGrid;",
   "uniform float uDt;",
   "uniform float uTime;",
-  "const float STEP_TEX = 1.5;",
-  "const float SPD_REF = 0.55;",
-  "const float SEED_THR = 0.992;",
+  LIFE_DECL,
+  STEP_K_DECL,
   "out vec4 fragColor;",
-  "float hash(vec2 p){",
-  "  return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);",
-  "}",
+  HASH,
   "void main(){",
-  "  vec2 uv = gl_FragCoord.xy / uGrid;",
-  "  vec3 wv = texture(uWind, uv).rgb;",
-  "  vec2 v = wv.xy;",
-  "  float spd = wv.z;",
+  "  ivec2 rc = ivec2(gl_FragCoord.xy);",
+  "  vec4 s = texelFetch(uPrev, rc, 0);",
+  "  vec2 pos = s.xy;",
+  "  float age = s.z;",
+  "  float seed = s.w;",
+  "  vec2 v = texture(uWind, pos).xy;",
   "  float vlen = length(v);",
   "  vec2 dir = vlen > 1e-4 ? v / vlen : vec2(0.0);",
-  "  float spdN = clamp(spd / SPD_REF, 0.0, 1.0);",
-  "  float fr = clamp(uDt * 60.0, 0.5, 2.0);",
-  "  float stepUv = (STEP_TEX / max(uGrid.x, uGrid.y)) * (0.15 + 0.85 * spdN) * fr;",
-  "  vec2 prevUv = uv - dir * stepUv;",
-  "  prevUv.x = fract(prevUv.x);",
-  "  prevUv.y = clamp(prevUv.y, 0.0, 1.0);",
-  "  float prev = texture(uPrevTrail, prevUv).r;",
-  "  float trail = prev * 0.9;",
-  "  float ph = hash(floor(uv * uGrid));",
-  "  float seed = hash(floor(uv * uGrid) + floor(uTime * 6.0 + ph * 97.0));",
-  "  trail = max(trail, step(SEED_THR, seed));",
-  "  float g = trail * smoothstep(0.0, SPD_REF, spd);",
-  "  fragColor = vec4(vec3(g), 1.0);",
+  "  pos += dir * uDt * STEP_K;",
+  "  pos.x = fract(pos.x);",
+  "  pos.y = clamp(pos.y, 0.0, 1.0);",
+  "  age += uDt;",
+  "  if (age > LIFE || vlen < 1e-4) {",
+  "    seed = hash(seed + uTime * 7.0);",
+  "    pos = vec2(hash(seed + 1.0), hash(seed + 2.0));",
+  "    age = 0.0;",
+  "  }",
+  "  fragColor = vec4(pos, age, seed);",
   "}",
 ].join("\n");
+
+export const FADE_FRAG = [
+  "uniform sampler2D uPrevTrail;",
+  "uniform vec2 uGrid;",
+  "out vec4 fragColor;",
+  "void main(){",
+  "  vec2 uv = gl_FragCoord.xy / uGrid;",
+  "  float t = texture(uPrevTrail, uv).r;",
+  "  fragColor = vec4(vec3(t * 0.9), 1.0);",
+  "}",
+].join("\n");
+
+export const SPLAT_VERT = [
+  "uniform sampler2D uPart;",
+  "uniform vec2 uPartDim;",
+  "uniform sampler2D uWind;",
+  LIFE_DECL,
+  SPD_REF_DECL,
+  "out float v_intensity;",
+  "void main(){",
+  "  int id = gl_VertexID;",
+  "  int w = int(uPartDim.x);",
+  "  ivec2 rc = ivec2(id - (id / w) * w, id / w);",
+  "  vec4 s = texelFetch(uPart, rc, 0);",
+  "  vec2 pos = s.xy;",
+  "  float age = s.z;",
+  "  gl_Position = vec4(pos * 2.0 - 1.0, 0.0, 1.0);",
+  "  gl_PointSize = 2.5;",
+  "  float spd = texture(uWind, pos).z;",
+  "  float speedGate = smoothstep(0.0, SPD_REF, spd);",
+  "  float ageFade = 1.0 - smoothstep(LIFE * 0.7, LIFE, age);",
+  "  v_intensity = speedGate * ageFade;",
+  "}",
+].join("\n");
+
+export const SPLAT_FRAG = [
+  "in float v_intensity;",
+  "out vec4 fragColor;",
+  "void main(){",
+  "  vec2 d = gl_PointCoord - 0.5;",
+  "  float falloff = smoothstep(0.5, 0.0, length(d));",
+  "  fragColor = vec4(vec3(v_intensity * falloff), 1.0);",
+  "}",
+].join("\n");
+
+/** @deprecated v2b compat alias — replaced by FADE_FRAG in v2c; removed in T3. */
+export const WINDFLOW_FRAG = FADE_FRAG;

--- a/apps/hayba-explorer/src/viewport/windFlow.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/windFlow.glsl.ts
@@ -110,6 +110,3 @@ export const SPLAT_FRAG = [
   "  fragColor = vec4(vec3(v_intensity * falloff), 1.0);",
   "}",
 ].join("\n");
-
-/** @deprecated v2b compat alias — replaced by FADE_FRAG in v2c; removed in T3. */
-export const WINDFLOW_FRAG = FADE_FRAG;

--- a/apps/hayba-explorer/src/viewport/windFlow.test.ts
+++ b/apps/hayba-explorer/src/viewport/windFlow.test.ts
@@ -103,3 +103,11 @@ describe("NX-3-v2b step dt clamp", () => {
     expect(__clampStepDt(NaN)).toBe(0);
   });
 });
+
+describe("NX-3-v2c particle dimensions", () => {
+  it("exports PARTICLE_DIM and PARTICLE_COUNT consistent with each other", () => {
+    expect(PARTICLE_DIM).toBe(64);
+    expect(PARTICLE_COUNT).toBe(4096);
+    expect(PARTICLE_COUNT).toBe(PARTICLE_DIM * PARTICLE_DIM);
+  });
+});

--- a/apps/hayba-explorer/src/viewport/windFlow.test.ts
+++ b/apps/hayba-explorer/src/viewport/windFlow.test.ts
@@ -1,33 +1,85 @@
 import { describe, it, expect } from "vitest";
-import { WINDFLOW_FRAG } from "./windFlow.glsl";
-import { windFlowSize, __clampStepDt } from "./windFlow";
+import {
+  INIT_FRAG,
+  ADVECT_FRAG,
+  FADE_FRAG,
+  SPLAT_VERT,
+  SPLAT_FRAG,
+} from "./windFlow.glsl";
+import {
+  windFlowSize,
+  __clampStepDt,
+  PARTICLE_DIM,
+  PARTICLE_COUNT,
+} from "./windFlow";
 
-describe("NX-3-v2b WINDFLOW_FRAG", () => {
-  it("is a semi-Lagrangian advected-dye fragment", () => {
-    expect(typeof WINDFLOW_FRAG).toBe("string");
-    expect(WINDFLOW_FRAG).toMatch(/uniform sampler2D uPrevTrail;/);
-    expect(WINDFLOW_FRAG).toMatch(/uniform sampler2D uWind;/);
-    expect(WINDFLOW_FRAG).toMatch(/uniform vec2 uGrid;/);
-    expect(WINDFLOW_FRAG).toMatch(/uniform float uDt;/);
-    expect(WINDFLOW_FRAG).toMatch(/uniform float uTime;/);
-    // Scale-robust advection: normalised direction, bounded per-frame
-    // step (NOT the raw |wvec| — that teleported the dye).
-    expect(WINDFLOW_FRAG).toMatch(/v \/ vlen/);
-    expect(WINDFLOW_FRAG).toMatch(/uv - dir \* stepUv/);
-    expect(WINDFLOW_FRAG).toMatch(/STEP_TEX/);
-    expect(WINDFLOW_FRAG).not.toMatch(/uDt \* ADV_K/);
-    expect(WINDFLOW_FRAG).toMatch(/fract\(prevUv\.x\)/);
-    expect(WINDFLOW_FRAG).toMatch(/clamp\(prevUv\.y, 0\.0, 1\.0\)/);
-    expect(WINDFLOW_FRAG).toMatch(/\* 0\.9/);
-    expect(WINDFLOW_FRAG).toMatch(/texture\(uWind, uv\)/);
-    expect(WINDFLOW_FRAG).toMatch(/smoothstep\(0\.0, SPD_REF/);
-    expect(WINDFLOW_FRAG).toMatch(/fragColor = vec4\(vec3\(/);
-    expect(WINDFLOW_FRAG).not.toMatch(/`/);
+describe("NX-3-v2c INIT_FRAG", () => {
+  it("seeds the particle state texture with hashed pos + age + seed", () => {
+    expect(typeof INIT_FRAG).toBe("string");
+    expect(INIT_FRAG).toMatch(/uniform vec2 uGrid;/);
+    expect(INIT_FRAG).toMatch(/hash\(/);
+    expect(INIT_FRAG).toMatch(/fragColor = vec4\(/);
+    expect(INIT_FRAG).not.toMatch(/`/);
     expect(
-      WINDFLOW_FRAG.split("\n").filter(
+      INIT_FRAG.split("\n").filter(
         (l) => /^\s*uniform /.test(l) && l.includes("//"),
       ).length,
     ).toBe(0);
+  });
+});
+
+describe("NX-3-v2c ADVECT_FRAG", () => {
+  it("advects particle state along normalised wind dir + age + respawn", () => {
+    expect(typeof ADVECT_FRAG).toBe("string");
+    expect(ADVECT_FRAG).toMatch(/uniform sampler2D uPrev;/);
+    expect(ADVECT_FRAG).toMatch(/uniform sampler2D uWind;/);
+    expect(ADVECT_FRAG).toMatch(/uniform vec2 uGrid;/);
+    expect(ADVECT_FRAG).toMatch(/uniform float uDt;/);
+    expect(ADVECT_FRAG).toMatch(/uniform float uTime;/);
+    expect(ADVECT_FRAG).toMatch(/texelFetch\(uPrev/);
+    expect(ADVECT_FRAG).toMatch(/v \/ vlen/);
+    expect(ADVECT_FRAG).toMatch(/fract\(pos\.x\)/);
+    expect(ADVECT_FRAG).toMatch(/clamp\(pos\.y, 0\.0, 1\.0\)/);
+    expect(ADVECT_FRAG).toMatch(/age > LIFE/);
+    expect(ADVECT_FRAG).toMatch(/fragColor = vec4\(pos/);
+    expect(ADVECT_FRAG).not.toMatch(/`/);
+  });
+});
+
+describe("NX-3-v2c FADE_FRAG", () => {
+  it("samples the trail and writes prev * 0.9", () => {
+    expect(typeof FADE_FRAG).toBe("string");
+    expect(FADE_FRAG).toMatch(/uniform sampler2D uPrevTrail;/);
+    expect(FADE_FRAG).toMatch(/uniform vec2 uGrid;/);
+    expect(FADE_FRAG).toMatch(/\* 0\.9/);
+    expect(FADE_FRAG).toMatch(/fragColor = vec4\(/);
+    expect(FADE_FRAG).not.toMatch(/`/);
+  });
+});
+
+describe("NX-3-v2c SPLAT_VERT", () => {
+  it("positions points by gl_VertexID into a particle texture", () => {
+    expect(typeof SPLAT_VERT).toBe("string");
+    expect(SPLAT_VERT).toMatch(/uniform sampler2D uPart;/);
+    expect(SPLAT_VERT).toMatch(/uniform vec2 uPartDim;/);
+    expect(SPLAT_VERT).toMatch(/uniform sampler2D uWind;/);
+    expect(SPLAT_VERT).toMatch(/out float v_intensity;/);
+    expect(SPLAT_VERT).toMatch(/gl_VertexID/);
+    expect(SPLAT_VERT).toMatch(/texelFetch\(uPart/);
+    expect(SPLAT_VERT).toMatch(/gl_Position = vec4\(/);
+    expect(SPLAT_VERT).toMatch(/gl_PointSize/);
+    expect(SPLAT_VERT).toMatch(/smoothstep\(0\.0, SPD_REF/);
+    expect(SPLAT_VERT).not.toMatch(/`/);
+  });
+});
+
+describe("NX-3-v2c SPLAT_FRAG", () => {
+  it("renders point with v_intensity + radial falloff", () => {
+    expect(typeof SPLAT_FRAG).toBe("string");
+    expect(SPLAT_FRAG).toMatch(/in float v_intensity;/);
+    expect(SPLAT_FRAG).toMatch(/gl_PointCoord/);
+    expect(SPLAT_FRAG).toMatch(/fragColor = vec4\(vec3\(/);
+    expect(SPLAT_FRAG).not.toMatch(/`/);
   });
 });
 

--- a/apps/hayba-explorer/src/viewport/windFlow.ts
+++ b/apps/hayba-explorer/src/viewport/windFlow.ts
@@ -1,7 +1,13 @@
 import * as THREE from "three";
-import { runRawPass } from "./bake/glPass";
+import { runRawPass, runPointPass } from "./bake/glPass";
 import { createPingPong } from "./bake/pingpong";
-import { WINDFLOW_FRAG } from "./windFlow.glsl";
+import {
+  INIT_FRAG,
+  ADVECT_FRAG,
+  FADE_FRAG,
+  SPLAT_VERT,
+  SPLAT_FRAG,
+} from "./windFlow.glsl";
 
 /** Cap the long side to `max`, preserving the source aspect, integer,
  *  always >= 1. Equirect WIND is 2:1 but this works for any aspect. */
@@ -19,6 +25,8 @@ export function windFlowSize(
 }
 
 export const WINDFLOW_MAX = 1024;
+export const PARTICLE_DIM = 64;
+export const PARTICLE_COUNT = 4096;
 
 /** Clamp a frame dt to a sane sim step (<= 1/15 s; NaN/negative -> 0). */
 export function __clampStepDt(dt: number): number {
@@ -32,15 +40,34 @@ export interface WindFlow {
   dispose(): void;
 }
 
-/** Display-only Eulerian wind flow-map engine. Owns a PRIVATE 2-RT
- *  trail ping-pong; never touches bake/erosion RTs. */
+/** Display-only Lagrangian wind flow-map engine (NX-3-v2c). Owns PRIVATE
+ *  particle state ping-pong (64x64) + trail ping-pong; never touches
+ *  bake/erosion RTs. */
 export function createWindFlow(
   renderer: THREE.WebGLRenderer,
   windRT: THREE.WebGLRenderTarget,
 ): WindFlow {
   const { w, h } = windFlowSize(windRT.width, windRT.height, WINDFLOW_MAX);
-  const pp = createPingPong(renderer, w, h, ["TRAIL"]);
-  const trail = pp.rt["TRAIL"]; // [RT0, RT1]
+
+  // Particle state ping-pong (64x64 RGBA32F = 4096 particles).
+  const partPP = createPingPong(renderer, PARTICLE_DIM, PARTICLE_DIM, ["P"]);
+  const part = partPP.rt["P"];
+
+  // Trail ping-pong (capped equirect, accumulates point splats + fades).
+  const trailPP = createPingPong(renderer, w, h, ["T"]);
+  const trail = trailPP.rt["T"];
+
+  // Seed initial particle state via a one-shot INIT pass into part[0].
+  runRawPass(
+    renderer,
+    INIT_FRAG,
+    {
+      uGrid: { value: new THREE.Vector2(PARTICLE_DIM, PARTICLE_DIM) },
+    },
+    part[0],
+  );
+
+  // Clear both trail halves to black so the first frames aren't garbage.
   const prevTarget = renderer.getRenderTarget();
   for (const rt of trail) {
     renderer.setRenderTarget(rt);
@@ -48,36 +75,68 @@ export function createWindFlow(
     renderer.clear(true, false, false);
   }
   renderer.setRenderTarget(prevTarget);
-  let read = 0;
+
+  let pRead = 0;
+  let tRead = 0;
   let acc = 0;
 
   return {
     trailTexture(): THREE.Texture {
-      return trail[read].texture;
+      return trail[tRead].texture;
     },
     step(dtSec: number): void {
-      const dt = __clampStepDt(dtSec);
-      if (dt === 0) return;
-      acc += dt;
-      const src = trail[read];
-      const dst = trail[read ^ 1];
+      const cdt = __clampStepDt(dtSec);
+      if (cdt === 0) return;
+      acc += cdt;
+
+      // (a) ADVECT particles: part[pRead] -> part[pRead ^ 1].
       runRawPass(
         renderer,
-        WINDFLOW_FRAG,
+        ADVECT_FRAG,
         {
-          uPrevTrail: { value: src.texture },
+          uPrev: { value: part[pRead].texture },
           uWind: { value: windRT.texture },
-          uGrid: { value: new THREE.Vector2(w, h) },
-          uDt: { value: dt },
+          uGrid: { value: new THREE.Vector2(PARTICLE_DIM, PARTICLE_DIM) },
+          uDt: { value: cdt },
           uTime: { value: acc },
         },
-        dst,
+        part[pRead ^ 1],
       );
-      read ^= 1;
+      pRead ^= 1;
+
+      // (b) FADE the trail: trail[tRead] * 0.9 -> trail[tRead ^ 1].
+      runRawPass(
+        renderer,
+        FADE_FRAG,
+        {
+          uPrevTrail: { value: trail[tRead].texture },
+          uGrid: { value: new THREE.Vector2(w, h) },
+        },
+        trail[tRead ^ 1],
+      );
+      tRead ^= 1;
+
+      // (c) SPLAT particles additively onto the just-faded trail.
+      runPointPass(
+        renderer,
+        SPLAT_VERT,
+        SPLAT_FRAG,
+        PARTICLE_COUNT,
+        {
+          uPart: { value: part[pRead].texture },
+          uPartDim: { value: new THREE.Vector2(PARTICLE_DIM, PARTICLE_DIM) },
+          uWind: { value: windRT.texture },
+        },
+        trail[tRead],
+        { additive: true },
+      );
     },
     dispose(): void {
+      part[0].dispose();
+      part[1].dispose();
       trail[0].dispose();
       trail[1].dispose();
+      // NEVER call disposeGlPassCache — that frees the shared bake cache.
     },
   };
 }


### PR DESCRIPTION
NX-3-v2c — Lagrangian particles via glPass.

- Replaces v2b's Eulerian dye with MdGBWG Buffer C-faithful Lagrangian particles. 4096 particles (64×64 RGBA32F ping-pong) advected by the v2a WIND vector and additively splatted into a fading trail RT.
- New `runPointPass` extension to glPass — own-FBO + full state-unbind + two-phase sampler bind (the load-bearing GPGPU-saga mitigation) replicated verbatim from `runRawPass`, only differs in 7 named ways (vert param, ensureProgramVF, _pointVao, optional additive blend, POINTS draw, count, blend restore).
- New shaders: INIT/ADVECT/FADE/SPLAT_VERT/SPLAT_FRAG. SPLAT_VERT uses `gl_VertexID` to index into the particle texture — no vertex buffer.
- `WindFlow` public interface byte-equal → scene.ts / App.tsx / debugMaterial.ts UNTOUCHED.
- Display-only; zero bake/erosion/Rust change → #218 8ecba5b intact by construction.
- Gates: tsc 0 · 10 vitest / 88 tests · cargo check --workspace 0 · tectonics-v2 + explorer-lib 58/0 · diff-stat = 5 display files. Acceptance: in-app eyeball on the Wind map-mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a multi-pass particle system for wind flow visualization with per-particle state tracking, aging, and deterministic respawning.
  * Added point-splat rendering capability with soft circular falloff for efficient particle display.

* **Tests**
  * Added comprehensive test coverage for new shader components and particle state consistency validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->