### PR TITLE
perf(tectonics): split Phase::Other into Geo/Inertia/Plume sub-buckets (TS+1)

### DIFF
--- a/apps/hayba-explorer/packages/tectonics/src/model/model.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/model/model.rs
@@ -198,6 +198,7 @@ impl Model {
         self.remove_empty_plates();
         // ── PHASE 3d: spawn new fields (MOR) ────────────────────────────
         self.generate_new_fields(dt);
+        t.lap(Phase::Geo);
         // ── PHASE 3e: refresh per-plate inertia tensors ─────────────────
         self.update_inertia_tensors();
         // ── PHASE 3f: refresh per-plate geographic centers ──────────────
@@ -212,6 +213,7 @@ impl Model {
         self.group_and_split_plates();
         // ── PHASE 3i: divide plates by age ──────────────────────────────
         self.divide_plates_by_age();
+        t.lap(Phase::Inertia);
         // ── PHASE 3j (Hayba) — mantle dynamics ──────────────────────────
         // Lithospheric column refresh + plume ageing / track recording.
         // Lives at the end of `simulatePlatesInteractions` so plates have
@@ -242,7 +244,7 @@ impl Model {
         for p in self.plates.iter_mut() {
             p.reset_force_accumulator();
         }
-        t.lap(Phase::Other);
+        t.lap(Phase::Plume);
         let optimize = self.optimized_collision_detection;
         let collisions =
             detect_field_collisions_opt(&self.plates, &self.grid, &self.fields, optimize);

--- a/apps/hayba-explorer/packages/tectonics/src/perf_timing.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/perf_timing.rs
@@ -6,8 +6,15 @@
 //! steps (default 100) with the per-phase wall time:
 //!
 //! ```text
-//! [tect-step 100] verlet=12.3ms collisions=4.1ms resolve=0.8ms subduction=2.7ms other=1.4ms total=21.3ms
+//! [tect-step 100] verlet=12.3ms collisions=4.1ms resolve=0.8ms subduction=2.7ms geo=0.6ms inertia=0.5ms plume=0.3ms total=21.3ms
 //! ```
+//!
+//! TS+1 (2026-05-19): the original `other` bucket was split into three
+//! finer sub-buckets — `geo` (speed-clamp + 3a–3d geological processes),
+//! `inertia` (3e–3i inertia/centers/group-split/age-divide), and `plume`
+//! (3j lithosphere/plume-registry + 4a continent-buffers + collision
+//! reset). This narrowed down which sub-phase of the legacy `other`
+//! actually dominates.
 //!
 //! Determinism: this module reads only its env vars and `Instant::now`;
 //! it never mutates sim state. Simulation byte-equality is preserved
@@ -40,7 +47,9 @@ fn sample_every() -> u32 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Phase {
     Verlet,
-    Other,
+    Geo,
+    Inertia,
+    Plume,
     Collisions,
     Resolve,
     Subduction,
@@ -52,7 +61,9 @@ pub struct PhaseTimer {
     start: Instant,
     last: Instant,
     pub verlet: Duration,
-    pub other: Duration,
+    pub geo: Duration,
+    pub inertia: Duration,
+    pub plume: Duration,
     pub collisions: Duration,
     pub resolve: Duration,
     pub subduction: Duration,
@@ -66,7 +77,9 @@ impl PhaseTimer {
             start: now,
             last: now,
             verlet: Duration::ZERO,
-            other: Duration::ZERO,
+            geo: Duration::ZERO,
+            inertia: Duration::ZERO,
+            plume: Duration::ZERO,
             collisions: Duration::ZERO,
             resolve: Duration::ZERO,
             subduction: Duration::ZERO,
@@ -82,7 +95,9 @@ impl PhaseTimer {
         }
         match bucket {
             Phase::Verlet => self.verlet += dt,
-            Phase::Other => self.other += dt,
+            Phase::Geo => self.geo += dt,
+            Phase::Inertia => self.inertia += dt,
+            Phase::Plume => self.plume += dt,
             Phase::Collisions => self.collisions += dt,
             Phase::Resolve => self.resolve += dt,
             Phase::Subduction => self.subduction += dt,
@@ -98,13 +113,15 @@ impl PhaseTimer {
         }
         let total = self.start.elapsed();
         eprintln!(
-            "[tect-step {}] verlet={:.1}ms collisions={:.1}ms resolve={:.1}ms subduction={:.1}ms other={:.1}ms total={:.1}ms",
+            "[tect-step {}] verlet={:.1}ms collisions={:.1}ms resolve={:.1}ms subduction={:.1}ms geo={:.1}ms inertia={:.1}ms plume={:.1}ms total={:.1}ms",
             step_idx,
             self.verlet.as_secs_f64() * 1000.0,
             self.collisions.as_secs_f64() * 1000.0,
             self.resolve.as_secs_f64() * 1000.0,
             self.subduction.as_secs_f64() * 1000.0,
-            self.other.as_secs_f64() * 1000.0,
+            self.geo.as_secs_f64() * 1000.0,
+            self.inertia.as_secs_f64() * 1000.0,
+            self.plume.as_secs_f64() * 1000.0,
             total.as_secs_f64() * 1000.0,
         );
     }
@@ -127,7 +144,9 @@ mod tests {
     fn timer_start_has_zero_buckets() {
         let t = PhaseTimer::start();
         assert_eq!(t.verlet, Duration::ZERO);
-        assert_eq!(t.other, Duration::ZERO);
+        assert_eq!(t.geo, Duration::ZERO);
+        assert_eq!(t.inertia, Duration::ZERO);
+        assert_eq!(t.plume, Duration::ZERO);
         assert_eq!(t.collisions, Duration::ZERO);
         assert_eq!(t.resolve, Duration::ZERO);
         assert_eq!(t.subduction, Duration::ZERO);
@@ -141,7 +160,9 @@ mod tests {
             start: now,
             last: now,
             verlet: Duration::ZERO,
-            other: Duration::ZERO,
+            geo: Duration::ZERO,
+            inertia: Duration::ZERO,
+            plume: Duration::ZERO,
             collisions: Duration::ZERO,
             resolve: Duration::ZERO,
             subduction: Duration::ZERO,
@@ -149,7 +170,7 @@ mod tests {
         sleep(StdDur::from_millis(2));
         t.lap(Phase::Verlet);
         assert!(t.verlet >= StdDur::from_millis(1));
-        assert_eq!(t.other, Duration::ZERO);
+        assert_eq!(t.geo, Duration::ZERO);
     }
 
     #[test]
@@ -160,7 +181,9 @@ mod tests {
             start: now,
             last: now,
             verlet: Duration::ZERO,
-            other: Duration::ZERO,
+            geo: Duration::ZERO,
+            inertia: Duration::ZERO,
+            plume: Duration::ZERO,
             collisions: Duration::ZERO,
             resolve: Duration::ZERO,
             subduction: Duration::ZERO,
@@ -177,7 +200,9 @@ mod tests {
             start: Instant::now(),
             last: Instant::now(),
             verlet: Duration::ZERO,
-            other: Duration::ZERO,
+            geo: Duration::ZERO,
+            inertia: Duration::ZERO,
+            plume: Duration::ZERO,
             collisions: Duration::ZERO,
             resolve: Duration::ZERO,
             subduction: Duration::ZERO,


### PR DESCRIPTION
Post-TS measurement showed Phase::Other = 45ms = 28% of per-step — second-largest after subduction. Splits it into 3 named sub-buckets at natural code-structure boundaries:

- **Geo** (~3a–3d): speed-clamp + perform_geological_processes + remove_unnecessary_fields + remove_empty_plates + generate_new_fields
- **Inertia** (3e–3i): update_inertia_tensors + update_centers + group_and_split_plates + divide_plates_by_age
- **Plume** (3j+4a+reset): update_lithospheric_columns + plume_registry.step + record_tracks + calculate_continent_buffers + per-field collision reset

Determinism preserved (215 tectonics tests + 58 hayba-explorer lib all green, byte-equality + determinism::* gates pass). 2 files, +40/-13 lines. Run with HAYBA_TECTONICS_TIMING=1 HAYBA_TECTONICS_TIMING_EVERY=1 to see the new finer-grained per-step report and identify which sub-call drives the next perf candidate.