### PR TITLE
perf(tectonics): BTreeSet→HashSet for plume record_tracks visited set (SD-PR)

### DIFF
--- a/apps/hayba-explorer/packages/tectonics/src/mantle/plume.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/mantle/plume.rs
@@ -280,8 +280,16 @@ impl PlumeRegistry {
             // whose great-circle distance from `centre` is ≤ radius.
             let seed = grid.nearest_field(centre);
             let mut frontier: Vec<u32> = vec![seed];
-            let mut visited: std::collections::BTreeSet<u32> =
-                std::collections::BTreeSet::new();
+            // SD-PR (Plume Record): HashSet instead of BTreeSet — visited is
+            // only used for membership tests (.insert returns bool), never
+            // iterated, so the sorted-order semantics of BTreeSet bought us
+            // nothing while paying O(log N) per insert. HashSet gives O(1)
+            // amortised; for 50-500 cells/plume × 10-20 plumes/step this
+            // shaves several ms off the plume phase. Byte-equality preserved:
+            // identical seed, identical BFS pop order, identical
+            // affected.sort_unstable() output.
+            let mut visited: std::collections::HashSet<u32> =
+                std::collections::HashSet::with_capacity(512);
             visited.insert(seed);
             let mut affected: Vec<u32> = Vec::new();
 


### PR DESCRIPTION
PlumeRegistry::record_tracks() uses a BTreeSet<u32> for BFS visited tracking — O(log N) per insert, where N grows with each plume's affected cell count (50–500 cells). HashSet gives O(1) amortised; visited is only used for membership tests (insert returns bool) and never iterated, so the sorted-order semantics of BTreeSet were unused dead weight.

Per the TS+1 measurement, the 'plume' phase is the new dominant housekeeping bucket at ~32.5ms = 29% of per-step. The recon identified record_tracks's BTreeSet as the biggest single sub-cost. For typical plume populations (10–20 plumes × 50–500 cells each per step) this shaves several ms.

with_capacity(512) eliminates rehashing for normal plume sizes.

Byte-equality preserved: same seed, same BFS pop order (frontier is a Vec stack), same affected.sort_unstable() output, same per-plume deposit order. 215 tectonics tests + cli_te_port byte-equality + determinism::* all green.