### PR TITLE
feat(wizard): GC — Grid cache + async start_wizard (kills 3s Planetary wait)

### DIFF
--- a/apps/hayba-explorer/packages/tectonics/src/lib.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/lib.rs
@@ -7,6 +7,7 @@
 //! during later phases. See the megasprint plan for details.
 
 pub mod sphere;
+pub use sphere::{Grid, VoronoiSphere};
 pub mod field;
 pub mod plate;
 pub mod subduction;

--- a/apps/hayba-explorer/packages/tectonics/src/sphere/grid.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/sphere/grid.rs
@@ -18,6 +18,8 @@
 
 use glam::Vec3;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use super::voronoi::VoronoiSphere;
 
@@ -27,6 +29,10 @@ pub const EARTH_AREA_KM2: f64 = 510_072_000.0;
 
 /// Mean Earth radius in km (matches TE `constants.earthRadius`).
 pub const EARTH_RADIUS_KM: f64 = 6_371.0;
+
+fn empty_flat_positions() -> Arc<OnceLock<Vec<f32>>> {
+    Arc::new(OnceLock::new())
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Grid {
@@ -41,6 +47,8 @@ pub struct Grid {
     /// Coarse lat/lon raster: each cell stores the nearest field id at that
     /// grid centre. Used for O(1) nearest-field lookups.
     raster: NearestRaster,
+    #[serde(skip, default = "empty_flat_positions")]
+    flat_positions: Arc<OnceLock<Vec<f32>>>,
 }
 
 impl Grid {
@@ -59,6 +67,7 @@ impl Grid {
             field_diameter_km,
             field_area_km2,
             raster,
+            flat_positions: empty_flat_positions(),
         }
     }
 
@@ -144,6 +153,24 @@ impl Grid {
                 None => return best,
             }
         }
+    }
+
+    /// Lazy flat XYZ position buffer `[x0,y0,z0, x1,y1,z1, …]` built
+    /// once per `Grid` instance via `OnceLock`. Reused across IPC calls
+    /// when `Grid` is cached by `Grid::for_divisions`. Length = `3 *
+    /// n_fields()`.
+    pub fn flat_positions(&self) -> &[f32] {
+        self.flat_positions.get_or_init(|| {
+            let n = self.n_fields();
+            let mut v = Vec::with_capacity((n as usize) * 3);
+            for fid in 0..n {
+                let p = self.position(fid);
+                v.push(p.x);
+                v.push(p.y);
+                v.push(p.z);
+            }
+            v
+        })
     }
 }
 
