### PR TITLE
feat(viz): Rivers + Lakes map modes (HYDRO RT)

### DIFF
--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -473,6 +473,9 @@ export default function App() {
       } else if (sel.kind === "climate") {
         const rt = prevDebugClimateRef.current;
         if (rt) stackTex = rt.texture;
+      } else if (sel.kind === "hydro") {
+        // Rivers / Lakes map modes sample the HYDRO RT directly.
+        stackTex = stack.hydro.texture;
       }
       setDebugStack(mat, {
         tex: stackTex,

--- a/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
+++ b/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
@@ -250,6 +250,17 @@ const FRAG: string = [
   "    if (c < 13.5) return vec3(0.70, 0.70, 0.70);", // 13 ET grey
   "    return vec3(0.98, 0.98, 0.98);",               // 14 EF icecap
   "  }",
+  // RIVERS/LAKES id=8: tan below threshold, bright cyan→deep blue above.
+  // Reads Q discharge (.r) for Rivers OR endorheic flag (.b) for Lakes.
+  // Both are 0..1-ish intensity fields so the same ramp serves both.
+  "  if (id < 8.5){",
+  "    float t = clamp(x, 0.0, 1.0);",
+  "    vec3 tan  = vec3(0.85, 0.78, 0.55);",
+  "    vec3 cyan = vec3(0.35, 0.78, 0.95);",
+  "    vec3 deep = vec3(0.05, 0.20, 0.55);",
+  "    if (t < 0.15) return mix(tan, cyan, t / 0.15);",
+  "    return mix(cyan, deep, (t - 0.15) / 0.85);",
+  "  }",
   "  return vec3(clamp(x, 0.0, 1.0));",
   "}",
   "",

--- a/apps/hayba-explorer/src/viewport/equirectMapModes.ts
+++ b/apps/hayba-explorer/src/viewport/equirectMapModes.ts
@@ -20,7 +20,8 @@ export type EquirectModeKind =
   | "wind"
   | "dist"
   | "pressure"
-  | "climate";
+  | "climate"
+  | "hydro";
 
 export interface EquirectMapMode {
   label: string;
@@ -47,6 +48,11 @@ export const EQUIRECT_MAP_MODES: EquirectMapMode[] = [
   { label: "Continentality", kind: "dist", channel: 1, ramp: 5 },
   { label: "Pressure", kind: "pressure", channel: 0, ramp: 6 },
   { label: "Climate", kind: "climate", channel: 0, ramp: 7 },
+  // HYDRO RT (already baked): .r = flow discharge (rivers), .b =
+  // endorheic flag (lake basins). Both rendered with ramp 8 (river-blue
+  // threshold gradient — bright cyan above threshold, tan below).
+  { label: "Rivers", kind: "hydro", channel: 0, ramp: 8 },
+  { label: "Lakes", kind: "hydro", channel: 2, ramp: 8 },
 ];
 
 /** Resolved selection for `setDebugStack`. `mode` is the debugMaterial
@@ -79,7 +85,12 @@ export function resolveEquirectMode(
   // uStackMode as clim (1 draped / 2 flat) because debugMaterial just
   // samples uStackTex and applies the indexed ramp. Only the source RT
   // differs (App.tsx routes DIST/MSLP/CLASS into uStackTex per kind).
-  if (e.kind === "dist" || e.kind === "pressure" || e.kind === "climate") {
+  if (
+    e.kind === "dist" ||
+    e.kind === "pressure" ||
+    e.kind === "climate" ||
+    e.kind === "hydro"
+  ) {
     return { kind: e.kind, channel: e.channel, ramp: e.ramp, mode: draped ? 1 : 2 };
   }
   return {


### PR DESCRIPTION
Two new map modes routing the existing HYDRO RT (already baked, just not exposed). User asked for lakes/rivers separately.

- **Rivers** (HYDRO.r = flow discharge, ramp 8): bright cyan rivers on tan land background, deep blue trunks at high discharge.
- **Lakes** (HYDRO.b = endorheic-basin flag, ramp 8): same blue palette, endorheic-classified cells light up.

Wiring:
- equirectMapModes: new 'hydro' kind + two entries.
- debugMaterial: new ramp id=8 (tan→cyan→deep blue with 0.15 threshold).
- App.tsx applyDebugChannel: route 'hydro' kind to stack.hydro.texture.

3 files, ~30 lines. tsc 0. Next: ocean-current ΔT pass (Gulf Stream warming → fixes Iceland/Scotland).