### PR TITLE
feat(climate): continentality on T — interiors swing more (CLIM-T-CONTINENTALITY)

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
@@ -119,6 +119,23 @@ describe("CLIM-MONSOON onshore moisture transport", () => {
   });
 });
 
+describe("CLIM-T-CONTINENTALITY (#193: interiors swing more)", () => {
+  it("CLIMATE_FRAG declares uContinentalT + season uniforms", () => {
+    expect(CLIMATE_FRAG).toContain("uniform float uContinentalT;");
+    expect(CLIMATE_FRAG).toContain("uniform float uSeasonAmp;");
+    expect(CLIMATE_FRAG).toContain("uniform float uSeasonPhase;");
+  });
+  it("CLIMATE_FRAG offsets T by hemisphere × season × continentality", () => {
+    expect(CLIMATE_FRAG).toContain("float isJulyish = cos((uSeasonPhase - 6.0) * 0.52359877);");
+    expect(CLIMATE_FRAG).toContain("float hemSign = sign(lat);");
+    expect(CLIMATE_FRAG).toContain("float landMask = step(0.0, a.r);");
+    expect(CLIMATE_FRAG).toContain(
+      "float continentalT = uContinentalT * uSeasonAmp * isJulyish * hemSign * landMask * (1.0 - oceanFrac);",
+    );
+    expect(CLIMATE_FRAG).toContain("T += continentalT;");
+  });
+});
+
 describe("NX-2c seasonality (MdGBWG Jan/July MSLP delta)", () => {
   it("MSLP_FRAG adds season uniforms + land/ocean delta + dfac blend", () => {
     expect(MSLP_FRAG).toContain("uniform float uSeasonAmp;");

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -818,6 +818,9 @@ export const CLIMATE_FRAG = [
   "uniform float uRainShadow;",
   "uniform float uOnshoreGain;",
   "uniform float uContinentalGain;",
+  "uniform float uContinentalT;",
+  "uniform float uSeasonAmp;",
+  "uniform float uSeasonPhase;",
   "void main(){",
   "  ivec2 rc = fragRC();",
   "  vec4 a = loadA(uA, uGrid, rc.x, rc.y);",
@@ -883,6 +886,18 @@ export const CLIMATE_FRAG = [
   "  float onshoreBonus = uOnshoreGain * max(oceanFrac - 0.5, 0.0);",
   "  float interiorDry = uContinentalGain * max(0.5 - oceanFrac, 0.0);",
   "  P = clamp((P + onshoreBonus - interiorDry) * oro, 0.05, 1.0);",
+  // CLIM-T-CONTINENTALITY (memory ticket #193): land cells away from
+  // ocean swing further from zonal mean in temperature. At seasonPhase=6
+  // (NH July) and seasonAmp > 0, NH continental interiors are HOTTER
+  // than zonal (summer heating), SH continental interiors COLDER
+  // (their winter). Reuses oceanFrac as continentality strength —
+  // deep-interior (oceanFrac→0) gets the full ±uContinentalT swing;
+  // coastal cells (oceanFrac→1) get ~zero shift.
+  "  float isJulyish = cos((uSeasonPhase - 6.0) * 0.52359877);", // 2π/12
+  "  float hemSign = sign(lat);",
+  "  float landMask = step(0.0, a.r);",
+  "  float continentalT = uContinentalT * uSeasonAmp * isJulyish * hemSign * landMask * (1.0 - oceanFrac);",
+  "  T += continentalT;",
   "  float windAz = fract(atan(wvec.y, wvec.x) / 6.28318530 + 0.5);",
   // SPEC-SAFE: GLSL ES 3.00 smoothstep is UNDEFINED if edge0 >= edge1.
   // uGlacOnsetC (-2) > uGlacFullC (-12), so keep edges ASCENDING

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -194,6 +194,12 @@ export interface HydraulicConfig {
    *  area of land". 0.3 default = moderate continental drying without
    *  blanking interiors. */
   continentalGain: number;
+  /** CLIM-T-CONTINENTALITY (memory #193): max continental T anomaly
+   *  from zonal mean, °C. At seasonPhase=6 (NH July) deep continental
+   *  interiors swing +uContinentalT in NH, -uContinentalT in SH.
+   *  Coastal cells unaffected. Inert when seasonAmp=0. Cookbook
+   *  principle: "T variations highest in interiors, lowest on coasts". */
+  continentalT: number;
   /** P2.3b-i Whittaker biome thermal cuts (°C) — mirrors
    *  ClimateParams.biome_cold_c / biome_hot_c. */
   biomeColdC: number;
@@ -315,6 +321,7 @@ export const DEFAULT_HYDRAULIC: HydraulicConfig = {
   rainShadow: 0.5,
   onshoreGain: 0.5,
   continentalGain: 0.3,
+  continentalT: 8.0,
   biomeColdC: 6.0,
   biomeHotC: 18.0,
   channelDepth: 0.02,
@@ -540,6 +547,9 @@ export async function runHydraulicBake(
         uRainShadow: u(cfg.rainShadow),
         uOnshoreGain: u(cfg.onshoreGain),
         uContinentalGain: u(cfg.continentalGain),
+        uContinentalT: u(cfg.continentalT),
+        uSeasonAmp: u(cfg.seasonAmp),
+        uSeasonPhase: u(cfg.seasonPhase),
       },
       CLIM[0],
     );


### PR DESCRIPTION
Closes the long-pending memory ticket #193 ('Climate realism: continentality in BASE temperature'). Cookbook principle: 'T variations are lowest along the coasts and highest in areas remote from maritime influence; eastern interiors thus experience the greatest variations.'

Since we bake one seasonal snapshot (seasonPhase=6, NH July by default), continentality manifests as an OFFSET from zonal mean: NH continental interiors are HOTTER than zonal (their summer), SH continental interiors COLDER (their winter). Coastal cells unaffected.

Math (added in CLIMATE_FRAG, AFTER oceanFrac is known):
  isJulyish = cos((seasonPhase − 6.0) · 2π/12)   // +1 at Jul, -1 at Jan
  hemSign   = sign(lat)                           // +1 NH, -1 SH
  landMask  = step(0.0, a.r)                      // 1 if land
  continentalT = uContinentalT · uSeasonAmp · isJulyish · hemSign · landMask · (1 − oceanFrac)
  T += continentalT

Reuses the K=4 upwind oceanFrac scan from CLIM-MONSOON — no new sampling cost. Inert when uSeasonAmp=0 (preserves the deep-time annual-mean philosophy).

Default uContinentalT=8.0°C. Effects at default seasonPhase=6 + seasonAmp=0.5:
- Russia, Mongolia, central Canada, Sahara interior: +4°C above zonal (Jul heating)
- Antarctica, central Patagonia: −4°C below zonal (Jul = their winter dead)
- Glaciation responds (cold interiors get more ice in winter; the snapshot at Jul shows less than zonal expected in NH).

3 files, 32 insertions. 14/14 climate-wind green. tsc 0.