### PR TITLE
feat(viz): Köppen-D + diverging meteorological ramps for new map modes (T3-RAMPS)

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
+++ b/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
@@ -101,7 +101,7 @@ const FRAG: string = [
   "uniform float uChannel;      /* which RGBA lane of uStackTex (0..3)      */",
   "uniform float uStackMode;    /* 0 relief 1 draped 2 flat 3 normal-map  */",
   "uniform float uWindTime;",
-  "uniform float uRamp;         /* 0 grey 1 temp 2 precip 3 hue 4 grey-elev */",
+  "uniform float uRamp;         /* 0 grey 1 temp 2 precip 3 hue 4 grey-elev 5 Koppen-D 6 pressure */",
   "",
   "const float PI = 3.141592653589793;",
   "",
@@ -170,8 +170,10 @@ const FRAG: string = [
   "/* Map a raw stack-channel value to a debug colour. ids:",
   "   0 grey (raw clamp 0..1) · 1 temp diverging (deg C, -30..+35) ·",
   "   2 precip white->blue (0..1) · 3 hue (turns, for wind/aspect) ·",
-  "   4 grey-elev (0..1). Calibration of climate units is downstream",
-  "   tuning; this is a deterministic debug visualiser. */",
+  "   4 grey-elev (0..1) · 5 Koppen-D continentality (pale → cyan → teal → navy) ·",
+  "   6 pressure diverging (low=blue, mid=cream, high=red). Calibration of",
+  "   climate units is downstream tuning; this is a deterministic debug",
+  "   visualiser. */",
   "vec3 ramp(float id, float x){",
   "  if (id < 0.5) return vec3(clamp(x, 0.0, 1.0));",
   "  if (id < 1.5){",
@@ -183,6 +185,40 @@ const FRAG: string = [
   "  }",
   "  if (id < 2.5) return mix(vec3(0.97), vec3(0.10, 0.35, 0.70), clamp(x, 0.0, 1.0));",
   "  if (id < 3.5) return hsv2rgb(fract(x));",
+  "  if (id < 4.5) return vec3(clamp(x, 0.0, 1.0));",
+  // T3-RAMPS id=5: Köppen-D continentality palette. Mirrors the standard
+  // continental-climate atlas legend (Dfa → Dfb → Dfc → Dfd):
+  //   0.00 pale cream (coast / non-continental)
+  //   0.25 light cyan (Dfa — hot-summer humid continental)
+  //   0.50 medium teal (Dfb — warm-summer humid continental)
+  //   0.75 dark teal (Dfc — subarctic)
+  //   1.00 deep navy (Dfd — extreme cold subarctic / interior)
+  "  if (id < 5.5){",
+  "    float t = clamp(x, 0.0, 1.0);",
+  "    vec3 c0 = vec3(0.95, 0.94, 0.82);",
+  "    vec3 c1 = vec3(0.42, 0.85, 0.90);",
+  "    vec3 c2 = vec3(0.10, 0.62, 0.70);",
+  "    vec3 c3 = vec3(0.04, 0.32, 0.48);",
+  "    vec3 c4 = vec3(0.00, 0.08, 0.22);",
+  "    if (t < 0.25) return mix(c0, c1, t / 0.25);",
+  "    if (t < 0.50) return mix(c1, c2, (t - 0.25) / 0.25);",
+  "    if (t < 0.75) return mix(c2, c3, (t - 0.50) / 0.25);",
+  "    return mix(c3, c4, (t - 0.75) / 0.25);",
+  "  }",
+  // T3-RAMPS id=6: pressure diverging (meteorological convention).
+  //   0.00 low pressure → deep blue
+  //   0.50 mid pressure → pale cream
+  //   1.00 high pressure → deep red
+  // Output is already normalised in PRESSURE_VIZ_FRAG to 0..1 covering
+  // mb [985..1030]. Anchored at 0.5 so the cream band lines up with the
+  // ~1013 mb global mean.
+  "  if (id < 6.5){",
+  "    float t = clamp(x, 0.0, 1.0);",
+  "    vec3 lowP  = vec3(0.13, 0.27, 0.65);",
+  "    vec3 midP  = vec3(0.97, 0.96, 0.88);",
+  "    vec3 highP = vec3(0.78, 0.13, 0.13);",
+  "    return (t < 0.5) ? mix(lowP, midP, t / 0.5) : mix(midP, highP, (t - 0.5) / 0.5);",
+  "  }",
   "  return vec3(clamp(x, 0.0, 1.0));",
   "}",
   "",

--- a/apps/hayba-explorer/src/viewport/equirectMapModes.test.ts
+++ b/apps/hayba-explorer/src/viewport/equirectMapModes.test.ts
@@ -45,20 +45,22 @@ describe("COOKBOOK-CLIMATE T3 — Distance/Continentality/Pressure modes", () =>
     });
     expect(resolveEquirectMode(idx, false).mode).toBe(2);
   });
