### PR TITLE
feat(hayba-mcp): asset connectors — Polyhaven, ambientCG, Sketchfab

### DIFF
--- a/mcp-tools/hayba-mcp/CHANGELOG.md
+++ b/mcp-tools/hayba-mcp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # HaybaMCPToolkit Changelog
 
+## Unreleased
+
+### Asset-source connectors (pure-Node, no UE C++ bridge)
+
+- **Poly Haven** — `hayba_polyhaven_search` (HDRIs / textures / models, CC0) and `hayba_polyhaven_download` (resolution-selectable, downloads individual map files for textures, prefers HDR for HDRIs, glTF for models). No auth.
+- **ambientCG** — `hayba_ambientcg_search` and `hayba_ambientcg_download` (CC0 PBR material zips; default attribute `2K-JPG`, falls back to first available zip). No auth.
+- **Sketchfab** — `hayba_sketchfab_search` and `hayba_sketchfab_download` (gltf / usdz / source flavours). **Requires `SKETCHFAB_API_TOKEN` env var** — obtain at https://sketchfab.com/settings/password (API tokens section). Missing-token error message is actionable.
+- Shared cache at `<os.tmpdir>/hayba-asset-connectors/<source>/<assetId>/`. Zip extraction via `adm-zip`. UE import is invoked via the existing `python_run` MCP command (build_import_data + import_asset_tasks); no new C++ handler. Failed imports surface as `imported: false` with an `importNote`.
+
 ## v0.3.0 — 2026-05-06
 
 Massive expansion from a PCG/landscape-only plugin into a 34-domain agentic level-design system.

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -17,12 +17,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@distube/ytdl-core": "^4.16.12",
     "@hayba/architecture": "*",
     "@hayba/linguistics": "*",
     "@hayba/planet-physics": "*",
-    "@distube/ytdl-core": "^4.16.12",
     "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "adm-zip": "^0.5.17",
     "better-sqlite3": "^11.0.0",
     "cheerio": "^1.2.0",
     "express": "^4.21.0",
