### PR TITLE
feat(settings): sea-level slider in SettingsPanel

### DIFF
--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -413,6 +413,21 @@ export default function App() {
     setBakeTier(fidelityToTier(f));
     saveFidelity(f);
   }, []);
+  // T4-TUNE-15: user-tunable sea level (applied at next bake). Persists
+  // across reloads via localStorage so the user's chosen shoreline
+  // sticks. Default matches DEFAULT_HYDRAULIC.seaLevel.
+  const [seaLevel, setSeaLevel] = useState<number>(() => {
+    try {
+      const v = parseFloat(localStorage.getItem("hayba.seaLevel") ?? "");
+      return Number.isFinite(v) ? v : DEFAULT_HYDRAULIC.seaLevel;
+    } catch {
+      return DEFAULT_HYDRAULIC.seaLevel;
+    }
+  });
+  const handleChangeSeaLevel = useCallback((v: number) => {
+    setSeaLevel(v);
+    try { localStorage.setItem("hayba.seaLevel", String(v)); } catch {}
+  }, []);
 
   // Playback speed (steps per rAF tick). 1× is the wizard's dt_ma per frame.
   const [speedMult, setSpeedMult] = useState<1 | 2 | 4 | 8>(1);
@@ -1224,6 +1239,7 @@ export default function App() {
           h,
           {
             ...DEFAULT_HYDRAULIC,
+            seaLevel,
             // Rust serde snake_case -> HydraulicConfig camelCase.
             scale: {
               terrainScale: inp.scale.terrain_scale,
@@ -1723,6 +1739,8 @@ export default function App() {
             onChangeMapMode={setMapMode}
             fidelity={fidelity}
             onChangeFidelity={handleChangeFidelity}
+            seaLevel={seaLevel}
+            onChangeSeaLevel={handleChangeSeaLevel}
           />
         )}
       </RightPanel>

--- a/apps/hayba-explorer/src/components/panels/SettingsPanel.tsx
+++ b/apps/hayba-explorer/src/components/panels/SettingsPanel.tsx
@@ -28,6 +28,8 @@ export interface SettingsPanelProps {
   onChangeMapMode: (n: number) => void;
   fidelity: Fidelity;
   onChangeFidelity: (f: Fidelity) => void;
+  seaLevel: number;
+  onChangeSeaLevel: (v: number) => void;
 }
 
 export default function SettingsPanel(p: SettingsPanelProps) {
@@ -36,7 +38,6 @@ export default function SettingsPanel(p: SettingsPanelProps) {
       <PropertySection heading="Performance">
         <PropertyRow
           label="Fidelity"
-          noSeparator
           value={
             <select
               aria-label="Bake fidelity"
@@ -47,6 +48,21 @@ export default function SettingsPanel(p: SettingsPanelProps) {
               <option value="medium">Medium (2048²)</option>
               <option value="high">High — slowest (2560²)</option>
             </select>
+          }
+        />
+        <PropertyRow
+          label={`Sea level (${p.seaLevel.toFixed(3)})`}
+          noSeparator
+          value={
+            <input
+              type="range"
+              min={-0.2}
+              max={0.3}
+              step={0.005}
+              value={p.seaLevel}
+              onChange={(e) => p.onChangeSeaLevel(parseFloat(e.target.value))}
+              aria-label="Sea level offset (applied at next bake)"
+            />
           }
         />
       </PropertySection>


### PR DESCRIPTION
User: 'expose this as a slider in SettingsPanel so you can drag it live instead of cycling PRs'. Wired:

- SettingsPanel: new Sea level range input (-0.2..0.3, step 0.005) under the Performance section, with the value shown in the label.
- App.tsx: seaLevel state persisted to localStorage ('hayba.seaLevel'), defaults to DEFAULT_HYDRAULIC.seaLevel. Plumbed into the runHydraulicBake cfg as a one-line override.

User now drags the slider, hits Bake, sees the new shoreline. No more dial-and-PR loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added adjustable sea level setting in the settings panel. Users can now control the sea level parameter for the erosion simulation via a range slider (−0.2 to 0.3). Settings persist across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->