### PR TITLE
refactor(tectonics): encapsulate Model mutations via 6 methods (EM)

### DIFF
--- a/apps/hayba-explorer/packages/tectonics/src/model/model.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/model/model.rs
@@ -444,6 +444,75 @@ impl Model {
         }
     }
 
+    /// Initialize a field's elevation + crust + lithosphere from the
+    /// painted/preset wizard input. `continental` selects the branch;
+    /// elevation is clamped to land (≥0) or ocean (<0) as appropriate.
+    /// Mirrors wizard.rs:701-711 / bake_equirect.rs:106-116 byte-for-byte.
+    pub fn apply_field_initial_state(&mut self, fid: usize, elevation: f32, continental: bool) {
+        if let Some(f) = self.fields.get_mut(fid) {
+            if continental {
+                f.crust = crate::field::Crust::new_continental();
+                f.elevation = elevation.max(0.0);
+                f.become_continental_lithosphere(200.0);
+            } else {
+                f.crust = crate::field::Crust::new_oceanic();
+                f.elevation = elevation.min(-0.0001);
+                f.refresh_oceanic_lithosphere();
+            }
+        }
+    }
+
+    /// Assign a field to a plate: sets `f.plate_id` and calls
+    /// `plate.add_field(fid)`. Used by `planet.rs::demo_model` to bucket
+    /// unclaimed ocean cells into ocean plates.
+    pub fn assign_field_to_plate(&mut self, fid: usize, pid: u32) {
+        if let Some(f) = self.fields.get_mut(fid) {
+            f.plate_id = Some(pid);
+        }
+        if let Some(p) = self.plates.iter_mut().find(|p| p.id == pid) {
+            p.add_field(fid as u32);
+        }
+    }
+
+    /// Recompute inertia for every plate using the current `fields` snapshot
+    /// and grid area. Mirrors wizard.rs:714-718 / planet.rs:197-201 byte-for-byte
+    /// (the clone is load-bearing: `update_inertia_tensor` borrows `&[Field]`
+    /// while iterating `&mut self.plates`).
+    pub fn refresh_plate_inertias(&mut self) {
+        let area = self.grid.field_area_km2();
+        let fields_ref = self.fields.clone();
+        for p in self.plates.iter_mut() {
+            p.update_inertia_tensor(&fields_ref, area);
+        }
+    }
+
+    /// Set a single plate's angular velocity by id. Used by
+    /// `apply_boundary_types` (wizard.rs:342-362).
+    pub fn set_plate_angular_velocity(&mut self, pid: u32, omega: Vec3) {
+        if let Some(p) = self.plates.iter_mut().find(|p| p.id == pid) {
+            p.angular_velocity = omega;
+        }
+    }
+
+    /// Set a single plate's density by id. Used by `apply_density_rank`
+    /// (wizard.rs:384-386).
+    pub fn set_plate_density(&mut self, pid: u32, density: f32) {
+        if let Some(p) = self.plates.iter_mut().find(|p| p.id == pid) {
+            p.density = density;
+        }
+    }
+
+    /// Write back a slice of eroded elevations (land only — ocean cells
+    /// untouched). Mirrors wizard.rs:743-748 byte-for-byte: applies
+    /// `.max(0.0)` clamp and the `if !is_ocean[i]` predicate.
+    pub fn apply_eroded_elevation(&mut self, elev: &[f32], is_ocean: &[bool]) {
+        for i in 0..elev.len() {
+            if let Some(f) = self.fields.get_mut(i) {
+                if !is_ocean[i] { f.elevation = elev[i].max(0.0); }
+            }
+        }
+    }
+
     /// Advance the `Subduction.dist` on each subducting field by one timestep.
     /// Mirrors the per-field call to `Subduction.update` that TE does inside
     /// `simulatePlatesInteractions` via `performGeologicalProcesses`.

