### PR TITLE
feat(ui): UE5 Details-panel restyle for sidebar

### DIFF
--- a/apps/hayba-explorer/src/components/CategoryStrip.tsx
+++ b/apps/hayba-explorer/src/components/CategoryStrip.tsx
@@ -81,6 +81,8 @@ export default function CategoryStrip({ active, enabled, disabledReason, onPick 
         title={tooltip}
         disabled={!isEnabled}
         onClick={() => isEnabled && onPick(item.id)}
+        onMouseEnter={(e) => { if (isEnabled && !isActive) (e.currentTarget.style.background = colors.bgRowHover); }}
+        onMouseLeave={(e) => { if (!isActive) (e.currentTarget.style.background = "transparent"); }}
         style={{
           // Slightly taller to fit icon + label without crowding.
           height: 52,
@@ -90,10 +92,10 @@ export default function CategoryStrip({ active, enabled, disabledReason, onPick 
           alignItems: "center",
           justifyContent: "center",
           gap: 3,
-          background: isActive ? colors.bgBase : "transparent",
+          background: isActive ? colors.accentDim : "transparent",
           border: "none",
-          borderLeft: `2px solid ${isActive ? colors.accent : "transparent"}`,
-          color: isActive ? colors.beige : colors.textSecondary,
+          borderLeft: `3px solid ${isActive ? colors.accent : "transparent"}`,
+          color: isActive ? colors.textValue : colors.textSecondary,
           opacity: isEnabled ? 1 : 0.4,
           cursor: isEnabled ? "pointer" : "not-allowed",
           padding: "4px 0 3px",

--- a/apps/hayba-explorer/src/components/PropertyRow.tsx
+++ b/apps/hayba-explorer/src/components/PropertyRow.tsx
@@ -1,31 +1,43 @@
 import React from "react";
-import { colors, fonts } from "@hayba/design-tokens";
+import { colors, fonts, space, fontSize } from "@hayba/design-tokens";
+import { rowMatches, usePropertySearch, useSectionVisibility } from "./propertySearch";
 
 export interface PropertyRowProps {
   label: string;
-  /** Right-side value. Strings render as Consolas beige; ReactNode lets callers pass controls. */
+  /** Right-side value. Strings render as label-style; ReactNode lets callers pass controls. */
   value: React.ReactNode;
   /** If true, no bottom separator is drawn (last row in a section). */
   noSeparator?: boolean;
 }
 
-/** 32px label-left value-right row with optional 1px bottom separator. */
+/** UE5-style tight row: 28px tall, 8px padding, hover lighten, 1px subtle separator. */
 export default function PropertyRow({ label, value, noSeparator }: PropertyRowProps) {
+  const [hover, setHover] = React.useState(false);
+  const { query } = usePropertySearch();
+  const section = useSectionVisibility();
+  const matched = rowMatches(label, query);
+  const id = React.useId();
+  React.useEffect(() => { section?.register(id, matched); }, [section, id, matched]);
+  React.useEffect(() => () => { section?.register(id, false); }, [section, id]);
+  if (!matched) return null;
   return (
     <div
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
       style={{
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
-        height: 32,
-        padding: "0 16px",
-        borderBottom: noSeparator ? "none" : `1px solid ${colors.rule}`,
+        height: space.rowHeight,
+        padding: `0 ${space.rowPadX}px`,
+        background: hover ? colors.bgRowHover : "transparent",
+        borderBottom: noSeparator ? "none" : `1px solid ${colors.borderSubtle}`,
         fontFamily: fonts.sans,
-        fontSize: 12,
+        fontSize: fontSize.label,
       }}
     >
-      <span style={{ color: colors.beigeMuted }}>{label}</span>
-      <span style={{ color: colors.beige, fontFamily: fonts.mono }}>{value}</span>
+      <span style={{ color: colors.textLabel }}>{label}</span>
+      <span style={{ color: colors.textValue, fontFamily: fonts.mono, fontSize: fontSize.value, textAlign: "right" }}>{value}</span>
     </div>
   );
 }

--- a/apps/hayba-explorer/src/components/PropertySection.tsx
+++ b/apps/hayba-explorer/src/components/PropertySection.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { colors, easings } from "@hayba/design-tokens";
+import { colors, easings, space, fontSize } from "@hayba/design-tokens";
+import { SectionVisibilityProvider, usePropertySearch } from "./propertySearch";
 
 export interface PropertySectionProps {
   /** Section label. Usually a string; ReactNode allows an interactive
-   *  header (e.g. the Climate Lab's auto-pair 📊 toggle). */
+   *  header (e.g. the Climate Lab's auto-pair toggle). */
   heading: React.ReactNode;
   children: React.ReactNode;
   /** Make the heading clickable to collapse/expand the body. Defaults to
@@ -41,11 +42,8 @@ const writePersisted = (panel: string | undefined, section: string | undefined, 
   } catch { /* noop — quota / private mode */ }
 };
 
-/** Small-caps tracked heading + row group. Only place letter-spacing is allowed.
- *
- *  When `collapsible` is set, the heading becomes a button that toggles the
- *  body open/closed with a chevron indicator. The collapsed/expanded state
- *  is persisted per (panelId, sectionId) in localStorage. */
+/** UE5-style section header: thin 24px band with chevron + small-caps tracked label.
+ *  Body renders flush — rows butt up to the section edges (no inner padding). */
 export default function PropertySection({
   heading,
   children,
@@ -59,6 +57,23 @@ export default function PropertySection({
     if (persisted !== null) return persisted;
     return collapsible ? !!defaultCollapsed : false;
   });
+  const [hover, setHover] = React.useState(false);
+  const { query } = usePropertySearch();
+  // Track how many child PropertyRow / PropertyStack rows currently match the
+  // search query. When a query is active and the count is zero, hide the
+  // section header entirely so search results read as a flat filtered list.
+  const [visibleCount, setVisibleCount] = React.useState<number>(0);
+  // When the section has no PropertyRow children at all (bespoke layouts —
+  // e.g. brush-mode grid, Templates buttons), the counter stays at 0 even
+  // without a query. Detect "no rows registered" by checking whether any
+  // descendant ever called register().
+  const seenAnyRef = React.useRef(false);
+  const onCountChange = React.useCallback((n: number) => {
+    if (n > 0) seenAnyRef.current = true;
+    setVisibleCount(n);
+  }, []);
+  const hiddenByFilter =
+    query.length > 0 && seenAnyRef.current && visibleCount === 0;
 
   const toggle = React.useCallback(() => {
     setCollapsed((prev) => {
@@ -68,59 +83,96 @@ export default function PropertySection({
     });
   }, [panelId, sectionId]);
 
+  // When a search query is active, force-expand so matching rows are visible.
+  const expanded = query.length > 0 ? true : !collapsed;
   const baseHeader: React.CSSProperties = {
-    fontSize: 10,
-    color: colors.beige,
-    letterSpacing: "0.18em",
+    height: space.sectionBandH,
+    boxSizing: "border-box",
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    padding: `0 ${space.rowPadX}px`,
+    background: hover ? colors.bgElevated : colors.bgSectionBand,
+    borderBottom: `1px solid ${colors.borderSubtle}`,
+    fontSize: fontSize.section,
+    color: colors.textLabel,
+    letterSpacing: "0.12em",
     textTransform: "uppercase",
-    opacity: 0.7,
-    padding: "8px 16px 6px",
+    transition: `background 120ms ${easings.out}`,
   };
+
+  const chevron = (
+    <span
+      aria-hidden
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 10,
+        height: 10,
+        color: colors.textLabel,
+        opacity: 0.85,
+        transform: expanded ? "rotate(0deg)" : "rotate(-90deg)",
+        transition: `transform 140ms ${easings.out}`,
+      }}
+    >
+      {/* Lucide chevron-down inline */}
+      <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="6 9 12 15 18 9" />
+      </svg>
+    </span>
+  );
+
+  // Always render children once into a SectionVisibilityProvider so the
+  // visible-row counter stays accurate even when the section is collapsed
+  // (otherwise unmount nukes registrations and visibleCount drops to 0 → the
+  // section gets mis-hidden by the filter). When collapsed we hide the body
+  // via CSS instead of unmounting.
+  const body = (
+    <SectionVisibilityProvider onCountChange={onCountChange}>
+      <div style={{ display: expanded ? "block" : "none" }}>{children}</div>
+    </SectionVisibilityProvider>
+  );
+
+  if (hiddenByFilter) return <>{body}</>;
 
   if (!collapsible) {
     return (
-      <div style={{ marginTop: 12 }}>
-        <div style={baseHeader}>{heading}</div>
-        {children}
+      <div>
+        <div
+          style={baseHeader}
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
+        >
+          {chevron}
+          <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{heading}</span>
+        </div>
+        {body}
       </div>
     );
   }
 
   return (
-    <div style={{ marginTop: 12 }}>
+    <div>
       <button
         type="button"
         onClick={toggle}
-        aria-expanded={!collapsed}
+        aria-expanded={expanded}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
         style={{
           ...baseHeader,
-          background: "transparent",
           border: "none",
           width: "100%",
           textAlign: "left",
-          display: "flex",
-          alignItems: "center",
-          gap: 6,
           cursor: "pointer",
           fontFamily: "inherit",
         }}
       >
-        <span
-          aria-hidden
-          style={{
-            display: "inline-block",
-            width: 10,
-            color: colors.beige,
-            opacity: 0.55,
-            transform: collapsed ? "rotate(0deg)" : "rotate(90deg)",
-            transition: `transform 140ms ${easings.out}`,
-          }}
-        >
-          ▶
-        </span>
-        <span style={{ flex: 1 }}>{heading}</span>
+        {chevron}
+        <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{heading}</span>
       </button>
-      {!collapsed && children}
+      {body}
     </div>
   );
 }

--- a/apps/hayba-explorer/src/components/PropertyStack.tsx
+++ b/apps/hayba-explorer/src/components/PropertyStack.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { colors, fonts } from "@hayba/design-tokens";
+import { colors, fonts, space, fontSize } from "@hayba/design-tokens";
+import { rowMatches, usePropertySearch, useSectionVisibility } from "./propertySearch";
 
 export interface PropertyStackProps {
   label: string;
   /** Optional readout shown right-aligned on the label row (e.g. the current
-   *  slider value). Strings render in Consolas beige. Pass `null` to hide. */
+   *  slider value). Strings render in white value-style. Pass `null` to hide. */
   value?: React.ReactNode;
   /** Full-width control rendered below the label row — typically a slider. */
   children: React.ReactNode;
@@ -13,25 +14,31 @@ export interface PropertyStackProps {
 }
 
 /**
- * Stacked-layout counterpart to PropertyRow: a label (+ optional readout)
- * sits on its own line, with the actual control rendered full-width
- * underneath. Used for sliders and other controls that need horizontal
- * room — putting them in PropertyRow's tiny value cell crushes the track.
+ * UE5-style stacked row: 18px label row + ~24-28px control row, 8px hpad,
+ * row-hover background, same separator rule as PropertyRow.
  *
  *   LABEL                                value
  *   █▒░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  ← full-width control here
- *
- * Spacing, separator rule, and typography match PropertyRow so the
- * sections read as a single column.
  */
 export default function PropertyStack({ label, value, children, noSeparator }: PropertyStackProps) {
+  const [hover, setHover] = React.useState(false);
+  const { query } = usePropertySearch();
+  const section = useSectionVisibility();
+  const matched = rowMatches(label, query);
+  const id = React.useId();
+  React.useEffect(() => { section?.register(id, matched); }, [section, id, matched]);
+  React.useEffect(() => () => { section?.register(id, false); }, [section, id]);
+  if (!matched) return null;
   return (
     <div
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
       style={{
-        padding: "6px 16px 8px",
-        borderBottom: noSeparator ? "none" : `1px solid ${colors.rule}`,
+        padding: `2px ${space.rowPadX}px 4px`,
+        background: hover ? colors.bgRowHover : "transparent",
+        borderBottom: noSeparator ? "none" : `1px solid ${colors.borderSubtle}`,
         fontFamily: fonts.sans,
-        fontSize: 12,
+        fontSize: fontSize.label,
       }}
     >
       <div
@@ -39,15 +46,15 @@ export default function PropertyStack({ label, value, children, noSeparator }: P
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          marginBottom: 4,
+          height: 18,
         }}
       >
-        <span style={{ color: colors.beigeMuted }}>{label}</span>
+        <span style={{ color: colors.textLabel }}>{label}</span>
         {value != null && (
-          <span style={{ color: colors.beige, fontFamily: fonts.mono }}>{value}</span>
+          <span style={{ color: colors.textValue, fontFamily: fonts.mono, fontSize: fontSize.value }}>{value}</span>
         )}
       </div>
-      <div style={{ display: "flex", alignItems: "center" }}>
+      <div style={{ display: "flex", alignItems: "center", height: 24 }}>
         {children}
       </div>
     </div>

--- a/apps/hayba-explorer/src/components/RightPanel.tsx
+++ b/apps/hayba-explorer/src/components/RightPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { colors, fonts } from "@hayba/design-tokens";
+import { colors, fonts, fontSize } from "@hayba/design-tokens";
 import CategoryStrip, { type PanelCategory } from "./CategoryStrip";
+import { PropertySearchProvider } from "./propertySearch";
 
 export interface RightPanelProps {
   active: PanelCategory;
@@ -21,14 +22,21 @@ const TITLES: Record<PanelCategory, { title: string; subtitle: string }> = {
   settings:   { title: "Settings",   subtitle: "App preferences" },
 };
 
+/** UE5-style Details panel shell. The header carries title + subtitle, then a
+ *  thin search input below that filters PropertyRow / PropertyStack matches
+ *  through React context (see propertySearch.tsx). Reset on category change. */
 export default function RightPanel({ active, enabled, disabledReason, onPick, children }: RightPanelProps) {
   const meta = TITLES[active];
+  const [query, setQuery] = React.useState<string>("");
+  // Clear the query whenever the user switches categories — otherwise stale
+  // filters silently hide the new panel's rows on mount.
+  React.useEffect(() => { setQuery(""); }, [active]);
   return (
     <div style={{
       display: "flex",
       height: "100%",
-      background: colors.bgBase,
-      borderLeft: `1px solid ${colors.borderMid}`,
+      background: colors.bgPanel,
+      borderLeft: `1px solid ${colors.borderSubtle}`,
       color: colors.textPrimary,
       fontFamily: fonts.sans,
     }}>
@@ -37,16 +45,91 @@ export default function RightPanel({ active, enabled, disabledReason, onPick, ch
         <div style={{
           display: "flex",
           alignItems: "center",
-          padding: "10px 14px",
+          padding: "10px 8px",
           gap: 10,
-          borderBottom: `1px solid ${colors.borderMid}`,
+          borderBottom: `1px solid ${colors.borderSubtle}`,
           background: colors.bgPanelHeader,
         }}>
-          <span style={{ fontSize: 13, color: colors.beige, fontWeight: 600 }}>{meta.title}</span>
+          <span style={{ fontSize: 13, color: colors.textValue, fontWeight: 600 }}>{meta.title}</span>
           <span style={{ fontSize: 11, color: colors.textMuted }}>{meta.subtitle}</span>
         </div>
+        {/* UE5 Details-panel search bar — sits directly under the title, no border on focus. */}
+        <div style={{
+          padding: "6px 8px",
+          background: colors.bgPanelHeader,
+          borderBottom: `1px solid ${colors.borderSubtle}`,
+        }}>
+          <div style={{ position: "relative" }}>
+            <span
+              aria-hidden
+              style={{
+                position: "absolute",
+                left: 6,
+                top: "50%",
+                transform: "translateY(-50%)",
+                color: colors.textMuted,
+                display: "inline-flex",
+                pointerEvents: "none",
+              }}
+            >
+              <svg width={11} height={11} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="11" cy="11" r="7" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+            </span>
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.currentTarget.value)}
+              placeholder="Search"
+              aria-label="Filter properties"
+              style={{
+                width: "100%",
+                boxSizing: "border-box",
+                height: 22,
+                padding: "0 22px 0 22px",
+                background: colors.bgDeep,
+                border: "none",
+                outline: "none",
+                color: colors.textValue,
+                fontFamily: fonts.sans,
+                fontSize: fontSize.label,
+                borderRadius: 3,
+              }}
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => setQuery("")}
+                aria-label="Clear search"
+                title="Clear"
+                style={{
+                  position: "absolute",
+                  right: 4,
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  width: 16,
+                  height: 16,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  background: "transparent",
+                  border: "none",
+                  color: colors.textMuted,
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                <svg width={10} height={10} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
         <div style={{ flex: 1, minHeight: 0 }}>
-          {children}
+          <PropertySearchProvider query={query}>{children}</PropertySearchProvider>
         </div>
       </div>
     </div>

--- a/apps/hayba-explorer/src/components/Toggle.tsx
+++ b/apps/hayba-explorer/src/components/Toggle.tsx
@@ -4,17 +4,19 @@ import { colors, easings } from "@hayba/design-tokens";
 export interface ToggleProps {
   checked: boolean;
   onChange: (v: boolean) => void;
-  /** Accessible label — exposed via aria-label so the iOS-style track has
-   *  semantic meaning even when the visible label sits in a PropertyRow. */
+  /** Accessible label — exposed via aria-label so the control has semantic
+   *  meaning even when its visible label sits in a PropertyRow. */
   ariaLabel: string;
   disabled?: boolean;
 }
 
 /**
- * Flat, dark-theme toggle that matches the rest of the docked chrome
- * (Hayba accent + thin border, no shadow). Used where a bare
- * `<input type="checkbox">` would render OS chrome that clashes with
- * the panel palette.
+ * UE5-style boolean checkbox: 14×14 box with 2px corners. When unchecked,
+ * shows a thin border on a dark inset. When checked, the box is filled with
+ * the amber accent and a small white check is drawn inside.
+ *
+ * Implemented as `role="switch"` for backwards compatibility with existing
+ * tests that look for the aria-checked switch role.
  */
 export default function Toggle({ checked, onChange, ariaLabel, disabled }: ToggleProps) {
   return (
@@ -26,31 +28,36 @@ export default function Toggle({ checked, onChange, ariaLabel, disabled }: Toggl
       disabled={disabled}
       onClick={() => !disabled && onChange(!checked)}
       style={{
-        width: 30,
-        height: 16,
-        borderRadius: 8,
+        width: 14,
+        height: 14,
+        borderRadius: 2,
         border: `1px solid ${checked ? colors.accent : colors.borderSoft}`,
-        background: checked ? colors.accentDim : "rgba(255,255,255,0.04)",
+        background: checked ? colors.accent : "rgba(0,0,0,0.35)",
         padding: 0,
         position: "relative",
         cursor: disabled ? "not-allowed" : "pointer",
         opacity: disabled ? 0.5 : 1,
-        transition: `background 160ms ${easings.out}, border-color 160ms ${easings.out}`,
+        transition: `background 140ms ${easings.out}, border-color 140ms ${easings.out}`,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
       }}
     >
-      <span
-        aria-hidden
-        style={{
-          position: "absolute",
-          top: 1,
-          left: checked ? 15 : 1,
-          width: 12,
-          height: 12,
-          borderRadius: "50%",
-          background: checked ? colors.accent : colors.beigeMuted,
-          transition: `left 160ms ${easings.out}, background 160ms ${easings.out}`,
-        }}
-      />
+      {checked && (
+        <svg
+          aria-hidden
+          width={10}
+          height={10}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#ffffff"
+          strokeWidth={3.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      )}
     </button>
   );
 }

--- a/apps/hayba-explorer/src/components/panels/HeightPaintPanel.tsx
+++ b/apps/hayba-explorer/src/components/panels/HeightPaintPanel.tsx
@@ -134,7 +134,7 @@ export default function HeightPaintPanel(p: HeightPaintPanelProps): React.ReactE
             world for validating the debug map modes. Bake to apply.
           </div>
           <button onClick={p.onLoadEarth} style={historyButtonStyle(true)}>
-            🌍 Load Earth
+            Load Earth
           </button>
         </div>
       </PropertySection>

--- a/apps/hayba-explorer/src/components/propertySearch.tsx
+++ b/apps/hayba-explorer/src/components/propertySearch.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+
+/**
+ * Lightweight context used to drive UE5-style Details-panel search:
+ *
+ *   - RightPanel writes the current search query.
+ *   - PropertyRow / PropertyStack hide themselves on miss and announce the
+ *     match to the nearest PropertySection via SectionVisibilityContext.
+ *   - PropertySection counts announcements and hides itself when zero rows
+ *     match (and the query is non-empty).
+ *
+ * Sections opt OUT of filtering by setting filterable=false (useful for
+ * sections whose body is bespoke layout — e.g. brush-mode grid — rather
+ * than PropertyRow rows).
+ */
+export interface PropertySearchValue {
+  /** Lower-cased trimmed query. Empty string means "no filtering". */
+  query: string;
+}
+
+const PropertySearchContext = React.createContext<PropertySearchValue>({ query: "" });
+
+export function PropertySearchProvider({
+  query,
+  children,
+}: {
+  query: string;
+  children: React.ReactNode;
+}) {
+  const value = React.useMemo<PropertySearchValue>(
+    () => ({ query: query.trim().toLowerCase() }),
+    [query],
+  );
+  return (
+    <PropertySearchContext.Provider value={value}>{children}</PropertySearchContext.Provider>
+  );
+}
+
+export function usePropertySearch(): PropertySearchValue {
+  return React.useContext(PropertySearchContext);
+}
+
+/** Returns true when the row's label matches the active query, OR when no
+ *  query is active. Case-insensitive substring match. */
+export function rowMatches(label: string, query: string): boolean {
+  if (!query) return true;
+  return label.toLowerCase().includes(query);
+}
+
+// --- Section visibility ---------------------------------------------------
+
+interface SectionVisibilityValue {
+  register: (key: string, visible: boolean) => void;
+}
+
+const SectionVisibilityContext = React.createContext<SectionVisibilityValue | null>(null);
+
+export function useSectionVisibility(): SectionVisibilityValue | null {
+  return React.useContext(SectionVisibilityContext);
+}
+
+export function SectionVisibilityProvider({
+  onCountChange,
+  children,
+}: {
+  onCountChange: (visibleCount: number) => void;
+  children: React.ReactNode;
+}) {
+  // Track each row's visibility in a ref + bump a counter to keep effects stable.
+  const map = React.useRef<Map<string, boolean>>(new Map());
+  const recompute = React.useCallback(() => {
+    let visible = 0;
+    for (const v of map.current.values()) if (v) visible++;
+    onCountChange(visible);
+  }, [onCountChange]);
+
+  const value = React.useMemo<SectionVisibilityValue>(
+    () => ({
+      register: (key, visible) => {
+        const prev = map.current.get(key);
+        if (prev === visible) return;
+        map.current.set(key, visible);
+        recompute();
+      },
+    }),
+    [recompute],
+  );
+
+  return (
+    <SectionVisibilityContext.Provider value={value}>{children}</SectionVisibilityContext.Provider>
+  );
+}

--- a/packages/design-tokens/index.ts
+++ b/packages/design-tokens/index.ts
@@ -6,38 +6,53 @@
 // stack are the marketing site's verbatim.
 
 export const colors = {
-  bgDeep:         "#1b1e24",
-  bgBase:         "#22262e",
-  bgPanel:        "#2a2e36",
-  bgRaised:       "#303540",
-  bgElevated:     "#353a45",
-  bgPanelHeader:  "#1d2129",
-  /** Hayba accent — matches the logo exactly (#B56A1D). */
-  accent:         "#B56A1D",
-  accentHover:    "#d27a25",
-  accentText:     "#B56A1D",
-  accentDim:      "#B56A1D22",
-  accentGlow:     "#B56A1D55",
-  textPrimary:    "#e5e8eb",
-  textSecondary:  "#a8aeb8",
-  textMuted:      "#6b7280",
-  borderMid:      "#2f343d",
-  borderSoft:     "#3d434e",
-  /** Top-bar background — one notch darker than bgDeep. */
-  bgTopBar:       "#16191f",
-  /** Status-bar background — same family as bgPanelHeader. */
-  bgStatusBar:    "#1d2129",
+  // UE5-aligned panel palette — tuned to match Unreal Engine 5.7's Details
+  // panel (dark band header + flat row body, amber accent).
+  bgDeep:         "#171717",
+  bgBase:         "#1e1e1e",
+  bgPanel:        "#1e1e1e",
+  bgRaised:       "#252525",
+  bgElevated:     "#2a2a2a",
+  bgPanelHeader:  "#1a1a1a",
+  /** Row hover background — barely-perceptible lighten. */
+  bgRowHover:     "#303030",
+  /** Section-band background — the thin header strip with chevron + label. */
+  bgSectionBand:  "#2a2a2a",
+  /** UE5 amber accent — used for selected category + primary actions only. */
+  accent:         "#ff8c00",
+  accentHover:    "#ffa128",
+  accentText:     "#ff8c00",
+  accentDim:      "#ff8c0022",
+  accentGlow:     "#ff8c0055",
+  textPrimary:    "#ffffff",
+  textSecondary:  "#c8c8c8",
+  textMuted:      "#7a7a7a",
+  borderMid:      "#2a2a2a",
+  borderSoft:     "#333333",
+  /** Subtle 1px separator — barely visible. */
+  borderSubtle:   "#2a2a2a",
+  /** Top-bar background. */
+  bgTopBar:       "#141414",
+  /** Status-bar background. */
+  bgStatusBar:    "#1a1a1a",
   /** Right-panel category strip background. */
-  bgCategoryStrip:"#1d2129",
-  /** Primary beige foreground (action labels, mode names). */
-  beige:          "#DED4C3",
-  /** Muted beige — property-row labels. */
-  beigeMuted:     "#a8aeb8",
-  /** 1px property-row separator (lighter than borderMid). */
-  rule:           "#2a2e36",
-  // Optional reserved second tone — used only on a few legacy paths.
+  bgCategoryStrip:"#1a1a1a",
+  /** Primary foreground — row values (white). */
+  beige:          "#ffffff",
+  /** Muted label color — row labels. */
+  beigeMuted:     "#c8c8c8",
+  /** Property-row separator. */
+  rule:           "#2a2a2a",
+  // Reserved second tone — used only on a few legacy paths.
   secondary:      "#6a9fdc",
   secondaryHover: "#8ab5e6",
+  // Semantic UE5 aliases (re-export by intent).
+  /** Row hover background. */
+  rowHover:       "#303030",
+  /** Label text color. */
+  textLabel:      "#c8c8c8",
+  /** Value text color. */
+  textValue:      "#ffffff",
 } as const;
 
 export const fonts = {
@@ -60,6 +75,21 @@ export const radii = {
 export const shadows = {
   sm: "0 1px 2px rgba(0, 0, 0, 0.35)",
   md: "0 4px 12px rgba(0, 0, 0, 0.45)",
+} as const;
+
+/** UE5-aligned spacing + sizing primitives for the Details panel. */
+export const space = {
+  rowHeight:    28,
+  rowHeightTall:46,
+  sectionBandH: 24,
+  rowPadX:      8,
+} as const;
+
+/** Typography sizes tuned to UE5's compact density. */
+export const fontSize = {
+  label:   11,
+  value:   11,
+  section: 10,
 } as const;
 
 export const easings = {


### PR DESCRIPTION
## Summary

Restyle Explorer right-side sidebar primitives to read like Unreal Engine 5.7's Details panel. Touches design tokens + primitive components only; viewport / globe / interact / Compose / Boundaries panels are untouched.

- **Tokens**: UE5 palette (`#1e1e1e` panel / `#252525` alt / `#303030` row hover / `#2a2a2a` section band / `#ff8c00` accent / `#c8c8c8` label / white value). New `space` + `fontSize` exports.
- **PropertyRow**: 28px tight row, 8px hpad, row-hover lighten, subtle border. Reads search context (hides on miss).
- **PropertyStack**: 18px label row + 24px control row, same hover/separator; participates in search filter.
- **PropertySection**: 24px band header with Lucide chevron + small-caps tracked label; flush body. Auto-expands during search; hides itself when zero rows match.
- **CategoryStrip**: 3px amber active border + dim-accent tint, hover lighten on inactive.
- **Toggle**: 14×14 UE5 checkbox (amber fill + white check on); keeps `role=switch` for back-compat.
- **RightPanel**: adds a UE5-style search bar that filters all `PropertyRow`/`PropertyStack` by label substring; query clears on category switch.
- **propertySearch.tsx**: new React context for query + section visibility.
- **HeightPaintPanel**: dropped the `🌍` emoji prefix from the Load Earth button.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` matches HEAD baseline (13 files / 3 tests fail, all unrelated to UI — baking pipeline / paint internals)
- [ ] Visual check in `hayba.exe` — confirm tight rows, amber active category, search bar filters rows + collapses empty sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable filtering for properties in the details panel.
  * Property sections now support collapsible headers.

* **UI/Styling Updates**
  * Redesigned details panel with UE5-style appearance.
  * Updated color palette and typography across UI.
  * Toggle controls now display as compact checkboxes.
  * Enhanced visual feedback on hover interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->