### PR TITLE
feat(tectonics): TS — perf_timing seam for Model::step phases

### DIFF
--- a/apps/hayba-explorer/packages/tectonics/src/lib.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/lib.rs
@@ -23,4 +23,5 @@ pub mod export;
 pub mod determinism;
 pub mod wizard;
 pub mod model;
+pub mod perf_timing;
 pub mod save;

--- a/apps/hayba-explorer/packages/tectonics/src/model/model.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/model/model.rs
@@ -49,6 +49,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::field::Field;
 use crate::mantle::PlumeRegistry;
+use crate::perf_timing::{Phase, PhaseTimer};
 use crate::plate::plate::{Plate, OCEAN_DENSITY};
 use crate::plate::plate_group::PlateGroup;
 use crate::sphere::Grid;
@@ -172,8 +173,10 @@ impl Model {
     }
 
     pub fn step(&mut self, dt: f32) {
+        let mut t = PhaseTimer::start();
         // ── PHASE A: verlet integrate all plates (TE step 1) ───────────
         self.step_verlet(dt);
+        t.lap(Phase::Verlet);
 
         // ── PHASE B: speed-clamp (TE step 2, `model.ts:268-272`) ───────
         // Applied to every plate after the integrator regardless of mass.
@@ -237,9 +240,11 @@ impl Model {
         for p in self.plates.iter_mut() {
             p.reset_force_accumulator();
         }
+        t.lap(Phase::Other);
         let optimize = self.optimized_collision_detection;
         let collisions =
             detect_field_collisions_opt(&self.plates, &self.grid, &self.fields, optimize);
+        t.lap(Phase::Collisions);
 
         // ── PHASE D: resolve each collision (Hayba addition) ───────────
         let plates_snapshot: Vec<Plate> = self.plates.clone();
@@ -261,10 +266,12 @@ impl Model {
                 f.mor_age_steps = f.mor_age_steps.saturating_add(1);
             }
         }
+        t.lap(Phase::Resolve);
 
         // ── PHASE E: advance subduction (Hayba addition) ───────────────
         let field_diam = self.grid.field_diameter();
         self.advance_subduction(dt, field_diam);
+        t.lap(Phase::Subduction);
 
         // ── PHASE F: try-detach loop. TODO Phase 4 — needs the slab
         // gradient calculator. Skipped for now.
@@ -273,6 +280,7 @@ impl Model {
         self.step_count += 1;
         self.sim_time_ma += dt;
         self.optimized_collision_detection = true;
+        t.report(self.step_count);
     }
 
     /// Faithful port of TE's `verletStep` over all plates simultaneously.

--- a/apps/hayba-explorer/packages/tectonics/src/perf_timing.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/perf_timing.rs
@@ -1,0 +1,187 @@
+//! TS — phase-timing seam for `Model::step()`.
+//!
+//! Zero overhead when off: a single `OnceLock<bool>` read on the hot
+//! path. When `HAYBA_TECTONICS_TIMING` is set to any non-empty value,
+//! one stderr line is emitted every `HAYBA_TECTONICS_TIMING_EVERY`
+//! steps (default 100) with the per-phase wall time:
+//!
+//! ```text
+//! [tect-step 100] verlet=12.3ms collisions=4.1ms resolve=0.8ms subduction=2.7ms other=1.4ms total=21.3ms
+//! ```
+//!
+//! Determinism: this module reads only its env vars and `Instant::now`;
+//! it never mutates sim state. Simulation byte-equality is preserved
+//! regardless of whether the env var is set (`cli_te_port` proves it).
+
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+static SAMPLE_EVERY: OnceLock<u32> = OnceLock::new();
+
+pub fn is_enabled() -> bool {
+    *ENABLED.get_or_init(|| {
+        std::env::var("HAYBA_TECTONICS_TIMING")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+    })
+}
+
+fn sample_every() -> u32 {
+    *SAMPLE_EVERY.get_or_init(|| {
+        std::env::var("HAYBA_TECTONICS_TIMING_EVERY")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(100)
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    Verlet,
+    Other,
+    Collisions,
+    Resolve,
+    Subduction,
+}
+
+#[derive(Debug)]
+pub struct PhaseTimer {
+    enabled: bool,
+    start: Instant,
+    last: Instant,
+    pub verlet: Duration,
+    pub other: Duration,
+    pub collisions: Duration,
+    pub resolve: Duration,
+    pub subduction: Duration,
+}
+
+impl PhaseTimer {
+    pub fn start() -> Self {
+        let now = Instant::now();
+        Self {
+            enabled: is_enabled(),
+            start: now,
+            last: now,
+            verlet: Duration::ZERO,
+            other: Duration::ZERO,
+            collisions: Duration::ZERO,
+            resolve: Duration::ZERO,
+            subduction: Duration::ZERO,
+        }
+    }
+
+    pub fn lap(&mut self, bucket: Phase) {
+        let now = Instant::now();
+        let dt = now - self.last;
+        self.last = now;
+        if !self.enabled {
+            return;
+        }
+        match bucket {
+            Phase::Verlet => self.verlet += dt,
+            Phase::Other => self.other += dt,
+            Phase::Collisions => self.collisions += dt,
+            Phase::Resolve => self.resolve += dt,
+            Phase::Subduction => self.subduction += dt,
+        }
+    }
+
+    pub fn report(self, step_idx: u32) {
+        if !self.enabled {
+            return;
+        }
+        if step_idx % sample_every() != 0 {
+            return;
+        }
+        let total = self.start.elapsed();
+        eprintln!(
+            "[tect-step {}] verlet={:.1}ms collisions={:.1}ms resolve={:.1}ms subduction={:.1}ms other={:.1}ms total={:.1}ms",
+            step_idx,
+            self.verlet.as_secs_f64() * 1000.0,
+            self.collisions.as_secs_f64() * 1000.0,
+            self.resolve.as_secs_f64() * 1000.0,
+            self.subduction.as_secs_f64() * 1000.0,
+            self.other.as_secs_f64() * 1000.0,
+            total.as_secs_f64() * 1000.0,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+    use std::time::Duration as StdDur;
+
+    #[test]
+    fn phase_is_copy() {
+        let a = Phase::Verlet;
+        let b = a;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn timer_start_has_zero_buckets() {
+        let t = PhaseTimer::start();
+        assert_eq!(t.verlet, Duration::ZERO);
+        assert_eq!(t.other, Duration::ZERO);
+        assert_eq!(t.collisions, Duration::ZERO);
+        assert_eq!(t.resolve, Duration::ZERO);
+        assert_eq!(t.subduction, Duration::ZERO);
+    }
+
+    #[test]
+    fn lap_accumulates_when_enabled() {
+        let now = Instant::now();
+        let mut t = PhaseTimer {
+            enabled: true,
+            start: now,
+            last: now,
+            verlet: Duration::ZERO,
+            other: Duration::ZERO,
+            collisions: Duration::ZERO,
+            resolve: Duration::ZERO,
+            subduction: Duration::ZERO,
+        };
+        sleep(StdDur::from_millis(2));
+        t.lap(Phase::Verlet);
+        assert!(t.verlet >= StdDur::from_millis(1));
+        assert_eq!(t.other, Duration::ZERO);
+    }
+
+    #[test]
+    fn lap_is_noop_when_disabled() {
+        let now = Instant::now();
+        let mut t = PhaseTimer {
+            enabled: false,
+            start: now,
+            last: now,
+            verlet: Duration::ZERO,
+            other: Duration::ZERO,
+            collisions: Duration::ZERO,
+            resolve: Duration::ZERO,
+            subduction: Duration::ZERO,
+        };
+        sleep(StdDur::from_millis(2));
+        t.lap(Phase::Verlet);
+        assert_eq!(t.verlet, Duration::ZERO);
+    }
+
+    #[test]
+    fn report_is_quiet_when_disabled() {
+        let t = PhaseTimer {
+            enabled: false,
+            start: Instant::now(),
+            last: Instant::now(),
+            verlet: Duration::ZERO,
+            other: Duration::ZERO,
+            collisions: Duration::ZERO,
+            resolve: Duration::ZERO,
+            subduction: Duration::ZERO,
+        };
+        t.report(100);
+    }
+}


### PR DESCRIPTION
TS — phase-timing seam for the deep-time sim. Architecture-review candidate #3 — prerequisite for the upcoming `step_verlet`/dragging-lookup perf wins (candidates #2 + #4) so they'\''re measurement-driven, not guessed.

- New `perf_timing` module: `PhaseTimer` (5-bucket stack-only timer) + `OnceLock<bool>`-cached `is_enabled()` reading `HAYBA_TECTONICS_TIMING` + `sample_every()` reading `HAYBA_TECTONICS_TIMING_EVERY` (default 100).
- `Model::step()` adds exactly 8 lines: 1 `use`, 1 `PhaseTimer::start()`, 5 `t.lap(Phase::…)` at verified phase boundaries (Verlet/Other/Collisions/Resolve/Subduction), 1 `t.report(self.step_count)` after bookkeeping.
- **Zero overhead when off**: env var unset → `is_enabled()` returns false → `lap`/`report` early-return. The only cost is one `Instant::now` per lap call.
- **Determinism preserved**: timer is a side channel; sim is byte-identical with or without the env var. `cli_te_port::cli_run_is_byte_deterministic_across_runs` + `determinism::*` stay green.

To use: `$env:HAYBA_TECTONICS_TIMING="1"` then run the wizard sim; stderr prints e.g. `[tect-step 100] verlet=12.3ms collisions=4.1ms resolve=0.8ms subduction=2.7ms other=1.4ms total=21.3ms` every 100 steps. Optional `$env:HAYBA_TECTONICS_TIMING_EVERY="10"` for finer sampling.

Gates: tsc 0 · 10 vitest / 88 tests · cargo check 0 · tectonics-v2 215 tests + cli_te_port byte-equality + determinism + grid_cache + hydrology + 5 new perf_timing tests all ok · explorer-lib 58/0 · diff-stat = 3 files. Bake / erosion / display untouched → #218 8ecba5b intact by construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional performance timing instrumentation for simulation phases with configurable sampling intervals and per-phase metrics reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->