@@ -31,6 +32,7 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.5",
     "@types/better-sqlite3": "^7.6.0",
     "@types/express": "^5.0.0",
     "@types/node": "^24.12.2",

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.ts
@@ -1,0 +1,89 @@
+import * as path from 'node:path';
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { cachePathFor, downloadToFile, ensureDir, extractZip, importIntoUe, type DownloadedAsset } from './shared.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: ['filesystem_write', 'asset_create'],
+  when: 'downloading an ambientCG material zip into the active UE project',
+  not_when: 'you only need metadata — use ambientcg_search',
+};
+
+export const schema = z.object({
+  asset_id: z.string().min(1),
+  resolution: z.string().default('2K-JPG').describe('ambientCG attribute string, e.g. 1K-JPG, 2K-JPG, 4K-JPG, 2K-PNG'),
+  target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/ambientcg/<asset_id>'),
+});
+export type AmbientCgDownloadParams = z.infer<typeof schema>;
+
+const API = 'https://ambientCG.com/api/v2';
+
+export function assetInfoUrl(assetId: string): string {
+  const qs = new URLSearchParams();
+  qs.set('id', assetId);
+  return `${API}/full_json?${qs.toString()}`;
+}
+
+/** Find the zip download URL for the requested attribute (e.g. "2K-JPG"). Exported for tests. */
+export function pickZipUrl(assetJson: any, resolution: string): string | null {
+  const found = Array.isArray(assetJson?.foundAssets) ? assetJson.foundAssets : [];
+  const asset = found[0] ?? assetJson;
+  const folders = asset?.downloadFolders ?? [];
+  for (const folder of folders) {
+    const cats = folder?.downloadFiletypeCategories ?? {};
+    const zip = cats?.zip ?? cats?.Zip;
+    const downloads = zip?.downloads ?? [];
+    for (const d of downloads) {
+      if (d?.attribute === resolution && d?.fullDownloadPath) return d.fullDownloadPath;
+    }
+  }
+  // Fallback: first available zip
+  for (const folder of folders) {
+    const cats = folder?.downloadFiletypeCategories ?? {};
+    const zip = cats?.zip ?? cats?.Zip;
+    const first = zip?.downloads?.[0];
+    if (first?.fullDownloadPath) return first.fullDownloadPath;
+  }
+  return null;
+}
+
+export async function handleAmbientCgDownload(params: AmbientCgDownloadParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const { asset_id, resolution, target_dir } = parsed.data;
+  try {
+    const res = await fetch(assetInfoUrl(asset_id));
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `ambientCG lookup failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const json = (await res.json()) as any;
+    const zipUrl = pickZipUrl(json, resolution);
+    if (!zipUrl) {
+      return { content: [{ type: 'text' as const, text: `No zip download found for ${asset_id} @ ${resolution}` }], isError: true };
+    }
+    const cacheDir = cachePathFor('ambientcg', asset_id);
+    await ensureDir(cacheDir);
+    const zipPath = path.join(cacheDir, `${asset_id}_${resolution}.zip`);
+    await downloadToFile(zipUrl, zipPath);
+    const extractDir = path.join(cacheDir, 'extracted');
+    const files = await extractZip(zipPath, extractDir);
+    const gamePath = target_dir ?? `/Game/AssetConnectors/ambientcg/${asset_id}`;
+    const importResult = await importIntoUe(extractDir, gamePath);
+    const data: DownloadedAsset = {
+      assetId: asset_id,
+      source: 'ambientcg',
+      cachePath: cacheDir,
+      files,
+      imported: importResult.ok,
+      importGamePath: gamePath,
+      importNote: importResult.note,
+    };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `ambientCG download error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-search.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-search.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'searching ambientCG for CC0 PBR materials, decals, or 3D models',
+  not_when: 'you already know the asset id — go straight to ambientcg_download',
+};
+
+export const schema = z.object({
+  query: z.string().min(1),
+  type: z.string().default('Material').describe('ambientCG asset type (Material, Atlas, Decal, 3DModel, …)'),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+export type AmbientCgSearchParams = z.infer<typeof schema>;
+
+const API = 'https://ambientCG.com/api/v2';
+
+export function buildSearchUrl(p: AmbientCgSearchParams): string {
+  const qs = new URLSearchParams();
+  qs.set('type', p.type);
+  qs.set('q', p.query);
+  qs.set('limit', String(p.limit));
+  return `${API}/full_json?${qs.toString()}`;
+}
+
+export async function handleAmbientCgSearch(params: AmbientCgSearchParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  try {
+    const url = buildSearchUrl(parsed.data);
+    const res = await fetch(url);
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `ambientCG search failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const raw = (await res.json()) as Record<string, any>;
+    const found = Array.isArray(raw?.foundAssets) ? raw.foundAssets : [];
+    const results = found.map((a: any) => ({
+      id: a?.assetId,
+      title: a?.displayName ?? a?.assetId,
+      thumbnail: a?.previewImage?.['512-PNG'] ?? a?.previewImage?.['512'] ?? a?.previewImage?.['256-PNG'] ?? null,
+      license: 'CC0',
+      tags: a?.tags ?? [],
+      category: a?.category ?? null,
+    }));
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ source: 'ambientcg', count: results.length, results }, null, 2),
+      }],
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `ambientCG search error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-download.ts
@@ -1,0 +1,105 @@
+import * as path from 'node:path';
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { cachePathFor, downloadToFile, ensureDir, importIntoUe, type DownloadedAsset } from './shared.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: ['filesystem_write', 'asset_create'],
+  when: 'downloading a Poly Haven HDRI / texture / model into the active UE project',
+  not_when: 'you only need metadata — use polyhaven_search',
+};
+
+export const schema = z.object({
+  asset_id: z.string().min(1),
+  type: z.enum(['hdris', 'textures', 'models']).default('textures'),
+  resolution: z.enum(['1k', '2k', '4k', '8k']).default('2k'),
+  target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/polyhaven/<asset_id>'),
+});
+export type PolyhavenDownloadParams = z.infer<typeof schema>;
+
+const API = 'https://api.polyhaven.com';
+
+export function filesUrl(assetId: string): string {
+  return `${API}/files/${encodeURIComponent(assetId)}`;
+}
+
+/** Picks (url, filename) tuples for the requested resolution + type. Exported for tests. */
+export function pickDownloads(
+  files: Record<string, any>,
+  type: 'hdris' | 'textures' | 'models',
+  resolution: string,
+): Array<{ mapName: string; url: string; filename: string }> {
+  const picks: Array<{ mapName: string; url: string; filename: string }> = [];
+
+  if (type === 'hdris') {
+    const hdri = files?.hdri?.[resolution];
+    if (hdri) {
+      const fmt = hdri.hdr ?? hdri.exr;
+      if (fmt?.url) picks.push({ mapName: 'hdri', url: fmt.url, filename: path.basename(fmt.url) });
+    }
+    return picks;
+  }
+
+  if (type === 'models') {
+    const gltf = files?.gltf?.[resolution]?.gltf;
+    if (gltf?.url) picks.push({ mapName: 'gltf', url: gltf.url, filename: path.basename(gltf.url) });
+    // Include the bin + textures referenced by the gltf if exposed in includes
+    const includes = gltf?.include ?? {};
+    for (const [name, info] of Object.entries(includes as Record<string, any>)) {
+      if (info?.url) picks.push({ mapName: name, url: info.url, filename: name });
+    }
+    return picks;
+  }
+
+  // textures: each top-level key is a map (Diffuse, Normal, Roughness, AO, …)
+  for (const [mapName, byRes] of Object.entries(files ?? {})) {
+    const block = (byRes as any)?.[resolution];
+    if (!block) continue;
+    const fmt = block.jpg ?? block.png ?? block.exr;
+    if (fmt?.url) picks.push({ mapName, url: fmt.url, filename: path.basename(fmt.url) });
+  }
+  return picks;
+}
+
+export async function handlePolyhavenDownload(params: PolyhavenDownloadParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const { asset_id, type, resolution, target_dir } = parsed.data;
+  try {
+    const res = await fetch(filesUrl(asset_id));
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `Poly Haven files lookup failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const files = (await res.json()) as Record<string, any>;
+    const picks = pickDownloads(files, type, resolution);
+    if (picks.length === 0) {
+      return { content: [{ type: 'text' as const, text: `No downloadable files for ${asset_id} at ${resolution}` }], isError: true };
+    }
+    const cacheDir = cachePathFor('polyhaven', asset_id);
+    await ensureDir(cacheDir);
+    const written: string[] = [];
+    for (const pick of picks) {
+      const dest = path.join(cacheDir, pick.filename);
+      await downloadToFile(pick.url, dest);
+      written.push(dest);
+    }
+    const gamePath = target_dir ?? `/Game/AssetConnectors/polyhaven/${asset_id}`;
+    const importResult = await importIntoUe(cacheDir, gamePath);
+    const data: DownloadedAsset = {
+      assetId: asset_id,
+      source: 'polyhaven',
+      cachePath: cacheDir,
+      files: written,
+      imported: importResult.ok,
+      importGamePath: gamePath,
+      importNote: importResult.note,
+    };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `Poly Haven download error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-search.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-search.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'searching Poly Haven for CC0 HDRIs, textures, or models',
+  not_when: 'you already know the exact asset slug — go straight to polyhaven_download',
+};
+
+export const schema = z.object({
+  query: z.string().min(1),
+  type: z.enum(['hdris', 'textures', 'models']).default('textures'),
+  categories: z.string().optional().describe('Comma-separated Poly Haven category filter'),
+});
+export type PolyhavenSearchParams = z.infer<typeof schema>;
+
+const API = 'https://api.polyhaven.com';
+
+export function buildSearchUrl(p: PolyhavenSearchParams): string {
+  const qs = new URLSearchParams();
+  qs.set('type', p.type);
+  if (p.query) qs.set('search', p.query);
+  if (p.categories) qs.set('categories', p.categories);
+  return `${API}/assets?${qs.toString()}`;
+}
+
+export async function handlePolyhavenSearch(params: PolyhavenSearchParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  try {
+    const url = buildSearchUrl(parsed.data);
+    const res = await fetch(url);
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `Poly Haven search failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const raw = (await res.json()) as Record<string, any>;
+    const results = Object.entries(raw).map(([id, info]) => ({
+      id,
+      title: info?.name ?? id,
+      thumbnail: `https://cdn.polyhaven.com/asset_img/thumbs/${id}.png?width=256`,
+      license: 'CC0',
+      tags: info?.tags ?? [],
+      categories: info?.categories ?? [],
+      type: parsed.data.type,
+    }));
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ source: 'polyhaven', count: results.length, results }, null, 2),
+      }],
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `Poly Haven search error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/shared.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/shared.ts
@@ -1,0 +1,100 @@
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { executeCommand } from '../tool-executor.js';
+
+export interface DownloadedAsset {
+  assetId: string;
+  source: string;
+  cachePath: string;
+  files: string[];
+  imported: boolean;
+  importGamePath?: string;
+  importNote?: string;
+}
+
+export function cachePathFor(source: string, assetId: string): string {
+  const safe = assetId.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return path.join(os.tmpdir(), 'hayba-asset-connectors', source, safe);
+}
+
+export async function ensureDir(dir: string): Promise<void> {
+  await fsp.mkdir(dir, { recursive: true });
+}
+
+export async function downloadToFile(url: string, dest: string, headers?: Record<string, string>): Promise<void> {
+  await ensureDir(path.dirname(dest));
+  const res = await fetch(url, { headers });
+  if (!res.ok || !res.body) {
+    throw new Error(`download failed: ${res.status} ${res.statusText} for ${url}`);
+  }
+  const nodeStream = Readable.fromWeb(res.body as any);
+  const out = fs.createWriteStream(dest);
+  await pipeline(nodeStream, out);
+}
+
+export async function extractZip(zipPath: string, destDir: string): Promise<string[]> {
+  await ensureDir(destDir);
+  // Lazy import — adm-zip is a CommonJS module.
+  const AdmZipMod = await import('adm-zip');
+  const AdmZip = (AdmZipMod as any).default ?? AdmZipMod;
+  const zip = new AdmZip(zipPath);
+  zip.extractAllTo(destDir, true);
+  return listFilesRecursive(destDir);
+}
+
+export async function listFilesRecursive(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(d: string): Promise<void> {
+    const entries = await fsp.readdir(d, { withFileTypes: true });
+    for (const e of entries) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) await walk(p);
+      else out.push(p);
+    }
+  }
+  if (fs.existsSync(dir)) await walk(dir);
+  return out;
+}
+
+/**
+ * Triggers UE import via python_run. Reaches UE only via the existing
+ * python_run MCP command. If UE is not running / python_run fails, returns
+ * { ok: false } and the caller surfaces it as importNote.
+ */
+export async function importIntoUe(localDir: string, gamePath: string): Promise<{ ok: boolean; note?: string }> {
+  const normalized = localDir.replace(/\\/g, '/');
+  const dest = gamePath.startsWith('/Game/') ? gamePath : `/Game/AssetConnectors/${gamePath}`;
+  const script = `
+import os, unreal
+src_dir = r"${normalized}"
+dest_path = "${dest}"
+files = []
+for root, _dirs, fnames in os.walk(src_dir):
+    for fn in fnames:
+        files.append(os.path.join(root, fn))
+if not files:
+    print("HAYBA_IMPORT_RESULT: no files to import")
+else:
+    asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
+    task = unreal.AssetImportTask()
+    task.filenames = files
+    task.destination_path = dest_path
+    task.automated = True
+    task.save = True
+    task.replace_existing = True
+    asset_tools.import_asset_tasks([task])
+    print("HAYBA_IMPORT_RESULT: imported %d file(s) to %s" % (len(files), dest_path))
+`.trim();
+
+  try {
+    const data = await executeCommand('python_run', { script });
+    return { ok: true, note: typeof data === 'object' && data ? JSON.stringify(data).slice(0, 240) : undefined };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, note: `python_run unavailable: ${msg}` };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-download.ts
@@ -1,0 +1,74 @@
+import * as path from 'node:path';
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { cachePathFor, downloadToFile, ensureDir, extractZip, importIntoUe, type DownloadedAsset } from './shared.js';
+import { tokenMissingMessage } from './sketchfab-search.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: ['filesystem_write', 'asset_create'],
+  when: 'downloading a Sketchfab model into the active UE project (requires SKETCHFAB_API_TOKEN env var)',
+  not_when: 'you only need metadata — use sketchfab_search',
+};
+
+export const schema = z.object({
+  uid: z.string().min(1).describe('Sketchfab model uid'),
+  flavour: z.enum(['gltf', 'usdz', 'source']).default('gltf'),
+  target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/sketchfab/<uid>'),
+});
+export type SketchfabDownloadParams = z.infer<typeof schema>;
+
+const API = 'https://api.sketchfab.com/v3';
+
+export function downloadInfoUrl(uid: string): string {
+  return `${API}/models/${encodeURIComponent(uid)}/download`;
+}
+
+/** Picks the signed download url for the requested flavour. Exported for tests. */
+export function pickFlavourUrl(downloadJson: any, flavour: 'gltf' | 'usdz' | 'source'): string | null {
+  return downloadJson?.[flavour]?.url ?? null;
+}
+
+export async function handleSketchfabDownload(params: SketchfabDownloadParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const token = process.env.SKETCHFAB_API_TOKEN;
+  if (!token) {
+    return { content: [{ type: 'text' as const, text: tokenMissingMessage() }], isError: true };
+  }
+  const { uid, flavour, target_dir } = parsed.data;
+  try {
+    const res = await fetch(downloadInfoUrl(uid), { headers: { Authorization: `Token ${token}` } });
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `Sketchfab download lookup failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const info = (await res.json()) as any;
+    const signedUrl = pickFlavourUrl(info, flavour);
+    if (!signedUrl) {
+      return { content: [{ type: 'text' as const, text: `No ${flavour} download available for ${uid}` }], isError: true };
+    }
+    const cacheDir = cachePathFor('sketchfab', uid);
+    await ensureDir(cacheDir);
+    const zipPath = path.join(cacheDir, `${uid}_${flavour}.zip`);
+    await downloadToFile(signedUrl, zipPath);
+    const extractDir = path.join(cacheDir, 'extracted');
+    const files = await extractZip(zipPath, extractDir);
+    const gamePath = target_dir ?? `/Game/AssetConnectors/sketchfab/${uid}`;
+    const importResult = await importIntoUe(extractDir, gamePath);
+    const data: DownloadedAsset = {
+      assetId: uid,
+      source: 'sketchfab',
+      cachePath: cacheDir,
+      files,
+      imported: importResult.ok,
+      importGamePath: gamePath,
+      importNote: importResult.note,
+    };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `Sketchfab download error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-search.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-search.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'searching Sketchfab for downloadable 3D models (requires SKETCHFAB_API_TOKEN env var)',
+  not_when: 'you already have a Sketchfab uid — go straight to sketchfab_download',
+};
+
+export const schema = z.object({
+  query: z.string().min(1),
+  downloadable: z.boolean().default(true),
+  count: z.number().int().min(1).max(48).default(24),
+});
+export type SketchfabSearchParams = z.infer<typeof schema>;
+
+const API = 'https://api.sketchfab.com/v3';
+
+export function buildSearchUrl(p: SketchfabSearchParams): string {
+  const qs = new URLSearchParams();
+  qs.set('type', 'models');
+  qs.set('q', p.query);
+  qs.set('downloadable', String(p.downloadable));
+  qs.set('archives_flavours', 'true');
+  qs.set('count', String(p.count));
+  return `${API}/search?${qs.toString()}`;
+}
+
+export function tokenMissingMessage(): string {
+  return 'SKETCHFAB_API_TOKEN env var is not set. Get a token at https://sketchfab.com/settings/password (API tokens section) and export SKETCHFAB_API_TOKEN before invoking this tool.';
+}
+
+export async function handleSketchfabSearch(params: SketchfabSearchParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const token = process.env.SKETCHFAB_API_TOKEN;
+  if (!token) {
+    return { content: [{ type: 'text' as const, text: tokenMissingMessage() }], isError: true };
+  }
+  try {
+    const url = buildSearchUrl(parsed.data);
+    const res = await fetch(url, { headers: { Authorization: `Token ${token}` } });
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `Sketchfab search failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const raw = (await res.json()) as any;
+    const items = Array.isArray(raw?.results) ? raw.results : [];
+    const results = items.map((m: any) => ({
+      uid: m?.uid,
+      name: m?.name,
+      thumbnail: m?.thumbnails?.images?.[0]?.url ?? null,
+      license: m?.license?.label ?? null,
+      viewerUrl: m?.viewerUrl ?? null,
+      archives: m?.archives ?? null,
+      downloadable: m?.isDownloadable ?? false,
+    }));
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ source: 'sketchfab', count: results.length, next: raw?.next ?? null, results }, null, 2),
+      }],
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `Sketchfab search error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -29,6 +29,14 @@ import { handleFabLibraryList, meta as fabLibraryListMeta } from './fab/library-
 import { handleFabMarketplaceSearch, meta as fabMarketplaceSearchMeta } from './fab/marketplace-search.js';
 import { handleFabDownload, meta as fabDownloadMeta } from './fab/download.js';
 
+// ── Asset-source connectors (pure Node — no UE bridge except python_run) ──────
+import { handlePolyhavenSearch, meta as polyhavenSearchMeta } from './asset-sources/polyhaven-search.js';
+import { handlePolyhavenDownload, meta as polyhavenDownloadMeta } from './asset-sources/polyhaven-download.js';
+import { handleAmbientCgSearch, meta as ambientcgSearchMeta } from './asset-sources/ambientcg-search.js';
+import { handleAmbientCgDownload, meta as ambientcgDownloadMeta } from './asset-sources/ambientcg-download.js';
+import { handleSketchfabSearch, meta as sketchfabSearchMeta } from './asset-sources/sketchfab-search.js';
+import { handleSketchfabDownload, meta as sketchfabDownloadMeta } from './asset-sources/sketchfab-download.js';
+
 // ── PCGEx tool handlers ───────────────────────────────────────────────────────
 import { searchNodeCatalog } from './search-node-catalog.js';
 import { getNodeDetails } from './get-node-details.js';
@@ -456,6 +464,81 @@ export function registerTools(server: McpServer, session: SessionManagerStub): v
     async (params) => handleFabDownload(params as any)
   );
   remember('hayba_fab_download', fabDownloadMeta);
+
+  // ── Asset-source connectors (Poly Haven / ambientCG / Sketchfab) ────────────
+
+  server.tool(
+    'hayba_polyhaven_search',
+    appendMeta('Search Poly Haven for CC0 HDRIs, textures, or models.', polyhavenSearchMeta),
+    {
+      query: z.string().min(1).describe('Search query string.'),
+      type: z.enum(['hdris', 'textures', 'models']).optional().describe('Asset type filter (default "textures").'),
+      categories: z.string().optional().describe('Comma-separated Poly Haven category filter.'),
+    },
+    async (params) => handlePolyhavenSearch(params as any)
+  );
+  remember('hayba_polyhaven_search', polyhavenSearchMeta);
+
+  server.tool(
+    'hayba_polyhaven_download',
+    appendMeta('Download a Poly Haven asset (HDRI / texture maps / glTF model) and import into UE.', polyhavenDownloadMeta),
+    {
+      asset_id: z.string().min(1).describe('Poly Haven asset slug.'),
+      type: z.enum(['hdris', 'textures', 'models']).optional().describe('Asset type (default "textures").'),
+      resolution: z.enum(['1k', '2k', '4k', '8k']).optional().describe('Resolution tier (default "2k").'),
+      target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/polyhaven/<asset_id>.'),
+    },
+    async (params) => handlePolyhavenDownload(params as any)
+  );
+  remember('hayba_polyhaven_download', polyhavenDownloadMeta);
+
+  server.tool(
+    'hayba_ambientcg_search',
+    appendMeta('Search ambientCG for CC0 PBR materials, decals, or 3D models.', ambientcgSearchMeta),
+    {
+      query: z.string().min(1).describe('Search query string.'),
+      type: z.string().optional().describe('ambientCG asset type (default "Material").'),
+      limit: z.number().int().min(1).max(100).optional().describe('Max results (default 20).'),
+    },
+    async (params) => handleAmbientCgSearch(params as any)
+  );
+  remember('hayba_ambientcg_search', ambientcgSearchMeta);
+
+  server.tool(
+    'hayba_ambientcg_download',
+    appendMeta('Download an ambientCG material zip and import into UE.', ambientcgDownloadMeta),
+    {
+      asset_id: z.string().min(1).describe('ambientCG asset id (e.g. "Bricks075A").'),
+      resolution: z.string().optional().describe('Attribute string (e.g. "1K-JPG", "2K-JPG", "4K-PNG"). Default "2K-JPG".'),
+      target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/ambientcg/<asset_id>.'),
+    },
+    async (params) => handleAmbientCgDownload(params as any)
+  );
+  remember('hayba_ambientcg_download', ambientcgDownloadMeta);
+
+  server.tool(
+    'hayba_sketchfab_search',
+    appendMeta('Search Sketchfab for downloadable 3D models. Requires SKETCHFAB_API_TOKEN env var.', sketchfabSearchMeta),
+    {
+      query: z.string().min(1).describe('Search query string.'),
+      downloadable: z.boolean().optional().describe('Filter to downloadable-only models (default true).'),
+      count: z.number().int().min(1).max(48).optional().describe('Max results (default 24).'),
+    },
+    async (params) => handleSketchfabSearch(params as any)
+  );
+  remember('hayba_sketchfab_search', sketchfabSearchMeta);
+
+  server.tool(
+    'hayba_sketchfab_download',
+    appendMeta('Download a Sketchfab model and import into UE. Requires SKETCHFAB_API_TOKEN env var.', sketchfabDownloadMeta),
+    {
+      uid: z.string().min(1).describe('Sketchfab model uid.'),
+      flavour: z.enum(['gltf', 'usdz', 'source']).optional().describe('Download flavour (default "gltf").'),
+      target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/sketchfab/<uid>.'),
+    },
+    async (params) => handleSketchfabDownload(params as any)
+  );
+  remember('hayba_sketchfab_download', sketchfabDownloadMeta);
 
   // ── PCGEx tools ─────────────────────────────────────────────────────────────
 

--- a/mcp-tools/hayba-mcp/tests/tools/asset-sources/ambientcg.test.ts
+++ b/mcp-tools/hayba-mcp/tests/tools/asset-sources/ambientcg.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { handleAmbientCgSearch, buildSearchUrl } from '../../../src/tools/asset-sources/ambientcg-search.js';
+import { pickZipUrl, assetInfoUrl } from '../../../src/tools/asset-sources/ambientcg-download.js';
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('ambientcg search', () => {
+  it('builds the full_json URL with query', () => {
+    const url = buildSearchUrl({ query: 'brick', type: 'Material', limit: 5 } as any);
+    expect(url).toContain('https://ambientCG.com/api/v2/full_json?');
+    expect(url).toContain('q=brick');
+    expect(url).toContain('type=Material');
+    expect(url).toContain('limit=5');
+  });
+
+  it('parses foundAssets into result shape', async () => {
+    const body = {
+      foundAssets: [
+        { assetId: 'Bricks075A', displayName: 'Bricks 075A', previewImage: { '512-PNG': 'https://cdn/b.png' }, tags: ['brick'], category: 'Bricks' },
+      ],
+    };
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(body), { status: 200 }));
+    const r = await handleAmbientCgSearch({ query: 'brick', type: 'Material', limit: 1 } as any);
+    const payload = JSON.parse((r.content as any)[0].text);
+    expect(payload.source).toBe('ambientcg');
+    expect(payload.results[0]).toMatchObject({ id: 'Bricks075A', license: 'CC0', thumbnail: 'https://cdn/b.png' });
+  });
+});
+
+describe('ambientcg download — URL construction', () => {
+  it('builds info URL', () => {
+    expect(assetInfoUrl('Bricks075A')).toContain('id=Bricks075A');
+  });
+
+  it('picks the zip matching requested attribute', () => {
+    const json = {
+      foundAssets: [{
+        assetId: 'Bricks075A',
+        downloadFolders: [{
+          downloadFiletypeCategories: {
+            zip: {
+              downloads: [
+                { attribute: '1K-JPG', fullDownloadPath: 'https://cdn/1k.zip' },
+                { attribute: '2K-JPG', fullDownloadPath: 'https://cdn/2k.zip' },
+                { attribute: '4K-JPG', fullDownloadPath: 'https://cdn/4k.zip' },
+              ],
+            },
+          },
+        }],
+      }],
+    };
+    expect(pickZipUrl(json, '2K-JPG')).toBe('https://cdn/2k.zip');
+    expect(pickZipUrl(json, '4K-JPG')).toBe('https://cdn/4k.zip');
+  });
+
+  it('falls back to first available zip when attribute not found', () => {
+    const json = {
+      foundAssets: [{
+        downloadFolders: [{ downloadFiletypeCategories: { zip: { downloads: [{ attribute: '8K-PNG', fullDownloadPath: 'https://cdn/only.zip' }] } } }],
+      }],
+    };
+    expect(pickZipUrl(json, '2K-JPG')).toBe('https://cdn/only.zip');
+  });
+});

--- a/mcp-tools/hayba-mcp/tests/tools/asset-sources/polyhaven.test.ts
+++ b/mcp-tools/hayba-mcp/tests/tools/asset-sources/polyhaven.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { handlePolyhavenSearch, buildSearchUrl } from '../../../src/tools/asset-sources/polyhaven-search.js';
+import { pickDownloads, filesUrl } from '../../../src/tools/asset-sources/polyhaven-download.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('polyhaven search', () => {
+  it('builds the expected /assets URL', () => {
+    const url = buildSearchUrl({ query: 'rock', type: 'textures' } as any);
+    expect(url).toContain('https://api.polyhaven.com/assets?');
+    expect(url).toContain('type=textures');
+    expect(url).toContain('search=rock');
+  });
+
+  it('returns a list of results from mocked /assets', async () => {
+    const fakeBody = {
+      rock_01: { name: 'Rock 01', tags: ['rock'], categories: ['rock'] },
+      rock_02: { name: 'Rock 02', tags: ['rock'] },
+    };
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(fakeBody), { status: 200 }));
+    const r = await handlePolyhavenSearch({ query: 'rock', type: 'textures' } as any);
+    const payload = JSON.parse((r.content as any)[0].text);
+    expect(payload.source).toBe('polyhaven');
+    expect(payload.count).toBe(2);
+    expect(payload.results[0]).toMatchObject({ id: 'rock_01', license: 'CC0' });
+  });
+});
+
+describe('polyhaven download — URL construction', () => {
+  it('builds /files URL for an asset', () => {
+    expect(filesUrl('rock_01')).toBe('https://api.polyhaven.com/files/rock_01');
+  });
+
+  it('picks 2k jpg map URLs from the files payload', () => {
+    const files = {
+      Diffuse: { '2k': { jpg: { url: 'https://cdn/d.jpg' } } },
+      Normal:  { '2k': { jpg: { url: 'https://cdn/n.jpg' } }, '4k': { jpg: { url: 'https://cdn/n4.jpg' } } },
+      Rough:   { '1k': { jpg: { url: 'https://cdn/r1.jpg' } } }, // wrong res — skipped
+    };
+    const picks = pickDownloads(files, 'textures', '2k');
+    const names = picks.map(p => p.mapName).sort();
+    expect(names).toEqual(['Diffuse', 'Normal']);
+    expect(picks.find(p => p.mapName === 'Normal')?.url).toBe('https://cdn/n.jpg');
+  });
+
+  it('prefers HDR for hdris', () => {
+    const files = { hdri: { '2k': { hdr: { url: 'https://cdn/x.hdr' } } } };
+    const picks = pickDownloads(files, 'hdris', '2k');
+    expect(picks).toHaveLength(1);
+    expect(picks[0].url).toBe('https://cdn/x.hdr');
+  });
+});

--- a/mcp-tools/hayba-mcp/tests/tools/asset-sources/sketchfab.test.ts
+++ b/mcp-tools/hayba-mcp/tests/tools/asset-sources/sketchfab.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { handleSketchfabSearch, buildSearchUrl } from '../../../src/tools/asset-sources/sketchfab-search.js';
+import { pickFlavourUrl, downloadInfoUrl } from '../../../src/tools/asset-sources/sketchfab-download.js';
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('sketchfab search', () => {
+  beforeEach(() => { delete process.env.SKETCHFAB_API_TOKEN; });
+
+  it('builds /search URL with downloadable=true', () => {
+    const url = buildSearchUrl({ query: 'tree', downloadable: true, count: 24 } as any);
+    expect(url).toContain('https://api.sketchfab.com/v3/search?');
+    expect(url).toContain('type=models');
+    expect(url).toContain('q=tree');
+    expect(url).toContain('downloadable=true');
+    expect(url).toContain('archives_flavours=true');
+  });
+
+  it('returns actionable error when token is missing', async () => {
+    const r = await handleSketchfabSearch({ query: 'tree' } as any);
+    expect(r.isError).toBe(true);
+    expect((r.content as any)[0].text).toContain('SKETCHFAB_API_TOKEN');
+    expect((r.content as any)[0].text).toContain('https://sketchfab.com/settings/password');
+  });
+
+  it('parses results when token is present', async () => {
+    process.env.SKETCHFAB_API_TOKEN = 'test-token';
+    const body = {
+      next: null,
+      results: [
+        { uid: 'abc', name: 'Tree', thumbnails: { images: [{ url: 'https://cdn/t.jpg' }] }, license: { label: 'CC-BY' }, viewerUrl: 'https://sketchfab/abc', isDownloadable: true },
+      ],
+    };
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(body), { status: 200 }));
+    const r = await handleSketchfabSearch({ query: 'tree' } as any);
+    const payload = JSON.parse((r.content as any)[0].text);
+    expect(payload.results[0]).toMatchObject({ uid: 'abc', license: 'CC-BY' });
+    // Verify Authorization header was sent
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as any).Authorization).toBe('Token test-token');
+  });
+});
+
+describe('sketchfab download — URL construction', () => {
+  it('builds /models/<uid>/download URL', () => {
+    expect(downloadInfoUrl('abc-123')).toBe('https://api.sketchfab.com/v3/models/abc-123/download');
+  });
+
+  it('picks the gltf signed URL', () => {
+    const info = { gltf: { url: 'https://signed/g.zip' }, usdz: { url: 'https://signed/u.zip' } };
+    expect(pickFlavourUrl(info, 'gltf')).toBe('https://signed/g.zip');
+    expect(pickFlavourUrl(info, 'usdz')).toBe('https://signed/u.zip');
+    expect(pickFlavourUrl(info, 'source')).toBeNull();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "eslint-config-prettier": "^10.0.0",
         "prettier": "^3.5.0",
         "typescript-eslint": "^8.24.0"
+      },
+      "engines": {
+        "node": ">=22.5.0"
       }
     },
     "apps/hayba-explorer": {
@@ -435,6 +438,7 @@
         "@hayba/planet-physics": "*",
         "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "adm-zip": "^0.5.17",
         "better-sqlite3": "^11.0.0",
         "cheerio": "^1.2.0",
         "express": "^4.21.0",
@@ -446,6 +450,7 @@
         "hayba-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.5",
         "@types/better-sqlite3": "^7.6.0",
         "@types/express": "^5.0.0",
         "@types/node": "^24.12.2",
@@ -3904,6 +3909,16 @@
       "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",


### PR DESCRIPTION
@
## Summary

Adds six MCP tools (search + download per source) for grabbing free assets and auto-importing them into UE.

### Tools
- `hayba_polyhaven_search` / `hayba_polyhaven_download` — CC0 HDRIs, textures, models (no auth)
- `hayba_ambientcg_search` / `hayba_ambientcg_download` — CC0 PBR materials (no auth)
- `hayba_sketchfab_search` / `hayba_sketchfab_download` — model marketplace (reads `SKETCHFAB_API_TOKEN`; emits an actionable error pointing to https://sketchfab.com/settings/password when missing)

### How downloads work
1. Stream from source API into `<os.tmpdir>/hayba-asset-connectors/<source>/<assetId>/` via Node web streams
2. Extract zips with `adm-zip` (Polyhaven serves loose files; ambientCG/Sketchfab serve zips)
3. Trigger UE import via the existing `python_run` MCP command — `AssetImportTask` + `import_asset_tasks` (headless) → `/Game/AssetConnectors/<source>/<id>/`

No new UE-side C++ — pure-Node connectors that reach UE only through `python_run`. Shared helpers live in `asset-sources/shared.ts`.

## Test Plan
- [x] `npx tsc` clean
- [x] `npx vitest run tests/tools/asset-sources/` — 15/15 pass (search shape + URL/resolution selection for each source)
- [ ] Live download/import smoke — not exercised in CI; needs a running UE editor

## Notes
- Pre-existing 26 failures across `actor`/`editor`/`scene`/`list-pcg-assets`/`validate-pcg-graph`/`editor-stream-log`/`get-node-details` ("No sender configured") are leftover fixture gaps from the ToolExecutor seam refactor (#158). Not introduced by this PR.
- `adm-zip ^0.5.17` added as a dependency.
- ambientCG `resolution` is a free-form string (default `"2K-JPG"`) so callers can request the full attribute matrix (`4K-PNG`, `8K-JPG`, …).
- Polyhaven model downloads include glTF `.include` siblings (bin + textures) so the imported model resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@