### PR TITLE
feat(climate): ITCZ + zonal bands migrate seasonally, land-amplified (CLIM-ITCZ-MIGRATION)

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
@@ -43,6 +43,10 @@ describe("NX-2a geostrophic wind GLSL", () => {
     expect(CLIMATE_FRAG).toContain(
       "float P = clamp(0.55 + 0.45*itcz + 0.30*midlat - 0.35*subtrop - 0.22*polar, 0.05, 1.0);",
     );
+    // CLIM-ITCZ-MIGRATION: bands still measured via `abs(dDeg - X)` but
+    // dDeg is now derived from the seasonally-migrating solar latitude
+    // (see the migration test below); the band offsets (25/50/66/88)
+    // are unchanged.
     expect(CLIMATE_FRAG).toContain(
       "1.0 - smoothstep(0.0, 14.0, abs(dDeg - 25.0))",
     );
@@ -126,13 +130,29 @@ describe("CLIM-T-CONTINENTALITY (#193: interiors swing more)", () => {
     expect(CLIMATE_FRAG).toContain("uniform float uSeasonPhase;");
   });
   it("CLIMATE_FRAG offsets T by hemisphere × season × continentality", () => {
+    // isJulyish / hemSign / landMask hoisted to the CLIM-ITCZ-MIGRATION
+    // block (used by both ITCZ shift and T continentality).
     expect(CLIMATE_FRAG).toContain("float isJulyish = cos((uSeasonPhase - 6.0) * 0.52359877);");
     expect(CLIMATE_FRAG).toContain("float hemSign = sign(lat);");
-    expect(CLIMATE_FRAG).toContain("float landMask = step(0.0, a.r);");
+    expect(CLIMATE_FRAG).toContain("float landMask = step(0.0, h);");
     expect(CLIMATE_FRAG).toContain(
       "float continentalT = uContinentalT * uSeasonAmp * isJulyish * hemSign * landMask * (1.0 - oceanFrac);",
     );
     expect(CLIMATE_FRAG).toContain("T += continentalT;");
+  });
+});
+
+describe("CLIM-ITCZ-MIGRATION (5° ocean, ~40° land)", () => {
+  it("CLIMATE_FRAG declares uItczShift + uItczLandAmp uniforms", () => {
+    expect(CLIMATE_FRAG).toContain("uniform float uItczShift;");
+    expect(CLIMATE_FRAG).toContain("uniform float uItczLandAmp;");
+  });
+  it("CLIMATE_FRAG shifts ALL zonal bands by a land-amplified solar latitude", () => {
+    expect(CLIMATE_FRAG).toContain("float latDeg = lat * 57.2957795;");
+    expect(CLIMATE_FRAG).toContain(
+      "float solarLat = uItczShift * uSeasonAmp * isJulyish * (1.0 + uItczLandAmp * landMask);",
+    );
+    expect(CLIMATE_FRAG).toContain("float dDeg = abs(latDeg - solarLat);");
   });
 });
 

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -821,6 +821,8 @@ export const CLIMATE_FRAG = [
   "uniform float uContinentalT;",
   "uniform float uSeasonAmp;",
   "uniform float uSeasonPhase;",
+  "uniform float uItczShift;",
+  "uniform float uItczLandAmp;",
   "void main(){",
   "  ivec2 rc = fragRC();",
   "  vec4 a = loadA(uA, uGrid, rc.x, rc.y);",
@@ -828,10 +830,21 @@ export const CLIMATE_FRAG = [
   "  float v = (float(rc.y) + 0.5) / float(wh.y);",
   "  float lat = (0.5 - v) * 3.14159265;",
   "  float s = sin(lat);",
-  "  float dDeg = abs(lat) * 57.2957795;",
   "  float h = a.r;",
   "  float elevKm = max(0.0, h) * uElevKmScale;",
   "  float T = uTEquatorC - uTLatDropC * (s * s) - uLapseCPerKm * elevKm;",
+  // CLIM-ITCZ-MIGRATION (cookbook: ITCZ moves ~5° over ocean, ~40° over
+  // land seasonally). All zonal bands (ITCZ / STHZ / midlat / polar)
+  // co-migrate by shifting the abs-latitude they're measured from.
+  // `solarLat` is positive in NH summer, negative in NH winter, and is
+  // land-amplified to mimic continental thermal lows pulling the ITCZ
+  // poleward over Africa/Asia in their summer.
+  "  float latDeg = lat * 57.2957795;",
+  "  float isJulyish = cos((uSeasonPhase - 6.0) * 0.52359877);",
+  "  float hemSign = sign(lat);",
+  "  float landMask = step(0.0, h);",
+  "  float solarLat = uItczShift * uSeasonAmp * isJulyish * (1.0 + uItczLandAmp * landMask);",
+  "  float dDeg = abs(latDeg - solarLat);",
   "  float itcz    = 1.0 - smoothstep(0.0, uItczWidthDeg, dDeg);",
   "  float subtrop = 1.0 - smoothstep(0.0, 14.0, abs(dDeg - 25.0));",
   "  float midlat  = 1.0 - smoothstep(0.0, 18.0, abs(dDeg - 50.0));",
@@ -893,9 +906,8 @@ export const CLIMATE_FRAG = [
   // (their winter). Reuses oceanFrac as continentality strength —
   // deep-interior (oceanFrac→0) gets the full ±uContinentalT swing;
   // coastal cells (oceanFrac→1) get ~zero shift.
-  "  float isJulyish = cos((uSeasonPhase - 6.0) * 0.52359877);", // 2π/12
-  "  float hemSign = sign(lat);",
-  "  float landMask = step(0.0, a.r);",
+  // CLIM-T-CONTINENTALITY: isJulyish / hemSign / landMask hoisted into
+  // the band-shift block above (CLIM-ITCZ-MIGRATION) — reused here.
   "  float continentalT = uContinentalT * uSeasonAmp * isJulyish * hemSign * landMask * (1.0 - oceanFrac);",
   "  T += continentalT;",
   "  float windAz = fract(atan(wvec.y, wvec.x) / 6.28318530 + 0.5);",

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -200,6 +200,15 @@ export interface HydraulicConfig {
    *  Coastal cells unaffected. Inert when seasonAmp=0. Cookbook
    *  principle: "T variations highest in interiors, lowest on coasts". */
   continentalT: number;
+  /** CLIM-ITCZ-MIGRATION (cookbook: "ITCZ moves ~5° over oceans, ~40°
+   *  over land seasonally"). `itczShift` is the base oceanic seasonal
+   *  shift in degrees; `itczLandAmp` is the land-amplification factor
+   *  applied multiplicatively over land cells. Effective continental
+   *  shift = itczShift × (1 + itczLandAmp). All zonal precip bands
+   *  (ITCZ / subtropics / midlatitudes / polar) co-migrate. Inert when
+   *  seasonAmp=0. */
+  itczShift: number;
+  itczLandAmp: number;
   /** P2.3b-i Whittaker biome thermal cuts (°C) — mirrors
    *  ClimateParams.biome_cold_c / biome_hot_c. */
   biomeColdC: number;
@@ -322,6 +331,8 @@ export const DEFAULT_HYDRAULIC: HydraulicConfig = {
   onshoreGain: 0.5,
   continentalGain: 0.3,
   continentalT: 8.0,
+  itczShift: 5.0,
+  itczLandAmp: 7.0,
   biomeColdC: 6.0,
   biomeHotC: 18.0,
   channelDepth: 0.02,
@@ -550,6 +561,8 @@ export async function runHydraulicBake(
         uContinentalT: u(cfg.continentalT),
         uSeasonAmp: u(cfg.seasonAmp),
         uSeasonPhase: u(cfg.seasonPhase),
+        uItczShift: u(cfg.itczShift),
+        uItczLandAmp: u(cfg.itczLandAmp),
       },
       CLIM[0],
     );


### PR DESCRIPTION
Cookbook principle: 'ITCZ moves ~5° over oceans, ~40° over land seasonally; northward over Africa/Asia in NH July, southward in January.' Implementation: shift all zonal precip bands (ITCZ / subtropics / midlat / polar) together by a 'solar latitude' that's land-amplified.

  solarLat = uItczShift × uSeasonAmp × isJulyish × (1 + uItczLandAmp × landMask)
  dDeg = abs(latDeg − solarLat)

Defaults: itczShift=5.0°, itczLandAmp=7.0 → effective land shift = 5 × (1+7) = 40° at July, matching the cookbook number. Inert when seasonAmp=0.

This is the missing piece for India's monsoon — at July with seasonAmp=0.5, solarLat over India = 5 × 0.5 × 1 × (1 + 7) = 20°, which pulls the wet ITCZ band right over the Indian subcontinent (was stuck at the dry subtropical belt). The four zonal bands co-migrate so the structure stays consistent.

Also hoists isJulyish / hemSign / landMask earlier in CLIMATE_FRAG so they're reused by both the new band migration AND the existing CLIM-T-CONTINENTALITY block (no duplication).

3 files. 16/16 climate-wind tests green (2 new pins for ITCZ migration). tsc 0.