### PR TITLE
feat(climate): orographic precipitation in CLIMATE_FRAG (P2.2-oro)

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
@@ -55,6 +55,33 @@ describe("NX-2a geostrophic wind GLSL", () => {
   });
 });
 
+describe("P2.2-oro orographic precipitation", () => {
+  it("CLIMATE_FRAG declares uOrographicGain + uRainShadow uniforms", () => {
+    expect(CLIMATE_FRAG).toContain("uniform float uOrographicGain;");
+    expect(CLIMATE_FRAG).toContain("uniform float uRainShadow;");
+  });
+  it("CLIMATE_FRAG samples 4-neighbour terrain to build a gradient", () => {
+    expect(CLIMATE_FRAG).toContain("vec4 aLh = loadA(uA, uGrid, rc.x - 1, rc.y);");
+    expect(CLIMATE_FRAG).toContain("vec4 aRh = loadA(uA, uGrid, rc.x + 1, rc.y);");
+    expect(CLIMATE_FRAG).toContain("vec4 aNh = loadA(uA, uGrid, rc.x, rc.y - 1);");
+    expect(CLIMATE_FRAG).toContain("vec4 aSh = loadA(uA, uGrid, rc.x, rc.y + 1);");
+    expect(CLIMATE_FRAG).toContain(
+      "vec2 gradH = vec2(aRh.r - aLh.r, aNh.r - aSh.r) * 0.5;",
+    );
+  });
+  it("CLIMATE_FRAG modulates P by wind · grad(h) with shadow split", () => {
+    // Upslope = cos angle between wind dir and gradient dir, guarded
+    // against zero magnitudes so flats / ocean produce oro=1.0 (no-op).
+    expect(CLIMATE_FRAG).toContain(
+      "float upslope = (ghlen > 1e-6 && wmag > 1e-6) ? dot(wvec / wmag, gradH / ghlen) : 0.0;",
+    );
+    expect(CLIMATE_FRAG).toContain(
+      "float oro = 1.0 + uOrographicGain * max(upslope, 0.0) - uRainShadow * max(-upslope, 0.0);",
+    );
+    expect(CLIMATE_FRAG).toContain("P = clamp(P * oro, 0.05, 1.0);");
+  });
+});
+
 describe("NX-2c seasonality (MdGBWG Jan/July MSLP delta)", () => {
   it("MSLP_FRAG adds season uniforms + land/ocean delta + dfac blend", () => {
     expect(MSLP_FRAG).toContain("uniform float uSeasonAmp;");

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -814,6 +814,8 @@ export const CLIMATE_FRAG = [
   "uniform float uGlacFullC;",
   "uniform sampler2D uMSLP;",
   "uniform float uCoriolisGain;",
+  "uniform float uOrographicGain;",
+  "uniform float uRainShadow;",
   "void main(){",
   "  ivec2 rc = fragRC();",
   "  vec4 a = loadA(uA, uGrid, rc.x, rc.y);",
@@ -837,6 +839,20 @@ export const CLIMATE_FRAG = [
   "  float coslat = max(cos(lat), 1e-3);",
   "  vec2 gp = vec2((pR - pL) * 0.5 / coslat, (pN - pS) * 0.5);",
   "  vec2 wvec = uCoriolisGain * s * vec2(-gp.y, gp.x) - gp;",
+  // P2.2-oro: orographic precipitation. Wind dotted with the normalised
+  // terrain gradient gives an "upslope" cosine in [-1, 1]: windward
+  // (positive) lifts the air -> more rain (gain), leeward (negative) sinks
+  // it -> drier (rain shadow). Ocean cells have ~zero gradient -> oro=1.0.
+  "  vec4 aLh = loadA(uA, uGrid, rc.x - 1, rc.y);",
+  "  vec4 aRh = loadA(uA, uGrid, rc.x + 1, rc.y);",
+  "  vec4 aNh = loadA(uA, uGrid, rc.x, rc.y - 1);",
+  "  vec4 aSh = loadA(uA, uGrid, rc.x, rc.y + 1);",
+  "  vec2 gradH = vec2(aRh.r - aLh.r, aNh.r - aSh.r) * 0.5;",
+  "  float ghlen = length(gradH);",
+  "  float wmag = length(wvec);",
+  "  float upslope = (ghlen > 1e-6 && wmag > 1e-6) ? dot(wvec / wmag, gradH / ghlen) : 0.0;",
+  "  float oro = 1.0 + uOrographicGain * max(upslope, 0.0) - uRainShadow * max(-upslope, 0.0);",
+  "  P = clamp(P * oro, 0.05, 1.0);",
   "  float windAz = fract(atan(wvec.y, wvec.x) / 6.28318530 + 0.5);",
   // SPEC-SAFE: GLSL ES 3.00 smoothstep is UNDEFINED if edge0 >= edge1.
   // uGlacOnsetC (-2) > uGlacFullC (-12), so keep edges ASCENDING

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -176,6 +176,12 @@ export interface HydraulicConfig {
    *  the simulated month in [0,12) (0=Jan, 6=Jul); inert while amp 0. */
   seasonAmp: number;
   seasonPhase: number;
+  /** P2.2-oro orographic precipitation. `orographicGain` multiplies the
+   *  windward (upslope, wind·∇h>0) precip boost; `rainShadow` multiplies
+   *  the leeward (downslope, wind·∇h<0) precip cut. Both clamped to keep
+   *  P in [0.05, 1.0]. Defaults mirror climate.rs ClimateParams. */
+  orographicGain: number;
+  rainShadow: number;
   /** P2.3b-i Whittaker biome thermal cuts (°C) — mirrors
    *  ClimateParams.biome_cold_c / biome_hot_c. */
   biomeColdC: number;
@@ -289,6 +295,8 @@ export const DEFAULT_HYDRAULIC: HydraulicConfig = {
   coriolisGain: 15.0,
   seasonAmp: 0.0,
   seasonPhase: 0.0,
+  orographicGain: 0.6,
+  rainShadow: 0.5,
   biomeColdC: 6.0,
   biomeHotC: 18.0,
   channelDepth: 0.02,
@@ -510,6 +518,8 @@ export async function runHydraulicBake(
         uItczWidthDeg: u(cfg.itczWidthDeg),
         uGlacOnsetC: u(cfg.glacOnsetC),
         uGlacFullC: u(cfg.glacFullC),
+        uOrographicGain: u(cfg.orographicGain),
+        uRainShadow: u(cfg.rainShadow),
       },
       CLIM[0],
     );


### PR DESCRIPTION
Adds windward-rain / leeward-rain-shadow physics to the climate bake. CLIMATE_FRAG now samples the 4-neighbour terrain gradient (∇h), dots it with the already-computed geostrophic wind vector to get an upslope cosine, and modulates precipitation:

P *= 1.0 + uOrographicGain * max(upslope, 0) - uRainShadow * max(-upslope, 0)

Clamped to [0.05, 1.0]. Flat / ocean cells (gradient ≈ 0) produce oro=1.0 → no-op.

Defaults match climate.rs ClimateParams: orographicGain=0.6, rainShadow=0.5. The two knobs already existed in HydraulicConfig-adjacent Rust + ClimateLabPanel TS (NX-2/P2.2 era) but were never wired into the bake — this lights them up.

Visible immediately via the existing CLIM 'Precipitation' map-mode (the modulation writes to CLIM.g, no new map mode needed).

3 files / 53 insertions. Tests: 9/9 climate-wind suite green incl. 3 new P2.2-oro asserts (uniforms declared, 4-neighbour sample, oro modulation formula present). Full vitest: 173 tests pass (11 pre-existing empty placeholder files unchanged). tsc 0.