-  it("Continentality resolves to dist ch1 (cont 0..1)", () => {
+  it("Continentality resolves to dist ch1 (cont 0..1) with Köppen-D ramp 5", () => {
     const idx = EQUIRECT_MAP_MODES.findIndex((m) => m.label === "Continentality");
     expect(idx).toBe(7);
     expect(resolveEquirectMode(idx, true)).toMatchObject({
       kind: "dist",
       channel: 1,
+      ramp: 5,
     });
   });
-  it("Pressure resolves to pressure ch0 (MSLP mb)", () => {
+  it("Pressure resolves to pressure ch0 with diverging ramp 6", () => {
     const idx = EQUIRECT_MAP_MODES.findIndex((m) => m.label === "Pressure");
     expect(idx).toBe(8);
     expect(resolveEquirectMode(idx, true)).toMatchObject({
       kind: "pressure",
       channel: 0,
+      ramp: 6,
     });
   });
 });

--- a/apps/hayba-explorer/src/viewport/equirectMapModes.ts
+++ b/apps/hayba-explorer/src/viewport/equirectMapModes.ts
@@ -37,9 +37,11 @@ export const EQUIRECT_MAP_MODES: EquirectMapMode[] = [
   { label: "Glaciation", kind: "clim", channel: 3, ramp: 4 },
   // COOKBOOK-CLIMATE T3: new geographic-debug map modes for the
   // cookbook-classification redesign. All three sample a non-CLIM RT.
+  // Ramps: 0=grey (distKm normalised), 5=Köppen-D (continentality),
+  // 6=meteorological diverging (pressure).
   { label: "Distance", kind: "dist", channel: 0, ramp: 0 },
-  { label: "Continentality", kind: "dist", channel: 1, ramp: 0 },
-  { label: "Pressure", kind: "pressure", channel: 0, ramp: 0 },
+  { label: "Continentality", kind: "dist", channel: 1, ramp: 5 },
+  { label: "Pressure", kind: "pressure", channel: 0, ramp: 6 },
 ];
 
 /** Resolved selection for `setDebugStack`. `mode` is the debugMaterial


### PR DESCRIPTION
User feedback after T3-FIX: maps now render but the grey ramp doesn't communicate the values well. Adds two new ramps to debugMaterial:

- **id=5 Köppen-D** (continentality): pale cream → light cyan → medium teal → dark teal → deep navy. Mirrors the standard Köppen-D atlas legend (Dfa/Dfb/Dfc/Dfd) so coastal/non-continental cells are pale and deep-interior cells progress through teal into navy.

- **id=6 Pressure diverging**: deep blue (low, ≤990 mb) → cream (mid, ~1013 mb) → deep red (high, ≥1030 mb). Standard meteorological diverging palette, anchored at 0.5 = 1013 mb so the cream band sits at global mean.

equirectMapModes: Continentality now uses ramp 5, Pressure uses ramp 6 (Distance keeps grey since it's just a normalised gradient).

3 files. 12/12 equirectMapModes green (Continentality + Pressure pins updated to include ramp). tsc 0. Next: T4 — cookbook climate classifier with monsoon detection (lat × east-coast × low distance-to-ocean → tropical-monsoon class).