### PR TITLE
ui(sidebar): styled Settings controls + PropertyStack + collapsible sections

### DIFF
--- a/apps/hayba-explorer/src/components/PropertySection.tsx
+++ b/apps/hayba-explorer/src/components/PropertySection.tsx
@@ -1,30 +1,126 @@
 import React from "react";
-import { colors } from "@hayba/design-tokens";
+import { colors, easings } from "@hayba/design-tokens";
 
 export interface PropertySectionProps {
   /** Section label. Usually a string; ReactNode allows an interactive
    *  header (e.g. the Climate Lab's auto-pair 📊 toggle). */
   heading: React.ReactNode;
   children: React.ReactNode;
+  /** Make the heading clickable to collapse/expand the body. Defaults to
+   *  non-collapsible (existing behaviour). */
+  collapsible?: boolean;
+  /** Stable id used to persist collapsed state under
+   *  `hayba.panel.<panel>.<sectionId>.collapsed`. Required when
+   *  `collapsible` is true. */
+  panelId?: string;
+  sectionId?: string;
+  /** If true, the section starts collapsed on first render (overridden by
+   *  any persisted localStorage value). */
+  defaultCollapsed?: boolean;
 }
 
-/** Small-caps tracked heading + row group. Only place letter-spacing is allowed. */
-export default function PropertySection({ heading, children }: PropertySectionProps) {
+const storageKey = (panel: string, section: string): string =>
+  `hayba.panel.${panel}.${section}.collapsed`;
+
+const readPersisted = (panel: string | undefined, section: string | undefined): boolean | null => {
+  if (!panel || !section) return null;
+  try {
+    const raw = localStorage.getItem(storageKey(panel, section));
+    if (raw === "1") return true;
+    if (raw === "0") return false;
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const writePersisted = (panel: string | undefined, section: string | undefined, collapsed: boolean): void => {
+  if (!panel || !section) return;
+  try {
+    localStorage.setItem(storageKey(panel, section), collapsed ? "1" : "0");
+  } catch { /* noop — quota / private mode */ }
+};
+
+/** Small-caps tracked heading + row group. Only place letter-spacing is allowed.
+ *
+ *  When `collapsible` is set, the heading becomes a button that toggles the
+ *  body open/closed with a chevron indicator. The collapsed/expanded state
+ *  is persisted per (panelId, sectionId) in localStorage. */
+export default function PropertySection({
+  heading,
+  children,
+  collapsible,
+  panelId,
+  sectionId,
+  defaultCollapsed,
+}: PropertySectionProps) {
+  const [collapsed, setCollapsed] = React.useState<boolean>(() => {
+    const persisted = readPersisted(panelId, sectionId);
+    if (persisted !== null) return persisted;
+    return collapsible ? !!defaultCollapsed : false;
+  });
+
+  const toggle = React.useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      writePersisted(panelId, sectionId, next);
+      return next;
+    });
+  }, [panelId, sectionId]);
+
+  const baseHeader: React.CSSProperties = {
+    fontSize: 10,
+    color: colors.beige,
+    letterSpacing: "0.18em",
+    textTransform: "uppercase",
+    opacity: 0.7,
+    padding: "8px 16px 6px",
+  };
+
+  if (!collapsible) {
+    return (
+      <div style={{ marginTop: 12 }}>
+        <div style={baseHeader}>{heading}</div>
+        {children}
+      </div>
+    );
+  }
+
   return (
     <div style={{ marginTop: 12 }}>
-      <div
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
         style={{
-          fontSize: 10,
-          color: colors.beige,
-          letterSpacing: "0.18em",
-          textTransform: "uppercase",
-          opacity: 0.7,
-          padding: "8px 16px 6px",
+          ...baseHeader,
+          background: "transparent",
+          border: "none",
+          width: "100%",
+          textAlign: "left",
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          cursor: "pointer",
+          fontFamily: "inherit",
         }}
       >
-        {heading}
-      </div>
-      {children}
+        <span
+          aria-hidden
+          style={{
+            display: "inline-block",
+            width: 10,
+            color: colors.beige,
+            opacity: 0.55,
+            transform: collapsed ? "rotate(0deg)" : "rotate(90deg)",
+            transition: `transform 140ms ${easings.out}`,
+          }}
+        >
+          ▶
+        </span>
+        <span style={{ flex: 1 }}>{heading}</span>
+      </button>
+      {!collapsed && children}
     </div>
   );
 }

