### PR TITLE
fix(build): pin hayba-explorer codegen-units=1 in dev (MSVC ICF link bug)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,15 @@ opt-level = 3
 
 [profile.dev.package."hayba-seeds"]
 opt-level = 3
+
+# Pin hayba-explorer (the Tauri cdylib) to single codegen unit. At
+# opt-level=2 (inherited from [profile.dev]) with rustc's default
+# multi-CGU codegen, LLVM emits per-CGU anon-symbol helpers that the
+# MSVC linker's /OPT:REF,ICF then folds inconsistently — manifesting
+# as LNK2019 "unresolved external symbol anon.*.llvm.*" referenced
+# from monomorphized serde_json::Number::serialize. Single CGU
+# eliminates the cross-CGU symbol collision. (Same reason
+# hayba-tectonics-v2 pins codegen-units = 1 above.)
+[profile.dev.package."hayba-explorer"]
+opt-level = 2
+codegen-units = 1


### PR DESCRIPTION
Fixes LNK2019 "unresolved external symbol anon.*.llvm.*" from `serde_json::Number::serialize` when linking `hayba_explorer_lib.dll`. With `[profile.dev] opt-level = 2` (from BR) and rustc's default multi-CGU codegen, LLVM emits per-CGU anon-symbol helpers that the MSVC linker's `/OPT:REF,ICF` then folds inconsistently across CGUs. Pinning the cdylib crate to codegen-units = 1 eliminates the cross-CGU symbol collision. Same workaround already in place for hayba-tectonics-v2. Tradeoff: slightly slower full rebuilds (single-threaded codegen for hayba-explorer only), acceptable for incremental dev. Verified: `cargo build -p hayba-explorer --lib` now succeeds at 1m 29s.