### PR TITLE
ui(sidebar): labels under category icons + distinct Compose/Texturing/Climate glyphs

### DIFF
--- a/apps/hayba-explorer/src/components/CategoryStrip.tsx
+++ b/apps/hayba-explorer/src/components/CategoryStrip.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { colors } from "@hayba/design-tokens";
+import { colors, fonts } from "@hayba/design-tokens";
 import { ICON_URLS } from "./icons";
 
 export type PanelCategory = "compose" | "texturing" | "climate" | "boundaries" | "densities" | "simulate" | "settings";
@@ -13,19 +13,55 @@ export interface CategoryStripProps {
   onPick: (cat: PanelCategory) => void;
 }
 
+// Distinct inline SVG icons for Compose / Texturing / Climate Lab. The
+// existing asset library only ships `IconCategoryCompose.svg` (a globe),
+// which all three categories used to share. To avoid creating new PNG
+// assets we render mountain (Compose), brush (Texturing), and cloud+sun
+// (Climate Lab) as inline 18x18 strokes that match the rest of the strip.
+type InlineKind = "compose" | "texturing" | "climate";
+
+const INLINE_SVGS: Record<InlineKind, React.ReactNode> = {
+  // Mountain — Compose (terrain authoring).
+  compose: (
+    <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 19 L9 9 L13 14 L16 10 L21 19 Z" />
+      <circle cx="16.5" cy="6.5" r="1.4" />
+    </svg>
+  ),
+  // Brush / palette — Texturing (per-biome SatMap library).
+  texturing: (
+    <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 17 L13 7 L17 11 L7 21 H3 Z" />
+      <path d="M13 7 L17 3 L21 7 L17 11" />
+      <circle cx="6.5" cy="17.5" r="0.8" fill="currentColor" />
+    </svg>
+  ),
+  // Cloud + sun — Climate Lab (per-band climate tuning).
+  climate: (
+    <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="8" cy="8" r="2.5" />
+      <path d="M8 3.5 V2 M8 14 V12.5 M3.5 8 H2 M12.5 8 H14 M4.8 4.8 L3.8 3.8 M12.2 4.8 L13.2 3.8" />
+      <path d="M9 17 a4 4 0 0 1 4 -4 a4.5 4.5 0 0 1 8.5 1.5 A3 3 0 0 1 20 20 H9 a3 3 0 0 1 0 -3 Z" />
+    </svg>
+  ),
+};
+
 interface Item {
   id: PanelCategory;
   label: string;
-  icon: string;
+  /** External SVG-URL icon (existing asset library). */
+  icon?: string;
+  /** Inline SVG kind (used where shared-asset icons would collide). */
+  inline?: InlineKind;
   bottom?: boolean;
 }
 
 const ITEMS: Item[] = [
-  { id: "compose",    label: "Compose",    icon: ICON_URLS.categoryCompose },
-  { id: "texturing",  label: "Texturing",  icon: ICON_URLS.categoryCompose },
-  { id: "climate",    label: "Climate Lab", icon: ICON_URLS.categoryCompose },
-  { id: "boundaries", label: "Boundaries", icon: ICON_URLS.categoryBoundaries },
-  { id: "densities",  label: "Densities",  icon: ICON_URLS.categoryDensities },
+  { id: "compose",    label: "Compose",    inline: "compose" },
+  { id: "texturing",  label: "Texture",    inline: "texturing" },
+  { id: "climate",    label: "Climate",    inline: "climate" },
+  { id: "boundaries", label: "Bounds",     icon: ICON_URLS.categoryBoundaries },
+  { id: "densities",  label: "Density",    icon: ICON_URLS.categoryDensities },
   { id: "simulate",   label: "Simulate",   icon: ICON_URLS.categorySimulate },
   { id: "settings",   label: "Settings",   icon: ICON_URLS.categorySettings, bottom: true },
 ];
@@ -46,34 +82,66 @@ export default function CategoryStrip({ active, enabled, disabledReason, onPick 
         disabled={!isEnabled}
         onClick={() => isEnabled && onPick(item.id)}
         style={{
-          height: 42,
+          // Slightly taller to fit icon + label without crowding.
+          height: 52,
           width: "100%",
           display: "flex",
+          flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
+          gap: 3,
           background: isActive ? colors.bgBase : "transparent",
           border: "none",
           borderLeft: `2px solid ${isActive ? colors.accent : "transparent"}`,
           color: isActive ? colors.beige : colors.textSecondary,
           opacity: isEnabled ? 1 : 0.4,
           cursor: isEnabled ? "pointer" : "not-allowed",
-          padding: 0,
+          padding: "4px 0 3px",
+          fontFamily: fonts.sans,
         }}
       >
-        <img
-          src={item.icon}
-          alt={item.label}
-          width={18}
-          height={18}
-          style={{ filter: "brightness(0) invert(1)", opacity: isActive ? 1 : 0.75 }}
-        />
+        {item.inline ? (
+          <span
+            aria-hidden
+            style={{
+              display: "inline-flex",
+              width: 18,
+              height: 18,
+              color: isActive ? colors.beige : colors.textSecondary,
+              opacity: isActive ? 1 : 0.85,
+            }}
+          >
+            {INLINE_SVGS[item.inline]}
+          </span>
+        ) : (
+          <img
+            src={item.icon}
+            alt=""
+            width={18}
+            height={18}
+            style={{ filter: "brightness(0) invert(1)", opacity: isActive ? 1 : 0.75 }}
+          />
+        )}
+        <span
+          style={{
+            fontSize: 9,
+            lineHeight: 1,
+            letterSpacing: "0.02em",
+            color: isActive ? colors.beige : colors.textSecondary,
+            opacity: isActive ? 0.95 : 0.7,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {item.label}
+        </span>
       </button>
     );
   };
 
   return (
     <div style={{
-      width: 44,
+      // Widened from 44 → 64 to fit icon + 9px label without truncation.
+      width: 64,
       background: colors.bgCategoryStrip,
       borderRight: `1px solid ${colors.borderMid}`,
       display: "flex",


### PR DESCRIPTION
## Summary
- Strip widens 44→64px so 18px icon stacks above a 9px label.
- Compose / Texturing / Climate Lab no longer all render the same globe — they get distinct inline-SVG glyphs (mountain / brush / cloud-sun).
- Tooltips retained for the abbreviated labels.

UI-QW Fix 1/4 from the sidebar UX audit.

## Test plan
- [x] tsc clean
- [ ] Eyeball CategoryStrip in the app — three top icons are now distinguishable, labels readable