--- a/apps/hayba-explorer/src/components/PropertyStack.tsx
+++ b/apps/hayba-explorer/src/components/PropertyStack.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { colors, fonts } from "@hayba/design-tokens";
+
+export interface PropertyStackProps {
+  label: string;
+  /** Optional readout shown right-aligned on the label row (e.g. the current
+   *  slider value). Strings render in Consolas beige. Pass `null` to hide. */
+  value?: React.ReactNode;
+  /** Full-width control rendered below the label row — typically a slider. */
+  children: React.ReactNode;
+  /** If true, no bottom separator is drawn (last row in a section). */
+  noSeparator?: boolean;
+}
+
+/**
+ * Stacked-layout counterpart to PropertyRow: a label (+ optional readout)
+ * sits on its own line, with the actual control rendered full-width
+ * underneath. Used for sliders and other controls that need horizontal
+ * room — putting them in PropertyRow's tiny value cell crushes the track.
+ *
+ *   LABEL                                value
+ *   █▒░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  ← full-width control here
+ *
+ * Spacing, separator rule, and typography match PropertyRow so the
+ * sections read as a single column.
+ */
+export default function PropertyStack({ label, value, children, noSeparator }: PropertyStackProps) {
+  return (
+    <div
+      style={{
+        padding: "6px 16px 8px",
+        borderBottom: noSeparator ? "none" : `1px solid ${colors.rule}`,
+        fontFamily: fonts.sans,
+        fontSize: 12,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 4,
+        }}
+      >
+        <span style={{ color: colors.beigeMuted }}>{label}</span>
+        {value != null && (
+          <span style={{ color: colors.beige, fontFamily: fonts.mono }}>{value}</span>
+        )}
+      </div>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/hayba-explorer/src/components/Toggle.tsx
+++ b/apps/hayba-explorer/src/components/Toggle.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { colors, easings } from "@hayba/design-tokens";
+
+export interface ToggleProps {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  /** Accessible label — exposed via aria-label so the iOS-style track has
+   *  semantic meaning even when the visible label sits in a PropertyRow. */
+  ariaLabel: string;
+  disabled?: boolean;
+}
+
+/**
+ * Flat, dark-theme toggle that matches the rest of the docked chrome
+ * (Hayba accent + thin border, no shadow). Used where a bare
+ * `<input type="checkbox">` would render OS chrome that clashes with
+ * the panel palette.
+ */
+export default function Toggle({ checked, onChange, ariaLabel, disabled }: ToggleProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={() => !disabled && onChange(!checked)}
+      style={{
+        width: 30,
+        height: 16,
+        borderRadius: 8,
+        border: `1px solid ${checked ? colors.accent : colors.borderSoft}`,
+        background: checked ? colors.accentDim : "rgba(255,255,255,0.04)",
+        padding: 0,
+        position: "relative",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        transition: `background 160ms ${easings.out}, border-color 160ms ${easings.out}`,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          position: "absolute",
+          top: 1,
+          left: checked ? 15 : 1,
+          width: 12,
+          height: 12,
+          borderRadius: "50%",
+          background: checked ? colors.accent : colors.beigeMuted,
+          transition: `left 160ms ${easings.out}, background 160ms ${easings.out}`,
+        }}
+      />
+    </button>
+  );
+}

--- a/apps/hayba-explorer/src/components/panels/ClimateLabPanel.tsx
+++ b/apps/hayba-explorer/src/components/panels/ClimateLabPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { colors, fonts } from "@hayba/design-tokens";
 import PropertySection from "../PropertySection";
+import PropertyStack from "../PropertyStack";
 
 // ─────────────────────────────────────────────────────────────────────────
 // Climate parameters — 1:1 with the Rust `ClimateParams` struct. Every
@@ -183,14 +184,6 @@ export default function ClimateLabPanel(p: ClimateLabPanelProps): React.ReactEle
     if (preset) p.onChange({ ...preset });
   };
 
