### PR TITLE
perf(tectonics): rayon-parallelise update_inertia_tensors (INE-RAY)

### DIFF
--- a/apps/hayba-explorer/packages/tectonics/src/model/model.rs
+++ b/apps/hayba-explorer/packages/tectonics/src/model/model.rs
@@ -423,11 +423,19 @@ impl Model {
         // PlateGroup-level recompute (TE updates group first, then any
         // ungrouped plates). Group bookkeeping is Phase 4 — we just iterate
         // standalone plates here.
-        for p in self.plates.iter_mut() {
+        //
+        // INE-RAY: each plate's update_inertia_tensor is independent —
+        // it sums over the plate's OWN field-id list (no cross-plate
+        // mutation) and reads only &self.fields immutably. Rayon
+        // par_iter_mut splits the &mut self.plates safely; result is
+        // byte-equal because per-plate sums are in fixed Vec order.
+        use rayon::prelude::*;
+        let fields_ref = &self.fields;
+        self.plates.par_iter_mut().for_each(|p| {
             if p.group.is_none() {
-                p.update_inertia_tensor(&self.fields, area);
+                p.update_inertia_tensor(fields_ref, area);
             }
-        }
+        });
         // TODO Phase 4: group.updateInertiaTensor() once PlateGroup carries
         // member plates.
     }


### PR DESCRIPTION
update_inertia_tensors iterates plates and computes each plate's moment-of-inertia tensor over its OWN field-id list. Per-plate work is independent — reads &self.fields immutably, writes &mut self.plates[i]. Rayon par_iter_mut splits the &mut self.plates safely.

Per the TS+1 measurement post-SV-RAY+SD-PR, the 'inertia' bucket is ~12.1ms = 12% of step. With this change, expect ~3-4ms (3-4× on 4+ cores) — saves ~8ms per step.

Determinism: each plate's inertia sum iterates self.fields (the plate's own Vec<u32> field-ids) in fixed Vec order — same sum, same arithmetic, same output regardless of thread scheduling. cli_te_port::cli_run_is_byte_deterministic_across_runs (which does two full sim runs and compares byte-by-byte) stays green. 215 tectonics tests + 3 cli_te_port + determinism::* all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized inertia tensor computation performance through improved computational efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->