### PR TITLE
perf(tectonics): SV — step_verlet O(P²) elim + O(1) dragging-plate lookup

### DIFF
--- a/apps/hayba-explorer/packages/tectonics/src/model/model.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/model/model.rs
@@ -44,6 +44,8 @@
 //! * Frame-stream emission is owned by the caller (`run_steps` writes one
 //!   frame per call); the encoder is not stored on the Model.
 
+use std::collections::HashMap;
+
 use glam::Vec3;
 use serde::{Deserialize, Serialize};
 
@@ -291,16 +293,24 @@ impl Model {
             return;
         }
 
+        // SV: build id→index map ONCE; reused by both predictor + corrector.
+        let id_to_idx: HashMap<u32, usize> = self
+            .plates
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (p.id, i))
+            .collect();
+
         // a1 = torques at current state for ALL plates.
         let mut a1: Vec<Vec3> = Vec::with_capacity(n);
         for i in 0..n {
-            let other_plates: Vec<Plate> = self
-                .plates
-                .iter()
-                .enumerate()
-                .filter_map(|(j, p)| if j != i { Some(p.clone()) } else { None })
-                .collect();
-            let t = self.plates[i].compute_total_torque(&self.fields, &other_plates, area);
+            let t = self.plates[i].compute_total_torque_indexed(
+                &self.fields,
+                &self.plates,
+                i,
+                &id_to_idx,
+                area,
+            );
             a1.push(acceleration_for(&self.plates[i], t));
         }
 
