### PR TITLE
feat(post-bake): route bake → boundaries + pink-seam overlay

### DIFF
--- a/apps/hayba-explorer/src/App.tsx
+++ b/apps/hayba-explorer/src/App.tsx
@@ -26,6 +26,7 @@ import BoundaryPopover from "./components/BoundaryPopover";
 import { IconPlay, IconPause, IconReset } from "./components/icons";
 import { buildPlateLabels, type PlateLabelsHandle } from "./viewport/overlays/plateLabels";
 import { buildForceArrows, type ForceArrowsHandle } from "./viewport/overlays/forceArrows";
+import { buildBoundaryLines, type BoundaryLinesHandle } from "./viewport/overlays/boundaryLines";
 import { buildPoleLabels,  type PoleLabelsHandle  } from "./viewport/overlays/poleLabels";
 import { createDefaultDraft, pairKey, type WizardDraft, type PresetName, type BoundaryType } from "./wizard/state";
 import { BoundaryModel, setBoundary, clearBoundary } from "./wizard/boundary-model";
@@ -270,6 +271,7 @@ export default function App() {
   const plateLabelsRef = useRef<PlateLabelsHandle | null>(null);
   const forceArrowsRef = useRef<ForceArrowsHandle | null>(null);
   const poleLabelsRef  = useRef<PoleLabelsHandle  | null>(null);
+  const boundaryLinesRef = useRef<BoundaryLinesHandle | null>(null);
 
   const [draft, setDraft] = useState<WizardDraft | null>(null);
   const [mode, setMode] = useState<Mode>("wizard");
@@ -1297,9 +1299,14 @@ export default function App() {
       // SP-A: explicit state — no painter-visibility games. The painter-
       // lifecycle effect is now gated on interact==="compose"; flipping
       // to "explore" deactivates it (its cleanup removes+disposes the
-      // painter mesh) so the eroded sphere is the only globe. Back to
-      // "wizard" mode (NOT boundaries — resolved SP-A decision).
-      setMode("wizard");
+      // painter mesh) so the eroded sphere is the only globe.
+      //
+      // Post-bake → boundaries: user picks plate boundary types (click
+      // any pink seam → convergent / divergent) before advancing to
+      // densities and Play. Replaces the old "stay in wizard after bake"
+      // SP-A decision — the bake → boundaries → densities → simulate
+      // pipeline mirrors the TectonicsExplorer flow the user wants.
+      setMode("boundaries");
       setInteract(nextInteract(interactRef.current, "bake"));
 
       setDebugBakeReady(true);
@@ -1365,6 +1372,13 @@ export default function App() {
     debugStackRef.current = null;
     debugMatRef.current = null;
     setDebugBakeReady(false);
+    // Tear down the pink-seam overlay — its geometry is built from the
+    // current snapshot and would point at stale cells after Edit.
+    if (boundaryLinesRef.current) {
+      scene?.scene.remove(boundaryLinesRef.current.object);
+      boundaryLinesRef.current.dispose();
+      boundaryLinesRef.current = null;
+    }
     setInteract(nextInteract(interactRef.current, "edit"));
     setMode("wizard");
     setPlaying(false);
@@ -1481,6 +1495,54 @@ export default function App() {
       arrows.update(snap, new Map());
     }
   }, [snapshot, mode, showPlateLabels, showForceArrows]);
+
+  // Pink-seam overlay (BoundaryLines). Lazily built on first snapshot
+  // (needs adjacency, which itself is lazily built inside the painter
+  // lifecycle effect — we trigger it here by reading trianglesRef and
+  // building adj if missing). Visible whenever the user is on the
+  // boundaries / densities / simulating stage so the seams stay readable
+  // throughout the post-bake flow; coloured by the user's per-pair
+  // assignments (red = convergent, blue = divergent, pink = unset).
+  useEffect(() => {
+    const scene = sceneRef.current;
+    const snap = snapshot;
+    if (!scene || !snap || !draft) return;
+
+    // Triangles + adjacency might not have been built yet (e.g. the user
+    // never opened the compose panel before baking). Build them on demand
+    // so the overlay always has the adjacency map it needs.
+    let cancelled = false;
+    void (async () => {
+      if (!trianglesRef.current) {
+        try {
+          const tris = await invoke<number[]>("get_grid_triangles", { divisions: draft.divisions });
+          if (cancelled) return;
+          trianglesRef.current = new Uint32Array(tris);
+        } catch (e) {
+          setError(String(e));
+          return;
+        }
+      }
+      if (!adjRef.current && trianglesRef.current) {
+        adjRef.current = buildAdjacency(trianglesRef.current, snap.n_cells);
+      }
+      const adj = adjRef.current;
+      if (!adj) return;
+
+      if (!boundaryLinesRef.current) {
+        const handle = buildBoundaryLines(adj);
+        boundaryLinesRef.current = handle;
+        scene.scene.add(handle.object);
+      }
+      const lines = boundaryLinesRef.current;
+      lines.update(snap, draft.boundary_types);
+      const show = mode === "boundaries" || mode === "densities" || mode === "simulating";
+      lines.setVisible(show);
+      scene.markDirty();
+    })();
+
+    return () => { cancelled = true; };
+  }, [snapshot, draft, mode]);
 
   return (
     <div style={{

--- a/apps/hayba-explorer/src/viewport/overlays/boundaryLines.ts
+++ b/apps/hayba-explorer/src/viewport/overlays/boundaryLines.ts
@@ -1,0 +1,109 @@
+// BoundaryLines — TE-style pink seam overlay drawn between adjacent cells
+// that belong to different plates. Lives as a separate THREE.LineSegments
+// Object3D so it sits on top of whatever globe is currently displayed
+// (point cloud during compose, eroded sphere post-bake). One overlay per
+// baked snapshot — rebuild via `update()` when the snapshot or
+// assignments change.
+//
+// Coloring per segment:
+//   - none        → BOUNDARY_PINK
+//   - convergent  → red
+//   - divergent   → blue
+//   - transform   → yellow (reserved; current sim only supports convergent
+//                   and divergent, but the segment lookup falls back to
+//                   pink for any unknown assignment).
+//
+// Endpoints are pushed slightly off the unit sphere (RADIUS) so the lines
+// are not z-fought into the surface texture. The overlay is drawn after
+// the globe (`renderOrder = 5`).
+
+import * as THREE from "three";
+import type { PlanetSnapshot } from "../../App";
+import type { BoundaryAssignments } from "../../wizard/boundary-model";
+import { pairKey } from "../../wizard/state";
+
+const RADIUS = 1.005;
+const COLOR_PINK       = new THREE.Color(0.80, 0.20, 0.50);
+const COLOR_CONVERGENT = new THREE.Color(0.95, 0.30, 0.30);
+const COLOR_DIVERGENT  = new THREE.Color(0.35, 0.60, 0.95);
+
+export interface BoundaryLinesHandle {
+  object: THREE.LineSegments;
+  setVisible: (v: boolean) => void;
+  /** Recompute geometry from the snapshot + per-pair assignments. */
+  update: (snap: PlanetSnapshot, assignments: BoundaryAssignments) => void;
+  dispose: () => void;
+}
+
+export function buildBoundaryLines(adjacency: number[][]): BoundaryLinesHandle {
+  const geo = new THREE.BufferGeometry();
+  // Start with an empty buffer; the first update() fills it. Vertex-coloured
+  // lines so each segment can carry its own (pink / red / blue) tint.
+  const mat = new THREE.LineBasicMaterial({
+    vertexColors: true,
+    transparent: true,
+    opacity: 0.95,
+    depthWrite: false,
+    depthTest: true,
+    linewidth: 1.5, // ignored by most WebGL impls but keeps the intent
+  });
+  const lines = new THREE.LineSegments(geo, mat);
+  lines.name = "hayba-boundary-lines";
+  lines.renderOrder = 5;
+  lines.visible = false;
+
+  const update = (snap: PlanetSnapshot, assignments: BoundaryAssignments): void => {
+    const positions: number[] = [];
+    const colors:    number[] = [];
+    const n = snap.n_cells;
+    const seen = new Set<number>(); // encoded edge (min, max) -> min * n + max
+
+    const pushSegment = (a: number, b: number, c: THREE.Color): void => {
+      const ax = snap.cell_positions[a * 3 + 0] * RADIUS;
+      const ay = snap.cell_positions[a * 3 + 1] * RADIUS;
+      const az = snap.cell_positions[a * 3 + 2] * RADIUS;
+      const bx = snap.cell_positions[b * 3 + 0] * RADIUS;
+      const by = snap.cell_positions[b * 3 + 1] * RADIUS;
+      const bz = snap.cell_positions[b * 3 + 2] * RADIUS;
+      positions.push(ax, ay, az, bx, by, bz);
+      colors.push(c.r, c.g, c.b, c.r, c.g, c.b);
+    };
+
+    for (let i = 0; i < n; i++) {
+      if (!snap.cell_is_boundary[i]) continue;
+      const pidA = snap.cell_plate_ids[i];
+      if (pidA < 0) continue;
+      const neighbours = adjacency[i];
+      if (!neighbours) continue;
+      for (const j of neighbours) {
+        if (j <= i) continue; // skip dupes — each unordered edge fires once
+        if (!snap.cell_is_boundary[j]) continue;
+        const pidB = snap.cell_plate_ids[j];
+        if (pidB < 0 || pidB === pidA) continue;
+        const key = i * n + j;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const pk = pairKey(pidA, pidB);
+        const t = assignments[pk];
+        const c = t === "convergent" ? COLOR_CONVERGENT
+                : t === "divergent"  ? COLOR_DIVERGENT
+                : COLOR_PINK;
+        pushSegment(i, j, c);
+      }
+    }
+
+    geo.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3));
+    geo.setAttribute("color",    new THREE.Float32BufferAttribute(colors, 3));
+    geo.computeBoundingSphere();
+  };
+
+  return {
+    object: lines,
+    setVisible: (v: boolean) => { lines.visible = v; },
+    update,
+    dispose: () => {
+      geo.dispose();
+      mat.dispose();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- After bake completes the user lands on the **boundaries** stage (instead of being dumped back into the wizard). The bake → boundaries → densities → simulate state machine and click-pink-seam popover were already wired up; the previous flow simply never entered them.
- New ${"`"}viewport/overlays/boundaryLines.ts${"`"} — a ${"`"}THREE.LineSegments${"`"} overlay that draws a pink seam between every pair of adjacent cells on different plates. Vertex-coloured so each segment tints by its current assignment (pink = unset, red = convergent, blue = divergent). Visible during boundaries / densities / simulating.
- App.tsx lazily builds the adjacency map on first snapshot (the painter-lifecycle effect that ordinarily owns it might never have run), mounts the overlay, and tears it down on Edit-back-to-wizard.
- Post-bake **Play** continues to live in the existing status-bar Play/Pause/Speed controls on the simulating mode — the user reaches it by ${"`"}Next: Densities${"`"} → ${"`"}Start${"`"}.

## Flow after this PR
1. compose continents (paint)
2. **Bake**
3. **boundaries** — click pink seams → pick convergent / divergent (live applied via ${"`"}apply_boundary_types${"`"}; segments retint)
4. **densities** — drag-rank plate densities → Start
5. **simulating** — status-bar Play / Pause / step-speed drives ${"`"}step_planet${"`"}

## Test plan
- [x] ${"`"}npx tsc --noEmit${"`"} clean
- [x] ${"`"}cargo check${"`"} + ${"`"}cargo test --lib${"`"} — 61 / 61 pass
- [x] ${"`"}npx vitest run${"`"} — same baseline 3 failures as main (pre-existing transform issues)