### PR TITLE
fix(viz): sharper Rivers/Lakes threshold + log compression

### DIFF
--- a/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
+++ b/apps/hayba-explorer/src/viewport/bake/debugMaterial.ts
@@ -254,16 +254,19 @@ const FRAG: string = [
   // Reads Q discharge (.r) for Rivers OR endorheic flag (.b) for Lakes.
   // Both are 0..1-ish intensity fields so the same ramp serves both.
   "  if (id < 8.5){",
+  // Rivers/Lakes — log-compress the discharge / endo field then apply a
+  // sharp 0.65 step so MOST of land stays tan and only true river
+  // trunks / lake basins show blue. Without the log compression every
+  // cell with any drainage lit up blue (Q has huge dynamic range).
+  // NOTE: `tan` is a GLSL builtin (tangent); local must NOT shadow it
+  // or some drivers fail-to-link the whole material → relief breaks.
   "    float t = clamp(x, 0.0, 1.0);",
-  // NOTE: `tan` is a GLSL builtin (tangent), so the dry-land swatch
-  // colour must NOT be named `tan` — some drivers reject the shadow
-  // and silently fail-to-compile the relief shader (= bake appears
-  // to do nothing visually). Renamed to `tanCol`.
+  "    float tLog = log(1.0 + 100.0 * t) / log(101.0);",
   "    vec3 tanCol = vec3(0.85, 0.78, 0.55);",
   "    vec3 cyan   = vec3(0.35, 0.78, 0.95);",
   "    vec3 deep   = vec3(0.05, 0.20, 0.55);",
-  "    if (t < 0.15) return mix(tanCol, cyan, t / 0.15);",
-  "    return mix(cyan, deep, (t - 0.15) / 0.85);",
+  "    if (tLog < 0.65) return tanCol;",
+  "    return mix(cyan, deep, (tLog - 0.65) / 0.35);",
   "  }",
   "  return vec3(clamp(x, 0.0, 1.0));",
   "}",


### PR DESCRIPTION
User: 'lake and river display looks a bit broken — whole continents show as blue'. Two fixes to the ramp id=8:

1. **Log-compress** the discharge field: `tLog = log(1 + 100·t) / log(101)` — Q has huge dynamic range (small streams ~0.01, big rivers ~1.0), linear ramp lights up every cell with any flow. Log compresses small values back to near-zero.

2. **Sharper step** at 0.65: tan below threshold, no mix, then cyan→deep above. The earlier 0.15 threshold + tan→cyan mix made most cells some shade of blue.

For Lakes (binary endo flag 0 or 1): tLog(0)=0→tan, tLog(1)=1→deep — only endo=1 cells light up.
For Rivers (Q normalized): only the top ~5% by discharge crosses threshold.