--- a/apps/hayba-explorer/src-tauri/src/bake_equirect.rs
+++ b/apps/hayba-explorer/src-tauri/src/bake_equirect.rs
@@ -16,7 +16,6 @@
 use glam::Vec3;
 use rayon::prelude::*;
 
-use hayba_tectonics_v2::field::Crust;
 use hayba_tectonics_v2::model::Model;
 
 use crate::climate::{compute_climate, ClimateParams};
@@ -103,17 +102,7 @@ fn painted_precip(draft: &WizardDraft, cells: &[(Vec3, f32)]) -> Vec<f32> {
     let n_cells = model.grid.n_fields() as usize;
     for (fid, &(_, elevation)) in cells.iter().enumerate().take(n_cells) {
         let cont = elevation > 0.0;
-        if let Some(f) = model.fields.get_mut(fid) {
-            if cont {
-                f.crust = Crust::new_continental();
-                f.elevation = elevation.max(0.0);
-                f.become_continental_lithosphere(200.0);
-            } else {
-                f.crust = Crust::new_oceanic();
-                f.elevation = elevation.min(-0.0001);
-                f.refresh_oceanic_lithosphere();
-            }
-        }
+        model.apply_field_initial_state(fid, elevation, cont);
     }
     let params = ClimateParams::default();
     compute_climate(&model, draft.seed, false, &params).precip

--- a/apps/hayba-explorer/src-tauri/src/planet.rs
+++ b/apps/hayba-explorer/src-tauri/src/planet.rs
@@ -181,24 +181,13 @@ pub fn bake_demo() -> PlanetSnapshot {
     for (i, &pid) in ocean_plate_ids.iter().enumerate() {
         // Mutate the existing plate's field assignments by re-adding (idempotent for ids).
         for &fid in &ocean_buckets[i] {
-            if let Some(f) = model.fields.get_mut(fid as usize) {
-                f.plate_id = Some(pid);
-                f.crust = hayba_tectonics_v2::field::Crust::new_oceanic();
-                f.elevation = -0.3;
-                f.refresh_oceanic_lithosphere();
-            }
-            if let Some(p) = model.plates.iter_mut().find(|p| p.id == pid) {
-                p.add_field(fid);
-            }
+            model.apply_field_initial_state(fid as usize, -0.3, false);
+            model.assign_field_to_plate(fid as usize, pid);
         }
     }
 
     // Refresh inertia after the ocean fill.
-    let area = model.grid.field_area_km2();
-    let fields_ref = model.fields.clone();
-    for p in model.plates.iter_mut() {
-        p.update_inertia_tensor(&fields_ref, area);
-    }
+    model.refresh_plate_inertias();
 
     // Run a short step loop so plates start moving.
     for _ in 0..DEMO_STEPS {

--- a/apps/hayba-explorer/src-tauri/src/wizard.rs
+++ b/apps/hayba-explorer/src-tauri/src/wizard.rs
@@ -19,7 +19,6 @@ use glam::Vec3;
 use serde::{Deserialize, Serialize};
 
 use hayba_tectonics_v2::determinism::split_mix_64;
-use hayba_tectonics_v2::field::Crust;
 use hayba_tectonics_v2::model::{Model, MAX_PLATE_SPEED};
 use hayba_tectonics_v2::sphere::Grid;
 
@@ -339,9 +338,9 @@ pub fn apply_boundary_types(
     }
 
     let seed = state.model.master_seed;
-    for plate in state.model.plates.iter_mut() {
+    let pairs: Vec<(u32, Vec3)> = state.model.plates.iter().filter_map(|plate| {
         let pid = plate.id;
-        let pos = match centroids.get(&pid) { Some(p) => *p, None => continue };
+        let pos = centroids.get(&pid).copied()?;
         let f = force_dir.get(&pid).copied().unwrap_or(Vec3::ZERO);
         let mut omega = if f.length_squared() > 1e-6 {
             let v = f.normalize() * 0.01;
@@ -358,8 +357,9 @@ pub fn apply_boundary_types(
         if len > MAX_PLATE_SPEED {
             omega *= MAX_PLATE_SPEED / len;
         }
-        plate.angular_velocity = omega;
-    }
+        Some((pid, omega))
+    }).collect();
+    for (pid, omega) in pairs { state.model.set_plate_angular_velocity(pid, omega); }
 
     let _ = counts; // silence unused; kept for future inertia recompute
     Ok(snapshot_model(&state.model, state.divisions, false, &ClimateParams::default()))
@@ -378,13 +378,12 @@ pub fn apply_density_rank(
     let mut guard = sim.0.lock().map_err(|_| "sim mutex poisoned".to_string())?;
     let state = guard.as_mut().ok_or_else(|| "no baked planet".to_string())?;
     let n = order.len().max(1) as f32;
-    for (i, pid) in order.iter().enumerate() {
+    let pairs: Vec<(u32, f32)> = order.iter().enumerate().map(|(i, &pid)| {
         let t = if n <= 1.0 { 0.5 } else { i as f32 / (n - 1.0) };
         let d = MIN_DENSITY + t * (MAX_DENSITY - MIN_DENSITY);
-        if let Some(plate) = state.model.plates.iter_mut().find(|p| p.id == *pid) {
-            plate.density = d;
-        }
-    }
+        (pid, d)
+    }).collect();
+    for (pid, d) in pairs { state.model.set_plate_density(pid, d); }
     Ok(snapshot_model(&state.model, state.divisions, false, &ClimateParams::default()))
 }
 
@@ -698,24 +697,10 @@ pub(crate) fn bake_impl(
             DEEP_OCEAN_FLOOR
         };
         let cont = elevation > 0.0;
-        if let Some(f) = model.fields.get_mut(fid as usize) {
-            if cont {
-                f.crust = Crust::new_continental();
-                f.elevation = elevation.max(0.0);
-                f.become_continental_lithosphere(200.0);
-            } else {
-                f.crust = Crust::new_oceanic();
-                f.elevation = elevation.min(-0.0001);
-                f.refresh_oceanic_lithosphere();
-            }
-        }
+        model.apply_field_initial_state(fid as usize, elevation, cont);
     }
 
-    let area = model.grid.field_area_km2();
-    let fields_ref = model.fields.clone();
-    for p in model.plates.iter_mut() {
-        p.update_inertia_tensor(&fields_ref, area);
-    }
+    model.refresh_plate_inertias();
 
     let bp3a_plates = _bp3a_t2.elapsed();
     let _bp3a_t3 = std::time::Instant::now();
@@ -740,12 +725,7 @@ pub(crate) fn bake_impl(
                             cell_area, erosion_params);
     let bp3a_erode = _bp3a_t5.elapsed();
     let _bp3a_t6 = std::time::Instant::now();
-    for i in 0..n_h {
-        if let Some(f) = model.fields.get_mut(i) {
-            // fluvial only sculpts land; never moves a cell across sea level.
-            if !is_ocean[i] { f.elevation = elev[i].max(0.0); }
-        }
-    }
+    model.apply_eroded_elevation(&elev, &is_ocean);
 
     let bp3a_writeback = _bp3a_t6.elapsed();
     eprintln!(


### PR DESCRIPTION
Architecture-review candidate #6. Replaces 9 shell-side direct mutations of model.fields[i] / model.plates[i] with 6 named Model methods. Byte-equal output (cli_te_port byte-equality + determinism::* all green, 215 tectonics tests pass). Prereq for safe rayon on the upcoming subduction-phase parallelization (post-TS measurement: subduction = 36% of per-step, new dominant phase).

Methods added on Model: apply_field_initial_state, assign_field_to_plate, refresh_plate_inertias, set_plate_angular_velocity, set_plate_density, apply_eroded_elevation. 4 files modified, 85 insertions, 58 deletions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal model state management through better encapsulation of field and plate initialization
  * Consolidated field setup logic for more consistent handling
  * Simplified plate property updates and inertia calculations
  * Streamlined erosion data writeback operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->