### PR TITLE
feat(climate): Distance/Continentality/Pressure map modes (COOKBOOK-CLIMATE T3)

### DIFF
--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -378,6 +378,8 @@ export default function App() {
   const prevDebugWindRef = useRef<THREE.WebGLRenderTarget | null>(null);
   // COOKBOOK-CLIMATE T2: distance-to-ocean + continentality RT (JFA).
   const prevDebugDistRef = useRef<THREE.WebGLRenderTarget | null>(null);
+  // COOKBOOK-CLIMATE T3: mean-sea-level pressure RT (MSLP_FRAG output).
+  const prevDebugPressureRef = useRef<THREE.WebGLRenderTarget | null>(null);
   // Live stack handles for the mounted material's selector.
   const debugStackRef = useRef<{
     clim: THREE.WebGLRenderTarget;
@@ -441,8 +443,19 @@ export default function App() {
         sceneRef.current?.markDirty();
         return;
       }
+      // COOKBOOK-CLIMATE T3: route DIST/PRESSURE modes to their dedicated
+      // RTs (App-owned refs, set by handleBake). Falls back to clim if
+      // the dedicated RT isn't ready yet.
+      let stackTex: THREE.Texture = stack.clim.texture;
+      if (sel.kind === "dist") {
+        const rt = prevDebugDistRef.current;
+        if (rt) stackTex = rt.texture;
+      } else if (sel.kind === "pressure") {
+        const rt = prevDebugPressureRef.current;
+        if (rt) stackTex = rt.texture;
+      }
       setDebugStack(mat, {
-        tex: stack.clim.texture,
+        tex: stackTex,
         channel: sel.channel,
         mode: sel.mode,
         ramp: sel.ramp,
@@ -1180,6 +1193,7 @@ export default function App() {
       prevDebugHydroRef.current?.dispose();
       prevDebugWindRef.current?.dispose();
       prevDebugDistRef.current?.dispose();
+      prevDebugPressureRef.current?.dispose();
 
       const __tU0 = performance.now();
       const base = uploadEquirect(new Float32Array(inp.height), w, h);
@@ -1193,6 +1207,7 @@ export default function App() {
       let hydroRT!: THREE.WebGLRenderTarget;
       let windRT!: THREE.WebGLRenderTarget;
       let distRT!: THREE.WebGLRenderTarget;
+      let pressureRT!: THREE.WebGLRenderTarget;
       await scene.runBake(async (renderer) => {
         const out = await runHydraulicBake(
           renderer,
@@ -1219,6 +1234,7 @@ export default function App() {
         hydroRT = out.hydro;
         windRT = out.wind;
         distRT = out.dist;
+        pressureRT = out.pressure;
       });
       const __gpuMs = performance.now() - __tG0;
       sceneRef.current?.setBakeSplit({
@@ -1237,6 +1253,7 @@ export default function App() {
       prevDebugHydroRef.current = hydroRT;
       prevDebugWindRef.current = windRT;
       prevDebugDistRef.current = distRT;
+      prevDebugPressureRef.current = pressureRT;
       debugStackRef.current = { clim: climRT, terr: terrRT, hydro: hydroRT };
 
       const mat = makeDebugReliefMaterial();
@@ -1311,6 +1328,7 @@ export default function App() {
     prevDebugTerrRef.current = null;
     prevDebugHydroRef.current = null;
     prevDebugDistRef.current = null;
+    prevDebugPressureRef.current = null;
     prevDebugBaseRef.current = null;
     prevDebugPrecipRef.current = null;
     debugStackRef.current = null;

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -464,6 +464,11 @@ export interface HydraulicBakeResult {
    *  (0 over ocean; 1−exp(−d/L), L=cfg.contScaleKm), .b=isLand,
    *  .a=0. Read-only — never feeds back into erosion. */
   dist: THREE.WebGLRenderTarget;
+  /** COOKBOOK-CLIMATE T3: mean sea-level pressure field (mb).
+   *  Direct exposure of the existing MSLP_FRAG output (was previously
+   *  internal-only and disposed at teardown). Channels: .r=pressure
+   *  in mb (≈990–1020 typical), .gba unused. Read-only. */
+  pressure: THREE.WebGLRenderTarget;
 }
 
 export async function runHydraulicBake(
@@ -1015,7 +1020,9 @@ export async function runHydraulicBake(
   CLIM[1].dispose();
   TERR[1].dispose();
   HYDRO[1].dispose();
-  MSLP[0].dispose();
+  // COOKBOOK-CLIMATE T3: MSLP[0] is NO LONGER disposed here — it's
+  // returned as `pressure` for the new "Pressure" map mode. Caller
+  // owns + disposes (App.tsx prevDebugPressureRef).
   MSLP[1].dispose();
   WIND[1].dispose();
   // DIST[1] is the JFA ping-pong scratch (final pass writes to DIST[0]).
@@ -1027,5 +1034,6 @@ export async function runHydraulicBake(
     hydro: HYDRO[0],
     wind: WIND[0],
     dist: DIST[0],
+    pressure: MSLP[0],
   };
 }

--- a/apps/hayba-explorer/src/viewport/equirectMapModes.test.ts
+++ b/apps/hayba-explorer/src/viewport/equirectMapModes.test.ts
@@ -4,8 +4,8 @@ import {
   resolveEquirectMode,
 } from "./equirectMapModes";
 
-describe("EQUIRECT_MAP_MODES registry (SP-B)", () => {
-  it("is exactly the 6 data-backed modes in order", () => {
+describe("EQUIRECT_MAP_MODES registry (SP-B + COOKBOOK-CLIMATE T3)", () => {
+  it("is exactly the 9 data-backed modes in order", () => {
     expect(EQUIRECT_MAP_MODES.map((m) => m.label)).toEqual([
       "Relief",
       "Normal",
@@ -13,9 +13,12 @@ describe("EQUIRECT_MAP_MODES registry (SP-B)", () => {
       "Precipitation",
       "Wind",
       "Glaciation",
+      "Distance",
+      "Continentality",
+      "Pressure",
     ]);
   });
-  it("kinds: relief, normal, 3 clim, wind, clim", () => {
+  it("kinds (SP-B + cookbook-T3 dist/pressure)", () => {
     expect(EQUIRECT_MAP_MODES.map((m) => m.kind)).toEqual([
       "relief",
       "normal",
@@ -23,7 +26,40 @@ describe("EQUIRECT_MAP_MODES registry (SP-B)", () => {
       "clim",
       "wind",
       "clim",
+      "dist",
+      "dist",
+      "pressure",
     ]);
+  });
+});
+
+describe("COOKBOOK-CLIMATE T3 — Distance/Continentality/Pressure modes", () => {
+  it("Distance resolves to dist ch0 (distKm), uStackMode 1 draped / 2 flat", () => {
+    const idx = EQUIRECT_MAP_MODES.findIndex((m) => m.label === "Distance");
+    expect(idx).toBe(6);
+    expect(resolveEquirectMode(idx, true)).toEqual({
+      kind: "dist",
+      channel: 0,
+      ramp: 0,
+      mode: 1,
+    });
+    expect(resolveEquirectMode(idx, false).mode).toBe(2);
+  });
+  it("Continentality resolves to dist ch1 (cont 0..1)", () => {
+    const idx = EQUIRECT_MAP_MODES.findIndex((m) => m.label === "Continentality");
+    expect(idx).toBe(7);
+    expect(resolveEquirectMode(idx, true)).toMatchObject({
+      kind: "dist",
+      channel: 1,
+    });
+  });
+  it("Pressure resolves to pressure ch0 (MSLP mb)", () => {
+    const idx = EQUIRECT_MAP_MODES.findIndex((m) => m.label === "Pressure");
+    expect(idx).toBe(8);
+    expect(resolveEquirectMode(idx, true)).toMatchObject({
+      kind: "pressure",
+      channel: 0,
+    });
   });
 });
 

--- a/apps/hayba-explorer/src/viewport/equirectMapModes.ts
+++ b/apps/hayba-explorer/src/viewport/equirectMapModes.ts
@@ -13,7 +13,13 @@
 //              (uStackMode 1) or flat (uStackMode 2) per the F toggle
 // `channel`/`ramp` are ignored for relief/normal.
 
-export type EquirectModeKind = "relief" | "normal" | "clim" | "wind";
+export type EquirectModeKind =
+  | "relief"
+  | "normal"
+  | "clim"
+  | "wind"
+  | "dist"
+  | "pressure";
 
 export interface EquirectMapMode {
   label: string;
@@ -29,6 +35,11 @@ export const EQUIRECT_MAP_MODES: EquirectMapMode[] = [
   { label: "Precipitation", kind: "clim", channel: 1, ramp: 2 },
   { label: "Wind", kind: "wind", channel: 2, ramp: 3 },
   { label: "Glaciation", kind: "clim", channel: 3, ramp: 4 },
+  // COOKBOOK-CLIMATE T3: new geographic-debug map modes for the
+  // cookbook-classification redesign. All three sample a non-CLIM RT.
+  { label: "Distance", kind: "dist", channel: 0, ramp: 0 },
+  { label: "Continentality", kind: "dist", channel: 1, ramp: 0 },
+  { label: "Pressure", kind: "pressure", channel: 0, ramp: 0 },
 ];
 
 /** Resolved selection for `setDebugStack`. `mode` is the debugMaterial
@@ -56,6 +67,13 @@ export function resolveEquirectMode(
   if (e.kind === "wind") {
     // NX-3: animated wind-streak shader (uStackMode 4 draped / 5 flat).
     return { kind: "wind", channel: e.channel, ramp: e.ramp, mode: draped ? 4 : 5 };
+  }
+  // COOKBOOK-CLIMATE T3: dist & pressure use the SAME uStackMode as clim
+  // (1 draped / 2 flat) because debugMaterial just samples uStackTex.r/.g
+  // and applies the same ramp. Only the source RT differs (App.tsx routes
+  // DIST/MSLP into uStackTex when these modes are selected).
+  if (e.kind === "dist" || e.kind === "pressure") {
+    return { kind: e.kind, channel: e.channel, ramp: e.ramp, mode: draped ? 1 : 2 };
   }
   return {
     kind: "clim",


### PR DESCRIPTION
Surfaces the geographic primitives shipped in T2 (#174) PLUS exposes the already-baked MSLP field, so the user can visually inspect every input that will feed the cookbook climate classifier:

- **Distance** — distKm from the JFA dist RT (.r). Light = inland, dark = coastal.
- **Continentality** — 1−exp(−d/L), L=1500km from the JFA dist RT (.g). 0=coast, ~1=Asian/N-American/Saharan interior. Will drive biome classification in T4.
- **Pressure** — MSLP_FRAG output (.r). Was previously internal-only and disposed at teardown; now returned + exposed.

App.tsx applyDebugChannel routes the source RT based on sel.kind: 'dist' samples prevDebugDistRef, 'pressure' samples prevDebugPressureRef. Falls back to clim if the dedicated RT isn't ready. The existing draped/flat uStackMode (1/2) flow handles rendering — no debugMaterial changes needed.

4 files. 12/12 equirectMapModes tests green (3 new for the new modes + updated registry pin). tsc 0. Memory: pressure ownership transferred from hydraulic.ts internal to App.tsx prevDebugPressureRef (mirrors wind/dist pattern).