### PR TITLE
feat(climate): seasonality + onshore moisture transport (CLIM-MONSOON)

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
@@ -78,7 +78,38 @@ describe("P2.2-oro orographic precipitation", () => {
     expect(CLIMATE_FRAG).toContain(
       "float oro = 1.0 + uOrographicGain * max(upslope, 0.0) - uRainShadow * max(-upslope, 0.0);",
     );
-    expect(CLIMATE_FRAG).toContain("P = clamp(P * oro, 0.05, 1.0);");
+    // CLIM-MONSOON replaced the original `P = clamp(P * oro, …)` with a
+    // form that composes onshore moisture additively before oro:
+    expect(CLIMATE_FRAG).toContain(
+      "P = clamp((P + onshoreBonus) * oro, 0.05, 1.0);",
+    );
+  });
+});
+
+describe("CLIM-MONSOON onshore moisture transport", () => {
+  it("CLIMATE_FRAG declares uOnshoreGain uniform", () => {
+    expect(CLIMATE_FRAG).toContain("uniform float uOnshoreGain;");
+  });
+  it("CLIMATE_FRAG walks K=4 cells upwind to measure ocean fraction", () => {
+    expect(CLIMATE_FRAG).toContain("vec2 wdir = (wmag > 1e-6) ? wvec / wmag : vec2(0.0);");
+    expect(CLIMATE_FRAG).toContain("float oceanFrac = 0.0;");
+    expect(CLIMATE_FRAG).toContain("for (int k = 1; k <= 4; k++) {");
+    expect(CLIMATE_FRAG).toContain("int dx = int(-wdir.x * float(k) * 4.0);");
+    expect(CLIMATE_FRAG).toContain("int dy = int(-wdir.y * float(k) * 4.0);");
+    expect(CLIMATE_FRAG).toContain("float upH = texelFetch(uA, ivec2(ux, uy), 0).r;");
+    expect(CLIMATE_FRAG).toContain("oceanFrac += float(upH < 0.0);");
+    expect(CLIMATE_FRAG).toContain("oceanFrac *= 0.25;");
+  });
+  it("CLIMATE_FRAG adds onshore moisture additively then applies orographic", () => {
+    // Additive bonus (lifts dry zonal areas) only above 50% ocean upwind.
+    // Combined with the orographic multiplier so wet wind + windward
+    // slope = monsoon-intense rain.
+    expect(CLIMATE_FRAG).toContain(
+      "float onshoreBonus = uOnshoreGain * max(oceanFrac - 0.5, 0.0);",
+    );
+    expect(CLIMATE_FRAG).toContain(
+      "P = clamp((P + onshoreBonus) * oro, 0.05, 1.0);",
+    );
   });
 });
 

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -816,6 +816,7 @@ export const CLIMATE_FRAG = [
   "uniform float uCoriolisGain;",
   "uniform float uOrographicGain;",
   "uniform float uRainShadow;",
+  "uniform float uOnshoreGain;",
   "void main(){",
   "  ivec2 rc = fragRC();",
   "  vec4 a = loadA(uA, uGrid, rc.x, rc.y);",
@@ -852,7 +853,28 @@ export const CLIMATE_FRAG = [
   "  float wmag = length(wvec);",
   "  float upslope = (ghlen > 1e-6 && wmag > 1e-6) ? dot(wvec / wmag, gradH / ghlen) : 0.0;",
   "  float oro = 1.0 + uOrographicGain * max(upslope, 0.0) - uRainShadow * max(-upslope, 0.0);",
-  "  P = clamp(P * oro, 0.05, 1.0);",
+  // CLIM-MONSOON: onshore moisture transport. Walk K=4 cells upwind along
+  // the geostrophic wind direction; count how many are ocean (a.r < 0).
+  // High ocean fraction = wind is freshly off the sea, carrying moisture
+  // → additive precip bonus that LIFTS the zonal-band baseline (so the
+  // subtropical-dry belt can be overridden on monsoon coasts, matching
+  // the cookbook: "summer low-pressure pulls moisture-laden air from
+  // ocean"). Combined with the existing orographic factor `oro`, this
+  // produces wet windward slopes near coasts (Western Ghats, Himalayan
+  // S-slope) without making continental interiors wet.
+  "  vec2 wdir = (wmag > 1e-6) ? wvec / wmag : vec2(0.0);",
+  "  float oceanFrac = 0.0;",
+  "  for (int k = 1; k <= 4; k++) {",
+  "    int dx = int(-wdir.x * float(k) * 4.0);",
+  "    int dy = int(-wdir.y * float(k) * 4.0);",
+  "    int ux = xw(rc.x + dx, wh.x);",
+  "    int uy = yc(rc.y + dy, wh.y);",
+  "    float upH = texelFetch(uA, ivec2(ux, uy), 0).r;",
+  "    oceanFrac += float(upH < 0.0);",
+  "  }",
+  "  oceanFrac *= 0.25;",
+  "  float onshoreBonus = uOnshoreGain * max(oceanFrac - 0.5, 0.0);",
+  "  P = clamp((P + onshoreBonus) * oro, 0.05, 1.0);",
   "  float windAz = fract(atan(wvec.y, wvec.x) / 6.28318530 + 0.5);",
   // SPEC-SAFE: GLSL ES 3.00 smoothstep is UNDEFINED if edge0 >= edge1.
   // uGlacOnsetC (-2) > uGlacFullC (-12), so keep edges ASCENDING

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -182,6 +182,12 @@ export interface HydraulicConfig {
    *  P in [0.05, 1.0]. Defaults mirror climate.rs ClimateParams. */
   orographicGain: number;
   rainShadow: number;
+  /** CLIM-MONSOON onshore moisture transport (cookbook principle:
+   *  "summer low pulls moisture-laden air from ocean"). Scales the
+   *  ADDITIVE precip boost driven by upwind ocean fraction (4 samples
+   *  along wind direction). 0.0 = off (no moisture transport); 0.5 =
+   *  monsoon coasts can override the subtropical-dry zonal band. */
+  onshoreGain: number;
   /** P2.3b-i Whittaker biome thermal cuts (°C) — mirrors
    *  ClimateParams.biome_cold_c / biome_hot_c. */
   biomeColdC: number;
@@ -293,10 +299,15 @@ export const DEFAULT_HYDRAULIC: HydraulicConfig = {
   mslpOceanAmp: 20.0,
   mslpBlurSigma: 6.0,
   coriolisGain: 15.0,
-  seasonAmp: 0.0,
-  seasonPhase: 0.0,
+  // CLIM-MONSOON: seasonality enabled by default so continental
+  // summer-low / oceanic-summer-high pressure swap can drive monsoon
+  // winds. seasonPhase=6.0 picks the NH summer (July) snapshot, peak
+  // Asian monsoon. This is the cookbook's "summer pressure" picture.
+  seasonAmp: 0.5,
+  seasonPhase: 6.0,
   orographicGain: 0.6,
   rainShadow: 0.5,
+  onshoreGain: 0.5,
   biomeColdC: 6.0,
   biomeHotC: 18.0,
   channelDepth: 0.02,
@@ -520,6 +531,7 @@ export async function runHydraulicBake(
         uGlacFullC: u(cfg.glacFullC),
         uOrographicGain: u(cfg.orographicGain),
         uRainShadow: u(cfg.rainShadow),
+        uOnshoreGain: u(cfg.onshoreGain),
       },
       CLIM[0],
     );


### PR DESCRIPTION
Per Geoff's Climate Cookbook (Gates 1972 / Tarbuck-Lutgens 1985 grade meteorology), the monsoon arises from TWO mechanisms we'd partially missing:

1. **Seasonal continental low/high pressure swap** — already shipped in NX-2c (Jan/July MSLP delta) but dormant at seasonAmp=0. Flipping seasonAmp=0.5, seasonPhase=6.0 turns on summer-NH continental low → SW geostrophic flow off Indian Ocean onto Asia.

2. **Onshore moisture transport** — net-new in CLIMATE_FRAG. Walks K=4 cells upwind along the geostrophic wind direction, counts what fraction are ocean (a.r<0), and adds an ADDITIVE precip bonus when oceanFrac>0.5. The bonus is then multiplied by the existing orographic factor, so wet wind + windward slope = monsoon-intense rain (Western Ghats / Himalayan southern face). Additive lift lets the subtropical-dry zonal band be overridden on monsoon coasts, matching the cookbook's 'summer low pulls moisture-laden air from ocean'.

Cookbook gap analysis (still pending after this ship, for future PRs):
- East-coast bias in continental pressure (Asia's monsoon lobe sits east-of-middle)
- ITCZ land-amplified migration (5° over ocean, 40° over land)
- Continentality decay in temperature (interior swings more)
- Ocean current temp anomalies in BAKE (Rust climate.rs has it, GLSL doesn't)

3 files, 69 lines. 12/12 climate-wind tests green (3 new for P2.2-oro + 3 new for CLIM-MONSOON + existing pins updated). tsc 0. No Rust touch.