@@ -260,6 +287,41 @@ fn hill_climb(sphere: &VoronoiSphere, seed: u32, target: Vec3) -> u32 {
             Some(nb) => best = nb,
             None => return best,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Process-global Grid cache
+// ---------------------------------------------------------------------------
+
+static GRID_CACHE: OnceLock<Mutex<HashMap<u32, Arc<Grid>>>> = OnceLock::new();
+
+fn grid_cache() -> &'static Mutex<HashMap<u32, Arc<Grid>>> {
+    GRID_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+impl Grid {
+    /// Cached constructor. Returns the shared `Arc<Grid>` for this
+    /// `divisions`, building once via `Grid::new` and memoising for
+    /// process lifetime. Thread-safe; the actual `Grid::new` runs
+    /// OUTSIDE the cache mutex so concurrent cold requests for
+    /// different tiers do not serialise.
+    pub fn for_divisions(divisions: u32) -> Arc<Grid> {
+        // Fast path: lock, look up, clone the Arc.
+        {
+            let map = grid_cache()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if let Some(g) = map.get(&divisions) {
+                return Arc::clone(g);
+            }
+        }
+        // Cold path: build OUTSIDE the lock, then double-checked insert.
+        let built = Arc::new(Grid::new(divisions));
+        let mut map = grid_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        Arc::clone(map.entry(divisions).or_insert(built))
     }
 }
 

--- a/apps/hayba-explorer/packages/tectonics/tests/grid_cache.rs
+++ b/apps/hayba-explorer/packages/tectonics/tests/grid_cache.rs
@@ -1,0 +1,34 @@
+//! GC — verifies `Grid::for_divisions` cache behaviour + `flat_positions`.
+
+use hayba_tectonics_v2::Grid;
+use std::sync::Arc;
+
+#[test]
+fn for_divisions_returns_same_arc_on_repeat_call() {
+    let a = Grid::for_divisions(4);
+    let b = Grid::for_divisions(4);
+    assert!(Arc::ptr_eq(&a, &b), "repeat call must return same Arc");
+}
+
+#[test]
+fn for_divisions_matches_new_field_count() {
+    let cached = Grid::for_divisions(4);
+    let fresh = Grid::new(4);
+    assert_eq!(cached.n_fields(), fresh.n_fields());
+}
+
+#[test]
+fn flat_positions_length_is_3n() {
+    let g = Grid::for_divisions(4);
+    let fp = g.flat_positions();
+    let n = g.n_fields() as usize;
+    assert_eq!(fp.len(), n * 3);
+}
+
+#[test]
+fn flat_positions_is_cached_within_arc() {
+    let g = Grid::for_divisions(4);
+    let p1 = g.flat_positions().as_ptr();
+    let p2 = g.flat_positions().as_ptr();
+    assert_eq!(p1, p2, "flat_positions slice pointer must be stable across calls");
+}

--- a/apps/hayba-explorer/src-tauri/src/wizard.rs
+++ b/apps/hayba-explorer/src-tauri/src/wizard.rs
@@ -173,17 +173,19 @@ pub struct WizardInit {
 }
 
 #[tauri::command]
-pub fn start_wizard(divisions: u32) -> WizardInit {
-    let grid = Grid::new(divisions);
-    let n = grid.n_fields();
-    let mut cell_positions = Vec::with_capacity((n * 3) as usize);
-    for fid in 0..n {
-        let p = grid.position(fid);
-        cell_positions.push(p.x);
-        cell_positions.push(p.y);
-        cell_positions.push(p.z);
-    }
-    WizardInit { divisions, n_cells: n, cell_positions }
+pub async fn start_wizard(divisions: u32) -> Result<WizardInit, String> {
+    // Heavy Grid::new (Voronoi + NearestRaster build, ~3s at 384 div)
+    // moved off the IPC thread via spawn_blocking — mirrors the NB
+    // pattern used by `bake_from_wizard`. The cached `Grid::for_divisions`
+    // makes repeat selections of the same tier microseconds.
+    let grid = tauri::async_runtime::spawn_blocking(move || {
+        Grid::for_divisions(divisions)
+    })
+    .await
+    .map_err(|e| format!("[start_wizard] join: {e}"))?;
+    let n_cells = grid.n_fields();
+    let cell_positions = grid.flat_positions().to_vec();
+    Ok(WizardInit { divisions, n_cells, cell_positions })
 }
 
 #[tauri::command]

--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -1571,7 +1571,7 @@ export default function App() {
         {panelCategory === "compose" && draft && (
           <ComposePanel
             draft={draft}
-            busy={mode === "baking"}
+            busy={mode === "baking" || initializingGrid}
             onChangeDivisions={handleChangeDivisions}
             onChangePreset={handleChangePreset}
             onReroll={handleReroll}

--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -385,6 +385,7 @@ export default function App() {
   const [debugBaking, setDebugBaking] = useState(false);
   const [debugBakeProgress, setDebugBakeProgress] = useState<string | null>(null);
   const [debugBakeReady, setDebugBakeReady] = useState(false);
+  const [initializingGrid, setInitializingGrid] = useState(false);
   // SP-A: the single authority for globe interactivity. `compose` =
   // paint strokes editable; `explore` = orbit + stack view only. A ref
   // mirror so pointer/effect closures read the live value with no
@@ -534,7 +535,13 @@ export default function App() {
     divisions: number,
     carry?: { preset?: PresetName; seed?: number },
   ) => {
-    const init = await invoke<WizardInit>("start_wizard", { divisions });
+    let init!: WizardInit;
+    setInitializingGrid(true);
+    try {
+      init = await invoke<WizardInit>("start_wizard", { divisions });
+    } finally {
+      setInitializingGrid(false);
+    }
     const positions = new Float32Array(init.cell_positions);
     kdTreeRef.current = buildCellKdTree(positions);
     cellCountRef.current = init.n_cells;
@@ -1556,6 +1563,11 @@ export default function App() {
         disabledReason={categoryDisabledReason}
         onPick={setPanelCategory}
       >
+        {initializingGrid && (
+          <div style={{ marginTop: 6, fontSize: 12, opacity: 0.7 }}>
+            Building grid…
+          </div>
+        )}
         {panelCategory === "compose" && draft && (
           <ComposePanel
             draft={draft}


### PR DESCRIPTION
GC sub-project — kills the 3s "Planetary" resolution-chip freeze.

- **Cache:** `Grid::for_divisions(u32) -> Arc<Grid>` process-global `OnceLock<Mutex<HashMap>>` cache in `hayba-tectonics-v2`. Build runs OUTSIDE the lock so concurrent cold requests don'\''t serialise. Repeat selections are microseconds.
- **Lazy positions:** new `Grid::flat_positions() -> &[f32]` (`Arc<OnceLock<Vec<f32>>>` field, `#[serde(skip, default)]` to preserve the existing `#[derive(Clone, Serialize, Deserialize)]`). IPC payload built once per Grid.
- **Async command:** `start_wizard` is now `pub async fn` returning `Result<WizardInit, String>`; body wraps `Grid::for_divisions` in `tauri::async_runtime::spawn_blocking` (mirrors the NB pattern from `bake_from_wizard`). IPC thread no longer blocked.
- **UI:** App.tsx gains `initializingGrid` state + try/finally around the await + a "Building grid…" indicator in the RightPanel + pipes the state into the existing `ComposePanel busy` gate (which already disables ResolutionChips/PresetChips/etc. — no new prop plumbing needed).
- **Bake byte-identical** (cache returns same content as `Grid::new`) → #218 8ecba5b intact by construction; `cli_te_port::cli_run_is_byte_deterministic_across_runs` + `determinism::*` stay green.
- Gates: tsc 0 · 10 vitest / 88 tests · cargo check 0 · tectonics-v2 incl. new grid_cache (4 tests) + determinism + cli_te_port byte-equality all green · explorer-lib 58/0 · diff-stat = 5 files.

**Cold path (~3s on first Planetary click) is still ~3s of compute** — parallelising `NearestRaster::build` is deferred to a measurement-driven follow-up (architecture review candidate #3 timing seam first).