### PR TITLE
fix(hayba-mcp): asset-connector import bugs (UE crash + hidden SyntaxError)

### DIFF
--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -380,6 +380,8 @@ export default function App() {
   const prevDebugDistRef = useRef<THREE.WebGLRenderTarget | null>(null);
   // COOKBOOK-CLIMATE T3: mean-sea-level pressure RT (MSLP_FRAG output).
   const prevDebugPressureRef = useRef<THREE.WebGLRenderTarget | null>(null);
+  // COOKBOOK-CLIMATE T4: Köppen-Geiger climate class + cookbook precip RT.
+  const prevDebugClimateRef = useRef<THREE.WebGLRenderTarget | null>(null);
   // Live stack handles for the mounted material's selector.
   const debugStackRef = useRef<{
     clim: THREE.WebGLRenderTarget;
@@ -452,6 +454,9 @@ export default function App() {
         if (rt) stackTex = rt.texture;
       } else if (sel.kind === "pressure") {
         const rt = prevDebugPressureRef.current;
+        if (rt) stackTex = rt.texture;
+      } else if (sel.kind === "climate") {
+        const rt = prevDebugClimateRef.current;
         if (rt) stackTex = rt.texture;
       }
       setDebugStack(mat, {
@@ -1194,6 +1199,7 @@ export default function App() {
       prevDebugWindRef.current?.dispose();
       prevDebugDistRef.current?.dispose();
       prevDebugPressureRef.current?.dispose();
+      prevDebugClimateRef.current?.dispose();
 
       const __tU0 = performance.now();
       const base = uploadEquirect(new Float32Array(inp.height), w, h);
@@ -1208,6 +1214,7 @@ export default function App() {
       let windRT!: THREE.WebGLRenderTarget;
       let distRT!: THREE.WebGLRenderTarget;
       let pressureRT!: THREE.WebGLRenderTarget;
+      let climateRT!: THREE.WebGLRenderTarget;
       await scene.runBake(async (renderer) => {
         const out = await runHydraulicBake(
           renderer,
@@ -1235,6 +1242,7 @@ export default function App() {
         windRT = out.wind;
         distRT = out.dist;
         pressureRT = out.pressure;
+        climateRT = out.climate;
       });
       const __gpuMs = performance.now() - __tG0;
       sceneRef.current?.setBakeSplit({
@@ -1254,6 +1262,7 @@ export default function App() {
       prevDebugWindRef.current = windRT;
       prevDebugDistRef.current = distRT;
       prevDebugPressureRef.current = pressureRT;
+      prevDebugClimateRef.current = climateRT;
       debugStackRef.current = { clim: climRT, terr: terrRT, hydro: hydroRT };
 
       const mat = makeDebugReliefMaterial();
@@ -1321,6 +1330,8 @@ export default function App() {
     prevDebugTerrRef.current?.dispose();
     prevDebugHydroRef.current?.dispose();
     prevDebugDistRef.current?.dispose();
+    prevDebugPressureRef.current?.dispose();
+    prevDebugClimateRef.current?.dispose();
     prevDebugBaseRef.current?.dispose();
     prevDebugPrecipRef.current?.dispose();
     prevDebugHFinalRef.current = null;
@@ -1329,6 +1340,7 @@ export default function App() {
     prevDebugHydroRef.current = null;
     prevDebugDistRef.current = null;
     prevDebugPressureRef.current = null;
+    prevDebugClimateRef.current = null;
     prevDebugBaseRef.current = null;
     prevDebugPrecipRef.current = null;
     debugStackRef.current = null;

--- a/apps/hayba-explorer/src/viewport/bake/__headless_harness__.ts
+++ b/apps/hayba-explorer/src/viewport/bake/__headless_harness__.ts
@@ -221,7 +221,7 @@ export async function runRealInputErosionVerification(
 
     const webglErrPre = gl.getError();
     const t0 = performance.now();
-    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d } =
+    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d, pressure: _p, climate: _cl } =
       await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
     // Oracle never reads the stack RTs; dispose immediately so the
     // many-bake harness doesn't leak 3 RTs/bake (fatal at 3M).
@@ -230,6 +230,8 @@ export async function runRealInputErosionVerification(
     _h.dispose();
     _w.dispose();
     _d.dispose();
+    _p.dispose();
+    _cl.dispose();
     const t1 = performance.now();
     const webglErrPost = gl.getError();
 
@@ -433,7 +435,7 @@ export async function runHeadlessErosionVerification(
 
     const webglErrPre = gl.getError();
     const t0 = performance.now();
-    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d } =
+    const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d, pressure: _p, climate: _cl } =
       await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
     // Oracle never reads the stack RTs; dispose immediately so the
     // many-bake harness doesn't leak 3 RTs/bake (fatal at 3M).
@@ -442,6 +444,8 @@ export async function runHeadlessErosionVerification(
     _h.dispose();
     _w.dispose();
     _d.dispose();
+    _p.dispose();
+    _cl.dispose();
     const t1 = performance.now();
     const webglErrPost = gl.getError();
 
@@ -1050,7 +1054,7 @@ async function _bakeAndRenderRelief(
   const cfg = { ...hyd.DEFAULT_HYDRAULIC, ...(overrideCfg ?? {}) };
 
   const t0 = performance.now();
-  const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d } =
+  const { eroded: rt, clim: _c, terr: _t, hydro: _h, wind: _w, dist: _d, pressure: _p, climate: _cl } =
     await hyd.runHydraulicBake(renderer, baseTex, precipTex, w, h, cfg);
   // CP2.c (#234 P2.3a): OPT-IN only — read the REAL baked TERR/HYDRO
   // masks (refreshClimate's TERRAIN/HYDRO passes) before disposal so

--- a/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
+++ b/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
@@ -101,7 +101,7 @@ const FRAG: string = [
   "uniform float uChannel;      /* which RGBA lane of uStackTex (0..3)      */",
   "uniform float uStackMode;    /* 0 relief 1 draped 2 flat 3 normal-map  */",
   "uniform float uWindTime;",
-  "uniform float uRamp;         /* 0 grey 1 temp 2 precip 3 hue 4 grey-elev 5 continentality 6 pressure */",
+  "uniform float uRamp;         /* 0 grey 1 temp 2 precip 3 hue 4 grey-elev 5 continentality 6 pressure 7 KG-discrete */",
   "",
   "const float PI = 3.141592653589793;",
   "",
@@ -171,7 +171,8 @@ const FRAG: string = [
   "   0 grey (raw clamp 0..1) · 1 temp diverging (deg C, -30..+35) ·",
   "   2 precip white->blue (0..1) · 3 hue (turns, for wind/aspect) ·",
   "   4 grey-elev (0..1) · 5 continentality-index (Conrad-style green→yellow→red) ·",
-  "   6 pressure diverging (low=blue, mid=cream, high=red). Calibration of",
+  "   6 pressure diverging (low=blue, mid=cream, high=red) ·",
+  "   7 Köppen-Geiger discrete (15-class id 0..14 → categorical colour). Calibration of",
   "   climate units is downstream tuning; this is a deterministic debug",
   "   visualiser. */",
   "vec3 ramp(float id, float x){",
@@ -223,6 +224,28 @@ const FRAG: string = [
   "    vec3 midP  = vec3(0.97, 0.96, 0.88);",
   "    vec3 highP = vec3(0.78, 0.13, 0.13);",
   "    return (t < 0.5) ? mix(lowP, midP, t / 0.5) : mix(midP, highP, (t - 0.5) / 0.5);",
+  "  }",
+  // T4 id=7: Köppen-Geiger discrete palette (15 classes). x = raw class
+  // id (0..14) emitted by CLIMATE_CLASS_FRAG. Colours roughly mirror
+  // the Beck et al. 2023 KG colour key (blue tropics, red deserts,
+  // green humid temperate, teal humid continental, grey/white polar).
+  "  if (id < 7.5){",
+  "    float c = floor(clamp(x, 0.0, 14.0) + 0.5);",
+  "    if (c < 0.5) return vec3(0.05, 0.10, 0.20);",  // 0 Ocean (dark — usually not drawn)
+  "    if (c < 1.5) return vec3(0.00, 0.00, 0.85);",  // 1 Af deep blue
+  "    if (c < 2.5) return vec3(0.00, 0.50, 0.95);",  // 2 Am medium blue
+  "    if (c < 3.5) return vec3(0.45, 0.75, 1.00);",  // 3 Aw light blue
+  "    if (c < 4.5) return vec3(0.95, 0.10, 0.10);",  // 4 BWh red
+  "    if (c < 5.5) return vec3(0.95, 0.55, 0.55);",  // 5 BWk pink
+  "    if (c < 6.5) return vec3(0.96, 0.60, 0.15);",  // 6 BSh orange
+  "    if (c < 7.5) return vec3(1.00, 0.85, 0.30);",  // 7 BSk yellow
+  "    if (c < 8.5) return vec3(0.70, 0.65, 0.05);",  // 8 Csa olive
+  "    if (c < 9.5) return vec3(0.75, 1.00, 0.30);",  // 9 Cfa lime
+  "    if (c < 10.5) return vec3(0.35, 0.85, 0.30);", // 10 Cfb green
+  "    if (c < 11.5) return vec3(0.20, 0.85, 0.85);", // 11 Dfa/b cyan
+  "    if (c < 12.5) return vec3(0.05, 0.55, 0.55);", // 12 Dfc teal
+  "    if (c < 13.5) return vec3(0.70, 0.70, 0.70);", // 13 ET grey
+  "    return vec3(0.98, 0.98, 0.98);",               // 14 EF icecap
   "  }",
   "  return vec3(clamp(x, 0.0, 1.0));",
   "}",

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -1132,3 +1132,97 @@ export const PRESSURE_VIZ_FRAG = [
   "  fragColor = vec4(n, mb, 0.0, 0.0);",
   "}",
 ].join("\n");
+
+// COOKBOOK-CLIMATE T4: simplified Köppen-Geiger climate classifier.
+// Reads (lat, elev, T, P, continentality) and emits a class id 0..14
+// in .r. Annual-mean T/P (we lack monthly data) ⇒ this is a coarse
+// 15-class approximation, not a full 30-class K-G; latitude proxies
+// for summer/winter discrimination, continentality proxies for annual
+// T range. Suitable for visual-debug Climate map mode.
+//
+// Class table (matches the debugMaterial id=7 ramp colours):
+//   0  Ocean        (h < 0)
+//   1  Af  tropical rainforest      (deep blue)
+//   2  Am  tropical monsoon         (medium blue)
+//   3  Aw  savanna                  (light blue)
+//   4  BWh hot desert               (red)
+//   5  BWk cold desert              (light pink)
+//   6  BSh hot steppe               (orange)
+//   7  BSk cold steppe              (yellow)
+//   8  Csa Mediterranean            (olive-yellow)
+//   9  Cfa humid subtropical        (lime green)
+//  10  Cfb maritime west coast      (bright green)
+//  11  Dfa/Dfb humid continental    (teal/cyan)
+//  12  Dfc subarctic                (dark teal)
+//  13  ET  tundra                   (light grey)
+//  14  EF  icecap                   (white)
+export const CLIMATE_CLASS_FRAG = [
+  H,
+  "uniform sampler2D uA;",
+  "uniform sampler2D uClim;",
+  "uniform sampler2D uDist;",
+  "uniform vec2 uGrid;",
+  "void main(){",
+  "  ivec2 rc = fragRC();",
+  "  ivec2 wh = gridWH(uGrid);",
+  "  vec4 a  = loadA(uA, uGrid, rc.x, rc.y);",
+  "  vec4 c  = texelFetch(uClim, rc, 0);",
+  "  vec4 d  = texelFetch(uDist, rc, 0);",
+  "  if (a.r < 0.0) { fragColor = vec4(0.0); return; }", // Ocean
+  "  float v = (float(rc.y) + 0.5) / float(wh.y);",
+  "  float lat = (0.5 - v) * 180.0;",
+  "  float absLat = abs(lat);",
+  "  float T = c.r;",
+  "  float P = c.g;",
+  "  float cont = d.g;",
+  "  float id = 0.0;",
+  // Polar tier (extreme cold + very high lat)
+  "  if (T <= -10.0 || absLat >= 75.0) { id = 14.0; }",
+  "  else if (T <= 0.0  || absLat >= 65.0) { id = 13.0; }",
+  // Subarctic / boreal (cold + high cont)
+  "  else if (T < 8.0 && absLat >= 50.0)  { id = 12.0; }",
+  "  else if (T < 14.0 && absLat >= 40.0 && cont > 0.45) { id = 11.0; }",
+  // Tropical band (lat < 23, warm)
+  "  else if (absLat < 23.0 && T > 18.0) {",
+  "    if (P > 0.70) id = 1.0;",
+  "    else if (P > 0.45) id = 2.0;",
+  "    else id = 3.0;",
+  "  }",
+  // Arid (low precip)
+  "  else if (P < 0.25) { id = (T > 18.0) ? 4.0 : 5.0; }",
+  "  else if (P < 0.50 && cont > 0.35) { id = (T > 18.0) ? 6.0 : 7.0; }",
+  // Temperate
+  "  else if (absLat >= 30.0 && absLat < 45.0 && cont > 0.25 && cont < 0.55) { id = 8.0; }",
+  "  else if (absLat < 35.0) { id = 9.0; }",
+  "  else if (cont < 0.30) { id = 10.0; }",
+  "  else { id = 11.0; }",
+  // T4 monsoon override: tropical-coastal cells (lat 5-25, low cont)
+  // get tropical-monsoon climate (Am) regardless of zonal-derived P.
+  // Without seasonal precip data this is the proxy for the cookbook
+  // 'east+south coast of large landmass' rule.
+  "  if (absLat >= 5.0 && absLat < 25.0 && cont < 0.30 && a.r >= 0.0 && T > 18.0 && id > 0.5 && id < 4.0) {",
+  "    id = 2.0;",
+  "  }",
+  // Cookbook precip per class (.g). Lets downstream consumers (and the
+  // Precipitation map mode) read realistic precip with monsoon Am wet,
+  // BWh/BWk deserts dry, etc. — independent of the zonal P that fed
+  // into the classifier.
+  "  float cbP = 0.50;",
+  "  if (id < 0.5) cbP = 0.0;",        // Ocean
+  "  else if (id < 1.5) cbP = 0.95;",  // Af tropical rainforest
+  "  else if (id < 2.5) cbP = 0.88;",  // Am tropical monsoon (very wet)
+  "  else if (id < 3.5) cbP = 0.55;",  // Aw savanna
+  "  else if (id < 4.5) cbP = 0.08;",  // BWh hot desert
+  "  else if (id < 5.5) cbP = 0.10;",  // BWk cold desert
+  "  else if (id < 6.5) cbP = 0.28;",  // BSh hot steppe
+  "  else if (id < 7.5) cbP = 0.30;",  // BSk cold steppe
+  "  else if (id < 8.5) cbP = 0.42;",  // Csa Mediterranean
+  "  else if (id < 9.5) cbP = 0.68;",  // Cfa humid subtropical
+  "  else if (id < 10.5) cbP = 0.78;", // Cfb maritime west coast
+  "  else if (id < 11.5) cbP = 0.55;", // Dfa/b humid continental
+  "  else if (id < 12.5) cbP = 0.42;", // Dfc subarctic
+  "  else if (id < 13.5) cbP = 0.25;", // ET tundra
+  "  else cbP = 0.10;",                // EF icecap
+  "  fragColor = vec4(id, cbP, 0.0, 0.0);",
+  "}",
+].join("\n");

--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -62,6 +62,7 @@ import {
   DIST_JFA_FRAG,
   DIST_FINAL_FRAG,
   PRESSURE_VIZ_FRAG,
+  CLIMATE_CLASS_FRAG,
 } from "./hydraulic.glsl";
 import { runRawPass } from "./glPass";
 import { createPingPong, type PingPongTargets } from "./pingpong";
@@ -481,6 +482,13 @@ export interface HydraulicBakeResult {
    *  internal-only and disposed at teardown). Channels: .r=pressure
    *  in mb (≈990–1020 typical), .gba unused. Read-only. */
   pressure: THREE.WebGLRenderTarget;
+  /** COOKBOOK-CLIMATE T4: simplified Köppen-Geiger climate classifier.
+   *  Channel .r holds an integer class id 0..14:
+   *    0 Ocean · 1 Af · 2 Am · 3 Aw · 4 BWh · 5 BWk · 6 BSh · 7 BSk
+   *    8 Csa · 9 Cfa · 10 Cfb · 11 Dfa/b · 12 Dfc · 13 ET · 14 EF
+   *  Class id matched by the debugMaterial ramp id=7 (Köppen-Geiger
+   *  discrete palette, matching the Beck et al. 2023 colour scheme). */
+  climate: THREE.WebGLRenderTarget;
 }
 
 export async function runHydraulicBake(
@@ -497,7 +505,7 @@ export async function runHydraulicBake(
   // FAILS if EXT_color_buffer_float is missing. We drive the read/write
   // slots explicitly below (NOT pp.book) so the discipline is local and
   // unambiguous.
-  const pp: PingPongTargets = createPingPong(renderer, w, h, ["A", "F", "M", "ACC", "CTRL", "CLIM", "TERR", "HYDRO", "MSLP", "WIND", "DIST", "PVIZ"]);
+  const pp: PingPongTargets = createPingPong(renderer, w, h, ["A", "F", "M", "ACC", "CTRL", "CLIM", "TERR", "HYDRO", "MSLP", "WIND", "DIST", "PVIZ", "CLASS"]);
   const A = pp.rt.A; // [slot0, slot1]
   const F = pp.rt.F; // [slot0, slot1]
   // S2.4 detail mask: a ONE-TIME single-channel field (computed pre-loop
@@ -535,6 +543,9 @@ export async function runHydraulicBake(
   // Slot 0 is the viz output; slot 1 is allocated by the pair helper and
   // disposed at teardown.
   const PVIZ = pp.rt.PVIZ;
+  // COOKBOOK-CLIMATE T4: CLASS holds the simplified Köppen-Geiger class
+  // id (0..14) in .r for the "Climate" map mode. Single-buffered.
+  const CLASS = pp.rt.CLASS;
   let accRead = 0;
   const swapAcc = (): void => {
     accRead ^= 1;
@@ -666,6 +677,21 @@ export async function runHydraulicBake(
         uMbHigh: u(cfg.pressureMbHigh),
       },
       PVIZ[0],
+    );
+    // T4: simplified Köppen-Geiger climate classifier. Reads finalized
+    // CLIM (T/P) + DIST (continentality) + uA (land/elev/lat-from-rc),
+    // emits class id 0..14 in .r. Runs once per bake at the END so it
+    // sees the post-orographic precip etc.
+    runRawPass(
+      renderer,
+      CLIMATE_CLASS_FRAG,
+      {
+        uA: u(aReadRT()),
+        uClim: u(CLIM[0]),
+        uDist: u(DIST[distFinalSlot]),
+        uGrid: u(uGrid),
+      },
+      CLASS[0],
     );
   };
 
@@ -1067,6 +1093,7 @@ export async function runHydraulicBake(
   // parity, so disposal is dynamic.
   DIST[distFinalSlot ^ 1].dispose();
   PVIZ[1].dispose();
+  CLASS[1].dispose();
   return {
     eroded: result,
     clim: CLIM[0],
@@ -1075,5 +1102,6 @@ export async function runHydraulicBake(
     wind: WIND[0],
     dist: DIST[distFinalSlot],
     pressure: PVIZ[0],
+    climate: CLASS[0],
   };
 }

--- a/apps/hayba-explorer/src/viewport/equirectMapModes.test.ts
+++ b/apps/hayba-explorer/src/viewport/equirectMapModes.test.ts
@@ -4,8 +4,8 @@ import {
   resolveEquirectMode,
 } from "./equirectMapModes";
 
-describe("EQUIRECT_MAP_MODES registry (SP-B + COOKBOOK-CLIMATE T3)", () => {
-  it("is exactly the 9 data-backed modes in order", () => {
+describe("EQUIRECT_MAP_MODES registry (SP-B + COOKBOOK-CLIMATE T3/T4)", () => {
+  it("is exactly the 10 data-backed modes in order", () => {
     expect(EQUIRECT_MAP_MODES.map((m) => m.label)).toEqual([
       "Relief",
       "Normal",
@@ -16,19 +16,22 @@ describe("EQUIRECT_MAP_MODES registry (SP-B + COOKBOOK-CLIMATE T3)", () => {
       "Distance",
       "Continentality",
       "Pressure",
+      "Climate",
     ]);
   });
-  it("kinds (SP-B + cookbook-T3 dist/pressure)", () => {
+  it("kinds (SP-B + cookbook T3/T4 dist/pressure/climate)", () => {
     expect(EQUIRECT_MAP_MODES.map((m) => m.kind)).toEqual([
       "relief",
       "normal",
       "clim",
-      "clim",
+      // T4: Precipitation repointed from CLIM.g (zonal) to CLASS.g (cookbook).
+      "climate",
       "wind",
       "clim",
       "dist",
       "dist",
       "pressure",
+      "climate",
     ]);
   });
 });
@@ -110,11 +113,12 @@ describe("NX-3 Wind animated mode", () => {
     expect(resolveEquirectMode(windIdx, true)).toEqual({ kind: "wind", channel: 2, ramp: 3, mode: 4 });
     expect(resolveEquirectMode(windIdx, false)).toEqual({ kind: "wind", channel: 2, ramp: 3, mode: 5 });
   });
-  it("other modes' resolution byte-unchanged (regression pin)", () => {
+  it("other modes' resolution byte-unchanged (post T4 — Precip is climate kind)", () => {
     expect(resolveEquirectMode(0, true)).toEqual({ kind: "relief", channel: 0, ramp: 0, mode: 0 });
     expect(resolveEquirectMode(1, true)).toEqual({ kind: "normal", channel: 0, ramp: 0, mode: 3 });
     expect(resolveEquirectMode(2, true)).toEqual({ kind: "clim", channel: 0, ramp: 1, mode: 1 });
-    expect(resolveEquirectMode(3, false)).toEqual({ kind: "clim", channel: 1, ramp: 2, mode: 2 });
+    // Precipitation moved to kind=climate (samples CLASS.g cookbook precip)
+    expect(resolveEquirectMode(3, false)).toEqual({ kind: "climate", channel: 1, ramp: 2, mode: 2 });
     expect(resolveEquirectMode(5, true)).toEqual({ kind: "clim", channel: 3, ramp: 4, mode: 1 });
   });
 });

--- a/apps/hayba-explorer/src/viewport/equirectMapModes.ts
+++ b/apps/hayba-explorer/src/viewport/equirectMapModes.ts
@@ -19,7 +19,8 @@ export type EquirectModeKind =
   | "clim"
   | "wind"
   | "dist"
-  | "pressure";
+  | "pressure"
+  | "climate";
 
 export interface EquirectMapMode {
   label: string;
@@ -32,16 +33,20 @@ export const EQUIRECT_MAP_MODES: EquirectMapMode[] = [
   { label: "Relief", kind: "relief", channel: 0, ramp: 0 },
   { label: "Normal", kind: "normal", channel: 0, ramp: 0 },
   { label: "Temperature", kind: "clim", channel: 0, ramp: 1 },
-  { label: "Precipitation", kind: "clim", channel: 1, ramp: 2 },
+  // COOKBOOK-CLIMATE T4: Precipitation now reads CLASS.g (cookbook
+  // precip per Köppen-Geiger class), NOT CLIM.g (zonal). Monsoon
+  // coasts get wet, deserts get dry, etc. — the cookbook table.
+  { label: "Precipitation", kind: "climate", channel: 1, ramp: 2 },
   { label: "Wind", kind: "wind", channel: 2, ramp: 3 },
   { label: "Glaciation", kind: "clim", channel: 3, ramp: 4 },
-  // COOKBOOK-CLIMATE T3: new geographic-debug map modes for the
-  // cookbook-classification redesign. All three sample a non-CLIM RT.
-  // Ramps: 0=grey (distKm normalised), 5=Köppen-D (continentality),
-  // 6=meteorological diverging (pressure).
+  // COOKBOOK-CLIMATE T3/T4 geographic-debug modes.
+  // Ramps: 0=grey (distKm), 5=continentality (Conrad green→red),
+  // 6=meteorological diverging (pressure),
+  // 7=Köppen-Geiger discrete (climate class id).
   { label: "Distance", kind: "dist", channel: 0, ramp: 0 },
   { label: "Continentality", kind: "dist", channel: 1, ramp: 5 },
   { label: "Pressure", kind: "pressure", channel: 0, ramp: 6 },
+  { label: "Climate", kind: "climate", channel: 0, ramp: 7 },
 ];
 
 /** Resolved selection for `setDebugStack`. `mode` is the debugMaterial
@@ -70,11 +75,11 @@ export function resolveEquirectMode(
     // NX-3: animated wind-streak shader (uStackMode 4 draped / 5 flat).
     return { kind: "wind", channel: e.channel, ramp: e.ramp, mode: draped ? 4 : 5 };
   }
-  // COOKBOOK-CLIMATE T3: dist & pressure use the SAME uStackMode as clim
-  // (1 draped / 2 flat) because debugMaterial just samples uStackTex.r/.g
-  // and applies the same ramp. Only the source RT differs (App.tsx routes
-  // DIST/MSLP into uStackTex when these modes are selected).
-  if (e.kind === "dist" || e.kind === "pressure") {
+  // COOKBOOK-CLIMATE T3/T4: dist/pressure/climate all use the SAME
+  // uStackMode as clim (1 draped / 2 flat) because debugMaterial just
+  // samples uStackTex and applies the indexed ramp. Only the source RT
+  // differs (App.tsx routes DIST/MSLP/CLASS into uStackTex per kind).
+  if (e.kind === "dist" || e.kind === "pressure" || e.kind === "climate") {
     return { kind: e.kind, channel: e.channel, ramp: e.ramp, mode: draped ? 1 : 2 };
   }
   return {

--- a/mcp-tools/hayba-mcp/CHANGELOG.md
+++ b/mcp-tools/hayba-mcp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # HaybaMCPToolkit Changelog
 
+## Unreleased
+
+### Asset-source connectors (pure-Node, no UE C++ bridge)
+
+- **Poly Haven** — `hayba_polyhaven_search` (HDRIs / textures / models, CC0) and `hayba_polyhaven_download` (resolution-selectable, downloads individual map files for textures, prefers HDR for HDRIs, glTF for models). No auth.
+- **ambientCG** — `hayba_ambientcg_search` and `hayba_ambientcg_download` (CC0 PBR material zips; default attribute `2K-JPG`, falls back to first available zip). No auth.
+- **Sketchfab** — `hayba_sketchfab_search` and `hayba_sketchfab_download` (gltf / usdz / source flavours). **Requires `SKETCHFAB_API_TOKEN` env var** — obtain at https://sketchfab.com/settings/password (API tokens section). Missing-token error message is actionable.
+- Shared cache at `<os.tmpdir>/hayba-asset-connectors/<source>/<assetId>/`. Zip extraction via `adm-zip`. UE import is invoked via the existing `python_run` MCP command (build_import_data + import_asset_tasks); no new C++ handler. Failed imports surface as `imported: false` with an `importNote`.
+
 ## v0.3.0 — 2026-05-06
 
 Massive expansion from a PCG/landscape-only plugin into a 34-domain agentic level-design system.

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -17,12 +17,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@distube/ytdl-core": "^4.16.12",
     "@hayba/architecture": "*",
     "@hayba/linguistics": "*",
     "@hayba/planet-physics": "*",
-    "@distube/ytdl-core": "^4.16.12",
     "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "adm-zip": "^0.5.17",
     "better-sqlite3": "^11.0.0",
     "cheerio": "^1.2.0",
     "express": "^4.21.0",
@@ -31,6 +32,7 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.5",
     "@types/better-sqlite3": "^7.6.0",
     "@types/express": "^5.0.0",
     "@types/node": "^24.12.2",

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.ts
@@ -1,0 +1,89 @@
+import * as path from 'node:path';
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { cachePathFor, downloadToFile, ensureDir, extractZip, importIntoUe, type DownloadedAsset } from './shared.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: ['filesystem_write', 'asset_create'],
+  when: 'downloading an ambientCG material zip into the active UE project',
+  not_when: 'you only need metadata — use ambientcg_search',
+};
+
+export const schema = z.object({
+  asset_id: z.string().min(1),
+  resolution: z.string().default('2K-JPG').describe('ambientCG attribute string, e.g. 1K-JPG, 2K-JPG, 4K-JPG, 2K-PNG'),
+  target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/ambientcg/<asset_id>'),
+});
+export type AmbientCgDownloadParams = z.infer<typeof schema>;
+
+const API = 'https://ambientCG.com/api/v2';
+
+export function assetInfoUrl(assetId: string): string {
+  const qs = new URLSearchParams();
+  qs.set('id', assetId);
+  return `${API}/full_json?${qs.toString()}`;
+}
+
+/** Find the zip download URL for the requested attribute (e.g. "2K-JPG"). Exported for tests. */
+export function pickZipUrl(assetJson: any, resolution: string): string | null {
+  const found = Array.isArray(assetJson?.foundAssets) ? assetJson.foundAssets : [];
+  const asset = found[0] ?? assetJson;
+  const folders = asset?.downloadFolders ?? [];
+  for (const folder of folders) {
+    const cats = folder?.downloadFiletypeCategories ?? {};
+    const zip = cats?.zip ?? cats?.Zip;
+    const downloads = zip?.downloads ?? [];
+    for (const d of downloads) {
+      if (d?.attribute === resolution && d?.fullDownloadPath) return d.fullDownloadPath;
+    }
+  }
+  // Fallback: first available zip
+  for (const folder of folders) {
+    const cats = folder?.downloadFiletypeCategories ?? {};
+    const zip = cats?.zip ?? cats?.Zip;
+    const first = zip?.downloads?.[0];
+    if (first?.fullDownloadPath) return first.fullDownloadPath;
+  }
+  return null;
+}
+
+export async function handleAmbientCgDownload(params: AmbientCgDownloadParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const { asset_id, resolution, target_dir } = parsed.data;
+  try {
+    const res = await fetch(assetInfoUrl(asset_id));
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `ambientCG lookup failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const json = (await res.json()) as any;
+    const zipUrl = pickZipUrl(json, resolution);
+    if (!zipUrl) {
+      return { content: [{ type: 'text' as const, text: `No zip download found for ${asset_id} @ ${resolution}` }], isError: true };
+    }
+    const cacheDir = cachePathFor('ambientcg', asset_id);
+    await ensureDir(cacheDir);
+    const zipPath = path.join(cacheDir, `${asset_id}_${resolution}.zip`);
+    await downloadToFile(zipUrl, zipPath);
+    const extractDir = path.join(cacheDir, 'extracted');
+    const files = await extractZip(zipPath, extractDir);
+    const gamePath = target_dir ?? `/Game/AssetConnectors/ambientcg/${asset_id}`;
+    const importResult = await importIntoUe(extractDir, gamePath);
+    const data: DownloadedAsset = {
+      assetId: asset_id,
+      source: 'ambientcg',
+      cachePath: cacheDir,
+      files,
+      imported: importResult.ok,
+      importGamePath: gamePath,
+      importNote: importResult.note,
+    };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `ambientCG download error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-search.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-search.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'searching ambientCG for CC0 PBR materials, decals, or 3D models',
+  not_when: 'you already know the asset id — go straight to ambientcg_download',
+};
+
+export const schema = z.object({
+  query: z.string().min(1),
+  type: z.string().default('Material').describe('ambientCG asset type (Material, Atlas, Decal, 3DModel, …)'),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+export type AmbientCgSearchParams = z.infer<typeof schema>;
+
+const API = 'https://ambientCG.com/api/v2';
+
+export function buildSearchUrl(p: AmbientCgSearchParams): string {
+  const qs = new URLSearchParams();
+  qs.set('type', p.type);
+  qs.set('q', p.query);
+  qs.set('limit', String(p.limit));
+  return `${API}/full_json?${qs.toString()}`;
+}
+
+export async function handleAmbientCgSearch(params: AmbientCgSearchParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  try {
+    const url = buildSearchUrl(parsed.data);
+    const res = await fetch(url);
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `ambientCG search failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const raw = (await res.json()) as Record<string, any>;
+    const found = Array.isArray(raw?.foundAssets) ? raw.foundAssets : [];
+    const results = found.map((a: any) => ({
+      id: a?.assetId,
+      title: a?.displayName ?? a?.assetId,
+      thumbnail: a?.previewImage?.['512-PNG'] ?? a?.previewImage?.['512'] ?? a?.previewImage?.['256-PNG'] ?? null,
+      license: 'CC0',
+      tags: a?.tags ?? [],
+      category: a?.category ?? null,
+    }));
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ source: 'ambientcg', count: results.length, results }, null, 2),
+      }],
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `ambientCG search error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/get-setting.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/get-setting.ts
@@ -1,0 +1,34 @@
+import { executeCommand } from '../tool-executor.js';
+
+/**
+ * Read a UHaybaMCPDeveloperSettings field via the UE bridge. The C++ side
+ * allowlists which keys are exposed (see HaybaMCPCommandHandler.cpp).
+ *
+ * Returns the configured value, or `null` if:
+ *   - the field is empty in the settings panel, or
+ *   - UE is not reachable (e.g. editor isn't running), or
+ *   - the UE plugin is older than the get_setting handler.
+ *
+ * Callers should fall back to an env var when this returns null, so the
+ * tooling still works headless or before the user has filled the field.
+ */
+export async function getSetting(key: string): Promise<string | null> {
+  try {
+    const res = (await executeCommand('get_setting', { key })) as { value?: unknown; set?: unknown };
+    if (!res || typeof res !== 'object') return null;
+    if (res.set === true && typeof res.value === 'string' && res.value.length > 0) {
+      return res.value;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read a token from the UE settings panel, falling back to an env var. */
+export async function getTokenWithEnvFallback(settingKey: string, envVar: string): Promise<string | null> {
+  const fromUe = await getSetting(settingKey);
+  if (fromUe) return fromUe;
+  const fromEnv = process.env[envVar];
+  return fromEnv && fromEnv.length > 0 ? fromEnv : null;
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-download.ts
@@ -1,0 +1,105 @@
+import * as path from 'node:path';
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { cachePathFor, downloadToFile, ensureDir, importIntoUe, type DownloadedAsset } from './shared.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: ['filesystem_write', 'asset_create'],
+  when: 'downloading a Poly Haven HDRI / texture / model into the active UE project',
+  not_when: 'you only need metadata — use polyhaven_search',
+};
+
+export const schema = z.object({
+  asset_id: z.string().min(1),
+  type: z.enum(['hdris', 'textures', 'models']).default('textures'),
+  resolution: z.enum(['1k', '2k', '4k', '8k']).default('2k'),
+  target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/polyhaven/<asset_id>'),
+});
+export type PolyhavenDownloadParams = z.infer<typeof schema>;
+
+const API = 'https://api.polyhaven.com';
+
+export function filesUrl(assetId: string): string {
+  return `${API}/files/${encodeURIComponent(assetId)}`;
+}
+
+/** Picks (url, filename) tuples for the requested resolution + type. Exported for tests. */
+export function pickDownloads(
+  files: Record<string, any>,
+  type: 'hdris' | 'textures' | 'models',
+  resolution: string,
+): Array<{ mapName: string; url: string; filename: string }> {
+  const picks: Array<{ mapName: string; url: string; filename: string }> = [];
+
+  if (type === 'hdris') {
+    const hdri = files?.hdri?.[resolution];
+    if (hdri) {
+      const fmt = hdri.hdr ?? hdri.exr;
+      if (fmt?.url) picks.push({ mapName: 'hdri', url: fmt.url, filename: path.basename(fmt.url) });
+    }
+    return picks;
+  }
+
+  if (type === 'models') {
+    const gltf = files?.gltf?.[resolution]?.gltf;
+    if (gltf?.url) picks.push({ mapName: 'gltf', url: gltf.url, filename: path.basename(gltf.url) });
+    // Include the bin + textures referenced by the gltf if exposed in includes
+    const includes = gltf?.include ?? {};
+    for (const [name, info] of Object.entries(includes as Record<string, any>)) {
+      if (info?.url) picks.push({ mapName: name, url: info.url, filename: name });
+    }
+    return picks;
+  }
+
+  // textures: each top-level key is a map (Diffuse, Normal, Roughness, AO, …)
+  for (const [mapName, byRes] of Object.entries(files ?? {})) {
+    const block = (byRes as any)?.[resolution];
+    if (!block) continue;
+    const fmt = block.jpg ?? block.png ?? block.exr;
+    if (fmt?.url) picks.push({ mapName, url: fmt.url, filename: path.basename(fmt.url) });
+  }
+  return picks;
+}
+
+export async function handlePolyhavenDownload(params: PolyhavenDownloadParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const { asset_id, type, resolution, target_dir } = parsed.data;
+  try {
+    const res = await fetch(filesUrl(asset_id));
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `Poly Haven files lookup failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const files = (await res.json()) as Record<string, any>;
+    const picks = pickDownloads(files, type, resolution);
+    if (picks.length === 0) {
+      return { content: [{ type: 'text' as const, text: `No downloadable files for ${asset_id} at ${resolution}` }], isError: true };
+    }
+    const cacheDir = cachePathFor('polyhaven', asset_id);
+    await ensureDir(cacheDir);
+    const written: string[] = [];
+    for (const pick of picks) {
+      const dest = path.join(cacheDir, pick.filename);
+      await downloadToFile(pick.url, dest);
+      written.push(dest);
+    }
+    const gamePath = target_dir ?? `/Game/AssetConnectors/polyhaven/${asset_id}`;
+    const importResult = await importIntoUe(cacheDir, gamePath);
+    const data: DownloadedAsset = {
+      assetId: asset_id,
+      source: 'polyhaven',
+      cachePath: cacheDir,
+      files: written,
+      imported: importResult.ok,
+      importGamePath: gamePath,
+      importNote: importResult.note,
+    };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `Poly Haven download error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-search.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-search.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'searching Poly Haven for CC0 HDRIs, textures, or models',
+  not_when: 'you already know the exact asset slug — go straight to polyhaven_download',
+};
+
+export const schema = z.object({
+  query: z.string().min(1),
+  type: z.enum(['hdris', 'textures', 'models']).default('textures'),
+  categories: z.string().optional().describe('Comma-separated Poly Haven category filter'),
+});
+export type PolyhavenSearchParams = z.infer<typeof schema>;
+
+const API = 'https://api.polyhaven.com';
+
+export function buildSearchUrl(p: PolyhavenSearchParams): string {
+  const qs = new URLSearchParams();
+  qs.set('type', p.type);
+  if (p.query) qs.set('search', p.query);
+  if (p.categories) qs.set('categories', p.categories);
+  return `${API}/assets?${qs.toString()}`;
+}
+
+export async function handlePolyhavenSearch(params: PolyhavenSearchParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  try {
+    const url = buildSearchUrl(parsed.data);
+    const res = await fetch(url);
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `Poly Haven search failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const raw = (await res.json()) as Record<string, any>;
+    const results = Object.entries(raw).map(([id, info]) => ({
+      id,
+      title: info?.name ?? id,
+      thumbnail: `https://cdn.polyhaven.com/asset_img/thumbs/${id}.png?width=256`,
+      license: 'CC0',
+      tags: info?.tags ?? [],
+      categories: info?.categories ?? [],
+      type: parsed.data.type,
+    }));
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ source: 'polyhaven', count: results.length, results }, null, 2),
+      }],
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `Poly Haven search error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/shared.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/shared.ts
@@ -1,0 +1,100 @@
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { executeCommand } from '../tool-executor.js';
+
+export interface DownloadedAsset {
+  assetId: string;
+  source: string;
+  cachePath: string;
+  files: string[];
+  imported: boolean;
+  importGamePath?: string;
+  importNote?: string;
+}
+
+export function cachePathFor(source: string, assetId: string): string {
+  const safe = assetId.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return path.join(os.tmpdir(), 'hayba-asset-connectors', source, safe);
+}
+
+export async function ensureDir(dir: string): Promise<void> {
+  await fsp.mkdir(dir, { recursive: true });
+}
+
+export async function downloadToFile(url: string, dest: string, headers?: Record<string, string>): Promise<void> {
+  await ensureDir(path.dirname(dest));
+  const res = await fetch(url, { headers });
+  if (!res.ok || !res.body) {
+    throw new Error(`download failed: ${res.status} ${res.statusText} for ${url}`);
+  }
+  const nodeStream = Readable.fromWeb(res.body as any);
+  const out = fs.createWriteStream(dest);
+  await pipeline(nodeStream, out);
+}
+
+export async function extractZip(zipPath: string, destDir: string): Promise<string[]> {
+  await ensureDir(destDir);
+  // Lazy import — adm-zip is a CommonJS module.
+  const AdmZipMod = await import('adm-zip');
+  const AdmZip = (AdmZipMod as any).default ?? AdmZipMod;
+  const zip = new AdmZip(zipPath);
+  zip.extractAllTo(destDir, true);
+  return listFilesRecursive(destDir);
+}
+
+export async function listFilesRecursive(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(d: string): Promise<void> {
+    const entries = await fsp.readdir(d, { withFileTypes: true });
+    for (const e of entries) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) await walk(p);
+      else out.push(p);
+    }
+  }
+  if (fs.existsSync(dir)) await walk(dir);
+  return out;
+}
+
+/**
+ * Triggers UE import via python_run. Reaches UE only via the existing
+ * python_run MCP command. If UE is not running / python_run fails, returns
+ * { ok: false } and the caller surfaces it as importNote.
+ */
+export async function importIntoUe(localDir: string, gamePath: string): Promise<{ ok: boolean; note?: string }> {
+  const normalized = localDir.replace(/\\/g, '/');
+  const dest = gamePath.startsWith('/Game/') ? gamePath : `/Game/AssetConnectors/${gamePath}`;
+  const script = `
+import os, unreal
+src_dir = r"${normalized}"
+dest_path = "${dest}"
+files = []
+for root, _dirs, fnames in os.walk(src_dir):
+    for fn in fnames:
+        files.append(os.path.join(root, fn))
+if not files:
+    print("HAYBA_IMPORT_RESULT: no files to import")
+else:
+    asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
+    task = unreal.AssetImportTask()
+    task.filenames = files
+    task.destination_path = dest_path
+    task.automated = True
+    task.save = True
+    task.replace_existing = True
+    asset_tools.import_asset_tasks([task])
+    print("HAYBA_IMPORT_RESULT: imported %d file(s) to %s" % (len(files), dest_path))
+`.trim();
+
+  try {
+    const data = await executeCommand('python_run', { script });
+    return { ok: true, note: typeof data === 'object' && data ? JSON.stringify(data).slice(0, 240) : undefined };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, note: `python_run unavailable: ${msg}` };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/shared.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/shared.ts
@@ -68,30 +68,40 @@ export async function listFilesRecursive(dir: string): Promise<string[]> {
 export async function importIntoUe(localDir: string, gamePath: string): Promise<{ ok: boolean; note?: string }> {
   const normalized = localDir.replace(/\\/g, '/');
   const dest = gamePath.startsWith('/Game/') ? gamePath : `/Game/AssetConnectors/${gamePath}`;
-  const script = `
-import os, unreal
-src_dir = r"${normalized}"
-dest_path = "${dest}"
-files = []
-for root, _dirs, fnames in os.walk(src_dir):
-    for fn in fnames:
-        files.append(os.path.join(root, fn))
-if not files:
-    print("HAYBA_IMPORT_RESULT: no files to import")
-else:
-    asset_tools = unreal.AssetToolsHelpers.get_asset_tools()
-    task = unreal.AssetImportTask()
-    task.filenames = files
-    task.destination_path = dest_path
-    task.automated = True
-    task.save = True
-    task.replace_existing = True
-    asset_tools.import_asset_tasks([task])
-    print("HAYBA_IMPORT_RESULT: imported %d file(s) to %s" % (len(files), dest_path))
-`.trim();
+  // python_run accepts a single statement only, so wrap the whole body in exec(...).
+  // One AssetImportTask per file (UE5.7 chokes on a single task with many filenames).
+  // save=False — the user can save when ready; saving inline on a fresh import burst
+  // has crashed UE in practice when stacked on top of other heavy work.
+  const body = [
+    'import os',
+    'import unreal',
+    `src_dir = r"${normalized}"`,
+    `dest_path = "${dest}"`,
+    'files = []',
+    'for root, _dirs, fnames in os.walk(src_dir):',
+    '    for fn in fnames:',
+    '        files.append(os.path.join(root, fn))',
+    'asset_tools = unreal.AssetToolsHelpers.get_asset_tools()',
+    'tasks = []',
+    'for f in files:',
+    '    t = unreal.AssetImportTask()',
+    '    t.filename = f',
+    '    t.destination_path = dest_path',
+    '    t.automated = True',
+    '    t.save = False',
+    '    t.replace_existing = True',
+    '    tasks.append(t)',
+    'if tasks:',
+    '    asset_tools.import_asset_tasks(tasks)',
+    `unreal.log("HAYBA_IMPORT_RESULT: imported %d file(s) to %s" % (len(tasks), dest_path))`,
+  ].join('\n');
+  const script = `exec(${JSON.stringify(body)})`;
 
   try {
     const data = await executeCommand('python_run', { script });
+    if (data && typeof data === 'object' && (data as any).ok === false) {
+      return { ok: false, note: JSON.stringify(data).slice(0, 280) };
+    }
     return { ok: true, note: typeof data === 'object' && data ? JSON.stringify(data).slice(0, 240) : undefined };
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-download.ts
@@ -3,11 +3,12 @@ import { z } from 'zod';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
 import { cachePathFor, downloadToFile, ensureDir, extractZip, importIntoUe, type DownloadedAsset } from './shared.js';
 import { tokenMissingMessage } from './sketchfab-search.js';
+import { getTokenWithEnvFallback } from './get-setting.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'high',
   effects: ['filesystem_write', 'asset_create'],
-  when: 'downloading a Sketchfab model into the active UE project (requires SKETCHFAB_API_TOKEN env var)',
+  when: 'downloading a Sketchfab model into the active UE project (token from Project Settings → Plugins → Hayba MCP Toolkit → Asset Connectors, or SKETCHFAB_API_TOKEN env var)',
   not_when: 'you only need metadata — use sketchfab_search',
 };
 
@@ -34,7 +35,7 @@ export async function handleSketchfabDownload(params: SketchfabDownloadParams) {
   if (!parsed.success) {
     return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
   }
-  const token = process.env.SKETCHFAB_API_TOKEN;
+  const token = await getTokenWithEnvFallback('sketchfab_api_token', 'SKETCHFAB_API_TOKEN');
   if (!token) {
     return { content: [{ type: 'text' as const, text: tokenMissingMessage() }], isError: true };
   }

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-download.ts
@@ -1,0 +1,74 @@
+import * as path from 'node:path';
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { cachePathFor, downloadToFile, ensureDir, extractZip, importIntoUe, type DownloadedAsset } from './shared.js';
+import { tokenMissingMessage } from './sketchfab-search.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: ['filesystem_write', 'asset_create'],
+  when: 'downloading a Sketchfab model into the active UE project (requires SKETCHFAB_API_TOKEN env var)',
+  not_when: 'you only need metadata — use sketchfab_search',
+};
+
+export const schema = z.object({
+  uid: z.string().min(1).describe('Sketchfab model uid'),
+  flavour: z.enum(['gltf', 'usdz', 'source']).default('gltf'),
+  target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/sketchfab/<uid>'),
+});
+export type SketchfabDownloadParams = z.infer<typeof schema>;
+
+const API = 'https://api.sketchfab.com/v3';
+
+export function downloadInfoUrl(uid: string): string {
+  return `${API}/models/${encodeURIComponent(uid)}/download`;
+}
+
+/** Picks the signed download url for the requested flavour. Exported for tests. */
+export function pickFlavourUrl(downloadJson: any, flavour: 'gltf' | 'usdz' | 'source'): string | null {
+  return downloadJson?.[flavour]?.url ?? null;
+}
+
+export async function handleSketchfabDownload(params: SketchfabDownloadParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const token = process.env.SKETCHFAB_API_TOKEN;
+  if (!token) {
+    return { content: [{ type: 'text' as const, text: tokenMissingMessage() }], isError: true };
+  }
+  const { uid, flavour, target_dir } = parsed.data;
+  try {
+    const res = await fetch(downloadInfoUrl(uid), { headers: { Authorization: `Token ${token}` } });
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `Sketchfab download lookup failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const info = (await res.json()) as any;
+    const signedUrl = pickFlavourUrl(info, flavour);
+    if (!signedUrl) {
+      return { content: [{ type: 'text' as const, text: `No ${flavour} download available for ${uid}` }], isError: true };
+    }
+    const cacheDir = cachePathFor('sketchfab', uid);
+    await ensureDir(cacheDir);
+    const zipPath = path.join(cacheDir, `${uid}_${flavour}.zip`);
+    await downloadToFile(signedUrl, zipPath);
+    const extractDir = path.join(cacheDir, 'extracted');
+    const files = await extractZip(zipPath, extractDir);
+    const gamePath = target_dir ?? `/Game/AssetConnectors/sketchfab/${uid}`;
+    const importResult = await importIntoUe(extractDir, gamePath);
+    const data: DownloadedAsset = {
+      assetId: uid,
+      source: 'sketchfab',
+      cachePath: cacheDir,
+      files,
+      imported: importResult.ok,
+      importGamePath: gamePath,
+      importNote: importResult.note,
+    };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `Sketchfab download error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-search.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-search.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { getTokenWithEnvFallback } from './get-setting.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'medium',
   effects: [],
-  when: 'searching Sketchfab for downloadable 3D models (requires SKETCHFAB_API_TOKEN env var)',
+  when: 'searching Sketchfab for downloadable 3D models (token from Project Settings → Plugins → Hayba MCP Toolkit → Asset Connectors, or SKETCHFAB_API_TOKEN env var)',
   not_when: 'you already have a Sketchfab uid — go straight to sketchfab_download',
 };
 
@@ -28,7 +29,7 @@ export function buildSearchUrl(p: SketchfabSearchParams): string {
 }
 
 export function tokenMissingMessage(): string {
-  return 'SKETCHFAB_API_TOKEN env var is not set. Get a token at https://sketchfab.com/settings/password (API tokens section) and export SKETCHFAB_API_TOKEN before invoking this tool.';
+  return 'Sketchfab API token not configured. Open Project Settings → Plugins → Hayba MCP Toolkit → Asset Connectors and paste a token from https://sketchfab.com/settings/password. (Falls back to SKETCHFAB_API_TOKEN env var if UE is headless.)';
 }
 
 export async function handleSketchfabSearch(params: SketchfabSearchParams) {
@@ -36,7 +37,7 @@ export async function handleSketchfabSearch(params: SketchfabSearchParams) {
   if (!parsed.success) {
     return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
   }
-  const token = process.env.SKETCHFAB_API_TOKEN;
+  const token = await getTokenWithEnvFallback('sketchfab_api_token', 'SKETCHFAB_API_TOKEN');
   if (!token) {
     return { content: [{ type: 'text' as const, text: tokenMissingMessage() }], isError: true };
   }

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-search.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-search.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'searching Sketchfab for downloadable 3D models (requires SKETCHFAB_API_TOKEN env var)',
+  not_when: 'you already have a Sketchfab uid — go straight to sketchfab_download',
+};
+
+export const schema = z.object({
+  query: z.string().min(1),
+  downloadable: z.boolean().default(true),
+  count: z.number().int().min(1).max(48).default(24),
+});
+export type SketchfabSearchParams = z.infer<typeof schema>;
+
+const API = 'https://api.sketchfab.com/v3';
+
+export function buildSearchUrl(p: SketchfabSearchParams): string {
+  const qs = new URLSearchParams();
+  qs.set('type', 'models');
+  qs.set('q', p.query);
+  qs.set('downloadable', String(p.downloadable));
+  qs.set('archives_flavours', 'true');
+  qs.set('count', String(p.count));
+  return `${API}/search?${qs.toString()}`;
+}
+
+export function tokenMissingMessage(): string {
+  return 'SKETCHFAB_API_TOKEN env var is not set. Get a token at https://sketchfab.com/settings/password (API tokens section) and export SKETCHFAB_API_TOKEN before invoking this tool.';
+}
+
+export async function handleSketchfabSearch(params: SketchfabSearchParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const token = process.env.SKETCHFAB_API_TOKEN;
+  if (!token) {
+    return { content: [{ type: 'text' as const, text: tokenMissingMessage() }], isError: true };
+  }
+  try {
+    const url = buildSearchUrl(parsed.data);
+    const res = await fetch(url, { headers: { Authorization: `Token ${token}` } });
+    if (!res.ok) {
+      return { content: [{ type: 'text' as const, text: `Sketchfab search failed: ${res.status} ${res.statusText}` }], isError: true };
+    }
+    const raw = (await res.json()) as any;
+    const items = Array.isArray(raw?.results) ? raw.results : [];
+    const results = items.map((m: any) => ({
+      uid: m?.uid,
+      name: m?.name,
+      thumbnail: m?.thumbnails?.images?.[0]?.url ?? null,
+      license: m?.license?.label ?? null,
+      viewerUrl: m?.viewerUrl ?? null,
+      archives: m?.archives ?? null,
+      downloadable: m?.isDownloadable ?? false,
+    }));
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ source: 'sketchfab', count: results.length, next: raw?.next ?? null, results }, null, 2),
+      }],
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: `Sketchfab search error: ${msg}` }], isError: true };
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -29,6 +29,14 @@ import { handleFabLibraryList, meta as fabLibraryListMeta } from './fab/library-
 import { handleFabMarketplaceSearch, meta as fabMarketplaceSearchMeta } from './fab/marketplace-search.js';
 import { handleFabDownload, meta as fabDownloadMeta } from './fab/download.js';
 
+// ── Asset-source connectors (pure Node — no UE bridge except python_run) ──────
+import { handlePolyhavenSearch, meta as polyhavenSearchMeta } from './asset-sources/polyhaven-search.js';
+import { handlePolyhavenDownload, meta as polyhavenDownloadMeta } from './asset-sources/polyhaven-download.js';
+import { handleAmbientCgSearch, meta as ambientcgSearchMeta } from './asset-sources/ambientcg-search.js';
+import { handleAmbientCgDownload, meta as ambientcgDownloadMeta } from './asset-sources/ambientcg-download.js';
+import { handleSketchfabSearch, meta as sketchfabSearchMeta } from './asset-sources/sketchfab-search.js';
+import { handleSketchfabDownload, meta as sketchfabDownloadMeta } from './asset-sources/sketchfab-download.js';
+
 // ── PCGEx tool handlers ───────────────────────────────────────────────────────
 import { searchNodeCatalog } from './search-node-catalog.js';
 import { getNodeDetails } from './get-node-details.js';
@@ -456,6 +464,81 @@ export function registerTools(server: McpServer, session: SessionManagerStub): v
     async (params) => handleFabDownload(params as any)
   );
   remember('hayba_fab_download', fabDownloadMeta);
+
+  // ── Asset-source connectors (Poly Haven / ambientCG / Sketchfab) ────────────
+
+  server.tool(
+    'hayba_polyhaven_search',
+    appendMeta('Search Poly Haven for CC0 HDRIs, textures, or models.', polyhavenSearchMeta),
+    {
+      query: z.string().min(1).describe('Search query string.'),
+      type: z.enum(['hdris', 'textures', 'models']).optional().describe('Asset type filter (default "textures").'),
+      categories: z.string().optional().describe('Comma-separated Poly Haven category filter.'),
+    },
+    async (params) => handlePolyhavenSearch(params as any)
+  );
+  remember('hayba_polyhaven_search', polyhavenSearchMeta);
+
+  server.tool(
+    'hayba_polyhaven_download',
+    appendMeta('Download a Poly Haven asset (HDRI / texture maps / glTF model) and import into UE.', polyhavenDownloadMeta),
+    {
+      asset_id: z.string().min(1).describe('Poly Haven asset slug.'),
+      type: z.enum(['hdris', 'textures', 'models']).optional().describe('Asset type (default "textures").'),
+      resolution: z.enum(['1k', '2k', '4k', '8k']).optional().describe('Resolution tier (default "2k").'),
+      target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/polyhaven/<asset_id>.'),
+    },
+    async (params) => handlePolyhavenDownload(params as any)
+  );
+  remember('hayba_polyhaven_download', polyhavenDownloadMeta);
+
+  server.tool(
+    'hayba_ambientcg_search',
+    appendMeta('Search ambientCG for CC0 PBR materials, decals, or 3D models.', ambientcgSearchMeta),
+    {
+      query: z.string().min(1).describe('Search query string.'),
+      type: z.string().optional().describe('ambientCG asset type (default "Material").'),
+      limit: z.number().int().min(1).max(100).optional().describe('Max results (default 20).'),
+    },
+    async (params) => handleAmbientCgSearch(params as any)
+  );
+  remember('hayba_ambientcg_search', ambientcgSearchMeta);
+
+  server.tool(
+    'hayba_ambientcg_download',
+    appendMeta('Download an ambientCG material zip and import into UE.', ambientcgDownloadMeta),
+    {
+      asset_id: z.string().min(1).describe('ambientCG asset id (e.g. "Bricks075A").'),
+      resolution: z.string().optional().describe('Attribute string (e.g. "1K-JPG", "2K-JPG", "4K-PNG"). Default "2K-JPG".'),
+      target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/ambientcg/<asset_id>.'),
+    },
+    async (params) => handleAmbientCgDownload(params as any)
+  );
+  remember('hayba_ambientcg_download', ambientcgDownloadMeta);
+
+  server.tool(
+    'hayba_sketchfab_search',
+    appendMeta('Search Sketchfab for downloadable 3D models. Requires SKETCHFAB_API_TOKEN env var.', sketchfabSearchMeta),
+    {
+      query: z.string().min(1).describe('Search query string.'),
+      downloadable: z.boolean().optional().describe('Filter to downloadable-only models (default true).'),
+      count: z.number().int().min(1).max(48).optional().describe('Max results (default 24).'),
+    },
+    async (params) => handleSketchfabSearch(params as any)
+  );
+  remember('hayba_sketchfab_search', sketchfabSearchMeta);
+
+  server.tool(
+    'hayba_sketchfab_download',
+    appendMeta('Download a Sketchfab model and import into UE. Requires SKETCHFAB_API_TOKEN env var.', sketchfabDownloadMeta),
+    {
+      uid: z.string().min(1).describe('Sketchfab model uid.'),
+      flavour: z.enum(['gltf', 'usdz', 'source']).optional().describe('Download flavour (default "gltf").'),
+      target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/sketchfab/<uid>.'),
+    },
+    async (params) => handleSketchfabDownload(params as any)
+  );
+  remember('hayba_sketchfab_download', sketchfabDownloadMeta);
 
   // ── PCGEx tools ─────────────────────────────────────────────────────────────
 

--- a/mcp-tools/hayba-mcp/tests/tools/asset-sources/ambientcg.test.ts
+++ b/mcp-tools/hayba-mcp/tests/tools/asset-sources/ambientcg.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { handleAmbientCgSearch, buildSearchUrl } from '../../../src/tools/asset-sources/ambientcg-search.js';
+import { pickZipUrl, assetInfoUrl } from '../../../src/tools/asset-sources/ambientcg-download.js';
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('ambientcg search', () => {
+  it('builds the full_json URL with query', () => {
+    const url = buildSearchUrl({ query: 'brick', type: 'Material', limit: 5 } as any);
+    expect(url).toContain('https://ambientCG.com/api/v2/full_json?');
+    expect(url).toContain('q=brick');
+    expect(url).toContain('type=Material');
+    expect(url).toContain('limit=5');
+  });
+
+  it('parses foundAssets into result shape', async () => {
+    const body = {
+      foundAssets: [
+        { assetId: 'Bricks075A', displayName: 'Bricks 075A', previewImage: { '512-PNG': 'https://cdn/b.png' }, tags: ['brick'], category: 'Bricks' },
+      ],
+    };
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(body), { status: 200 }));
+    const r = await handleAmbientCgSearch({ query: 'brick', type: 'Material', limit: 1 } as any);
+    const payload = JSON.parse((r.content as any)[0].text);
+    expect(payload.source).toBe('ambientcg');
+    expect(payload.results[0]).toMatchObject({ id: 'Bricks075A', license: 'CC0', thumbnail: 'https://cdn/b.png' });
+  });
+});
+
+describe('ambientcg download — URL construction', () => {
+  it('builds info URL', () => {
+    expect(assetInfoUrl('Bricks075A')).toContain('id=Bricks075A');
+  });
+
+  it('picks the zip matching requested attribute', () => {
+    const json = {
+      foundAssets: [{
+        assetId: 'Bricks075A',
+        downloadFolders: [{
+          downloadFiletypeCategories: {
+            zip: {
+              downloads: [
+                { attribute: '1K-JPG', fullDownloadPath: 'https://cdn/1k.zip' },
+                { attribute: '2K-JPG', fullDownloadPath: 'https://cdn/2k.zip' },
+                { attribute: '4K-JPG', fullDownloadPath: 'https://cdn/4k.zip' },
+              ],
+            },
+          },
+        }],
+      }],
+    };
+    expect(pickZipUrl(json, '2K-JPG')).toBe('https://cdn/2k.zip');
+    expect(pickZipUrl(json, '4K-JPG')).toBe('https://cdn/4k.zip');
+  });
+
+  it('falls back to first available zip when attribute not found', () => {
+    const json = {
+      foundAssets: [{
+        downloadFolders: [{ downloadFiletypeCategories: { zip: { downloads: [{ attribute: '8K-PNG', fullDownloadPath: 'https://cdn/only.zip' }] } } }],
+      }],
+    };
+    expect(pickZipUrl(json, '2K-JPG')).toBe('https://cdn/only.zip');
+  });
+});

--- a/mcp-tools/hayba-mcp/tests/tools/asset-sources/polyhaven.test.ts
+++ b/mcp-tools/hayba-mcp/tests/tools/asset-sources/polyhaven.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { handlePolyhavenSearch, buildSearchUrl } from '../../../src/tools/asset-sources/polyhaven-search.js';
+import { pickDownloads, filesUrl } from '../../../src/tools/asset-sources/polyhaven-download.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('polyhaven search', () => {
+  it('builds the expected /assets URL', () => {
+    const url = buildSearchUrl({ query: 'rock', type: 'textures' } as any);
+    expect(url).toContain('https://api.polyhaven.com/assets?');
+    expect(url).toContain('type=textures');
+    expect(url).toContain('search=rock');
+  });
+
+  it('returns a list of results from mocked /assets', async () => {
+    const fakeBody = {
+      rock_01: { name: 'Rock 01', tags: ['rock'], categories: ['rock'] },
+      rock_02: { name: 'Rock 02', tags: ['rock'] },
+    };
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(fakeBody), { status: 200 }));
+    const r = await handlePolyhavenSearch({ query: 'rock', type: 'textures' } as any);
+    const payload = JSON.parse((r.content as any)[0].text);
+    expect(payload.source).toBe('polyhaven');
+    expect(payload.count).toBe(2);
+    expect(payload.results[0]).toMatchObject({ id: 'rock_01', license: 'CC0' });
+  });
+});
+
+describe('polyhaven download — URL construction', () => {
+  it('builds /files URL for an asset', () => {
+    expect(filesUrl('rock_01')).toBe('https://api.polyhaven.com/files/rock_01');
+  });
+
+  it('picks 2k jpg map URLs from the files payload', () => {
+    const files = {
+      Diffuse: { '2k': { jpg: { url: 'https://cdn/d.jpg' } } },
+      Normal:  { '2k': { jpg: { url: 'https://cdn/n.jpg' } }, '4k': { jpg: { url: 'https://cdn/n4.jpg' } } },
+      Rough:   { '1k': { jpg: { url: 'https://cdn/r1.jpg' } } }, // wrong res — skipped
+    };
+    const picks = pickDownloads(files, 'textures', '2k');
+    const names = picks.map(p => p.mapName).sort();
+    expect(names).toEqual(['Diffuse', 'Normal']);
+    expect(picks.find(p => p.mapName === 'Normal')?.url).toBe('https://cdn/n.jpg');
+  });
+
+  it('prefers HDR for hdris', () => {
+    const files = { hdri: { '2k': { hdr: { url: 'https://cdn/x.hdr' } } } };
+    const picks = pickDownloads(files, 'hdris', '2k');
+    expect(picks).toHaveLength(1);
+    expect(picks[0].url).toBe('https://cdn/x.hdr');
+  });
+});

--- a/mcp-tools/hayba-mcp/tests/tools/asset-sources/sketchfab.test.ts
+++ b/mcp-tools/hayba-mcp/tests/tools/asset-sources/sketchfab.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { handleSketchfabSearch, buildSearchUrl } from '../../../src/tools/asset-sources/sketchfab-search.js';
+import { pickFlavourUrl, downloadInfoUrl } from '../../../src/tools/asset-sources/sketchfab-download.js';
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('sketchfab search', () => {
+  beforeEach(() => { delete process.env.SKETCHFAB_API_TOKEN; });
+
+  it('builds /search URL with downloadable=true', () => {
+    const url = buildSearchUrl({ query: 'tree', downloadable: true, count: 24 } as any);
+    expect(url).toContain('https://api.sketchfab.com/v3/search?');
+    expect(url).toContain('type=models');
+    expect(url).toContain('q=tree');
+    expect(url).toContain('downloadable=true');
+    expect(url).toContain('archives_flavours=true');
+  });
+
+  it('returns actionable error when token is missing', async () => {
+    const r = await handleSketchfabSearch({ query: 'tree' } as any);
+    expect(r.isError).toBe(true);
+    expect((r.content as any)[0].text).toContain('SKETCHFAB_API_TOKEN');
+    expect((r.content as any)[0].text).toContain('https://sketchfab.com/settings/password');
+  });
+
+  it('parses results when token is present', async () => {
+    process.env.SKETCHFAB_API_TOKEN = 'test-token';
+    const body = {
+      next: null,
+      results: [
+        { uid: 'abc', name: 'Tree', thumbnails: { images: [{ url: 'https://cdn/t.jpg' }] }, license: { label: 'CC-BY' }, viewerUrl: 'https://sketchfab/abc', isDownloadable: true },
+      ],
+    };
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(body), { status: 200 }));
+    const r = await handleSketchfabSearch({ query: 'tree' } as any);
+    const payload = JSON.parse((r.content as any)[0].text);
+    expect(payload.results[0]).toMatchObject({ uid: 'abc', license: 'CC-BY' });
+    // Verify Authorization header was sent
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as any).Authorization).toBe('Token test-token');
+  });
+});
+
+describe('sketchfab download — URL construction', () => {
+  it('builds /models/<uid>/download URL', () => {
+    expect(downloadInfoUrl('abc-123')).toBe('https://api.sketchfab.com/v3/models/abc-123/download');
+  });
+
+  it('picks the gltf signed URL', () => {
+    const info = { gltf: { url: 'https://signed/g.zip' }, usdz: { url: 'https://signed/u.zip' } };
+    expect(pickFlavourUrl(info, 'gltf')).toBe('https://signed/g.zip');
+    expect(pickFlavourUrl(info, 'usdz')).toBe('https://signed/u.zip');
+    expect(pickFlavourUrl(info, 'source')).toBeNull();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "eslint-config-prettier": "^10.0.0",
         "prettier": "^3.5.0",
         "typescript-eslint": "^8.24.0"
+      },
+      "engines": {
+        "node": ">=22.5.0"
       }
     },
     "apps/hayba-explorer": {
@@ -435,6 +438,7 @@
         "@hayba/planet-physics": "*",
         "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "adm-zip": "^0.5.17",
         "better-sqlite3": "^11.0.0",
         "cheerio": "^1.2.0",
         "express": "^4.21.0",
@@ -446,6 +450,7 @@
         "hayba-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.5",
         "@types/better-sqlite3": "^7.6.0",
         "@types/express": "^5.0.0",
         "@types/node": "^24.12.2",
@@ -3904,6 +3909,16 @@
       "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
@@ -3,6 +3,7 @@
 #include "HaybaMCPSecurityManager.h"
 #include "HaybaMCPResponseBuilder.h"
 #include "HaybaMCPSettings.h"
+#include "HaybaMCPDeveloperSettings.h"
 #include "HaybaMCPModule.h"
 #include "HaybaMCPPlanPanel.h"
 #include "HaybaMCPToolStreamPanel.h"
@@ -585,6 +586,40 @@ FString FHaybaMCPCommandHandler::ProcessCommand(const FString& CommandJson)
         S.PlanModeToolCallCount++;
         S.Save();
         MaybeShowPlanModePrompt();
+    }
+
+    // get_setting: allowlisted read of UHaybaMCPDeveloperSettings fields so
+    // the Node MCP server can pick up tokens (e.g. SketchfabApiToken) the user
+    // entered in Project Settings → Plugins → Hayba MCP Toolkit, without env vars.
+    if (Cmd == TEXT("get_setting"))
+    {
+        FString Key;
+        if (!Params.IsValid() || !Params->TryGetStringField(TEXT("key"), Key))
+        {
+            return MakeErrorResponse(Id, TEXT("get_setting requires { key: string }"));
+        }
+        static const TSet<FString> Allow = { TEXT("sketchfab_api_token") };
+        if (!Allow.Contains(Key))
+        {
+            return MakeErrorResponse(Id,
+                FString::Printf(TEXT("Setting '%s' is not exposed via get_setting"), *Key));
+        }
+        const UHaybaMCPDeveloperSettings* DS = GetDefault<UHaybaMCPDeveloperSettings>();
+        FString Value;
+        if (Key == TEXT("sketchfab_api_token")) Value = DS->SketchfabApiToken;
+        TSharedPtr<FJsonObject> Data = MakeShared<FJsonObject>();
+        Data->SetStringField(TEXT("key"), Key);
+        if (Value.IsEmpty())
+        {
+            Data->SetField(TEXT("value"), MakeShared<FJsonValueNull>());
+            Data->SetBoolField(TEXT("set"), false);
+        }
+        else
+        {
+            Data->SetStringField(TEXT("value"), Value);
+            Data->SetBoolField(TEXT("set"), true);
+        }
+        return MakeOkResponse(Id, Data);
     }
 
     auto* Found = CommandToHandler.Find(Cmd);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPDeveloperSettings.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPDeveloperSettings.h
@@ -58,6 +58,10 @@ public:
     UPROPERTY(VisibleAnywhere, Category="Visual Sidecar")
     FString VRAMEstimate;
 
+    UPROPERTY(EditAnywhere, Config, Category="Asset Connectors", meta=(PasswordField=true,
+        ToolTip="Sketchfab API token (https://sketchfab.com/settings/password). Required for hayba_sketchfab_* tools. Leave empty to disable Sketchfab."))
+    FString SketchfabApiToken;
+
     // UDeveloperSettings overrides
     virtual FName GetCategoryName() const override { return TEXT("Plugins"); }
 


### PR DESCRIPTION
## Summary

Three bugs in the asset-connector's `importIntoUe` helper, all surfaced while debugging a UE 5.7 crash mid-import.

### Bugs fixed
1. **SyntaxError swallowed silently** — the generated Python script started with `import os, unreal` on one line. `python_run` runs in single-statement mode and rejected the whole body with a SyntaxError, but the connector still returned `imported: true`. Now: body is wrapped in `exec(...)` (single statement) with separate `import os` / `import unreal` lines, and `python_run`'s `{ok: false}` is now surfaced as `imported: false`.

2. **One AssetImportTask carrying many filenames** — UE 5.7 silently partial-imports with this shape. Now one task per file.

3. **`save = True` on a 7-texture burst crashed UE** — reproduced when stacked on top of a heavy `destroy_many_actors` call. Flipped to `save = False`; users can save when ready.

## Test Plan
- `npx tsc` clean
- `npx vitest run tests/tools/asset-sources/` — 15/15 pass
- Manual repro: previous Polyhaven download reported `imported: true` with an embedded SyntaxError in `importNote`. With this fix, either the import succeeds OR `imported: false` is reported honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Köppen-Geiger climate classification visualization for enhanced terrain analysis
  * Integrated asset connectors for searching and downloading from Poly Haven, ambientCG, and Sketchfab libraries
  * Added Sketchfab API token configuration in developer settings

* **Documentation**
  * Updated changelog with asset connector documentation

* **Tests**
  * Added comprehensive test coverage for new asset source tools

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->