### PR TITLE
feat(climate): JFA distance-to-ocean + continentality RT (COOKBOOK-CLIMATE T2)

### DIFF
--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -376,6 +376,8 @@ export default function App() {
   const prevDebugTerrRef = useRef<THREE.WebGLRenderTarget | null>(null);
   const prevDebugHydroRef = useRef<THREE.WebGLRenderTarget | null>(null);
   const prevDebugWindRef = useRef<THREE.WebGLRenderTarget | null>(null);
+  // COOKBOOK-CLIMATE T2: distance-to-ocean + continentality RT (JFA).
+  const prevDebugDistRef = useRef<THREE.WebGLRenderTarget | null>(null);
   // Live stack handles for the mounted material's selector.
   const debugStackRef = useRef<{
     clim: THREE.WebGLRenderTarget;
@@ -1177,6 +1179,7 @@ export default function App() {
       prevDebugTerrRef.current?.dispose();
       prevDebugHydroRef.current?.dispose();
       prevDebugWindRef.current?.dispose();
+      prevDebugDistRef.current?.dispose();
 
       const __tU0 = performance.now();
       const base = uploadEquirect(new Float32Array(inp.height), w, h);
@@ -1189,6 +1192,7 @@ export default function App() {
       let terrRT!: THREE.WebGLRenderTarget;
       let hydroRT!: THREE.WebGLRenderTarget;
       let windRT!: THREE.WebGLRenderTarget;
+      let distRT!: THREE.WebGLRenderTarget;
       await scene.runBake(async (renderer) => {
         const out = await runHydraulicBake(
           renderer,
@@ -1214,6 +1218,7 @@ export default function App() {
         terrRT = out.terr;
         hydroRT = out.hydro;
         windRT = out.wind;
+        distRT = out.dist;
       });
       const __gpuMs = performance.now() - __tG0;
       sceneRef.current?.setBakeSplit({
@@ -1231,6 +1236,7 @@ export default function App() {
       prevDebugTerrRef.current = terrRT;
       prevDebugHydroRef.current = hydroRT;
       prevDebugWindRef.current = windRT;
+      prevDebugDistRef.current = distRT;
       debugStackRef.current = { clim: climRT, terr: terrRT, hydro: hydroRT };
 
       const mat = makeDebugReliefMaterial();
@@ -1297,12 +1303,14 @@ export default function App() {
     prevDebugClimRef.current?.dispose();
     prevDebugTerrRef.current?.dispose();
     prevDebugHydroRef.current?.dispose();
+    prevDebugDistRef.current?.dispose();
     prevDebugBaseRef.current?.dispose();
     prevDebugPrecipRef.current?.dispose();
     prevDebugHFinalRef.current = null;
     prevDebugClimRef.current = null;
     prevDebugTerrRef.current = null;
     prevDebugHydroRef.current = null;
+    prevDebugDistRef.current = null;
     prevDebugBaseRef.current = null;
     prevDebugPrecipRef.current = null;
     debugStackRef.current = null;

--- a/apps/hayba-explorer/src/viewport/bake/__headless_harness__.ts
+++ b/apps/hayba-explorer/src/viewport/bake/__headless_harness__.ts
@@ -221,7 +221,7 @@ export async function runRealInputErosionVerification(
 
     const webglErrPre = gl.getError();
     const t0 = performance.now();
-    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w } =
+    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d } =
       await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
     // Oracle never reads the stack RTs; dispose immediately so the
     // many-bake harness doesn't leak 3 RTs/bake (fatal at 3M).
@@ -229,6 +229,7 @@ export async function runRealInputErosionVerification(
     _t.dispose();
     _h.dispose();
     _w.dispose();
+    _d.dispose();
     const t1 = performance.now();
     const webglErrPost = gl.getError();
 
@@ -432,7 +433,7 @@ export async function runHeadlessErosionVerification(
 
     const webglErrPre = gl.getError();
     const t0 = performance.now();
-    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w } =
+    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d } =
       await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
     // Oracle never reads the stack RTs; dispose immediately so the
     // many-bake harness doesn't leak 3 RTs/bake (fatal at 3M).
@@ -440,6 +441,7 @@ export async function runHeadlessErosionVerification(
     _t.dispose();
     _h.dispose();
     _w.dispose();
+    _d.dispose();
     const t1 = performance.now();
     const webglErrPost = gl.getError();
 
@@ -1048,7 +1050,7 @@ async function _bakeAndRenderRelief(
   const cfg = { ...hyd.DEFAULT_HYDRAULIC, ...(overrideCfg ?? {}) };
 
   const t0 = performance.now();
-  const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w } =
+  const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d } =
     await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
   // CP2.c (#234 P2.3a): OPT-IN only — read the REAL baked TERR/HYDRO
   // masks (refreshClimate's TERRAIN/HYDRO passes) before disposal so
@@ -1070,6 +1072,7 @@ async function _bakeAndRenderRelief(
   _t.dispose();
   _h.dispose();
   _w.dispose();
+  _d.dispose();
   const t1 = performance.now();
 
   const buf = new Float32Array(w * h * 4);

--- a/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
+++ b/apps/hayba-explorer/src/viewport/bake/climate-wind.test.ts
@@ -4,6 +4,9 @@ import {
   BLUR_H_FRAG,
   BLUR_V_FRAG,
   CLIMATE_FRAG,
+  DIST_INIT_FRAG,
+  DIST_JFA_FRAG,
+  DIST_FINAL_FRAG,
 } from "./hydraulic.glsl";
 
 describe("NX-2a geostrophic wind GLSL", () => {
@@ -142,6 +145,38 @@ describe("CLIM-T-CONTINENTALITY (#193: interiors swing more)", () => {
       "float continentalT = uContinentalT * uSeasonAmp * isJulyish * hemSign * landMask * (1.0 - oceanFrac);",
     );
     expect(CLIMATE_FRAG).toContain("T += continentalT;");
+  });
+});
+
+describe("COOKBOOK-CLIMATE T2 — JFA distance-to-ocean", () => {
+  it("DIST_INIT_FRAG seeds ocean cells with own (x,y), land with (-1,-1,0)", () => {
+    expect(typeof DIST_INIT_FRAG).toBe("string");
+    expect(DIST_INIT_FRAG).toContain("uniform sampler2D uA;");
+    expect(DIST_INIT_FRAG).toContain("bool isOcean = a.r < 0.0;");
+    expect(DIST_INIT_FRAG).toContain(
+      "fragColor = vec4(float(rc.x), float(rc.y), 1.0, 0.0);",
+    );
+    expect(DIST_INIT_FRAG).toContain("fragColor = vec4(-1.0, -1.0, 0.0, 0.0);");
+  });
+  it("DIST_JFA_FRAG honours longitude wrap in the distance metric", () => {
+    expect(DIST_JFA_FRAG).toContain("uniform float uStep;");
+    expect(DIST_JFA_FRAG).toContain("float wrapDistJfa(vec2 a, vec2 b, float wx)");
+    expect(DIST_JFA_FRAG).toContain("dx = min(dx, wx - dx);");
+    expect(DIST_JFA_FRAG).toContain("for (int dy = -1; dy <= 1; dy++) {");
+    expect(DIST_JFA_FRAG).toContain("for (int dx = -1; dx <= 1; dx++) {");
+    expect(DIST_JFA_FRAG).toContain("if (c.z > 0.5) {");
+  });
+  it("DIST_FINAL_FRAG converts texel distance to km + continentality", () => {
+    expect(DIST_FINAL_FRAG).toContain("uniform float uContScaleKm;");
+    expect(DIST_FINAL_FRAG).toContain("uniform float uEarthCircKm;");
+    expect(DIST_FINAL_FRAG).toContain("float kmPerTex = uEarthCircKm / uGrid.x;");
+    expect(DIST_FINAL_FRAG).toContain("float distKm = texDist * kmPerTex;");
+    expect(DIST_FINAL_FRAG).toContain(
+      "float cont = isLand ? (1.0 - exp(-distKm / uContScaleKm)) : 0.0;",
+    );
+    expect(DIST_FINAL_FRAG).toContain(
+      "fragColor = vec4(distKm, cont, isLand ? 1.0 : 0.0, 0.0);",
+    );
   });
 });
 

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -1016,3 +1016,95 @@ export const HYDRO_FRAG = [
   "  fragColor = vec4(fin(Q), fin(elevN), clamp(fin(endo), 0.0, 1.0), fin(classifyBiome(cl.r, cl.g)));",
   "}",
 ].join("\n");
+
+// COOKBOOK-CLIMATE T2: distance-to-ocean field via Jump Flooding Algorithm.
+// Three passes:
+//   DIST_INIT_FRAG : seed RT with each ocean cell's own (x,y); land cells
+//                    sentinel (-1,-1, valid=0).
+//   DIST_JFA_FRAG  : run log2(max(w,h)) times with halving stride;
+//                    each cell adopts the nearest valid seed from its
+//                    8-neighborhood at offset `uStep`.
+//   DIST_FINAL_FRAG: convert the seed coord to distance-km (using
+//                    Earth circumference at equator) + continentality
+//                    (1 - exp(-d/L), L = uContScaleKm), output:
+//                       .r = distKm (ocean → 0)
+//                       .g = continentality 0..1 (ocean → 0)
+//                       .b = isLand (1 land, 0 ocean)
+//                       .a = 0
+// Longitude wrap is honoured in the distance metric (the world is a
+// torus in x). Latitude is clamped (no wrap, sphere caps at poles).
+
+export const DIST_INIT_FRAG = [
+  H,
+  "uniform sampler2D uA;",
+  "uniform vec2 uGrid;",
+  "void main(){",
+  "  ivec2 rc = fragRC();",
+  "  vec4 a = loadA(uA, uGrid, rc.x, rc.y);",
+  "  bool isOcean = a.r < 0.0;",
+  "  if (isOcean) {",
+  "    fragColor = vec4(float(rc.x), float(rc.y), 1.0, 0.0);",
+  "  } else {",
+  "    fragColor = vec4(-1.0, -1.0, 0.0, 0.0);",
+  "  }",
+  "}",
+].join("\n");
+
+export const DIST_JFA_FRAG = [
+  H,
+  "uniform sampler2D uSeed;",
+  "uniform vec2 uGrid;",
+  "uniform float uStep;",
+  "float wrapDistJfa(vec2 a, vec2 b, float wx) {",
+  "  float dx = abs(a.x - b.x);",
+  "  dx = min(dx, wx - dx);",
+  "  float dy = a.y - b.y;",
+  "  return sqrt(dx * dx + dy * dy);",
+  "}",
+  "void main(){",
+  "  ivec2 rc = fragRC();",
+  "  ivec2 wh = gridWH(uGrid);",
+  "  vec4 best = texelFetch(uSeed, rc, 0);",
+  "  float bestDist = (best.z > 0.5) ? wrapDistJfa(vec2(rc), best.xy, uGrid.x) : 1.0e9;",
+  "  int s = int(uStep);",
+  "  for (int dy = -1; dy <= 1; dy++) {",
+  "    for (int dx = -1; dx <= 1; dx++) {",
+  "      if (dx == 0 && dy == 0) continue;",
+  "      int nx = xw(rc.x + dx * s, wh.x);",
+  "      int ny = yc(rc.y + dy * s, wh.y);",
+  "      vec4 c = texelFetch(uSeed, ivec2(nx, ny), 0);",
+  "      if (c.z > 0.5) {",
+  "        float d = wrapDistJfa(vec2(rc), c.xy, uGrid.x);",
+  "        if (d < bestDist) { bestDist = d; best = c; }",
+  "      }",
+  "    }",
+  "  }",
+  "  fragColor = best;",
+  "}",
+].join("\n");
+
+export const DIST_FINAL_FRAG = [
+  H,
+  "uniform sampler2D uA;",
+  "uniform sampler2D uSeed;",
+  "uniform vec2 uGrid;",
+  "uniform float uContScaleKm;",
+  "uniform float uEarthCircKm;",
+  "float wrapDistFinal(vec2 a, vec2 b, float wx) {",
+  "  float dx = abs(a.x - b.x);",
+  "  dx = min(dx, wx - dx);",
+  "  float dy = a.y - b.y;",
+  "  return sqrt(dx * dx + dy * dy);",
+  "}",
+  "void main(){",
+  "  ivec2 rc = fragRC();",
+  "  vec4 a = loadA(uA, uGrid, rc.x, rc.y);",
+  "  vec4 seed = texelFetch(uSeed, rc, 0);",
+  "  float texDist = (seed.z > 0.5) ? wrapDistFinal(vec2(rc), seed.xy, uGrid.x) : 0.0;",
+  "  float kmPerTex = uEarthCircKm / uGrid.x;",
+  "  float distKm = texDist * kmPerTex;",
+  "  bool isLand = a.r >= 0.0;",
+  "  float cont = isLand ? (1.0 - exp(-distKm / uContScaleKm)) : 0.0;",
+  "  fragColor = vec4(distKm, cont, isLand ? 1.0 : 0.0, 0.0);",
+  "}",
+].join("\n");

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -58,6 +58,9 @@ import {
   MSLP_FRAG,
   BLUR_H_FRAG,
   BLUR_V_FRAG,
+  DIST_INIT_FRAG,
+  DIST_JFA_FRAG,
+  DIST_FINAL_FRAG,
 } from "./hydraulic.glsl";
 import { runRawPass } from "./glPass";
 import { createPingPong, type PingPongTargets } from "./pingpong";
@@ -209,6 +212,12 @@ export interface HydraulicConfig {
    *  seasonAmp=0. */
   itczShift: number;
   itczLandAmp: number;
+  /** COOKBOOK-CLIMATE T2: e-folding scale in km for continentality.
+   *  continentality = 1 - exp(-distKm / contScaleKm). At distKm =
+   *  contScaleKm, continentality ≈ 0.63. Default 1500km is the
+   *  approximate continental-interior threshold (Sahel↔Sahara, central
+   *  Eurasia start of strong continental winters). */
+  contScaleKm: number;
   /** P2.3b-i Whittaker biome thermal cuts (°C) — mirrors
    *  ClimateParams.biome_cold_c / biome_hot_c. */
   biomeColdC: number;
@@ -339,6 +348,7 @@ export const DEFAULT_HYDRAULIC: HydraulicConfig = {
   continentalT: 0.0,
   itczShift: 0.0,
   itczLandAmp: 0.0,
+  contScaleKm: 1500.0,
   biomeColdC: 6.0,
   biomeHotC: 18.0,
   channelDepth: 0.02,
@@ -448,6 +458,12 @@ export interface HydraulicBakeResult {
   terr: THREE.WebGLRenderTarget;
   hydro: THREE.WebGLRenderTarget;
   wind: THREE.WebGLRenderTarget;
+  /** COOKBOOK-CLIMATE T2: distance-to-ocean SDF + continentality.
+   *  Computed once per bake via Jump Flooding (log2(max(w,h)) jumps).
+   *  Channels: .r=distKm (0 over ocean), .g=continentality 0..1
+   *  (0 over ocean; 1−exp(−d/L), L=cfg.contScaleKm), .b=isLand,
+   *  .a=0. Read-only — never feeds back into erosion. */
+  dist: THREE.WebGLRenderTarget;
 }
 
 export async function runHydraulicBake(
@@ -464,7 +480,7 @@ export async function runHydraulicBake(
   // FAILS if EXT_color_buffer_float is missing. We drive the read/write
   // slots explicitly below (NOT pp.book) so the discipline is local and
   // unambiguous.
-  const pp: PingPongTargets = createPingPong(renderer, w, h, ["A", "F", "M", "ACC", "CTRL", "CLIM", "TERR", "HYDRO", "MSLP", "WIND"]);
+  const pp: PingPongTargets = createPingPong(renderer, w, h, ["A", "F", "M", "ACC", "CTRL", "CLIM", "TERR", "HYDRO", "MSLP", "WIND", "DIST"]);
   const A = pp.rt.A; // [slot0, slot1]
   const F = pp.rt.F; // [slot0, slot1]
   // S2.4 detail mask: a ONE-TIME single-channel field (computed pre-loop
@@ -491,6 +507,11 @@ export async function runHydraulicBake(
   // tick, disposed once at teardown; never escapes, never feeds erosion.
   const MSLP = pp.rt.MSLP;
   const WIND = pp.rt.WIND;
+  // COOKBOOK-CLIMATE T2: DIST ping-pong for JFA distance-to-ocean.
+  // INIT fills DIST[0]; each JFA jump alternates slots; DIST_FINAL
+  // writes the converted distKm/continentality into DIST[0] (so the
+  // returned RT slot is stable regardless of how many jumps run).
+  const DIST = pp.rt.DIST;
   let accRead = 0;
   const swapAcc = (): void => {
     accRead ^= 1;
@@ -629,6 +650,52 @@ export async function runHydraulicBake(
   // first step's RAIN/FLUX read the seeded state.
   runRawPass(renderer, SEED_A_FRAG, { uBase: u(base) }, aReadRT());
   runRawPass(renderer, SEED_F_FRAG, {}, fReadRT());
+
+  // ---- COOKBOOK-CLIMATE T2: distance-to-ocean via JFA ------------------
+  // Runs ONCE per bake on the seeded land/ocean partition (a.r<0 = ocean,
+  // i.e. the post-paint world before erosion). Reads aReadRT()'s ocean
+  // flag; writes nothing back into A/F.
+  //   1. INIT seeds DIST[0]: ocean cells store own (x,y); land = (-1,-1).
+  //   2. JFA jumps log2(max(w,h)) times, halving stride each pass; ping-
+  //      pong DIST[0]↔DIST[1]. After convergence the read slot holds the
+  //      nearest-ocean seed for every cell.
+  //   3. FINAL converts seed coords → distKm + continentality, writes
+  //      into DIST[0] so the returned RT slot is stable.
+  {
+    runRawPass(
+      renderer,
+      DIST_INIT_FRAG,
+      { uA: u(aReadRT()), uGrid: u(uGrid) },
+      DIST[0],
+    );
+    let distRead = 0;
+    const nMax = Math.max(w, h);
+    const jumps = Math.max(1, Math.ceil(Math.log2(nMax)));
+    for (let k = 0; k < jumps; k++) {
+      const step = Math.max(1, Math.floor(nMax / Math.pow(2, k + 1)));
+      runRawPass(
+        renderer,
+        DIST_JFA_FRAG,
+        { uSeed: u(DIST[distRead]), uGrid: u(uGrid), uStep: u(step) },
+        DIST[distRead ^ 1],
+      );
+      distRead ^= 1;
+    }
+    // Land final pass into DIST[0] (the returned slot), reading whichever
+    // slot the JFA ended in.
+    runRawPass(
+      renderer,
+      DIST_FINAL_FRAG,
+      {
+        uA: u(aReadRT()),
+        uSeed: u(DIST[distRead]),
+        uGrid: u(uGrid),
+        uContScaleKm: u(cfg.contScaleKm),
+        uEarthCircKm: u(2 * Math.PI * 6371),
+      },
+      DIST[0],
+    );
+  }
 
   // ---- S2.4 DETAIL MASK (ONE-TIME): from the seeded base height, write
   // M[0] = elevGate*slopeGate (ocean -> 0). Read every step by ERODE
@@ -951,5 +1018,14 @@ export async function runHydraulicBake(
   MSLP[0].dispose();
   MSLP[1].dispose();
   WIND[1].dispose();
-  return { eroded: result, clim: CLIM[0], terr: TERR[0], hydro: HYDRO[0], wind: WIND[0] };
+  // DIST[1] is the JFA ping-pong scratch (final pass writes to DIST[0]).
+  DIST[1].dispose();
+  return {
+    eroded: result,
+    clim: CLIM[0],
+    terr: TERR[0],
+    hydro: HYDRO[0],
+    wind: WIND[0],
+    dist: DIST[0],
+  };
 }


### PR DESCRIPTION
Adds the missing geographic primitive that every cookbook-style climate rule depends on: **distance-to-nearest-ocean** as a baked equirect SDF.

Implementation: classic Jump Flooding Algorithm (Rong & Tan 2006), three new GLSL passes:

- **DIST_INIT_FRAG**: ocean cells store own (x,y) as seed; land = sentinel.
- **DIST_JFA_FRAG**: run log2(max(w,h)) times with halving stride (1024 → 10 passes). Each cell adopts nearest valid seed from its 8-neighborhood at offset uStep. Longitude wrap honoured in the distance metric (world is a torus in x).
- **DIST_FINAL_FRAG**: convert seed coords → distance (km via Earth circumference) → continentality (1 − exp(−d/L), L = uContScaleKm, default 1500 km).

Output RT (`HydraulicBakeResult.dist`):
- .r = distKm (0 over ocean)
- .g = continentality 0..1 (0 over ocean; ≈0.63 at 1500 km inland; ≈0.96 at 5000 km)
- .b = isLand (1 land, 0 ocean)
- .a = 0

Read-only (#218 8ecba5b degradation contract intact). Caller owns the RT, same as clim/terr/hydro/wind.

5 files modified, 219 insertions, 5 deletions. 19/19 climate-wind tests green (3 new JFA pins). tsc 0. headless_harness disposes the new RT to avoid the 3M-bake leak. App.tsx tracks `prevDebugDistRef` mirroring the existing wind/hydro pattern.

Next (T3): expose DIST.r and DIST.g as map modes (Distance, Continentality) + PRESSURE map mode (MSLP already exists, just needs to be exposed). After that, T4 rewrites CLIMATE_FRAG precip using the cookbook classification table.