### PR TITLE
perf(tectonics): rayon-parallelise step_verlet torque computation (SV-RAY)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,6 +1309,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_core 0.6.4",
  "rand_pcg",
+ "rayon",
  "serde",
  "serde_json",
 ]

--- a/apps/hayba-explorer/packages/tectonics/Cargo.toml
+++ b/apps/hayba-explorer/packages/tectonics/Cargo.toml
@@ -15,6 +15,7 @@ glam = { version = "0.27", features = ["serde", "rand"] }
 rand = "0.8"
 rand_core = "0.6"
 rand_pcg = "0.3"
+rayon = "1"
 
 [dev-dependencies]
 proptest = "1"

--- a/apps/hayba-explorer/packages/tectonics/src/model/model.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/model/model.rs
@@ -322,18 +322,26 @@ impl Model {
             .map(|(i, p)| (p.id, i))
             .collect();
 
-        // a1 = torques at current state for ALL plates.
-        let mut a1: Vec<Vec3> = Vec::with_capacity(n);
-        for i in 0..n {
-            let t = self.plates[i].compute_total_torque_indexed(
-                &self.fields,
-                &self.plates,
-                i,
-                &id_to_idx,
-                area,
-            );
-            a1.push(acceleration_for(&self.plates[i], t));
-        }
+        // a1 = torques at current state for ALL plates. SV-RAY: parallel
+        // via rayon. Each plate's torque depends only on shared immutable
+        // references (&fields, &plates, &id_to_idx, area) — no cross-plate
+        // mutation, no shared accumulator. `collect::<Vec<_>>()` preserves
+        // index order, so a1[i] is bit-identical to the serial version
+        // (each plate's compute_total_torque_indexed sums over its OWN
+        // fields in the SAME order on any thread).
+        use rayon::prelude::*;
+        let fields_ref = &self.fields;
+        let plates_ref = &self.plates;
+        let idx_ref = &id_to_idx;
+        let a1: Vec<Vec3> = (0..n)
+            .into_par_iter()
+            .map(|i| {
+                let t = plates_ref[i].compute_total_torque_indexed(
+                    fields_ref, plates_ref, i, idx_ref, area,
+                );
+                acceleration_for(&plates_ref[i], t)
+            })
+            .collect();
 
         // v1, q1 saved per plate.
         let v1: Vec<Vec3> = self.plates.iter().map(|p| p.angular_velocity).collect();
@@ -348,18 +356,22 @@ impl Model {
             self.plates[i].angular_velocity = v_prov;
         }
 
-        // a2 = torques at NEW state for ALL plates.
-        let mut a2: Vec<Vec3> = Vec::with_capacity(n);
-        for i in 0..n {
-            let t = self.plates[i].compute_total_torque_indexed(
-                &self.fields,
-                &self.plates,
-                i,
-                &id_to_idx,
-                area,
-            );
-            a2.push(acceleration_for(&self.plates[i], t));
-        }
+        // a2 = torques at NEW state for ALL plates. SV-RAY: same rayon
+        // pattern as a1 above. Re-bind the references because the
+        // intermediate `for i in 0..n` provisional-update loop took
+        // &mut self.plates[i].
+        let fields_ref = &self.fields;
+        let plates_ref = &self.plates;
+        let idx_ref = &id_to_idx;
+        let a2: Vec<Vec3> = (0..n)
+            .into_par_iter()
+            .map(|i| {
+                let t = plates_ref[i].compute_total_torque_indexed(
+                    fields_ref, plates_ref, i, idx_ref, area,
+                );
+                acceleration_for(&plates_ref[i], t)
+            })
+            .collect();
 
         // Apply the corrector + hot-spot decay per plate.
         for i in 0..n {


### PR DESCRIPTION
step_verlet's two per-plate torque-computation loops (a1 predictor, a2 corrector) are perfectly parallelisable: each plate's compute_total_torque_indexed call reads only shared-immutable state (&fields, &plates, &id_to_idx, area) and produces a self-contained Vec3 result. Switched to rayon's into_par_iter().map(...).collect::<Vec<_>>() — order preserved, per-plate arithmetic identical on any thread → byte-equal.

Per the TS+1 measurement, verlet is the new dominant phase at ~36.5ms = 33% of step (post-SV/SD wins). On 4+ cores, expect a ~3-4× speedup of this phase = ~25ms saved per step on typical P=10-20 plate counts. Total step time projected to drop from ~110ms to ~80ms.

EM (PR #159) was the prereq: the rayon closure needs to borrow self.plates immutably while iterating, which the previous direct-mutation shell pattern would have made awkward. EM closed the seam.

Added rayon = "1" to the tectonics Cargo.toml (rayon 1.12.0 already in workspace lock). No new transitive deps.

Determinism: cli_te_port::cli_run_is_byte_deterministic_across_runs runs the sim TWICE on the same seed and compares — explicitly checks parallel determinism. 215 tectonics tests + 3 cli_te_port + determinism::* all GREEN.