### PR TITLE
fix(climate): bump Climate sea-level cutoff 0.05 → 0.08 (T4-TUNE-7)

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.glsl.ts
@@ -1174,7 +1174,7 @@ export const CLIMATE_CLASS_FRAG = [
   // were currently classifying as land — producing the spotty cyan
   // patches inside continents. CLIM/TERR/HYDRO still see the raw 0.0
   // shoreline; only the Climate viz uses the higher cutoff.
-  "  if (a.r < 0.05) { fragColor = vec4(0.0); return; }", // Ocean
+  "  if (a.r < 0.08) { fragColor = vec4(0.0); return; }", // Ocean (T4-TUNE-7)
   "  float v = (float(rc.y) + 0.5) / float(wh.y);",
   "  float lat = (0.5 - v) * 180.0;",
   "  float absLat = abs(lat);",


### PR DESCRIPTION
User: 'increase sea level a tiny bit more'. Bumped the Climate map mode's land-classification threshold from 0.05 to 0.08. CLIM/TERR/HYDRO still see the raw 0.0 shoreline.