### PR TITLE
fix(climate): KG arid-before-tropical + Af stricter + Aw yellow (T4-TUNE-2)

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
+++ b/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
@@ -232,9 +232,12 @@ const FRAG: string = [
   "  if (id < 7.5){",
   "    float c = floor(clamp(x, 0.0, 14.0) + 0.5);",
   "    if (c < 0.5) return vec3(0.05, 0.10, 0.20);",  // 0 Ocean (dark — usually not drawn)
+  // Beck et al. 2023 Köppen palette: Af deep blue, Am medium blue,
+  // Aw is YELLOW-cream (savanna), not light blue. Light blue for Aw
+  // made the three A-classes visually indistinguishable.
   "    if (c < 1.5) return vec3(0.00, 0.00, 0.85);",  // 1 Af deep blue
-  "    if (c < 2.5) return vec3(0.00, 0.50, 0.95);",  // 2 Am medium blue
-  "    if (c < 3.5) return vec3(0.45, 0.75, 1.00);",  // 3 Aw light blue
+  "    if (c < 2.5) return vec3(0.00, 0.55, 0.95);",  // 2 Am medium blue
+  "    if (c < 3.5) return vec3(0.98, 0.85, 0.40);",  // 3 Aw yellow-cream
   "    if (c < 4.5) return vec3(0.95, 0.10, 0.10);",  // 4 BWh red
   "    if (c < 5.5) return vec3(0.95, 0.55, 0.55);",  // 5 BWk pink
   "    if (c < 6.5) return vec3(0.96, 0.60, 0.15);",  // 6 BSh orange

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -1182,18 +1182,22 @@ export const CLIMATE_CLASS_FRAG = [
   // Subarctic / boreal (cold + high cont)
   "  else if (T < 8.0 && absLat >= 50.0)  { id = 12.0; }",
   "  else if (T < 14.0 && absLat >= 40.0 && cont > 0.45) { id = 11.0; }",
-  // Tropical band — narrowed to lat < 15 (real Köppen-A requires T_cold
-  // month > 18°C; with our annual mean only, lat<15 is the conservative
-  // proxy that keeps Sahel / outback / N Australia OUT of the A-zone
-  // where they belong in BSh/BWh).
+  // T4-TUNE-2: B (arid) tier MOVED BEFORE A (tropical) — matches the
+  // canonical Köppen-Geiger algorithm where the aridity test trumps
+  // the temperature test. Eliminates the "all tropical lat = Af/Aw"
+  // overflow by funneling dry-zone cells (P < 0.20) into BWh/BWk first.
+  // Steppe (semi-arid) belt also moved before tropical.
+  "  else if (P < 0.20) { id = (T > 18.0) ? 4.0 : 5.0; }",
+  "  else if (P < 0.45 && cont > 0.30) { id = (T > 18.0) ? 6.0 : 7.0; }",
+  // Tropical band — narrowed to lat<15 AND we already filtered B-zone
+  // cells out above, so only TRUE-wet tropics reach here. Af requires
+  // P>0.85 (rainforest core only — Amazon/Congo basin/Indonesia/Bay
+  // of Bengal); Am 0.60..0.85; Aw 0.45..0.60 (above Sahel-steppe cut).
   "  else if (absLat < 15.0 && T > 18.0) {",
-  "    if (P > 0.75) id = 1.0;",   // Af tropical rainforest
-  "    else if (P > 0.55) id = 2.0;",  // Am tropical monsoon
+  "    if (P > 0.85) id = 1.0;",      // Af tropical rainforest
+  "    else if (P > 0.60) id = 2.0;", // Am tropical monsoon
   "    else id = 3.0;",                // Aw savanna
   "  }",
-  // Arid (low precip)
-  "  else if (P < 0.25) { id = (T > 18.0) ? 4.0 : 5.0; }",
-  "  else if (P < 0.50 && cont > 0.35) { id = (T > 18.0) ? 6.0 : 7.0; }",
   // Temperate
   "  else if (absLat >= 30.0 && absLat < 45.0 && cont > 0.25 && cont < 0.55) { id = 8.0; }",
   "  else if (absLat < 35.0) { id = 9.0; }",


### PR DESCRIPTION
User: 'Aw and Am are blown out of proportion AND Af'. Three structural fixes:

1. **Reorder: arid (B) before tropical (A)** — matches the canonical KG algorithm where aridity check overrides temperature check. Cells with P<0.20 go to BWh/BWk regardless of lat. Cells with P<0.45 + cont>0.30 go to BSh/BSk. Eliminates the 'every warm cell = A-zone' overflow.

2. **Tighten Af threshold to P>0.85** (was 0.75) — Af is restricted to true rainforest cores (Amazon/Congo basin/Indonesia/Bay of Bengal). Am is now P 0.60..0.85.

3. **Recolor Aw to yellow-cream** (Beck KG standard) — was light blue, visually indistinguishable from Am/Af. Now you can actually tell the three A-classes apart in the Climate map.

2 files. tsc 0.