### PR TITLE
fix(bake): rename 'tan' (GLSL builtin) -> 'tanCol'

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
+++ b/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
@@ -255,10 +255,14 @@ const FRAG: string = [
   // Both are 0..1-ish intensity fields so the same ramp serves both.
   "  if (id < 8.5){",
   "    float t = clamp(x, 0.0, 1.0);",
-  "    vec3 tan  = vec3(0.85, 0.78, 0.55);",
-  "    vec3 cyan = vec3(0.35, 0.78, 0.95);",
-  "    vec3 deep = vec3(0.05, 0.20, 0.55);",
-  "    if (t < 0.15) return mix(tan, cyan, t / 0.15);",
+  // NOTE: `tan` is a GLSL builtin (tangent), so the dry-land swatch
+  // colour must NOT be named `tan` — some drivers reject the shadow
+  // and silently fail-to-compile the relief shader (= bake appears
+  // to do nothing visually). Renamed to `tanCol`.
+  "    vec3 tanCol = vec3(0.85, 0.78, 0.55);",
+  "    vec3 cyan   = vec3(0.35, 0.78, 0.95);",
+  "    vec3 deep   = vec3(0.05, 0.20, 0.55);",
+  "    if (t < 0.15) return mix(tanCol, cyan, t / 0.15);",
   "    return mix(cyan, deep, (t - 0.15) / 0.85);",
   "  }",
   "  return vec3(clamp(x, 0.0, 1.0));",


### PR DESCRIPTION
**Root cause of 'bake doesn't work'**: in PR #199 (Rivers/Lakes ramp id=8) I declared `vec3 tan = ...` for the swatch colour. `tan` is a reserved GLSL builtin (tangent function). Some drivers silently fail-to-link the relief shader when a local shadows a builtin — bake completed correctly but the planet sphere had no visible material → user saw the pre-bake view.

Renamed `tan` -> `tanCol`. 1 file, 8 lines. tsc 0.

Diagnosed via subagent code-read after browser-harness couldn't connect to the Tauri webview.