-  const labelStyle: React.CSSProperties = {
-    display: "flex",
-    justifyContent: "space-between",
-    fontSize: 11,
-    color: colors.textMuted,
-    fontFamily: fonts.sans,
-    marginBottom: 3,
-  };
   const sliderStyle: React.CSSProperties = { flex: 1, accentColor: colors.accent };
 
   return (
@@ -240,18 +233,30 @@ export default function ClimateLabPanel(p: ClimateLabPanelProps): React.ReactEle
         </div>
       </div>
 
-      {/* Grouped sliders (scrollable) */}
+      {/* Grouped sliders (scrollable). Each section is collapsible — the
+          first group (Temperature) defaults open, the rest collapsed, to
+          shorten the panel since Climate Lab has 6+ sections. */}
       <div style={{ flex: 1, overflowY: "auto" }}>
-        {GROUPS.map((g) => (
+        {GROUPS.map((g, gi) => (
           <PropertySection
             key={g.heading}
+            collapsible
+            panelId="climate"
+            sectionId={g.heading.toLowerCase()}
+            defaultCollapsed={gi !== 0}
             heading={
               <span
                 role="button"
                 tabIndex={0}
                 title={`Show the ${g.heading} diagnostic mask on the planet`}
                 onFocus={() => p.onFocusGroup(g.mapMode)}
-                onClick={() => p.onFocusGroup(g.mapMode)}
+                onClick={(e) => {
+                  // Emit the map-mode side-effect, then let the click
+                  // bubble to the surrounding header button so the
+                  // section still toggles collapse.
+                  p.onFocusGroup(g.mapMode);
+                  e.stopPropagation();
+                }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") p.onFocusGroup(g.mapMode);
                 }}
@@ -261,55 +266,53 @@ export default function ClimateLabPanel(p: ClimateLabPanelProps): React.ReactEle
               </span>
             }
           >
-            <div style={{ padding: "2px 16px 8px" }}>
-              {g.fields.map((f) => {
-                const v = p.params[f.key];
-                const def = DEFAULT_CLIMATE_PARAMS[f.key];
-                const fmt = f.fmt ?? ((x: number) => x.toFixed(2));
-                return (
-                  <div key={f.key} style={{ marginBottom: 8 }}>
-                    <div style={labelStyle}>
-                      <span>{f.label}</span>
-                      <span style={{ color: colors.beige, fontFamily: fonts.mono }}>{fmt(v)}</span>
-                    </div>
-                    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                      <input
-                        type="range"
-                        min={f.min}
-                        max={f.max}
-                        step={f.step}
-                        value={v}
-                        onFocus={() => p.onFocusGroup(g.mapMode)}
-                        onChange={(e) => set(f.key, Number(e.target.value))}
-                        style={sliderStyle}
-                        aria-label={f.label}
-                      />
-                      <button
-                        type="button"
-                        title={`Reset ${f.label} to ${fmt(def)}`}
-                        onClick={() => set(f.key, def)}
-                        disabled={v === def}
-                        style={{
-                          width: 18,
-                          height: 18,
-                          padding: 0,
-                          fontSize: 10,
-                          lineHeight: "16px",
-                          background: "transparent",
-                          color: v === def ? colors.textMuted : colors.beige,
-                          border: `1px solid ${colors.borderSoft}`,
-                          borderRadius: 2,
-                          cursor: v === def ? "default" : "pointer",
-                          opacity: v === def ? 0.4 : 1,
-                        }}
-                      >
-                        ↺
-                      </button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
+            {g.fields.map((f, fi) => {
+              const v = p.params[f.key];
+              const def = DEFAULT_CLIMATE_PARAMS[f.key];
+              const fmt = f.fmt ?? ((x: number) => x.toFixed(2));
+              return (
+                <PropertyStack
+                  key={f.key}
+                  label={f.label}
+                  value={fmt(v)}
+                  noSeparator={fi === g.fields.length - 1}
+                >
+                  <input
+                    type="range"
+                    min={f.min}
+                    max={f.max}
+                    step={f.step}
+                    value={v}
+                    onFocus={() => p.onFocusGroup(g.mapMode)}
+                    onChange={(e) => set(f.key, Number(e.target.value))}
+                    style={sliderStyle}
+                    aria-label={f.label}
+                  />
+                  <button
+                    type="button"
+                    title={`Reset ${f.label} to ${fmt(def)}`}
+                    onClick={() => set(f.key, def)}
+                    disabled={v === def}
+                    style={{
+                      width: 18,
+                      height: 18,
+                      marginLeft: 6,
+                      padding: 0,
+                      fontSize: 10,
+                      lineHeight: "16px",
+                      background: "transparent",
+                      color: v === def ? colors.textMuted : colors.beige,
+                      border: `1px solid ${colors.borderSoft}`,
+                      borderRadius: 2,
+                      cursor: v === def ? "default" : "pointer",
+                      opacity: v === def ? 0.4 : 1,
+                    }}
+                  >
+                    ↺
+                  </button>
+                </PropertyStack>
+              );
+            })}
           </PropertySection>
         ))}
 

--- a/apps/hayba-explorer/src/components/panels/HeightPaintPanel.tsx
+++ b/apps/hayba-explorer/src/components/panels/HeightPaintPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { colors, fonts } from "@hayba/design-tokens";
 import PropertyRow from "../PropertyRow";
+import PropertyStack from "../PropertyStack";
 import PropertySection from "../PropertySection";
 import Select from "../Select";
 import type { BrushConfig } from "../../wizard/paint/HeightPainter";
@@ -54,34 +55,34 @@ export default function HeightPaintPanel(p: HeightPaintPanelProps): React.ReactE
             ))}
           </div>
         </div>
-        <PropertyRow
+        <PropertyStack
           label="Radius"
-          value={
-            <input
-              type="range"
-              min={0.02}
-              max={0.30}
-              step={0.005}
-              value={p.brush.radiusRad}
-              onChange={(e) => set("radiusRad", Number(e.target.value))}
-              style={{ width: "100%" }}
-            />
-          }
-        />
-        <PropertyRow
+          value={p.brush.radiusRad.toFixed(3)}
+        >
+          <input
+            type="range"
+            min={0.02}
+            max={0.30}
+            step={0.005}
+            value={p.brush.radiusRad}
+            onChange={(e) => set("radiusRad", Number(e.target.value))}
+            style={{ width: "100%" }}
+          />
+        </PropertyStack>
+        <PropertyStack
           label="Strength"
-          value={
-            <input
-              type="range"
-              min={0}
-              max={1}
-              step={0.01}
-              value={p.brush.strength}
-              onChange={(e) => set("strength", Number(e.target.value))}
-              style={{ width: "100%" }}
-            />
-          }
-        />
+          value={p.brush.strength.toFixed(2)}
+        >
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={p.brush.strength}
+            onChange={(e) => set("strength", Number(e.target.value))}
+            style={{ width: "100%" }}
+          />
+        </PropertyStack>
         <PropertyRow
           label="Falloff"
           value={
@@ -108,21 +109,21 @@ export default function HeightPaintPanel(p: HeightPaintPanelProps): React.ReactE
           }
         />
         {p.brush.mode === "flatten" && (
-          <PropertyRow
+          <PropertyStack
             label="Target"
+            value={p.brush.flattenTarget.toFixed(2)}
             noSeparator
-            value={
-              <input
-                type="range"
-                min={-1}
-                max={1}
-                step={0.05}
-                value={p.brush.flattenTarget}
-                onChange={(e) => set("flattenTarget", Number(e.target.value))}
-                style={{ width: "100%" }}
-              />
-            }
-          />
+          >
+            <input
+              type="range"
+              min={-1}
+              max={1}
+              step={0.05}
+              value={p.brush.flattenTarget}
+              onChange={(e) => set("flattenTarget", Number(e.target.value))}
+              style={{ width: "100%" }}
+            />
+          </PropertyStack>
         )}
       </PropertySection>
 

--- a/apps/hayba-explorer/src/components/panels/SettingsPanel.tsx
+++ b/apps/hayba-explorer/src/components/panels/SettingsPanel.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 import PropertyRow from "../PropertyRow";
 import PropertySection from "../PropertySection";
+import PropertyStack from "../PropertyStack";
+import Select from "../Select";
+import Toggle from "../Toggle";
 import type { Fidelity } from "../../viewport/bake/fidelity";
 
+/**
+ * @deprecated Map-mode UI now lives in the bottom-bar (`equirectMapModes.ts`).
+ * The export is retained because `App.tsx` still imports the symbol; once
+ * that import is removed this entire constant can be deleted.
+ */
 export const MAP_MODES: { value: number; label: string }[] = [
   { value: 0,  label: "Final render" },
   { value: 1,  label: "Temperature" },
@@ -24,7 +32,9 @@ export interface SettingsPanelProps {
   showForceArrows: boolean;
   onToggleLabels: (v: boolean) => void;
   onToggleArrows: (v: boolean) => void;
+  /** @deprecated kept for App.tsx compatibility; no longer surfaced in the UI. */
   mapMode: number;
+  /** @deprecated kept for App.tsx compatibility; no longer surfaced in the UI. */
   onChangeMapMode: (n: number) => void;
   fidelity: Fidelity;
   onChangeFidelity: (f: Fidelity) => void;
@@ -39,42 +49,42 @@ export default function SettingsPanel(p: SettingsPanelProps) {
         <PropertyRow
           label="Fidelity"
           value={
-            <select
-              aria-label="Bake fidelity"
+            <Select<Fidelity>
               value={p.fidelity}
-              onChange={(e) => p.onChangeFidelity(e.target.value as Fidelity)}
-            >
-              <option value="low">Low — fastest (1024²)</option>
-              <option value="medium">Medium (2048²)</option>
-              <option value="high">High — slowest (2560²)</option>
-            </select>
-          }
-        />
-        <PropertyRow
-          label={`Sea level (${p.seaLevel.toFixed(3)})`}
-          noSeparator
-          value={
-            <input
-              type="range"
-              min={-0.2}
-              max={0.3}
-              step={0.005}
-              value={p.seaLevel}
-              onChange={(e) => p.onChangeSeaLevel(parseFloat(e.target.value))}
-              aria-label="Sea level offset (applied at next bake)"
+              onChange={p.onChangeFidelity}
+              options={[
+                { value: "low",    label: "Low (1024²)" },
+                { value: "medium", label: "Medium (2048²)" },
+                { value: "high",   label: "High (2560²)" },
+              ]}
             />
           }
         />
+        <PropertyStack
+          label="Sea level"
+          value={p.seaLevel.toFixed(3)}
+          noSeparator
+        >
+          <input
+            type="range"
+            min={-0.2}
+            max={0.3}
+            step={0.005}
+            value={p.seaLevel}
+            onChange={(e) => p.onChangeSeaLevel(parseFloat(e.target.value))}
+            aria-label="Sea level offset (applied at next bake)"
+            style={{ width: "100%" }}
+          />
+        </PropertyStack>
       </PropertySection>
       <PropertySection heading="Viewport overlays">
         <PropertyRow
           label="Plate labels"
           value={
-            <input
-              type="checkbox"
+            <Toggle
               checked={p.showPlateLabels}
-              onChange={(e) => p.onToggleLabels(e.target.checked)}
-              aria-label="Toggle plate labels"
+              onChange={p.onToggleLabels}
+              ariaLabel="Toggle plate labels"
             />
           }
         />
@@ -82,11 +92,10 @@ export default function SettingsPanel(p: SettingsPanelProps) {
           label="Force arrows"
           noSeparator
           value={
-            <input
-              type="checkbox"
+            <Toggle
               checked={p.showForceArrows}
-              onChange={(e) => p.onToggleArrows(e.target.checked)}
-              aria-label="Toggle force arrows"
+              onChange={p.onToggleArrows}
+              ariaLabel="Toggle force arrows"
             />
           }
         />

--- a/apps/hayba-explorer/src/components/panels/TexturingPanel.tsx
+++ b/apps/hayba-explorer/src/components/panels/TexturingPanel.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { colors, fonts } from "@hayba/design-tokens";
+import PropertySection from "../PropertySection";
+import PropertyStack from "../PropertyStack";
 import {
   SATMAP_NAMES,
   SATMAP_FAMILIES,
@@ -59,19 +61,15 @@ export default function TexturingPanel(p: TexturingPanelProps): React.ReactEleme
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      {/* Global surface controls (not per-biome) */}
-      <div style={{ padding: "10px 12px", borderBottom: `1px solid ${colors.borderMid}` }}>
-        <div style={{ fontSize: 11, color: colors.textMuted, marginBottom: 8 }}>
-          Surface
-        </div>
-
-        <div style={{ marginBottom: 8 }}>
-          <div style={labelStyle}>
-            <span>Surface brightness</span>
-            <span style={{ color: colors.beige, fontFamily: fonts.mono }}>
-              {p.brightness.toFixed(2)}
-            </span>
-          </div>
+      {/* Global surface controls — collapsible so the per-biome SatMap
+          library below gets more vertical room when these are tuned. */}
+      <PropertySection
+        heading="Surface"
+        collapsible
+        panelId="texturing"
+        sectionId="surface"
+      >
+        <PropertyStack label="Surface brightness" value={p.brightness.toFixed(2)}>
           <input
             type="range"
             min={0.6}
@@ -81,15 +79,8 @@ export default function TexturingPanel(p: TexturingPanelProps): React.ReactEleme
             onChange={(e) => p.onBrightness(Number(e.target.value))}
             style={sliderStyle}
           />
-        </div>
-
-        <div>
-          <div style={labelStyle}>
-            <span>Smoothing</span>
-            <span style={{ color: colors.beige, fontFamily: fonts.mono }}>
-              {p.smooth.toFixed(2)}
-            </span>
-          </div>
+        </PropertyStack>
+        <PropertyStack label="Smoothing" value={p.smooth.toFixed(2)}>
           <input
             type="range"
             min={0}
@@ -99,15 +90,8 @@ export default function TexturingPanel(p: TexturingPanelProps): React.ReactEleme
             onChange={(e) => p.onSmooth(Number(e.target.value))}
             style={sliderStyle}
           />
-        </div>
-
-        <div style={{ marginTop: 8 }}>
-          <div style={labelStyle}>
-            <span>Saturation</span>
-            <span style={{ color: colors.beige, fontFamily: fonts.mono }}>
-              {p.saturation.toFixed(2)}
-            </span>
-          </div>
+        </PropertyStack>
+        <PropertyStack label="Saturation" value={p.saturation.toFixed(2)} noSeparator>
           <input
             type="range"
             min={0}
@@ -117,8 +101,8 @@ export default function TexturingPanel(p: TexturingPanelProps): React.ReactEleme
             onChange={(e) => p.onSaturation(Number(e.target.value))}
             style={sliderStyle}
           />
-        </div>
-      </div>
+        </PropertyStack>
+      </PropertySection>
 
       {/* Biome selector chips */}
       <div style={{ padding: "10px 12px 6px", borderBottom: `1px solid ${colors.borderMid}` }}>


### PR DESCRIPTION
## Summary
Sidebar UX quick-wins 2-4 from the audit, shipped together because they share new PropertyStack / Toggle / collapsible-section primitives.

- **SettingsPanel**: native `<select>` → styled `Select`; bare checkboxes → `Toggle`; Sea-level slider moves to `PropertyStack` so the slider gets full width.
- **PropertyStack** primitive: stacked label/value-readout/full-width control. Migrated `HeightPaintPanel` (Radius/Strength/Target), `ClimateLabPanel` (all sliders), `SettingsPanel` (Sea level).
- **Collapsible `PropertySection`**: new `collapsible` / `panelId` / `sectionId` / `defaultCollapsed` props; chevron indicator; state persisted to `localStorage` under `hayba.panel.<panel>.<section>.collapsed`. Climate Lab opens with Temperature only; Texturing surface section collapses too.
- `MAP_MODES` in `SettingsPanel.tsx` is marked `@deprecated` (App.tsx still imports it; cleanup is a follow-up).

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — the 3 pre-existing equirectMapModes/stack-mapmode test failures are unchanged (confirmed on `origin/main`).
- [ ] Eyeball: open Settings panel — Sea-level row is full-width with the value top-right; Fidelity is the dark Select; toggles look like the rest of the chrome.
- [ ] Climate Lab opens with Temperature expanded, others collapsed; collapse state survives reload.
- [ ] Texturing Surface section collapses.