@@ -320,13 +330,13 @@ impl Model {
         // a2 = torques at NEW state for ALL plates.
         let mut a2: Vec<Vec3> = Vec::with_capacity(n);
         for i in 0..n {
-            let other_plates: Vec<Plate> = self
-                .plates
-                .iter()
-                .enumerate()
-                .filter_map(|(j, p)| if j != i { Some(p.clone()) } else { None })
-                .collect();
-            let t = self.plates[i].compute_total_torque(&self.fields, &other_plates, area);
+            let t = self.plates[i].compute_total_torque_indexed(
+                &self.fields,
+                &self.plates,
+                i,
+                &id_to_idx,
+                area,
+            );
             a2.push(acceleration_for(&self.plates[i], t));
         }
 

--- a/apps/hayba-explorer/packages/tectonics/src/plate/plate.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/plate/plate.rs
@@ -46,6 +46,8 @@
 //! For deterministic builds we never call `Quat::from_xyzw` with random data;
 //! every operation is a pure function of the prior state.
 
+use std::collections::HashMap;
+
 use glam::{Mat3, Quat, Vec3};
 use serde::{Deserialize, Serialize};
 
@@ -409,6 +411,63 @@ impl Plate {
             // `field.ts:221-223`).
             if let Some(other_id) = f.dragging_plate {
                 if let Some(other) = other_plates.iter().find(|p| p.id == other_id) {
+                    let v_other = other.linear_velocity(abs);
+                    force += f.orogenic_drag(
+                        v_self,
+                        v_other,
+                        field_area_km2,
+                        OROGENY_FORCE_MOD,
+                        CONSTANT_HOT_SPOTS,
+                    );
+                }
+            }
+            total += abs.cross(force);
+        }
+        total
+    }
+
+    /// Identical semantics to `compute_total_torque` but takes a pre-built
+    /// `id_to_idx` map (plate.id → index in `plates`) for O(1) drag-target
+    /// lookup, eliminating the per-call O(P) `iter().find` scan. The
+    /// `self_idx` parameter is the caller's index of `self` in `plates`;
+    /// looking up `dragging_plate.id == self.id` is suppressed (preserves
+    /// the exclude-self semantics of the filtered-slice form that
+    /// `step_verlet` uses). All other behaviour BYTE-IDENTICAL.
+    ///
+    /// SV (architecture-review #2 + #4): used by `Model::step_verlet` to
+    /// kill per-plate `Vec<Plate>::clone`. The existing
+    /// `compute_total_torque` stays for the other 8 callers (tests +
+    /// `plate_group.rs`).
+    pub fn compute_total_torque_indexed(
+        &self,
+        fields: &[Field],
+        plates: &[Plate],
+        self_idx: usize,
+        id_to_idx: &HashMap<u32, usize>,
+        field_area_km2: f32,
+    ) -> Vec3 {
+        // Hot-spot torque term (TE `plate.ts:142`).
+        let mut total = self.hot_spot.position.cross(self.hot_spot.force);
+        // Cross-plate / orchestrator-staged torque accumulator. The
+        // accumulator stores torques already in plate-local frame; we rotate
+        // them back into world space so they compose with the field-pass
+        // torque (which is computed in world space).
+        total += self.quaternion * self.force_accumulator;
+        for &fid in &self.fields {
+            let Some(f) = fields.get(fid as usize) else {
+                continue;
+            };
+            let abs = self.compute_field_position(f.local_pos);
+            let v_self = self.linear_velocity(abs);
+            // Basic drag — always present (TE `field.ts:220`).
+            let mut force = f.basic_drag(v_self, field_area_km2, BASIC_DRAG_FORCE_MOD, CONSTANT_HOT_SPOTS);
+            // Orogenic drag when this field is dragging another plate (TE
+            // `field.ts:221-223`).
+            if let Some(other_id) = f.dragging_plate {
+                if let Some(other) = id_to_idx
+                    .get(&other_id)
+                    .and_then(|&idx| if idx == self_idx { None } else { plates.get(idx) })
+                {
                     let v_other = other.linear_velocity(abs);
                     force += f.orogenic_drag(
                         v_self,


### PR DESCRIPTION
SV — architecture-review candidates #2 + #4. Measurement-driven follow-up to the TS timing seam (#155).

Kills two quadratics per tectonics step:
- **`step_verlet`** was cloning `Vec<Plate>` of size `P-1` for every plate, **twice per step** (predictor + corrector half-steps). Each clone copies a `Plate`'s `Vec<u32> fields` (potentially thousands of IDs). At P=10–20: 200–800 plate clones per step.
- **`compute_total_torque`** was doing `other_plates.iter().find(|p| p.id == other_id)` for every drag-tagged field — `O(P)` per field, `O(F·P)` per call, `O(P²·F)` per step.

Fix is additive (zero risk to 8 existing callers in tests + `plate_group.rs`): a new sibling method `compute_total_torque_indexed(&self, fields, plates, self_idx, id_to_idx, area)` that takes a pre-built `HashMap<u32, usize>` lookup. `step_verlet` builds the map ONCE per call and threads it into both halves. The existing `compute_total_torque` stays BYTE-UNCHANGED for the other callers.

The `self_idx` guard preserves the exclude-self semantics of the old filtered-slice form (so passing the full `&self.plates` is byte-equivalent to passing the filtered `Vec<Plate>`).

**Determinism preserved by construction**: same iteration order over `self.fields`, same arithmetic order, same float results. `cli_te_port::cli_run_is_byte_deterministic_across_runs` + `determinism::two_models_same_seed_byte_identical_after_n_steps` + `plate::tests::determinism_two_plates_byte_identical` all GREEN.

Gates: cargo check 0 · tectonics-v2 ALL ok (incl. byte-equality + determinism + the new in-method path covered transitively by `step_verlet` tests) · explorer-lib 58/0 · diff-stat = 2 files (`plate.rs` + `model.rs`).

Per-step heap allocations dropped from `2·P·(P-1)·O(F̄) + 2·P` to `2·P + 1`. The user can measure the perf delta via `HAYBA_TECTONICS_TIMING=1` — expect `verlet=Xms` to drop meaningfully at P ≥ 10.

Bake / display / Tauri / climate untouched → #218 8ecba5b intact by construction.