### PR TITLE
fix(climate): CLIM-MONSOON-TUNE — fix Sahara-wet / Indonesia-dry / Europe-dry / N-India-dry

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
@@ -95,15 +95,18 @@ describe("CLIM-MONSOON onshore moisture transport", () => {
   it("CLIMATE_FRAG declares uOnshoreGain uniform", () => {
     expect(CLIMATE_FRAG).toContain("uniform float uOnshoreGain;");
   });
-  it("CLIMATE_FRAG walks K=4 cells upwind to measure ocean fraction", () => {
+  it("CLIMATE_FRAG walks K=8 cells upwind to measure ocean fraction", () => {
+    // CLIM-MONSOON-TUNE widened the scan from K=4 (≈5°) to K=8 (≈11°)
+    // so interior cells can reach distant coasts (Europe→Atlantic,
+    // N India→Arabian Sea).
     expect(CLIMATE_FRAG).toContain("vec2 wdir = (wmag > 1e-6) ? wvec / wmag : vec2(0.0);");
     expect(CLIMATE_FRAG).toContain("float oceanFrac = 0.0;");
-    expect(CLIMATE_FRAG).toContain("for (int k = 1; k <= 4; k++) {");
+    expect(CLIMATE_FRAG).toContain("for (int k = 1; k <= 8; k++) {");
     expect(CLIMATE_FRAG).toContain("int dx = int(-wdir.x * float(k) * 4.0);");
     expect(CLIMATE_FRAG).toContain("int dy = int(-wdir.y * float(k) * 4.0);");
     expect(CLIMATE_FRAG).toContain("float upH = texelFetch(uA, ivec2(ux, uy), 0).r;");
     expect(CLIMATE_FRAG).toContain("oceanFrac += float(upH < 0.0);");
-    expect(CLIMATE_FRAG).toContain("oceanFrac *= 0.25;");
+    expect(CLIMATE_FRAG).toContain("oceanFrac *= 0.125;");
   });
   it("CLIMATE_FRAG adds onshore moisture additively then applies orographic", () => {
     // Additive bonus (lifts dry zonal areas) only above 50% ocean upwind.

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -879,9 +879,13 @@ export const CLIMATE_FRAG = [
   // ocean"). Combined with the existing orographic factor `oro`, this
   // produces wet windward slopes near coasts (Western Ghats, Himalayan
   // S-slope) without making continental interiors wet.
+  // CLIM-MONSOON-TUNE: widened scan from K=4 stride=4 (≈5°) to K=8
+  // stride=4 (≈11°) so interior cells > 5° from coast can still detect
+  // upwind ocean. Europe interior can now reach the Atlantic; central
+  // India can reach Arabian Sea given correct SW wind direction.
   "  vec2 wdir = (wmag > 1e-6) ? wvec / wmag : vec2(0.0);",
   "  float oceanFrac = 0.0;",
-  "  for (int k = 1; k <= 4; k++) {",
+  "  for (int k = 1; k <= 8; k++) {",
   "    int dx = int(-wdir.x * float(k) * 4.0);",
   "    int dy = int(-wdir.y * float(k) * 4.0);",
   "    int ux = xw(rc.x + dx, wh.x);",
@@ -889,7 +893,7 @@ export const CLIMATE_FRAG = [
   "    float upH = texelFetch(uA, ivec2(ux, uy), 0).r;",
   "    oceanFrac += float(upH < 0.0);",
   "  }",
-  "  oceanFrac *= 0.25;",
+  "  oceanFrac *= 0.125;",
   // CLIM-CONTINENTALITY: symmetric counterpart of the onshore boost.
   // When oceanFrac < 0.5 the upwind path is mostly LAND — wind has
   // exhausted its moisture before reaching this cell (cookbook:

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -320,19 +320,30 @@ export const DEFAULT_HYDRAULIC: HydraulicConfig = {
   mslpOceanAmp: 20.0,
   mslpBlurSigma: 6.0,
   coriolisGain: 15.0,
-  // CLIM-MONSOON: seasonality enabled by default so continental
-  // summer-low / oceanic-summer-high pressure swap can drive monsoon
-  // winds. seasonPhase=6.0 picks the NH summer (July) snapshot, peak
-  // Asian monsoon. This is the cookbook's "summer pressure" picture.
-  seasonAmp: 0.5,
+  // CLIM-MONSOON-TUNE: seasonAmp bumped 0.5 → 0.7 so the continental
+  // thermal low (Asia in July) is strong enough to flip the wind
+  // direction over India from zonal NE trades to actual SW monsoon
+  // flow. Below ~0.6 the trade-wind component still dominated and the
+  // upwind ocean scan couldn't find moisture for monsoon coasts.
+  seasonAmp: 0.7,
   seasonPhase: 6.0,
   orographicGain: 0.6,
   rainShadow: 0.5,
   onshoreGain: 0.5,
   continentalGain: 0.3,
   continentalT: 8.0,
+  // CLIM-MONSOON-TUNE: itczLandAmp disabled (was 2.0, originally 7.0).
+  // Per-cell land-amplified ITCZ shift had the wrong granularity:
+  // - it pushed Indonesia LAND cells off the equatorial ITCZ band
+  //   (Indonesia is the wettest place on Earth, must NOT shift)
+  // - it pulled the wet band onto Sahara/Arabia LAND cells
+  // - it under-shifted oceanic monsoon regions
+  // Real ITCZ migration is REGIONAL (driven by broad continental heat
+  // sinks), not per-cell. We get monsoon via the continental thermal
+  // low → SW wind flip → onshore moisture transport, all already
+  // wired. itczShift=5 alone gives a uniform ~2.5° NH-summer shift.
   itczShift: 5.0,
-  itczLandAmp: 7.0,
+  itczLandAmp: 0.0,
   biomeColdC: 6.0,
   biomeHotC: 18.0,
   channelDepth: 0.02,


### PR DESCRIPTION
User eyeball after CLIM-ITCZ-MIGRATION shipped: Sahara turned wet, Indonesia dry, Europe dry, N India still dry. Three root causes diagnosed and fixed:

1. **Per-cell ITCZ land amp had wrong granularity** — pushed Indonesia LAND cells off the equator (lost ITCZ rain) AND pulled the wet ITCZ band onto Sahara/Arabia LAND cells. Real ITCZ migration is regional (broad continental heat-sink driven), not per-cell. Set itczLandAmp=0 — uniform 2.5°N seasonal shift everywhere, no continental amplification. Monsoon still works via the separate continental-thermal-low / SW-wind / onshore-moisture mechanisms.

2. **Onshore scan K=4 stride=4 = 16 texels (~5°)** — too short to reach distant coasts from continental interiors. Central Europe → Atlantic: ~10° distance, missed it. N India → Arabian Sea: ~25° distance, missed it. Widened to K=8 stride=4 = 32 texels (~11°) — Europe interior can now find Atlantic; central India can find Indian Ocean given correct wind direction.

3. **seasonAmp=0.5 too weak to flip wind direction over India** — the continental thermal low needs to dominate the zonal NE trades to produce actual SW monsoon flow. Bumped 0.5 → 0.7. Test: pin updated to K=8 / 0.125 multiplier; 16/16 green.

3 files, ~20 lines net. tsc 0.