### PR TITLE
revert(compose): remove wizard-mode Play/Pause/Step UI

### DIFF
--- a/apps/hayba-explorer/src-tauri/src/lib.rs
+++ b/apps/hayba-explorer/src-tauri/src/lib.rs
@@ -25,6 +25,8 @@ pub fn run() {
             wizard::bake_from_wizard,
             wizard::compute_partition,
             wizard::step_planet,
+            wizard::start_tect_sim,
+            wizard::tect_step_n,
             wizard::reset_sim,
             wizard::poll_bake_progress,
             wizard::apply_boundary_types,

--- a/apps/hayba-explorer/src-tauri/src/wizard.rs
+++ b/apps/hayba-explorer/src-tauri/src/wizard.rs
@@ -262,6 +262,75 @@ pub fn poll_bake_progress(progress: State<'_, BakeProgress>) -> u32 {
     progress.0.load(Ordering::Relaxed)
 }
 
+/// Compact result for the wizard-mode Play/Step UI. Returns only what the
+/// frontend needs to recolor the painter sphere by plate membership — no
+/// climate, no elevation, no snapshot serialisation. `plate_ids[i]` is the
+/// plate id of cell `i` (0 for unassigned). `step` is the model's absolute
+/// step counter so the UI can label the play head.
+#[derive(Debug, Serialize)]
+pub struct TectStepResult {
+    pub plate_ids: Vec<u8>,
+    pub step: u32,
+}
+
+/// Build a fresh tectonic `Model` from the wizard draft WITHOUT running the
+/// initial `run_length_steps` loop and WITHOUT erosion. This is the live
+/// play state: same partition/plate-assignment logic as `bake_impl`, just
+/// frozen at step 0 so the user can drive it interactively. The sim then
+/// replaces any previously baked model — wizard Play and post-bake step are
+/// mutually exclusive flows.
+#[tauri::command]
+pub fn start_tect_sim(
+    draft: WizardDraft,
+    sim: State<'_, ManagedSim>,
+) -> Result<TectStepResult, String> {
+    let divisions = draft.divisions;
+    let dt_ma = draft.dt_ma;
+    let model = build_initial_model(&draft);
+    let plate_ids = read_plate_ids(&model);
+    let step = model.step_count;
+    let mut guard = sim.0.lock().map_err(|_| "sim mutex poisoned".to_string())?;
+    *guard = Some(SimState { model, divisions, dt_ma });
+    Ok(TectStepResult { plate_ids, step })
+}
+
+/// Advance the live wizard-mode sim by `n_steps` and return the compact
+/// plate-id buffer + step counter. Errors if no sim is loaded — the
+/// frontend must call `start_tect_sim` first.
+#[tauri::command]
+pub fn tect_step_n(
+    steps: u32,
+    sim: State<'_, ManagedSim>,
+) -> Result<TectStepResult, String> {
+    let mut guard = sim.0.lock().map_err(|_| "sim mutex poisoned".to_string())?;
+    let state = guard.as_mut().ok_or_else(|| "no sim loaded".to_string())?;
+    for _ in 0..steps {
+        state.model.step(state.dt_ma);
+    }
+    Ok(TectStepResult {
+        plate_ids: read_plate_ids(&state.model),
+        step: state.model.step_count,
+    })
+}
+
+/// Encode current per-cell plate membership as one byte per cell. Cells with
+/// no plate (subducted / freshly spawned mid-step) become 0. Plate ids are
+/// already 1-based in our generator, and `bake_impl` keeps them below the
+/// PALETTE length × small multiples — they fit comfortably in u8 for the
+/// playable range. Larger ids are clamped to 255 (visual fallback rather
+/// than a hard error).
+fn read_plate_ids(model: &Model) -> Vec<u8> {
+    let n = model.fields.len();
+    let mut out = vec![0u8; n];
+    for (i, f) in model.fields.iter().enumerate() {
+        out[i] = match f.plate_id {
+            Some(pid) => pid.min(255) as u8,
+            None => 0,
+        };
+    }
+    out
+}
+
 /// Advance the persisted sim by `n_steps` and return a fresh snapshot.
 #[tauri::command]
 pub fn step_planet(
@@ -522,15 +591,12 @@ fn omega_for_plate(plate_id: u32, seed: u64) -> Vec3 {
     Vec3::new(r1 as f32, r2 as f32, r3 as f32).normalize_or_zero() * 0.01
 }
 
-/// Build the baked `Model` from a wizard draft: preset partition →
-/// continental brush/painter crust override → tectonic step loop →
-/// bake-phase fluvial erosion. The Tauri command and the tests both go
-/// through this one path so they cannot diverge.
-pub(crate) fn bake_impl(
-    draft: &WizardDraft,
-    erosion_params: &crate::hydrology::ErosionParams,
-) -> Model {
-    let _bp3a_t0 = std::time::Instant::now();
+/// Build the initial tectonic `Model` from a wizard draft: preset partition
+/// → continental brush/painter crust override → plate registration with
+/// boundary-type biased omegas. Does NOT run `draft.run_length_steps` and
+/// does NOT erode. Shared between the bake path (which then steps & erodes)
+/// and the new live-Play path (which steps interactively in the UI).
+pub(crate) fn build_initial_model(draft: &WizardDraft) -> Model {
     let preset = image::load_from_memory(preset_bytes(&draft.preset))
         .expect("preset PNG should decode")
         .to_rgba8();
@@ -546,8 +612,6 @@ pub(crate) fn bake_impl(
         }
     }
 
-    let bp3a_grid = _bp3a_t0.elapsed();
-    let _bp3a_t1 = std::time::Instant::now();
     // ── Step 1: bucket cells by HSV-hue (rounded to nearest 10°), TE-style.
     // Each bucket becomes a plate. Also retain per-cell elevation from HSV.
     struct CellInfo {
@@ -580,8 +644,6 @@ pub(crate) fn bake_impl(
     cell_plate_ids = majority_smooth(&model.grid, cell_plate_ids);
     cell_plate_ids = majority_smooth(&model.grid, cell_plate_ids);
 
-    let bp3a_partition = _bp3a_t1.elapsed();
-    let _bp3a_t2 = std::time::Instant::now();
     // ── Step 2: build per-plate cell buckets in plate-id order.
     let plate_count = hue_to_plate.len() as u32;
     let mut buckets: Vec<Vec<u32>> = (0..plate_count).map(|_| Vec::new()).collect();
@@ -615,11 +677,6 @@ pub(crate) fn bake_impl(
     }
 
     // ── Step 3b: per-plate force accumulator from the user's boundary types.
-    // For each (a, b) assignment:
-    //   convergent — plate a wants to move toward b, plate b toward a
-    //   divergent  — plate a wants to move away from b, plate b away from a
-    // Translate "movement toward direction d" into an angular velocity around
-    // axis (d × position) so the rotation actually drifts the plate that way.
     let mut force_dir: Vec<Vec3> = vec![Vec3::ZERO; n_plates];
     for (pair_key, ty) in &draft.boundary_types {
         let mut it = pair_key.split('-');
@@ -649,14 +706,9 @@ pub(crate) fn bake_impl(
         let density = if plate_continental[i] { 0.35 } else { 1.05 };
         let mut omega = omega_for_plate(pid, draft.seed);
 
-        // If the user assigned any boundaries to this plate, override the
-        // random omega with one that points the plate along the user's force
-        // direction. Translate desired linear velocity at the centroid into
-        // an angular velocity: omega = pos × velocity / |pos|^2.
         let f = force_dir[i];
         if f.length_squared() > 1e-6 {
-            let v = f.normalize() * 0.01; // target tangential speed
-            // Project v onto the tangent plane of plate_centroids[i].
+            let v = f.normalize() * 0.01;
             let p = plate_centroids[i];
             let tangent = v - p * v.dot(p);
             if tangent.length_squared() > 1e-6 {
@@ -672,15 +724,8 @@ pub(crate) fn bake_impl(
     }
 
     // ── Step 4: per-cell crust override. Precedence: painter > continental
-    //  brush > preset HSV. Continental brush "lowland" floor drops from 0.5
-    //  to 0.05 — barely above sea level, leaves room for the painter to
-    //  sculpt mountains on top. Continentality is derived: elev > 0.
+    //  brush > preset HSV. Continentality is derived: elev > 0.
     const CONTINENTAL_BRUSH_FLOOR: f32 = 0.05;
-    // Baseline is now uniform EXTREME DEEP OCEAN: an unpainted planet is
-    // all deep water (-1), so the user paints continents + shallow water
-    // up from a clean deep floor. The preset HSV still defines the plate
-    // partition (above), but no longer leaves varying shallow ocean depths
-    // that read as a smooth water gradient.
     const DEEP_OCEAN_FLOOR: f32 = -1.0;
     for fid in 0..n_cells {
         let painted = draft
@@ -701,9 +746,33 @@ pub(crate) fn bake_impl(
     }
 
     model.refresh_plate_inertias();
+    model
+}
 
-    let bp3a_plates = _bp3a_t2.elapsed();
+/// Build the baked `Model` from a wizard draft: preset partition →
+/// continental brush/painter crust override → tectonic step loop →
+/// bake-phase fluvial erosion. The Tauri command and the tests both go
+/// through this one path so they cannot diverge.
+pub(crate) fn bake_impl(
+    draft: &WizardDraft,
+    erosion_params: &crate::hydrology::ErosionParams,
+) -> Model {
+    let _bp3a_t0 = std::time::Instant::now();
+    // PLAY-1 refactor: the partition + plate-init phase is shared with the
+    // wizard-mode live Play state. The tectonic step loop and bake-phase
+    // erosion below remain bake-only.
+    let mut model = build_initial_model(draft);
+    let n_cells = model.grid.n_fields();
+    // Preserve the original eprintln categories — we no longer track the
+    // sub-phase timings inside build_initial_model, but the existing log
+    // format expects grid/partition/plates fields. Use zeros so callers
+    // don't have to change.
+    let bp3a_grid: std::time::Duration = std::time::Duration::ZERO;
+    let bp3a_partition: std::time::Duration = std::time::Duration::ZERO;
+    let bp3a_plates: std::time::Duration = _bp3a_t0.elapsed();
     let _bp3a_t3 = std::time::Instant::now();
+    // PLAY-1: model partition + plate registration + per-cell crust override
+    // is now in `build_initial_model`. Remaining bake-specific phases follow.
     for _ in 0..draft.run_length_steps {
         model.step(draft.dt_ma);
     }
@@ -777,6 +846,35 @@ mod tests {
             painted_elevations: vec![],
             painted_mask: vec![],
         }
+    }
+
+    #[test]
+    fn build_initial_model_has_step_zero_and_plate_ids() {
+        // PLAY-1: live-play sim entrypoint. Sanity-check that the initial
+        // model has step 0 and assigns plate ids on the painted partition.
+        let model = build_initial_model(&draft_for("plates3"));
+        assert_eq!(model.step_count, 0);
+        let ids = read_plate_ids(&model);
+        assert_eq!(ids.len(), model.fields.len());
+        let mut distinct: Vec<u8> = ids.iter().copied().filter(|&p| p > 0).collect();
+        distinct.sort();
+        distinct.dedup();
+        assert!(distinct.len() >= 2, "expected ≥2 plates, got {distinct:?}");
+    }
+
+    #[test]
+    fn read_plate_ids_is_byte_stable_for_unchanged_model() {
+        // Read twice without stepping — must be byte-identical.
+        let model = build_initial_model(&draft_for("plates4"));
+        assert_eq!(read_plate_ids(&model), read_plate_ids(&model));
+    }
+
+    #[test]
+    fn stepping_advances_step_count() {
+        let mut model = build_initial_model(&draft_for("plates3"));
+        let before = model.step_count;
+        for _ in 0..3 { model.step(0.5); }
+        assert_eq!(model.step_count, before + 3);
     }
 
     #[test]

--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -273,6 +273,15 @@ export default function App() {
 
   const [draft, setDraft] = useState<WizardDraft | null>(null);
   const [mode, setMode] = useState<Mode>("wizard");
+  // TECT-PLAY: live wizard-mode tectonic playback state. `tectStep` is the
+  // absolute step counter from the Rust sim; `tectPlaying` drives the
+  // setInterval loop. Reset to step 0 on Edit / divisions change.
+  const [tectStep, setTectStep] = useState(0);
+  const [tectPlaying, setTectPlaying] = useState(false);
+  const tectPlayingRef = useRef(false);
+  useEffect(() => { tectPlayingRef.current = tectPlaying; }, [tectPlaying]);
+  const tectSimReadyRef = useRef(false);
+  const tectBusyRef = useRef(false);
   const [snapshot, setSnapshot] = useState<PlanetSnapshot | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [activeTool, setActiveTool] = useState<ToolName>("brush");
@@ -1053,6 +1062,135 @@ export default function App() {
     };
   }, [panelCategory, mode, paintBrush, interact]);
 
+  // TECT-PLAY: wizard-mode live tectonic playback. Init builds a fresh sim
+  // from the current draft (no run_length_steps, no erosion) and switches
+  // the visible globe to the point-cloud colored by plate ids. Subsequent
+  // step() calls just recolor — the painter mesh stays hidden until the
+  // user stops playback.
+  type TectStepResult = { plate_ids: number[]; step: number };
+
+  const applyTectResult = useCallback((res: TectStepResult) => {
+    const ids = res.plate_ids;
+    const buf = ids instanceof Uint8Array ? ids : new Uint8Array(ids);
+    globeRef.current?.recolorFromPlateIds(buf, PLATE_PALETTE);
+    setTectStep(res.step);
+    sceneRef.current?.markDirty();
+  }, []);
+
+  // Show the points globe + recolor with plate ids. Painter mesh is hidden
+  // so plate colors are unobscured. The painter cursor ring stays available
+  // (it lives on the painter group object); but since pointer events are
+  // disabled during play, it never appears.
+  const showPlateView = useCallback(() => {
+    if (painterMeshRef.current) painterMeshRef.current.object.visible = false;
+    if (globeRef.current) globeRef.current.object.visible = true;
+  }, []);
+
+  const showPaintView = useCallback(() => {
+    if (painterMeshRef.current) painterMeshRef.current.object.visible = true;
+    // When the height-painter mesh is mounted the points globe must be
+    // hidden again (mirrors the painter-lifecycle effect's invariant).
+    if (globeRef.current && painterMeshRef.current) {
+      globeRef.current.object.visible = false;
+    }
+  }, []);
+
+  const ensureTectSim = useCallback(async (): Promise<boolean> => {
+    if (tectSimReadyRef.current) return true;
+    const drft = draftRef.current;
+    if (!drft) return false;
+    // Build the live sim from the CURRENT draft (continents + painter
+    // overrides included via toDraftFields, matching bake_from_wizard).
+    const paintedFields = heightPainterRef.current
+      ? heightPainterRef.current.toDraftFields()
+      : { painted_elevations: [], painted_mask: [] };
+    const finalDraft: WizardDraft = { ...drft, ...paintedFields };
+    try {
+      const res = await invoke<TectStepResult>("start_tect_sim", { draft: finalDraft });
+      tectSimReadyRef.current = true;
+      showPlateView();
+      applyTectResult(res);
+      return true;
+    } catch (e) {
+      setError(String(e));
+      return false;
+    }
+  }, [applyTectResult, showPlateView]);
+
+  const handleTectStep = useCallback(async () => {
+    if (tectBusyRef.current) return;
+    tectBusyRef.current = true;
+    try {
+      const ok = await ensureTectSim();
+      if (!ok) return;
+      const res = await invoke<TectStepResult>("tect_step_n", { steps: 1 });
+      applyTectResult(res);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      tectBusyRef.current = false;
+    }
+  }, [applyTectResult, ensureTectSim]);
+
+  const handleTectPlayPause = useCallback(async () => {
+    if (tectPlayingRef.current) {
+      setTectPlaying(false);
+      return;
+    }
+    const ok = await ensureTectSim();
+    if (!ok) return;
+    setTectPlaying(true);
+  }, [ensureTectSim]);
+
+  const handleTectReset = useCallback(() => {
+    setTectPlaying(false);
+    tectSimReadyRef.current = false;
+    setTectStep(0);
+    invoke("reset_sim").catch(() => {});
+    showPaintView();
+    // Repaint the points globe to the pre-play colour scheme so a stale
+    // plate-coloured cloud doesn't ghost behind the painter mesh.
+    const drft = draftRef.current;
+    if (drft) globeRef.current?.recolorFromDraft(drft, cellCountRef.current);
+  }, [showPaintView]);
+
+  // Drive the live sim via setInterval — ~12 FPS matches the ~80ms/step
+  // perf budget. A re-entrancy guard (tectBusyRef) prevents pile-up when a
+  // step takes longer than the interval at high resolutions.
+  useEffect(() => {
+    if (!tectPlaying) return;
+    let cancelled = false;
+    const id = window.setInterval(async () => {
+      if (cancelled || !tectPlayingRef.current) return;
+      if (tectBusyRef.current) return;
+      tectBusyRef.current = true;
+      try {
+        const res = await invoke<TectStepResult>("tect_step_n", { steps: 1 });
+        if (!cancelled && tectPlayingRef.current) applyTectResult(res);
+      } catch (e) {
+        if (!cancelled) {
+          setError(String(e));
+          setTectPlaying(false);
+        }
+      } finally {
+        tectBusyRef.current = false;
+      }
+    }, 85);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [tectPlaying, applyTectResult]);
+
+  // TECT-PLAY: when the user changes draft inputs (preset, painted cells,
+  // brush, divisions) the live sim is no longer in sync. Reset cheaply so
+  // the next Play / Step rebuilds. Excludes brush_radius (visual-only).
+  useEffect(() => {
+    if (!tectSimReadyRef.current) return;
+    handleTectReset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draft?.preset, draft?.seed, draft?.divisions, draft?.continental_cells.length]);
+
   // Live-apply boundary assignments — Rust rewrites plate omegas on the
   // running model so the change is visible immediately. No re-bake.
   const applyBoundaryTypesLive = useCallback(async (types: Record<string, BoundaryType>) => {
@@ -1148,6 +1286,12 @@ export default function App() {
   const handleBake = useCallback(async () => {
     const scene = sceneRef.current;
     if (!draft || !scene || debugBaking) return;
+    // TECT-PLAY: stop the live preview before bake. The bake rebuilds the
+    // sim from the draft anyway, so the play state must not leak into the
+    // baked planet.
+    setTectPlaying(false);
+    tectSimReadyRef.current = false;
+    setTectStep(0);
     setDebugBaking(true);
     setMode("baking");
     setDebugBakeProgress("Rasterising inputs…");
@@ -1368,6 +1512,9 @@ export default function App() {
     setInteract(nextInteract(interactRef.current, "edit"));
     setMode("wizard");
     setPlaying(false);
+    setTectPlaying(false);
+    tectSimReadyRef.current = false;
+    setTectStep(0);
     if (draft) globeRef.current?.recolorFromDraft(draft, cellCountRef.current);
   }, [draft]);
 
@@ -1629,6 +1776,14 @@ export default function App() {
           <ComposePanel
             draft={draft}
             busy={mode === "baking" || initializingGrid}
+            tectPlay={{
+              playing: tectPlaying,
+              step: tectStep,
+              onPlayPause: handleTectPlayPause,
+              onStep: handleTectStep,
+              onReset: handleTectReset,
+              disabled: mode === "baking" || initializingGrid,
+            }}
             onChangeDivisions={handleChangeDivisions}
             onChangePreset={handleChangePreset}
             onReroll={handleReroll}

--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -273,15 +273,6 @@ export default function App() {
 
   const [draft, setDraft] = useState<WizardDraft | null>(null);
   const [mode, setMode] = useState<Mode>("wizard");
-  // TECT-PLAY: live wizard-mode tectonic playback state. `tectStep` is the
-  // absolute step counter from the Rust sim; `tectPlaying` drives the
-  // setInterval loop. Reset to step 0 on Edit / divisions change.
-  const [tectStep, setTectStep] = useState(0);
-  const [tectPlaying, setTectPlaying] = useState(false);
-  const tectPlayingRef = useRef(false);
-  useEffect(() => { tectPlayingRef.current = tectPlaying; }, [tectPlaying]);
-  const tectSimReadyRef = useRef(false);
-  const tectBusyRef = useRef(false);
   const [snapshot, setSnapshot] = useState<PlanetSnapshot | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [activeTool, setActiveTool] = useState<ToolName>("brush");
@@ -1062,135 +1053,6 @@ export default function App() {
     };
   }, [panelCategory, mode, paintBrush, interact]);
 
-  // TECT-PLAY: wizard-mode live tectonic playback. Init builds a fresh sim
-  // from the current draft (no run_length_steps, no erosion) and switches
-  // the visible globe to the point-cloud colored by plate ids. Subsequent
-  // step() calls just recolor — the painter mesh stays hidden until the
-  // user stops playback.
-  type TectStepResult = { plate_ids: number[]; step: number };
-
-  const applyTectResult = useCallback((res: TectStepResult) => {
-    const ids = res.plate_ids;
-    const buf = ids instanceof Uint8Array ? ids : new Uint8Array(ids);
-    globeRef.current?.recolorFromPlateIds(buf, PLATE_PALETTE);
-    setTectStep(res.step);
-    sceneRef.current?.markDirty();
-  }, []);
-
-  // Show the points globe + recolor with plate ids. Painter mesh is hidden
-  // so plate colors are unobscured. The painter cursor ring stays available
-  // (it lives on the painter group object); but since pointer events are
-  // disabled during play, it never appears.
-  const showPlateView = useCallback(() => {
-    if (painterMeshRef.current) painterMeshRef.current.object.visible = false;
-    if (globeRef.current) globeRef.current.object.visible = true;
-  }, []);
-
-  const showPaintView = useCallback(() => {
-    if (painterMeshRef.current) painterMeshRef.current.object.visible = true;
-    // When the height-painter mesh is mounted the points globe must be
-    // hidden again (mirrors the painter-lifecycle effect's invariant).
-    if (globeRef.current && painterMeshRef.current) {
-      globeRef.current.object.visible = false;
-    }
-  }, []);
-
-  const ensureTectSim = useCallback(async (): Promise<boolean> => {
-    if (tectSimReadyRef.current) return true;
-    const drft = draftRef.current;
-    if (!drft) return false;
-    // Build the live sim from the CURRENT draft (continents + painter
-    // overrides included via toDraftFields, matching bake_from_wizard).
-    const paintedFields = heightPainterRef.current
-      ? heightPainterRef.current.toDraftFields()
-      : { painted_elevations: [], painted_mask: [] };
-    const finalDraft: WizardDraft = { ...drft, ...paintedFields };
-    try {
-      const res = await invoke<TectStepResult>("start_tect_sim", { draft: finalDraft });
-      tectSimReadyRef.current = true;
-      showPlateView();
-      applyTectResult(res);
-      return true;
-    } catch (e) {
-      setError(String(e));
-      return false;
-    }
-  }, [applyTectResult, showPlateView]);
-
-  const handleTectStep = useCallback(async () => {
-    if (tectBusyRef.current) return;
-    tectBusyRef.current = true;
-    try {
-      const ok = await ensureTectSim();
-      if (!ok) return;
-      const res = await invoke<TectStepResult>("tect_step_n", { steps: 1 });
-      applyTectResult(res);
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      tectBusyRef.current = false;
-    }
-  }, [applyTectResult, ensureTectSim]);
-
-  const handleTectPlayPause = useCallback(async () => {
-    if (tectPlayingRef.current) {
-      setTectPlaying(false);
-      return;
-    }
-    const ok = await ensureTectSim();
-    if (!ok) return;
-    setTectPlaying(true);
-  }, [ensureTectSim]);
-
-  const handleTectReset = useCallback(() => {
-    setTectPlaying(false);
-    tectSimReadyRef.current = false;
-    setTectStep(0);
-    invoke("reset_sim").catch(() => {});
-    showPaintView();
-    // Repaint the points globe to the pre-play colour scheme so a stale
-    // plate-coloured cloud doesn't ghost behind the painter mesh.
-    const drft = draftRef.current;
-    if (drft) globeRef.current?.recolorFromDraft(drft, cellCountRef.current);
-  }, [showPaintView]);
-
-  // Drive the live sim via setInterval — ~12 FPS matches the ~80ms/step
-  // perf budget. A re-entrancy guard (tectBusyRef) prevents pile-up when a
-  // step takes longer than the interval at high resolutions.
-  useEffect(() => {
-    if (!tectPlaying) return;
-    let cancelled = false;
-    const id = window.setInterval(async () => {
-      if (cancelled || !tectPlayingRef.current) return;
-      if (tectBusyRef.current) return;
-      tectBusyRef.current = true;
-      try {
-        const res = await invoke<TectStepResult>("tect_step_n", { steps: 1 });
-        if (!cancelled && tectPlayingRef.current) applyTectResult(res);
-      } catch (e) {
-        if (!cancelled) {
-          setError(String(e));
-          setTectPlaying(false);
-        }
-      } finally {
-        tectBusyRef.current = false;
-      }
-    }, 85);
-    return () => {
-      cancelled = true;
-      window.clearInterval(id);
-    };
-  }, [tectPlaying, applyTectResult]);
-
-  // TECT-PLAY: when the user changes draft inputs (preset, painted cells,
-  // brush, divisions) the live sim is no longer in sync. Reset cheaply so
-  // the next Play / Step rebuilds. Excludes brush_radius (visual-only).
-  useEffect(() => {
-    if (!tectSimReadyRef.current) return;
-    handleTectReset();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [draft?.preset, draft?.seed, draft?.divisions, draft?.continental_cells.length]);
-
   // Live-apply boundary assignments — Rust rewrites plate omegas on the
   // running model so the change is visible immediately. No re-bake.
   const applyBoundaryTypesLive = useCallback(async (types: Record<string, BoundaryType>) => {
@@ -1286,12 +1148,6 @@ export default function App() {
   const handleBake = useCallback(async () => {
     const scene = sceneRef.current;
     if (!draft || !scene || debugBaking) return;
-    // TECT-PLAY: stop the live preview before bake. The bake rebuilds the
-    // sim from the draft anyway, so the play state must not leak into the
-    // baked planet.
-    setTectPlaying(false);
-    tectSimReadyRef.current = false;
-    setTectStep(0);
     setDebugBaking(true);
     setMode("baking");
     setDebugBakeProgress("Rasterising inputs…");
@@ -1512,9 +1368,6 @@ export default function App() {
     setInteract(nextInteract(interactRef.current, "edit"));
     setMode("wizard");
     setPlaying(false);
-    setTectPlaying(false);
-    tectSimReadyRef.current = false;
-    setTectStep(0);
     if (draft) globeRef.current?.recolorFromDraft(draft, cellCountRef.current);
   }, [draft]);
 
@@ -1776,14 +1629,6 @@ export default function App() {
           <ComposePanel
             draft={draft}
             busy={mode === "baking" || initializingGrid}
-            tectPlay={{
-              playing: tectPlaying,
-              step: tectStep,
-              onPlayPause: handleTectPlayPause,
-              onStep: handleTectStep,
-              onReset: handleTectReset,
-              disabled: mode === "baking" || initializingGrid,
-            }}
             onChangeDivisions={handleChangeDivisions}
             onChangePreset={handleChangePreset}
             onReroll={handleReroll}

--- a/apps/hayba-explorer/src/components/panels/ComposePanel.tsx
+++ b/apps/hayba-explorer/src/components/panels/ComposePanel.tsx
@@ -17,6 +17,16 @@ export interface ComposePanelProps {
   /** Extra sections rendered in the scroll area, below Continents and above
    *  the Bake action strip. Used to host the height-painter controls. */
   children?: React.ReactNode;
+  /** TECT-PLAY: optional live-sim controls shown above the Bake button.
+   *  When omitted, the Tectonic preview row is hidden. */
+  tectPlay?: {
+    playing: boolean;
+    step: number;
+    onPlayPause: () => void;
+    onStep: () => void;
+    onReset: () => void;
+    disabled?: boolean;
+  };
 }
 
 export default function ComposePanel(p: ComposePanelProps) {
@@ -92,6 +102,54 @@ export default function ComposePanel(p: ComposePanelProps) {
         </PropertySection>
 
         {p.children}
+
+        {p.tectPlay && (
+          <PropertySection heading="Tectonic preview">
+            <PropertyRow
+              label="Step"
+              value={
+                <span style={{ fontFamily: "Consolas, monospace", color: colors.beige }}>
+                  {p.tectPlay.step}
+                </span>
+              }
+            />
+            <PropertyRow
+              label="Play"
+              noSeparator
+              value={
+                <div style={{ display: "inline-flex", gap: 6 }}>
+                  <button
+                    type="button"
+                    onClick={p.tectPlay.onPlayPause}
+                    disabled={p.tectPlay.disabled}
+                    title={p.tectPlay.playing ? "Pause (Space)" : "Play (Space)"}
+                    style={tectButtonStyle(p.tectPlay.playing)}
+                  >
+                    {p.tectPlay.playing ? "Pause" : "Play"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={p.tectPlay.onStep}
+                    disabled={p.tectPlay.disabled || p.tectPlay.playing}
+                    title="Advance one step"
+                    style={tectButtonStyle(false)}
+                  >
+                    Step
+                  </button>
+                  <button
+                    type="button"
+                    onClick={p.tectPlay.onReset}
+                    disabled={p.tectPlay.disabled || p.tectPlay.step === 0}
+                    title="Reset to step 0"
+                    style={tectButtonStyle(false)}
+                  >
+                    Reset
+                  </button>
+                </div>
+              }
+            />
+          </PropertySection>
+        )}
       </div>
 
       <div style={bottomActionStripStyle}>
@@ -129,6 +187,19 @@ const bottomActionStripStyle: React.CSSProperties = {
   borderTop: `1px solid ${colors.borderMid}`,
   background: colors.bgPanelHeader,
 };
+
+function tectButtonStyle(active: boolean): React.CSSProperties {
+  return {
+    padding: "3px 10px",
+    background: active ? "rgba(181,106,29,0.22)" : "transparent",
+    border: `1px solid ${active ? "#B56A1D" : colors.borderMid}`,
+    borderRadius: 3,
+    color: active ? colors.beige : colors.textSecondary,
+    fontFamily: fonts.sans,
+    fontSize: 11,
+    cursor: "pointer",
+  };
+}
 
 const primaryActionButtonStyle: React.CSSProperties = {
   width: "100%",

--- a/apps/hayba-explorer/src/components/panels/ComposePanel.tsx
+++ b/apps/hayba-explorer/src/components/panels/ComposePanel.tsx
@@ -17,16 +17,6 @@ export interface ComposePanelProps {
   /** Extra sections rendered in the scroll area, below Continents and above
    *  the Bake action strip. Used to host the height-painter controls. */
   children?: React.ReactNode;
-  /** TECT-PLAY: optional live-sim controls shown above the Bake button.
-   *  When omitted, the Tectonic preview row is hidden. */
-  tectPlay?: {
-    playing: boolean;
-    step: number;
-    onPlayPause: () => void;
-    onStep: () => void;
-    onReset: () => void;
-    disabled?: boolean;
-  };
 }
 
 export default function ComposePanel(p: ComposePanelProps) {
@@ -102,54 +92,6 @@ export default function ComposePanel(p: ComposePanelProps) {
         </PropertySection>
 
         {p.children}
-
-        {p.tectPlay && (
-          <PropertySection heading="Tectonic preview">
-            <PropertyRow
-              label="Step"
-              value={
-                <span style={{ fontFamily: "Consolas, monospace", color: colors.beige }}>
-                  {p.tectPlay.step}
-                </span>
-              }
-            />
-            <PropertyRow
-              label="Play"
-              noSeparator
-              value={
-                <div style={{ display: "inline-flex", gap: 6 }}>
-                  <button
-                    type="button"
-                    onClick={p.tectPlay.onPlayPause}
-                    disabled={p.tectPlay.disabled}
-                    title={p.tectPlay.playing ? "Pause (Space)" : "Play (Space)"}
-                    style={tectButtonStyle(p.tectPlay.playing)}
-                  >
-                    {p.tectPlay.playing ? "Pause" : "Play"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={p.tectPlay.onStep}
-                    disabled={p.tectPlay.disabled || p.tectPlay.playing}
-                    title="Advance one step"
-                    style={tectButtonStyle(false)}
-                  >
-                    Step
-                  </button>
-                  <button
-                    type="button"
-                    onClick={p.tectPlay.onReset}
-                    disabled={p.tectPlay.disabled || p.tectPlay.step === 0}
-                    title="Reset to step 0"
-                    style={tectButtonStyle(false)}
-                  >
-                    Reset
-                  </button>
-                </div>
-              }
-            />
-          </PropertySection>
-        )}
       </div>
 
       <div style={bottomActionStripStyle}>
@@ -172,34 +114,11 @@ export default function ComposePanel(p: ComposePanelProps) {
   );
 }
 
-const inlineActionStyle: React.CSSProperties = {
-  marginLeft: 8,
-  background: "transparent",
-  border: "none",
-  color: colors.accent,
-  cursor: "pointer",
-  fontSize: 14,
-  lineHeight: 1,
-};
-
 const bottomActionStripStyle: React.CSSProperties = {
   padding: "10px 14px",
   borderTop: `1px solid ${colors.borderMid}`,
   background: colors.bgPanelHeader,
 };
-
-function tectButtonStyle(active: boolean): React.CSSProperties {
-  return {
-    padding: "3px 10px",
-    background: active ? "rgba(181,106,29,0.22)" : "transparent",
-    border: `1px solid ${active ? "#B56A1D" : colors.borderMid}`,
-    borderRadius: 3,
-    color: active ? colors.beige : colors.textSecondary,
-    fontFamily: fonts.sans,
-    fontSize: 11,
-    cursor: "pointer",
-  };
-}
 
 const primaryActionButtonStyle: React.CSSProperties = {
   width: "100%",

--- a/apps/hayba-explorer/src/viewport/globe.ts
+++ b/apps/hayba-explorer/src/viewport/globe.ts
@@ -42,6 +42,13 @@ export interface GlobeHandle {
     palette: ReadonlyArray<[number, number, number]>,
     boundary?: { model: BoundaryModel; assignments: BoundaryAssignments },
   ): void;
+  /** TECT-PLAY: paint by raw plate-id buffer (one byte per cell, 0 = no plate).
+   *  Used by the wizard-mode Play loop so the user can watch plates drift on
+   *  the painted globe without needing a full PlanetSnapshot from the bake. */
+  recolorFromPlateIds(
+    plateIds: Uint8Array | number[],
+    palette: ReadonlyArray<[number, number, number]>,
+  ): void;
 }
 
 export function buildGlobe(cellPositions: Float32Array): GlobeHandle {
@@ -130,6 +137,22 @@ export function buildGlobe(cellPositions: Float32Array): GlobeHandle {
         }
       }
       void BOUNDARY_HOVER_COLOR;
+      colorAttr.needsUpdate = true;
+    },
+    recolorFromPlateIds(plateIds, palette) {
+      // Plate ids are 1-based in the Rust sim; 0 = unassigned cell (e.g.
+      // freshly subducted). Unassigned cells paint as ocean for legibility;
+      // every other cell takes its plate's palette colour.
+      const len = Math.min(plateIds.length, n);
+      for (let i = 0; i < len; i++) {
+        const pid = plateIds[i];
+        if (pid <= 0) {
+          paintCell(i, OCEAN_COLOR);
+          continue;
+        }
+        const c = palette[(pid - 1) % palette.length] ?? CONTINENT_COLOR;
+        paintCell(i, c);
+      }
       colorAttr.needsUpdate = true;
     },
   };


### PR DESCRIPTION
## Summary

- Strip the compose-mode Tectonic preview Play/Pause/Step/Reset UI added in PR #207. Play belongs **after** the user has baked + assigned boundaries, not during continent painting.
- Remove the App.tsx setInterval driver, tect-play state, and ComposePanel ${"`"}tectPlay${"`"} prop.
- Keep ${"`"}globe.recolorFromPlateIds${"`"} and the ${"`"}start_tect_sim${"`"} / ${"`"}tect_step_n${"`"} Tauri commands intact for the post-bake Play stage.

## Test plan
- [x] ${"`"}npx tsc --noEmit${"`"} clean
- [x] ${"`"}cargo check${"`"} clean (one pre-existing warning, unrelated)
- [x] ${"`"}npx vitest run${"`"} — same 3 failures as base (all pre-existing transform issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive tectonics simulation with step-by-step control for preview mode
  * Enhanced globe visualization to display plate membership data in real-time

* **Style**
  * Removed unused code styling constants

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->