### PR TITLE
feat(climate): continentality precip suppression (CLIM-CONTINENTALITY)

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
@@ -79,9 +79,10 @@ describe("P2.2-oro orographic precipitation", () => {
       "float oro = 1.0 + uOrographicGain * max(upslope, 0.0) - uRainShadow * max(-upslope, 0.0);",
     );
     // CLIM-MONSOON replaced the original `P = clamp(P * oro, …)` with a
-    // form that composes onshore moisture additively before oro:
+    // form that composes onshore moisture and continentality additively
+    // before oro:
     expect(CLIMATE_FRAG).toContain(
-      "P = clamp((P + onshoreBonus) * oro, 0.05, 1.0);",
+      "P = clamp((P + onshoreBonus - interiorDry) * oro, 0.05, 1.0);",
     );
   });
 });
@@ -107,8 +108,13 @@ describe("CLIM-MONSOON onshore moisture transport", () => {
     expect(CLIMATE_FRAG).toContain(
       "float onshoreBonus = uOnshoreGain * max(oceanFrac - 0.5, 0.0);",
     );
+    // CLIM-CONTINENTALITY pair: symmetric suppression below 0.5
+    expect(CLIMATE_FRAG).toContain("uniform float uContinentalGain;");
     expect(CLIMATE_FRAG).toContain(
-      "P = clamp((P + onshoreBonus) * oro, 0.05, 1.0);",
+      "float interiorDry = uContinentalGain * max(0.5 - oceanFrac, 0.0);",
+    );
+    expect(CLIMATE_FRAG).toContain(
+      "P = clamp((P + onshoreBonus - interiorDry) * oro, 0.05, 1.0);",
     );
   });
 });

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -817,6 +817,7 @@ export const CLIMATE_FRAG = [
   "uniform float uOrographicGain;",
   "uniform float uRainShadow;",
   "uniform float uOnshoreGain;",
+  "uniform float uContinentalGain;",
   "void main(){",
   "  ivec2 rc = fragRC();",
   "  vec4 a = loadA(uA, uGrid, rc.x, rc.y);",
@@ -873,8 +874,15 @@ export const CLIMATE_FRAG = [
   "    oceanFrac += float(upH < 0.0);",
   "  }",
   "  oceanFrac *= 0.25;",
+  // CLIM-CONTINENTALITY: symmetric counterpart of the onshore boost.
+  // When oceanFrac < 0.5 the upwind path is mostly LAND — wind has
+  // exhausted its moisture before reaching this cell (cookbook:
+  // "wind will become dry after blowing across a large area of land").
+  // Suppress precip proportionally. Two knobs so monsoon coasts and
+  // interior dryness can be tuned independently.
   "  float onshoreBonus = uOnshoreGain * max(oceanFrac - 0.5, 0.0);",
-  "  P = clamp((P + onshoreBonus) * oro, 0.05, 1.0);",
+  "  float interiorDry = uContinentalGain * max(0.5 - oceanFrac, 0.0);",
+  "  P = clamp((P + onshoreBonus - interiorDry) * oro, 0.05, 1.0);",
   "  float windAz = fract(atan(wvec.y, wvec.x) / 6.28318530 + 0.5);",
   // SPEC-SAFE: GLSL ES 3.00 smoothstep is UNDEFINED if edge0 >= edge1.
   // uGlacOnsetC (-2) > uGlacFullC (-12), so keep edges ASCENDING

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -188,6 +188,12 @@ export interface HydraulicConfig {
    *  along wind direction). 0.0 = off (no moisture transport); 0.5 =
    *  monsoon coasts can override the subtropical-dry zonal band. */
   onshoreGain: number;
+  /** CLIM-CONTINENTALITY symmetric counterpart of onshoreGain. Suppresses
+   *  precip when upwind path is mostly LAND (oceanFrac < 0.5), modelling
+   *  the cookbook's "wind will become dry after blowing across a large
+   *  area of land". 0.3 default = moderate continental drying without
+   *  blanking interiors. */
+  continentalGain: number;
   /** P2.3b-i Whittaker biome thermal cuts (°C) — mirrors
    *  ClimateParams.biome_cold_c / biome_hot_c. */
   biomeColdC: number;
@@ -308,6 +314,7 @@ export const DEFAULT_HYDRAULIC: HydraulicConfig = {
   orographicGain: 0.6,
   rainShadow: 0.5,
   onshoreGain: 0.5,
+  continentalGain: 0.3,
   biomeColdC: 6.0,
   biomeHotC: 18.0,
   channelDepth: 0.02,
@@ -532,6 +539,7 @@ export async function runHydraulicBake(
         uOrographicGain: u(cfg.orographicGain),
         uRainShadow: u(cfg.rainShadow),
         uOnshoreGain: u(cfg.onshoreGain),
+        uContinentalGain: u(cfg.continentalGain),
       },
       CLIM[0],
     );


### PR DESCRIPTION
Cookbook principle: 'wind will become dry after blowing across a large area of land'. Adds uContinentalGain as the symmetric counterpart to uOnshoreGain — suppresses precip when oceanFrac<0.5 (wind has crossed mostly land before reaching this cell). Reuses the same K=4 upwind scan from CLIM-MONSOON (no extra texture sampling).

Together with CLIM-MONSOON, the precip term is now:
  P_final = clamp((P_zonal + onshoreBonus − interiorDry) × oro, 0.05, 1.0)

Defaults: uContinentalGain=0.3 (moderate interior drying without blanking).

Effects: deep Asia (Mongolia/central Siberia), central Australia, central US, central S America become noticeably drier; coastal & windward bands stay wet. Matches the cookbook's hot-desert / cold-desert distribution.

3 files. 12/12 climate-wind tests green (added 2 new pins). tsc 0.