### PR TITLE
fix(bake): revert SEED_A uSeaLevel — bake stopped applying

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
+++ b/apps/hayba-explorer/src/viewport/bake/hydraulic.ts
@@ -435,10 +435,9 @@ const SEED_A_FRAG = [
   "precision highp int;",
   "out vec4 fragColor;",
   "uniform sampler2D uBase;",
-  "uniform float uSeaLevel;",
   "void main(){",
   "  ivec2 rc = ivec2(int(gl_FragCoord.x), int(gl_FragCoord.y));",
-  "  float b = texelFetch(uBase, rc, 0).r - uSeaLevel;",
+  "  float b = texelFetch(uBase, rc, 0).r;",
   "  float ocean = b < 0.0 ? 1.0 : 0.0;",
   "  fragColor = vec4(b, 0.0, 0.0, ocean);",
   "}",
@@ -725,7 +724,7 @@ export async function runHydraulicBake(
   // ---- SEED: A := (base.r, 0, 0, base.r<0?1:0) ; F := 0 ----------------
   // Seed writes into the READ slot of each channel (A[0]/F[0]) so the
   // first step's RAIN/FLUX read the seeded state.
-  runRawPass(renderer, SEED_A_FRAG, { uBase: u(base), uSeaLevel: u(cfg.seaLevel) }, aReadRT());
+  runRawPass(renderer, SEED_A_FRAG, { uBase: u(base) }, aReadRT());
   runRawPass(renderer, SEED_F_FRAG, {}, fReadRT());
 
   // ---- COOKBOOK-CLIMATE T2: distance-to-ocean via JFA ------------------


### PR DESCRIPTION
User: 'baking doesnt work / after i press bake it goes back to the non-baked input'.

Reverting the SEED_A_FRAG uSeaLevel uniform modification (PR #193 / T4-TUNE-10). The uniform value was being passed via runRawPass but evidently failing somewhere in the pipeline — handleBake throws and the UI reverts to pre-bake state.

The seaLevel knob in SettingsPanel still exists but no longer affects the bake. We'll re-introduce it differently (likely as a post-bake display offset rather than a SEED-time height shift) once the immediate breakage is fixed.

2 files, ~5 lines reverted. tsc 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected terrain elevation calculations affecting ocean and land formation in hydraulic simulations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->