### PR TITLE
feat(climate): Köppen-Geiger classifier + cookbook precip override (COOKBOOK-CLIMATE T4)

### DIFF
--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -380,6 +380,8 @@ export default function App() {
   const prevDebugDistRef = useRef<THREE.WebGLRenderTarget | null>(null);
   // COOKBOOK-CLIMATE T3: mean-sea-level pressure RT (MSLP_FRAG output).
   const prevDebugPressureRef = useRef<THREE.WebGLRenderTarget | null>(null);
+  // COOKBOOK-CLIMATE T4: Köppen-Geiger climate class + cookbook precip RT.
+  const prevDebugClimateRef = useRef<THREE.WebGLRenderTarget | null>(null);
   // Live stack handles for the mounted material's selector.
   const debugStackRef = useRef<{
     clim: THREE.WebGLRenderTarget;
@@ -452,6 +454,9 @@ export default function App() {
         if (rt) stackTex = rt.texture;
       } else if (sel.kind === "pressure") {
         const rt = prevDebugPressureRef.current;
+        if (rt) stackTex = rt.texture;
+      } else if (sel.kind === "climate") {
+        const rt = prevDebugClimateRef.current;
         if (rt) stackTex = rt.texture;
       }
       setDebugStack(mat, {
@@ -1194,6 +1199,7 @@ export default function App() {
       prevDebugWindRef.current?.dispose();
       prevDebugDistRef.current?.dispose();
       prevDebugPressureRef.current?.dispose();
+      prevDebugClimateRef.current?.dispose();
 
       const __tU0 = performance.now();
       const base = uploadEquirect(new Float32Array(inp.height), w, h);
@@ -1208,6 +1214,7 @@ export default function App() {
       let windRT!: THREE.WebGLRenderTarget;
       let distRT!: THREE.WebGLRenderTarget;
       let pressureRT!: THREE.WebGLRenderTarget;
+      let climateRT!: THREE.WebGLRenderTarget;
       await scene.runBake(async (renderer) => {
         const out = await runHydraulicBake(
           renderer,
@@ -1235,6 +1242,7 @@ export default function App() {
         windRT = out.wind;
         distRT = out.dist;
         pressureRT = out.pressure;
+        climateRT = out.climate;
       });
       const __gpuMs = performance.now() - __tG0;
       sceneRef.current?.setBakeSplit({
@@ -1254,6 +1262,7 @@ export default function App() {
       prevDebugWindRef.current = windRT;
       prevDebugDistRef.current = distRT;
       prevDebugPressureRef.current = pressureRT;
+      prevDebugClimateRef.current = climateRT;
       debugStackRef.current = { clim: climRT, terr: terrRT, hydro: hydroRT };
 
       const mat = makeDebugReliefMaterial();
@@ -1321,6 +1330,8 @@ export default function App() {
     prevDebugTerrRef.current?.dispose();
     prevDebugHydroRef.current?.dispose();
     prevDebugDistRef.current?.dispose();
+    prevDebugPressureRef.current?.dispose();
+    prevDebugClimateRef.current?.dispose();
     prevDebugBaseRef.current?.dispose();
     prevDebugPrecipRef.current?.dispose();
     prevDebugHFinalRef.current = null;
@@ -1329,6 +1340,7 @@ export default function App() {
     prevDebugHydroRef.current = null;
     prevDebugDistRef.current = null;
     prevDebugPressureRef.current = null;
+    prevDebugClimateRef.current = null;
     prevDebugBaseRef.current = null;
     prevDebugPrecipRef.current = null;
     debugStackRef.current = null;

--- a/apps/hayba-explorer/src/viewport/bake/__headless_harness__.ts
+++ b/apps/hayba-explorer/src/viewport/bake/__headless_harness__.ts
@@ -221,7 +221,7 @@ export async function runRealInputErosionVerification(
 
     const webglErrPre = gl.getError();
     const t0 = performance.now();
-    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d } =
+    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d, pressure: _p, climate: _cl } =
       await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
     // Oracle never reads the stack RTs; dispose immediately so the
     // many-bake harness doesn't leak 3 RTs/bake (fatal at 3M).
@@ -230,6 +230,8 @@ export async function runRealInputErosionVerification(
     _h.dispose();
     _w.dispose();
     _d.dispose();
+    _p.dispose();
+    _cl.dispose();
     const t1 = performance.now();
     const webglErrPost = gl.getError();
 
@@ -433,7 +435,7 @@ export async function runHeadlessErosionVerification(
 
     const webglErrPre = gl.getError();
     const t0 = performance.now();
-    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d } =
+    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d, pressure: _p, climate: _cl } =
       await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
     // Oracle never reads the stack RTs; dispose immediately so the
     // many-bake harness doesn't leak 3 RTs/bake (fatal at 3M).
@@ -442,6 +444,8 @@ export async function runHeadlessErosionVerification(
     _h.dispose();
     _w.dispose();
     _d.dispose();
+    _p.dispose();
+    _cl.dispose();
     const t1 = performance.now();
     const webglErrPost = gl.getError();
 
@@ -1050,7 +1054,7 @@ async function _bakeAndRenderRelief(
   const cfg = { ...hyd.DEFAULT_HYDRAULIC, ...(overrideCfg ?? {}) };
 
   const t0 = performance.now();
-  const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d } =
+  const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d, pressure: _p, climate: _cl } =
     await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
   // CP2.c (#234 P2.3a): OPT-IN only — read the REAL baked TERR/HYDRO
   // masks (refreshClimate's TERRAIN/HYDRO passes) before disposal so

--- a/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
+++ b/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
@@ -101,7 +101,7 @@ const FRAG: string = [
   "uniform float uChannel;      /* which RGBA lane of uStackTex (0..3)      */",
   "uniform float uStackMode;    /* 0 relief 1 draped 2 flat 3 normal-map  */",
   "uniform float uWindTime;",
-  "uniform float uRamp;         /* 0 grey 1 temp 2 precip 3 hue 4 grey-elev 5 continentality 6 pressure */",
+  "uniform float uRamp;         /* 0 grey 1 temp 2 precip 3 hue 4 grey-elev 5 continentality 6 pressure 7 KG-discrete */",
   "",
   "const float PI = 3.141592653589793;",
   "",
@@ -171,7 +171,8 @@ const FRAG: string = [
   "   0 grey (raw clamp 0..1) · 1 temp diverging (deg C, -30..+35) ·",
   "   2 precip white->blue (0..1) · 3 hue (turns, for wind/aspect) ·",
   "   4 grey-elev (0..1) · 5 continentality-index (Conrad-style green→yellow→red) ·",
-  "   6 pressure diverging (low=blue, mid=cream, high=red). Calibration of",
+  "   6 pressure diverging (low=blue, mid=cream, high=red) ·",
+  "   7 Köppen-Geiger discrete (15-class id 0..14 → categorical colour). Calibration of",
   "   climate units is downstream tuning; this is a deterministic debug",
   "   visualiser. */",
   "vec3 ramp(float id, float x){",
@@ -223,6 +224,28 @@ const FRAG: string = [
   "    vec3 midP  = vec3(0.97, 0.96, 0.88);",
   "    vec3 highP = vec3(0.78, 0.13, 0.13);",
   "    return (t < 0.5) ? mix(lowP, midP, t / 0.5) : mix(midP, highP, (t - 0.5) / 0.5);",
+  "  }",
+  // T4 id=7: Köppen-Geiger discrete palette (15 classes). x = raw class
+  // id (0..14) emitted by CLIMATE_CLASS_FRAG. Colours roughly mirror
+  // the Beck et al. 2023 KG colour key (blue tropics, red deserts,
+  // green humid temperate, teal humid continental, grey/white polar).
+  "  if (id < 7.5){",
+  "    float c = floor(clamp(x, 0.0, 14.0) + 0.5);",
+  "    if (c < 0.5) return vec3(0.05, 0.10, 0.20);",  // 0 Ocean (dark — usually not drawn)
+  "    if (c < 1.5) return vec3(0.00, 0.00, 0.85);",  // 1 Af deep blue
+  "    if (c < 2.5) return vec3(0.00, 0.50, 0.95);",  // 2 Am medium blue
+  "    if (c < 3.5) return vec3(0.45, 0.75, 1.00);",  // 3 Aw light blue
+  "    if (c < 4.5) return vec3(0.95, 0.10, 0.10);",  // 4 BWh red
+  "    if (c < 5.5) return vec3(0.95, 0.55, 0.55);",  // 5 BWk pink
+  "    if (c < 6.5) return vec3(0.96, 0.60, 0.15);",  // 6 BSh orange
+  "    if (c < 7.5) return vec3(1.00, 0.85, 0.30);",  // 7 BSk yellow
+  "    if (c < 8.5) return vec3(0.70, 0.65, 0.05);",  // 8 Csa olive
+  "    if (c < 9.5) return vec3(0.75, 1.00, 0.30);",  // 9 Cfa lime
+  "    if (c < 10.5) return vec3(0.35, 0.85, 0.30);", // 10 Cfb green
+  "    if (c < 11.5) return vec3(0.20, 0.85, 0.85);", // 11 Dfa/b cyan
+  "    if (c < 12.5) return vec3(0.05, 0.55, 0.55);", // 12 Dfc teal
+  "    if (c < 13.5) return vec3(0.70, 0.70, 0.70);", // 13 ET grey
+  "    return vec3(0.98, 0.98, 0.98);",               // 14 EF icecap
   "  }",
   "  return vec3(clamp(x, 0.0, 1.0));",
   "}",

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -1132,3 +1132,97 @@ export const PRESSURE_VIZ_FRAG = [
   "  fragColor = vec4(n, mb, 0.0, 0.0);",
   "}",
 ].join("\n");
+
+// COOKBOOK-CLIMATE T4: simplified Köppen-Geiger climate classifier.
+// Reads (lat, elev, T, P, continentality) and emits a class id 0..14
+// in .r. Annual-mean T/P (we lack monthly data) ⇒ this is a coarse
+// 15-class approximation, not a full 30-class K-G; latitude proxies
+// for summer/winter discrimination, continentality proxies for annual
+// T range. Suitable for visual-debug Climate map mode.
+//
+// Class table (matches the debugMaterial id=7 ramp colours):
+//   0  Ocean        (h < 0)
+//   1  Af  tropical rainforest      (deep blue)
+//   2  Am  tropical monsoon         (medium blue)
+//   3  Aw  savanna                  (light blue)
+//   4  BWh hot desert               (red)
+//   5  BWk cold desert              (light pink)
+//   6  BSh hot steppe               (orange)
+//   7  BSk cold steppe              (yellow)
+//   8  Csa Mediterranean            (olive-yellow)
+//   9  Cfa humid subtropical        (lime green)
+//  10  Cfb maritime west coast      (bright green)
+//  11  Dfa/Dfb humid continental    (teal/cyan)
+//  12  Dfc subarctic                (dark teal)
+//  13  ET  tundra                   (light grey)
+//  14  EF  icecap                   (white)
+export const CLIMATE_CLASS_FRAG = [
+  H,
+  "uniform sampler2D uA;",
+  "uniform sampler2D uClim;",
+  "uniform sampler2D uDist;",
+  "uniform vec2 uGrid;",
+  "void main(){",
+  "  ivec2 rc = fragRC();",
+  "  ivec2 wh = gridWH(uGrid);",
+  "  vec4 a  = loadA(uA, uGrid, rc.x, rc.y);",
+  "  vec4 c  = texelFetch(uClim, rc, 0);",
+  "  vec4 d  = texelFetch(uDist, rc, 0);",
+  "  if (a.r < 0.0) { fragColor = vec4(0.0); return; }", // Ocean
+  "  float v = (float(rc.y) + 0.5) / float(wh.y);",
+  "  float lat = (0.5 - v) * 180.0;",
+  "  float absLat = abs(lat);",
+  "  float T = c.r;",
+  "  float P = c.g;",
+  "  float cont = d.g;",
+  "  float id = 0.0;",
+  // Polar tier (extreme cold + very high lat)
+  "  if (T <= -10.0 || absLat >= 75.0) { id = 14.0; }",
+  "  else if (T <= 0.0  || absLat >= 65.0) { id = 13.0; }",
+  // Subarctic / boreal (cold + high cont)
+  "  else if (T < 8.0 && absLat >= 50.0)  { id = 12.0; }",
+  "  else if (T < 14.0 && absLat >= 40.0 && cont > 0.45) { id = 11.0; }",
+  // Tropical band (lat < 23, warm)
+  "  else if (absLat < 23.0 && T > 18.0) {",
+  "    if (P > 0.70) id = 1.0;",
+  "    else if (P > 0.45) id = 2.0;",
+  "    else id = 3.0;",
+  "  }",
+  // Arid (low precip)
+  "  else if (P < 0.25) { id = (T > 18.0) ? 4.0 : 5.0; }",
+  "  else if (P < 0.50 && cont > 0.35) { id = (T > 18.0) ? 6.0 : 7.0; }",
+  // Temperate
+  "  else if (absLat >= 30.0 && absLat < 45.0 && cont > 0.25 && cont < 0.55) { id = 8.0; }",
+  "  else if (absLat < 35.0) { id = 9.0; }",
+  "  else if (cont < 0.30) { id = 10.0; }",
+  "  else { id = 11.0; }",
+  // T4 monsoon override: tropical-coastal cells (lat 5-25, low cont)
+  // get tropical-monsoon climate (Am) regardless of zonal-derived P.
+  // Without seasonal precip data this is the proxy for the cookbook
+  // 'east+south coast of large landmass' rule.
+  "  if (absLat >= 5.0 && absLat < 25.0 && cont < 0.30 && a.r >= 0.0 && T > 18.0 && id > 0.5 && id < 4.0) {",
+  "    id = 2.0;",
+  "  }",
+  // Cookbook precip per class (.g). Lets downstream consumers (and the
+  // Precipitation map mode) read realistic precip with monsoon Am wet,
+  // BWh/BWk deserts dry, etc. — independent of the zonal P that fed
+  // into the classifier.
+  "  float cbP = 0.50;",
+  "  if (id < 0.5) cbP = 0.0;",        // Ocean
+  "  else if (id < 1.5) cbP = 0.95;",  // Af tropical rainforest
+  "  else if (id < 2.5) cbP = 0.88;",  // Am tropical monsoon (very wet)
+  "  else if (id < 3.5) cbP = 0.55;",  // Aw savanna
+  "  else if (id < 4.5) cbP = 0.08;",  // BWh hot desert
+  "  else if (id < 5.5) cbP = 0.10;",  // BWk cold desert
+  "  else if (id < 6.5) cbP = 0.28;",  // BSh hot steppe
+  "  else if (id < 7.5) cbP = 0.30;",  // BSk cold steppe
+  "  else if (id < 8.5) cbP = 0.42;",  // Csa Mediterranean
+  "  else if (id < 9.5) cbP = 0.68;",  // Cfa humid subtropical
+  "  else if (id < 10.5) cbP = 0.78;", // Cfb maritime west coast
+  "  else if (id < 11.5) cbP = 0.55;", // Dfa/b humid continental
+  "  else if (id < 12.5) cbP = 0.42;", // Dfc subarctic
+  "  else if (id < 13.5) cbP = 0.25;", // ET tundra
+  "  else cbP = 0.10;",                // EF icecap
+  "  fragColor = vec4(id, cbP, 0.0, 0.0);",
+  "}",
+].join("\n");

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -62,6 +62,7 @@ import {
   DIST_JFA_FRAG,
   DIST_FINAL_FRAG,
   PRESSURE_VIZ_FRAG,
+  CLIMATE_CLASS_FRAG,
 } from "./hydraulic.glsl";
 import { runRawPass } from "./glPass";
 import { createPingPong, type PingPongTargets } from "./pingpong";
@@ -481,6 +482,13 @@ export interface HydraulicBakeResult {
    *  internal-only and disposed at teardown). Channels: .r=pressure
    *  in mb (≈990–1020 typical), .gba unused. Read-only. */
   pressure: THREE.WebGLRenderTarget;
+  /** COOKBOOK-CLIMATE T4: simplified Köppen-Geiger climate classifier.
+   *  Channel .r holds an integer class id 0..14:
+   *    0 Ocean · 1 Af · 2 Am · 3 Aw · 4 BWh · 5 BWk · 6 BSh · 7 BSk
+   *    8 Csa · 9 Cfa · 10 Cfb · 11 Dfa/b · 12 Dfc · 13 ET · 14 EF
+   *  Class id matched by the debugMaterial ramp id=7 (Köppen-Geiger
+   *  discrete palette, matching the Beck et al. 2023 colour scheme). */
+  climate: THREE.WebGLRenderTarget;
 }
 
 export async function runHydraulicBake(
@@ -497,7 +505,7 @@ export async function runHydraulicBake(
   // FAILS if EXT_color_buffer_float is missing. We drive the read/write
   // slots explicitly below (NOT pp.book) so the discipline is local and
   // unambiguous.
-  const pp: PingPongTargets = createPingPong(renderer, w, h, ["A", "F", "M", "ACC", "CTRL", "CLIM", "TERR", "HYDRO", "MSLP", "WIND", "DIST", "PVIZ"]);
+  const pp: PingPongTargets = createPingPong(renderer, w, h, ["A", "F", "M", "ACC", "CTRL", "CLIM", "TERR", "HYDRO", "MSLP", "WIND", "DIST", "PVIZ", "CLASS"]);
   const A = pp.rt.A; // [slot0, slot1]
   const F = pp.rt.F; // [slot0, slot1]
   // S2.4 detail mask: a ONE-TIME single-channel field (computed pre-loop
@@ -535,6 +543,9 @@ export async function runHydraulicBake(
   // Slot 0 is the viz output; slot 1 is allocated by the pair helper and
   // disposed at teardown.
   const PVIZ = pp.rt.PVIZ;
+  // COOKBOOK-CLIMATE T4: CLASS holds the simplified Köppen-Geiger class
+  // id (0..14) in .r for the "Climate" map mode. Single-buffered.
+  const CLASS = pp.rt.CLASS;
   let accRead = 0;
   const swapAcc = (): void => {
     accRead ^= 1;
@@ -666,6 +677,21 @@ export async function runHydraulicBake(
         uMbHigh: u(cfg.pressureMbHigh),
       },
       PVIZ[0],
+    );
+    // T4: simplified Köppen-Geiger climate classifier. Reads finalized
+    // CLIM (T/P) + DIST (continentality) + uA (land/elev/lat-from-rc),
+    // emits class id 0..14 in .r. Runs once per bake at the END so it
+    // sees the post-orographic precip etc.
+    runRawPass(
+      renderer,
+      CLIMATE_CLASS_FRAG,
+      {
+        uA: u(aReadRT()),
+        uClim: u(CLIM[0]),
+        uDist: u(DIST[distFinalSlot]),
+        uGrid: u(uGrid),
+      },
+      CLASS[0],
     );
   };
 
@@ -1067,6 +1093,7 @@ export async function runHydraulicBake(
   // parity, so disposal is dynamic.
   DIST[distFinalSlot ^ 1].dispose();
   PVIZ[1].dispose();
+  CLASS[1].dispose();
   return {
     eroded: result,
     clim: CLIM[0],
@@ -1075,5 +1102,6 @@ export async function runHydraulicBake(
     wind: WIND[0],
     dist: DIST[distFinalSlot],
     pressure: PVIZ[0],
+    climate: CLASS[0],
   };
 }

--- a/apps/hayba-explorer/src/viewport/equirectMapModes.test.ts
+++ b/apps/hayba-explorer/src/viewport/equirectMapModes.test.ts
@@ -4,8 +4,8 @@ import {
   resolveEquirectMode,
 } from "./equirectMapModes";
 
-describe("EQUIRECT_MAP_MODES registry (SP-B + COOKBOOK-CLIMATE T3)", () => {
-  it("is exactly the 9 data-backed modes in order", () => {
+describe("EQUIRECT_MAP_MODES registry (SP-B + COOKBOOK-CLIMATE T3/T4)", () => {
+  it("is exactly the 10 data-backed modes in order", () => {
     expect(EQUIRECT_MAP_MODES.map((m) => m.label)).toEqual([
       "Relief",
       "Normal",
@@ -16,19 +16,22 @@ describe("EQUIRECT_MAP_MODES registry (SP-B + COOKBOOK-CLIMATE T3)", () => {
       "Distance",
       "Continentality",
       "Pressure",
+      "Climate",
     ]);
   });
-  it("kinds (SP-B + cookbook-T3 dist/pressure)", () => {
+  it("kinds (SP-B + cookbook T3/T4 dist/pressure/climate)", () => {
     expect(EQUIRECT_MAP_MODES.map((m) => m.kind)).toEqual([
       "relief",
       "normal",
       "clim",
-      "clim",
+      // T4: Precipitation repointed from CLIM.g (zonal) to CLASS.g (cookbook).
+      "climate",
       "wind",
       "clim",
       "dist",
       "dist",
       "pressure",
+      "climate",
     ]);
   });
 });
@@ -110,11 +113,12 @@ describe("NX-3 Wind animated mode", () => {
     expect(resolveEquirectMode(windIdx, true)).toEqual({ kind: "wind", channel: 2, ramp: 3, mode: 4 });
     expect(resolveEquirectMode(windIdx, false)).toEqual({ kind: "wind", channel: 2, ramp: 3, mode: 5 });
   });
-  it("other modes' resolution byte-unchanged (regression pin)", () => {
+  it("other modes' resolution byte-unchanged (post T4 — Precip is climate kind)", () => {
     expect(resolveEquirectMode(0, true)).toEqual({ kind: "relief", channel: 0, ramp: 0, mode: 0 });
     expect(resolveEquirectMode(1, true)).toEqual({ kind: "normal", channel: 0, ramp: 0, mode: 3 });
     expect(resolveEquirectMode(2, true)).toEqual({ kind: "clim", channel: 0, ramp: 1, mode: 1 });
-    expect(resolveEquirectMode(3, false)).toEqual({ kind: "clim", channel: 1, ramp: 2, mode: 2 });
+    // Precipitation moved to kind=climate (samples CLASS.g cookbook precip)
+    expect(resolveEquirectMode(3, false)).toEqual({ kind: "climate", channel: 1, ramp: 2, mode: 2 });
     expect(resolveEquirectMode(5, true)).toEqual({ kind: "clim", channel: 3, ramp: 4, mode: 1 });
   });
 });

--- a/apps/hayba-explorer/src/viewport/equirectMapModes.ts
+++ b/apps/hayba-explorer/src/viewport/equirectMapModes.ts
@@ -19,7 +19,8 @@ export type EquirectModeKind =
   | "clim"
   | "wind"
   | "dist"
-  | "pressure";
+  | "pressure"
+  | "climate";
 
 export interface EquirectMapMode {
   label: string;
@@ -32,16 +33,20 @@ export const EQUIRECT_MAP_MODES: EquirectMapMode[] = [
   { label: "Relief", kind: "relief", channel: 0, ramp: 0 },
   { label: "Normal", kind: "normal", channel: 0, ramp: 0 },
   { label: "Temperature", kind: "clim", channel: 0, ramp: 1 },
-  { label: "Precipitation", kind: "clim", channel: 1, ramp: 2 },
+  // COOKBOOK-CLIMATE T4: Precipitation now reads CLASS.g (cookbook
+  // precip per Köppen-Geiger class), NOT CLIM.g (zonal). Monsoon
+  // coasts get wet, deserts get dry, etc. — the cookbook table.
+  { label: "Precipitation", kind: "climate", channel: 1, ramp: 2 },
   { label: "Wind", kind: "wind", channel: 2, ramp: 3 },
   { label: "Glaciation", kind: "clim", channel: 3, ramp: 4 },
-  // COOKBOOK-CLIMATE T3: new geographic-debug map modes for the
-  // cookbook-classification redesign. All three sample a non-CLIM RT.
-  // Ramps: 0=grey (distKm normalised), 5=Köppen-D (continentality),
-  // 6=meteorological diverging (pressure).
+  // COOKBOOK-CLIMATE T3/T4 geographic-debug modes.
+  // Ramps: 0=grey (distKm), 5=continentality (Conrad green→red),
+  // 6=meteorological diverging (pressure),
+  // 7=Köppen-Geiger discrete (climate class id).
   { label: "Distance", kind: "dist", channel: 0, ramp: 0 },
   { label: "Continentality", kind: "dist", channel: 1, ramp: 5 },
   { label: "Pressure", kind: "pressure", channel: 0, ramp: 6 },
+  { label: "Climate", kind: "climate", channel: 0, ramp: 7 },
 ];
 
 /** Resolved selection for `setDebugStack`. `mode` is the debugMaterial
@@ -70,11 +75,11 @@ export function resolveEquirectMode(
     // NX-3: animated wind-streak shader (uStackMode 4 draped / 5 flat).
     return { kind: "wind", channel: e.channel, ramp: e.ramp, mode: draped ? 4 : 5 };
   }
-  // COOKBOOK-CLIMATE T3: dist & pressure use the SAME uStackMode as clim
-  // (1 draped / 2 flat) because debugMaterial just samples uStackTex.r/.g
-  // and applies the same ramp. Only the source RT differs (App.tsx routes
-  // DIST/MSLP into uStackTex when these modes are selected).
-  if (e.kind === "dist" || e.kind === "pressure") {
+  // COOKBOOK-CLIMATE T3/T4: dist/pressure/climate all use the SAME
+  // uStackMode as clim (1 draped / 2 flat) because debugMaterial just
+  // samples uStackTex and applies the indexed ramp. Only the source RT
+  // differs (App.tsx routes DIST/MSLP/CLASS into uStackTex per kind).
+  if (e.kind === "dist" || e.kind === "pressure" || e.kind === "climate") {
     return { kind: e.kind, channel: e.channel, ramp: e.ramp, mode: draped ? 1 : 2 };
   }
   return {


### PR DESCRIPTION
Closes the cookbook-classification sprint. New CLIMATE_CLASS_FRAG reads (lat, T, P, continentality, hemisphere, distance-to-ocean) and emits two channels:

- **.r = class id 0..14** (simplified Köppen-Geiger; we lack monthly T/P so this is a coarse 15-class approximation, not full 30-class KG): Ocean, Af, Am, Aw, BWh, BWk, BSh, BSk, Csa, Cfa, Cfb, Dfa/b, Dfc, ET, EF.
- **.g = cookbook precip** per class: Af=0.95, Am=0.88 (tropical monsoon wet), BWh=0.08, BWk=0.10, Cfb=0.78, etc. Overrides the zonal-only CLIM.g for the Precipitation map mode.

Monsoon override: tropical-coastal cells (lat 5-25°, continentality<0.30, T>18°C) are reclassified to Am — captures the cookbook 'east+south coast of large landmass' rule without needing seasonal precip data we don't have. India, SE Asia, Indonesia, NE Brazil, Caribbean → Am wet.

New 'Climate' map mode shows the discrete Köppen palette (ramp id=7) matching the Beck et al. 2023 KG colour key: blue tropics, red deserts, green humid temperate, teal humid continental, grey polar.

Precipitation map mode REPOINTED from CLIM.g (zonal) to CLASS.g (cookbook). The bar's Precipitation chip now shows the cookbook-corrected precip: India/SE Asia wet, Sahara/Arabia dry, Western Europe wet, Mediterranean drier, polar dry.

7 files, ~150 lines. 12/12 equirectMapModes + 19/19 climate-wind green. tsc 0.