### PR TITLE
fix(viewport): wind retune #3 — magnitude-aware advection (stagnation fix)

### DIFF
--- a/apps/hayba-explorer/src/viewport/windFlow.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/windFlow.glsl.ts
@@ -16,9 +16,11 @@ const HASH = [
   "}",
 ].join("\n");
 
-const LIFE_DECL = "const float LIFE = 4.0;";
+const LIFE_DECL = "const float LIFE = 2.5;";
 const STEP_K_DECL = "const float STEP_K = 0.10;";
 const SPD_REF_DECL = "const float SPD_REF = 0.55;";
+const V_REF_DECL = "const float V_REF = 1.0;";
+const STALL_THRESH_DECL = "const float STALL_THRESH = 0.15;";
 
 export const INIT_FRAG = [
   "uniform vec2 uGrid;",
@@ -43,6 +45,8 @@ export const ADVECT_FRAG = [
   "uniform float uTime;",
   LIFE_DECL,
   STEP_K_DECL,
+  V_REF_DECL,
+  STALL_THRESH_DECL,
   "out vec4 fragColor;",
   HASH,
   "void main(){",
@@ -53,12 +57,16 @@ export const ADVECT_FRAG = [
   "  float seed = s.w;",
   "  vec2 v = texture(uWind, pos).xy;",
   "  float vlen = length(v);",
-  "  vec2 dir = vlen > 1e-4 ? v / vlen : vec2(0.0);",
-  "  pos += dir * uDt * STEP_K;",
+  "  // Magnitude-aware advection with soft cap: at |v|>=V_REF particles",
+  "  // move at full STEP_K (the old direction-normalised speed); at",
+  "  // |v|<V_REF they slow proportionally so stagnation points produce",
+  "  // ~zero motion (which the STALL_THRESH respawn then catches).",
+  "  vec2 motion = v * (STEP_K / max(vlen, V_REF));",
+  "  pos += motion * uDt;",
   "  pos.x = fract(pos.x);",
   "  pos.y = clamp(pos.y, 0.0, 1.0);",
   "  age += uDt;",
-  "  if (age > LIFE || vlen < 1e-4) {",
+  "  if (age > LIFE || vlen < STALL_THRESH) {",
   "    seed = hash(seed + uTime * 7.0);",
   "    pos = vec2(hash(seed + 1.0), hash(seed + 2.0));",
   "    age = 0.0;",

--- a/apps/hayba-explorer/src/viewport/windFlow.test.ts
+++ b/apps/hayba-explorer/src/viewport/windFlow.test.ts
@@ -29,7 +29,7 @@ describe("NX-3-v2c INIT_FRAG", () => {
 });
 
 describe("NX-3-v2c ADVECT_FRAG", () => {
-  it("advects particle state along normalised wind dir + age + respawn", () => {
+  it("advects particle state with magnitude-aware soft cap + stall respawn", () => {
     expect(typeof ADVECT_FRAG).toBe("string");
     expect(ADVECT_FRAG).toMatch(/uniform sampler2D uPrev;/);
     expect(ADVECT_FRAG).toMatch(/uniform sampler2D uWind;/);
@@ -37,7 +37,16 @@ describe("NX-3-v2c ADVECT_FRAG", () => {
     expect(ADVECT_FRAG).toMatch(/uniform float uDt;/);
     expect(ADVECT_FRAG).toMatch(/uniform float uTime;/);
     expect(ADVECT_FRAG).toMatch(/texelFetch\(uPrev/);
-    expect(ADVECT_FRAG).toMatch(/v \/ vlen/);
+    // Retune #3: magnitude-aware advection (slow areas slow, capped
+    // at STEP_K when |v|>=V_REF) + STALL_THRESH respawn (kills the
+    // pile-up at stagnation centers from the direction-normalised
+    // form). The teleport guard `not /uDt \* ADV_K/` from retune #1
+    // also stays asserted.
+    expect(ADVECT_FRAG).toMatch(/STEP_K \/ max\(vlen, V_REF\)/);
+    expect(ADVECT_FRAG).toMatch(/pos \+= motion \* uDt/);
+    expect(ADVECT_FRAG).toMatch(/vlen < STALL_THRESH/);
+    expect(ADVECT_FRAG).not.toMatch(/v \/ vlen/);
+    expect(ADVECT_FRAG).not.toMatch(/uDt \* ADV_K/);
     expect(ADVECT_FRAG).toMatch(/fract\(pos\.x\)/);
     expect(ADVECT_FRAG).toMatch(/clamp\(pos\.y, 0\.0, 1\.0\)/);
     expect(ADVECT_FRAG).toMatch(/age > LIFE/);


### PR DESCRIPTION
NX-3-v2c eyeball retune #3.

User feedback: stuck/concentrated particle rings (= particles piling up at anticyclone stagnation centers); Atlantic flow direction read backwards (= south-side trade winds of the anticyclone visually dominant while the north-side westerlies were washed out by the pile-up).

Root cause: direction-normalised advection meant slow ≠ stopped — particles drift asymptotically toward zero-magnitude points and orbit them forever.

Fix:
- **Magnitude-aware advection with soft cap**: `motion = v * (STEP_K / max(|v|, V_REF))`. At |v|≥V_REF particles move at full STEP_K (old normalised speed); at |v|<V_REF they slow proportionally. Stagnation centers produce ~zero motion.
- **Earlier respawn**: `vlen < STALL_THRESH` (0.15) instead of `vlen < 1e-4`. Stagnant particles die and respawn elsewhere instead of orbiting forever.
- **Faster turnover**: LIFE 4.0 → 2.5s so pile-ups can'\''t accumulate visibly.

Display-only · WIND/CLIM read-only · #218 8ecba5b intact by construction. tsc 0 · 10 vitest / 88 tests · diff-stat = 2 files. Acceptance: in-app eyeball — expect dynamic flow with no stuck rings; jets read fast; calm areas dim. Banding from the analytic annual-mean MSLP is still inherent (P2.2-oro).