### PR TITLE
wait_for_idle — UE subsystem readiness primitive

### DIFF
--- a/docs/superpowers/plans/2026-05-21-wait-for-idle.md
+++ b/docs/superpowers/plans/2026-05-21-wait-for-idle.md
@@ -1,0 +1,603 @@
+# `wait_for_idle` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) or superpowers:subagent-driven-development.
+
+**Goal:** Ship one MCP tool `wait_for_idle(subsystems?, timeout_s, pcg_actors?, world_ticks?)` plus its C++ UE handler, consolidating subsystem-readiness waits behind one primitive. Fold `wait_for_shaders` into a thin TS wrapper.
+
+**Architecture:** TS tool dispatches via `executeCommand('wait_for_idle', ...)`. C++ handler polls per-subsystem `IsBusy()` predicates at 250ms cadence via `FTSTicker`, resolves response when all settled or on timeout. Structured `{ok, durationMs, settled, timedOut?}` response.
+
+**Tech Stack:** TypeScript + vitest + zod (TS); C++ + UE 5.7 (HaybaMCPToolkit plugin).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-wait-for-idle-design.md`
+
+---
+
+### Task 1: TS tool — `wait-for-idle.ts` + schema test
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/tools/wait-for-idle.ts`
+- Create: `mcp-tools/hayba-mcp/src/tools/wait-for-idle.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+`wait-for-idle.test.ts`:
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { schema, handleWaitForIdle } from './wait-for-idle.js';
+import { setDefaultSender } from './tool-executor.js';
+
+describe('wait-for-idle schema', () => {
+  it('accepts a subset of subsystems', () => {
+    expect(z.object(schema.shape).parse({ subsystems: ['pcg', 'shaders'], timeout_s: 30 }).subsystems)
+      .toEqual(['pcg', 'shaders']);
+  });
+  it('subsystems is optional (means wait for all)', () => {
+    const parsed = z.object(schema.shape).parse({ timeout_s: 10 });
+    expect(parsed.subsystems).toBeUndefined();
+  });
+  it('rejects unknown subsystem names', () => {
+    expect(() => z.object(schema.shape).parse({ subsystems: ['typo'], timeout_s: 10 }))
+      .toThrow();
+  });
+  it('timeout_s default = 60', () => {
+    expect(z.object(schema.shape).parse({}).timeout_s).toBe(60);
+  });
+  it('timeout_s bounds [1, 600]', () => {
+    expect(() => z.object(schema.shape).parse({ timeout_s: 0 })).toThrow();
+    expect(() => z.object(schema.shape).parse({ timeout_s: 601 })).toThrow();
+  });
+  it('pcg_actors + world_ticks accepted', () => {
+    const parsed = z.object(schema.shape).parse({
+      subsystems: ['pcg', 'world_tick'], timeout_s: 5, pcg_actors: ['/Game/X'], world_ticks: 3,
+    });
+    expect(parsed.pcg_actors).toEqual(['/Game/X']);
+    expect(parsed.world_ticks).toBe(3);
+  });
+});
+
+describe('handleWaitForIdle', () => {
+  it('dispatches wait_for_idle with timeout_s*1000 + 5000ms socket timeout', async () => {
+    const sender = vi.fn(async (cmd: string, params: Record<string, unknown>, timeout: number) => ({
+      ok: true,
+      data: { ok: true, durationMs: 42, settled: { shaders: { busyOnEntry: true, settledAtMs: 30 } } },
+    }));
+    setDefaultSender(sender as never);
+    const res = await handleWaitForIdle({ subsystems: ['shaders'], timeout_s: 10 });
+    expect(sender).toHaveBeenCalledWith('wait_for_idle', expect.objectContaining({ subsystems: ['shaders'], timeout_s: 10 }), 15000);
+    expect(res.content[0].text).toContain('"ok": true');
+  });
+});
+```
+
+- [ ] **Step 2: Confirm failure**
+
+`cd mcp-tools/hayba-mcp; npx vitest run src/tools/wait-for-idle.test.ts`
+Expect: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`wait-for-idle.ts`:
+```ts
+import { z } from 'zod';
+import type { HaybaToolMeta } from './hayba-tool-meta.js';
+import { executeCommand } from './tool-executor.js';
+
+const SUBSYSTEMS = ['shaders', 'assets', 'gc', 'pcg', 'world_tick'] as const;
+
+export const schema = z.object({
+  subsystems: z.array(z.enum(SUBSYSTEMS)).optional()
+    .describe('Subsystems to wait on. Omit = wait for all five.'),
+  timeout_s: z.number().int().min(1).max(600).default(60)
+    .describe('Hard timeout in seconds.'),
+  pcg_actors: z.array(z.string()).optional()
+    .describe('Optional scope: only wait on these PCGComponent owners (full actor paths). Omit = all PCG actors in the active level.'),
+  world_ticks: z.number().int().min(1).max(60).optional()
+    .describe('When world_tick is in subsystems: wait at least N world ticks past request start. Default 1.'),
+});
+
+export type WaitForIdleParams = z.infer<typeof schema>;
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: ['wait'],
+  when: 'After mutating asset/PCG/level state, before reading back or rendering.',
+  not_when: 'You did a pure read-only call; no state was mutated.',
+};
+
+export async function handleWaitForIdle(params: WaitForIdleParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const data = await executeCommand('wait_for_idle', parsed.data as Record<string, unknown>, {
+    timeout: parsed.data.timeout_s * 1000 + 5000,
+  });
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+```
+
+- [ ] **Step 4: Verify pass + commit**
+
+```
+cd mcp-tools/hayba-mcp; npx vitest run src/tools/wait-for-idle.test.ts
+cd D:/Hackathons/hayba; git add mcp-tools/hayba-mcp/src/tools/wait-for-idle.ts mcp-tools/hayba-mcp/src/tools/wait-for-idle.test.ts; git commit -m "feat(wait-for-idle): TS tool + schema validation"
+```
+
+---
+
+### Task 2: `wait-for-shaders.ts` becomes thin wrapper
+
+**Files:**
+- Modify: `mcp-tools/hayba-mcp/src/tools/wait-for-shaders.ts`
+
+- [ ] **Step 1: Modify**
+
+Replace the body of `handleWaitForShaders`:
+```ts
+import { z } from 'zod';
+import { executeCommand } from './tool-executor.js';
+import type { HaybaToolMeta } from './hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: [],
+  when: 'waiting for UE shader compilation to settle before taking a screenshot or executing a graph that touches new materials',
+  not_when: 'you do not actually care if shaders are still compiling (most read-only tools)',
+};
+
+export const schema = z.object({
+  max_seconds: z.number().int().min(1).max(600).default(60),
+  poll_seconds: z.number().min(0.05).max(10).default(1),
+});
+
+export type WaitForShadersParams = z.infer<typeof schema>;
+
+let pollWarned = false;
+
+export async function handleWaitForShaders(params: WaitForShadersParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  if (params.poll_seconds !== undefined && !pollWarned) {
+    pollWarned = true;
+    console.warn('[wait-for-shaders] poll_seconds is ignored; UE-side polling is fixed at 250ms.');
+  }
+  const data = await executeCommand('wait_for_idle', {
+    subsystems: ['shaders'],
+    timeout_s: parsed.data.max_seconds,
+  }, { timeout: parsed.data.max_seconds * 1000 + 5000 });
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+```
+
+- [ ] **Step 2: Run existing wait-for-shaders tests if any + commit**
+
+```
+cd mcp-tools/hayba-mcp; npx vitest run src/tools/ 2>&1 | tail -5
+cd D:/Hackathons/hayba; git add mcp-tools/hayba-mcp/src/tools/wait-for-shaders.ts; git commit -m "refactor(wait-for-shaders): become thin wrapper around wait_for_idle"
+```
+
+---
+
+### Task 3: Register `wait_for_idle` in `tools/index.ts` + packs.yaml
+
+**Files:**
+- Modify: `mcp-tools/hayba-mcp/src/tools/index.ts`
+- Modify: `mcp-tools/hayba-mcp/src/tools/routing/packs.yaml`
+
+- [ ] **Step 1: Add import + registration to index.ts**
+
+Near top, add:
+```ts
+import { handleWaitForIdle, meta as waitForIdleMeta, schema as waitForIdleSchema } from './wait-for-idle.js';
+```
+
+In `registerToolsCore`, where existing tool registrations live (search for `wait_for_shaders` registration as anchor), add:
+```ts
+  server.tool(
+    'wait_for_idle',
+    appendMeta('Wait for UE subsystems (shaders/assets/gc/pcg/world_tick) to settle before reading back or rendering. Default = all five.', waitForIdleMeta),
+    waitForIdleSchema.shape,
+    async (params) => handleWaitForIdle(params as never),
+  );
+  remember('wait_for_idle', waitForIdleMeta);
+```
+
+- [ ] **Step 2: Add to editor workflow pack in packs.yaml**
+
+Find the `editor` pack entry, add `wait_for_idle` to its tools list:
+```yaml
+  - name: editor
+    kind: workflow
+    description: Live UE editor introspection and PIE control.
+    autoLoadOn: ue_connected
+    tools:
+      - editor_capture_viewport
+      - editor_stream_log
+      - editor_start_pie
+      - wait_for_shaders
+      - wait_for_idle   # added
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+```
+cd mcp-tools/hayba-mcp; npm run typecheck
+cd D:/Hackathons/hayba; git add mcp-tools/hayba-mcp/src/tools/index.ts mcp-tools/hayba-mcp/src/tools/routing/packs.yaml; git commit -m "feat(wait-for-idle): register tool in index.ts + add to editor pack"
+```
+
+---
+
+### Task 4: Integration test (TS, mocked UE)
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/tests/wait-for-idle-integration.test.ts`
+
+- [ ] **Step 1: Write test**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setDefaultSender, type Sender } from '../src/tools/tool-executor.js';
+import { handleWaitForIdle } from '../src/tools/wait-for-idle.js';
+import { handleWaitForShaders } from '../src/tools/wait-for-shaders.js';
+
+describe('wait-for-idle integration', () => {
+  let sender: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    sender = vi.fn(async (_cmd, _params, _timeout) => ({
+      ok: true,
+      data: { ok: true, durationMs: 12, settled: { shaders: { busyOnEntry: true, settledAtMs: 8 } } },
+    }));
+    setDefaultSender(sender as unknown as Sender);
+  });
+
+  it('returns the unwrapped UE response shape', async () => {
+    const res = await handleWaitForIdle({ subsystems: ['shaders'], timeout_s: 5 });
+    const body = JSON.parse(res.content[0].text);
+    expect(body.ok).toBe(true);
+    expect(body.settled.shaders.busyOnEntry).toBe(true);
+  });
+
+  it('preserves timedOut on partial timeout', async () => {
+    sender.mockResolvedValueOnce({
+      ok: true,
+      data: { ok: false, durationMs: 5000, settled: { pcg: { busyOnEntry: true, settledAtMs: 5000 } }, timedOut: ['pcg'] },
+    });
+    const res = await handleWaitForIdle({ subsystems: ['pcg'], timeout_s: 5 });
+    const body = JSON.parse(res.content[0].text);
+    expect(body.ok).toBe(false);
+    expect(body.timedOut).toEqual(['pcg']);
+  });
+
+  it('wait-for-shaders wrapper delegates to wait_for_idle', async () => {
+    await handleWaitForShaders({ max_seconds: 30, poll_seconds: 1 });
+    expect(sender).toHaveBeenCalledWith(
+      'wait_for_idle',
+      expect.objectContaining({ subsystems: ['shaders'], timeout_s: 30 }),
+      35000,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run + commit**
+
+```
+cd mcp-tools/hayba-mcp; npx vitest run tests/wait-for-idle-integration.test.ts
+cd D:/Hackathons/hayba; git add mcp-tools/hayba-mcp/tests/wait-for-idle-integration.test.ts; git commit -m "test(wait-for-idle): integration — unwrap, partial timeout, wait-for-shaders wrapper"
+```
+
+---
+
+### Task 5: C++ handler — `HaybaMCPIdleHandler.{h,cpp}`
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp`
+
+- [ ] **Step 1: Write `HaybaMCPIdleHandler.h`**
+
+```cpp
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+
+// Forward decl matching the existing handler signature pattern.
+using FHaybaMCPResponseCallback = TFunction<void(const TSharedPtr<FJsonObject>& Response, bool bSuccess)>;
+
+class FHaybaMCPIdleHandler {
+public:
+  static void HandleWaitForIdle(
+    const TSharedPtr<FJsonObject>& Params,
+    FHaybaMCPResponseCallback Done);
+};
+```
+
+- [ ] **Step 2: Write `HaybaMCPIdleHandler.cpp`**
+
+```cpp
+#include "HaybaMCPIdleHandler.h"
+
+#include "Containers/Ticker.h"
+#include "Editor.h"
+#include "Editor/EditorEngine.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetRegistry/IAssetRegistry.h"
+#include "ShaderCompiler.h"
+#include "UObject/UObjectGlobals.h"
+#include "UObject/GarbageCollection.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "PCGComponent.h"
+
+namespace {
+
+constexpr double POLL_INTERVAL_SECONDS = 0.25;
+
+bool IsShadersBusyImpl() {
+  return GShaderCompilingManager && GShaderCompilingManager->IsCompiling();
+}
+
+bool IsAssetsBusyImpl() {
+  FAssetRegistryModule& Mod = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+  return Mod.Get().IsLoadingAssets();
+}
+
+bool IsGCBusyImpl() {
+  return IsGarbageCollecting() || IsIncrementalPurgePending();
+}
+
+UWorld* ActiveEditorWorld() {
+  if (GEditor) {
+    if (FWorldContext* Ctx = GEditor->GetEditorWorldContext().World() ? &GEditor->GetEditorWorldContext() : nullptr) {
+      return Ctx->World();
+    }
+  }
+  return GWorld;
+}
+
+bool IsPCGBusyImpl(const TSet<FString>& ScopedActorPaths) {
+  UWorld* World = ActiveEditorWorld();
+  if (!World) return false;
+  for (TObjectIterator<UPCGComponent> It; It; ++It) {
+    UPCGComponent* Comp = *It;
+    if (!Comp || Comp->GetWorld() != World) continue;
+    AActor* Owner = Comp->GetOwner();
+    if (!Owner) continue;
+    if (ScopedActorPaths.Num() > 0) {
+      const FString Path = Owner->GetPathName();
+      if (!ScopedActorPaths.Contains(Path)) continue;
+    }
+    if (Comp->IsGenerating()) return true;
+  }
+  return false;
+}
+
+bool IsWorldTickPendingImpl(int32 TicksRequired, uint64 StartTickCount) {
+  UWorld* World = ActiveEditorWorld();
+  if (!World) return false;
+  const uint64 Now = (uint64)World->GetTimeSeconds();  // fallback if GetTickCount unavailable; see note
+  // UE's UWorld does not directly expose a "tick count" — use frame counter.
+  return (uint64)GFrameCounter - StartTickCount < (uint64)TicksRequired;
+}
+
+struct FWaitState {
+  TSet<FString> Subsystems;
+  TSet<FString> ScopedPcgActors;
+  int32 WorldTicksRequired = 1;
+  uint64 StartFrameCounter = 0;
+  double T0Seconds = 0.0;
+  double TimeoutSeconds = 60.0;
+  TMap<FString, bool> BusyOnEntry;
+  TMap<FString, double> SettledAtMs;
+  FHaybaMCPResponseCallback Done;
+  FTSTicker::FDelegateHandle TickHandle;
+};
+
+bool IsBusy(const FString& Subsystem, const FWaitState& State) {
+  if (Subsystem == TEXT("shaders"))    return IsShadersBusyImpl();
+  if (Subsystem == TEXT("assets"))     return IsAssetsBusyImpl();
+  if (Subsystem == TEXT("gc"))         return IsGCBusyImpl();
+  if (Subsystem == TEXT("pcg"))        return IsPCGBusyImpl(State.ScopedPcgActors);
+  if (Subsystem == TEXT("world_tick")) return IsWorldTickPendingImpl(State.WorldTicksRequired, State.StartFrameCounter);
+  return false;
+}
+
+TSharedPtr<FJsonObject> BuildResponse(const FWaitState& State, bool bOk, double DurationMs) {
+  TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+  Out->SetBoolField(TEXT("ok"), bOk);
+  Out->SetNumberField(TEXT("durationMs"), DurationMs);
+
+  TSharedPtr<FJsonObject> Settled = MakeShared<FJsonObject>();
+  for (const FString& S : State.Subsystems) {
+    TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+    Entry->SetBoolField(TEXT("busyOnEntry"), State.BusyOnEntry.FindRef(S));
+    const double* Settled_ms = State.SettledAtMs.Find(S);
+    Entry->SetNumberField(TEXT("settledAtMs"), Settled_ms ? *Settled_ms : DurationMs);
+    Settled->SetObjectField(S, Entry);
+  }
+  Out->SetObjectField(TEXT("settled"), Settled);
+
+  if (!bOk) {
+    TArray<TSharedPtr<FJsonValue>> TimedOut;
+    for (const FString& S : State.Subsystems) {
+      if (!State.SettledAtMs.Contains(S)) {
+        TimedOut.Add(MakeShared<FJsonValueString>(S));
+      }
+    }
+    Out->SetArrayField(TEXT("timedOut"), TimedOut);
+  }
+  return Out;
+}
+
+bool PollOnce(float /*DeltaTime*/, FWaitState* State) {
+  const double Now = FPlatformTime::Seconds();
+  const double DurationMs = (Now - State->T0Seconds) * 1000.0;
+
+  for (const FString& S : State->Subsystems) {
+    if (State->SettledAtMs.Contains(S)) continue;
+    if (!IsBusy(S, *State)) {
+      State->SettledAtMs.Add(S, DurationMs);
+    }
+  }
+
+  const bool bAllSettled = State->SettledAtMs.Num() == State->Subsystems.Num();
+  const bool bTimedOut = (Now - State->T0Seconds) >= State->TimeoutSeconds;
+
+  if (bAllSettled || bTimedOut) {
+    TSharedPtr<FJsonObject> Resp = BuildResponse(*State, bAllSettled, DurationMs);
+    if (State->Done) State->Done(Resp, true);
+    delete State;
+    return false; // unregister ticker
+  }
+  return true;
+}
+
+} // namespace
+
+void FHaybaMCPIdleHandler::HandleWaitForIdle(
+    const TSharedPtr<FJsonObject>& Params,
+    FHaybaMCPResponseCallback Done)
+{
+  FWaitState* State = new FWaitState();
+  State->T0Seconds = FPlatformTime::Seconds();
+  State->StartFrameCounter = GFrameCounter;
+  State->Done = MoveTemp(Done);
+  State->TimeoutSeconds = Params.IsValid() && Params->HasField(TEXT("timeout_s"))
+    ? Params->GetNumberField(TEXT("timeout_s"))
+    : 60.0;
+
+  // Parse subsystems
+  if (Params.IsValid() && Params->HasField(TEXT("subsystems"))) {
+    const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+    if (Params->TryGetArrayField(TEXT("subsystems"), Arr) && Arr) {
+      for (const TSharedPtr<FJsonValue>& V : *Arr) {
+        State->Subsystems.Add(V->AsString());
+      }
+    }
+  }
+  if (State->Subsystems.Num() == 0) {
+    State->Subsystems = { TEXT("shaders"), TEXT("assets"), TEXT("gc"), TEXT("pcg"), TEXT("world_tick") };
+  }
+
+  // Parse pcg_actors
+  if (Params.IsValid() && Params->HasField(TEXT("pcg_actors"))) {
+    const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+    if (Params->TryGetArrayField(TEXT("pcg_actors"), Arr) && Arr) {
+      for (const TSharedPtr<FJsonValue>& V : *Arr) {
+        State->ScopedPcgActors.Add(V->AsString());
+      }
+    }
+  }
+
+  if (Params.IsValid() && Params->HasField(TEXT("world_ticks"))) {
+    State->WorldTicksRequired = (int32)Params->GetNumberField(TEXT("world_ticks"));
+  }
+
+  // GC nudge: when gc requested, queue a non-blocking collect so IsBusy goes true once and then settles.
+  if (State->Subsystems.Contains(TEXT("gc"))) {
+    GEngine->ForceGarbageCollection(true);
+  }
+
+  // Capture busyOnEntry
+  for (const FString& S : State->Subsystems) {
+    State->BusyOnEntry.Add(S, IsBusy(S, *State));
+  }
+
+  // Register ticker
+  State->TickHandle = FTSTicker::GetCoreTicker().AddTicker(
+    FTickerDelegate::CreateLambda([State](float Dt) { return PollOnce(Dt, State); }),
+    POLL_INTERVAL_SECONDS);
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```
+cd D:/Hackathons/hayba; git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.h unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp; git commit -m "feat(wait-for-idle): C++ handler — per-subsystem IsBusy polling at 250ms"
+```
+
+---
+
+### Task 6: Register handler in `HaybaMCPModule.cpp`
+
+**Files:**
+- Modify: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp`
+
+- [ ] **Step 1: Add include + registration**
+
+Find where other handlers are registered (search for `wait_for_shaders` as anchor). Add:
+```cpp
+#include "handlers/HaybaMCPIdleHandler.h"
+// ...
+// In the handler-registration section:
+RegisterHandler(TEXT("wait_for_idle"), &FHaybaMCPIdleHandler::HandleWaitForIdle);
+```
+
+(Exact signature of `RegisterHandler` to follow the existing convention. If `RegisterHandler` doesn't exist as a function and dispatch is via a string→function map, follow that pattern instead.)
+
+- [ ] **Step 2: Commit**
+
+```
+cd D:/Hackathons/hayba; git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp; git commit -m "feat(wait-for-idle): register C++ handler in HaybaMCPModule"
+```
+
+---
+
+### Task 7: CHANGELOG + run full suite + push + PR
+
+**Files:**
+- Modify: `mcp-tools/hayba-mcp/CHANGELOG.md`
+
+- [ ] **Step 1: CHANGELOG entry**
+
+Under `## Unreleased`:
+```markdown
+### wait_for_idle (UE subsystem readiness)
+
+- New `wait_for_idle(subsystems?, timeout_s, pcg_actors?, world_ticks?)` MCP tool covering `shaders`, `assets`, `gc`, `pcg`, `world_tick`. Default `subsystems` unset = wait for all five. Structured `{ok, durationMs, settled, timedOut?}` response distinguishes settled-in-time vs. partial-timeout per subsystem.
+- `wait_for_shaders` now delegates to `wait_for_idle({subsystems:['shaders']})`. `poll_seconds` parameter is ignored (UE-side polling is fixed at 250ms); a one-time warning is logged. Existing callers keep working.
+- Closes `.scratch/mcp-architectural-issues.md` #3.
+- Pending: ship the C++ `HaybaMCPIdleHandler` to the live plugin location (`D:/UnrealEngine/geoforge/Plugins/HaybaMCPToolkit/`) alongside this repo's `unreal/HaybaMCPToolkit/`.
+```
+
+- [ ] **Step 2: Run full suite**
+
+```
+cd mcp-tools/hayba-mcp; npm test 2>&1 | tail -5
+```
+
+Expect: existing pass count + ~10 new tests pass; 26 pre-existing TCP-sender failures unchanged.
+
+- [ ] **Step 3: Commit + push + PR**
+
+```
+cd D:/Hackathons/hayba; git add mcp-tools/hayba-mcp/CHANGELOG.md; git commit -m "docs(wait-for-idle): CHANGELOG entry"
+git push -u origin spec/wait-for-idle
+gh pr create --title "wait_for_idle — UE subsystem readiness primitive" --body "$(cat <<'EOF'
+## Summary
+- Single MCP tool wait_for_idle(subsystems?, timeout_s, pcg_actors?, world_ticks?) covering shaders/assets/gc/pcg/world_tick
+- Default subsystems unset = wait for all five
+- C++ handler polls IsBusy() predicates at 250ms cadence via FTSTicker
+- Structured {ok, durationMs, settled, timedOut?} response
+- wait_for_shaders becomes a thin TS wrapper around wait_for_idle (backward compat preserved)
+- Closes .scratch/mcp-architectural-issues.md #3
+
+## Spec / Plan
+- docs/superpowers/specs/2026-05-21-wait-for-idle-design.md
+- docs/superpowers/plans/2026-05-21-wait-for-idle.md
+
+## Test plan
+- [x] TS unit (schema, dispatch)
+- [x] TS integration (unwrap, partial timeout, wait-for-shaders wrapper)
+- [ ] C++ unit (UE-side, follow-up sub-PR)
+- [ ] Manual smoke against live UE: wait_for_idle({subsystems:['pcg']}) settles after generate burst, wait_for_idle({subsystems:['gc']}) waits past GC pass
+
+## UE plugin follow-up
+The C++ handler ships in this PR under unreal/HaybaMCPToolkit/. To take effect in the live editor, sync to the dev plugin directory (D:/UnrealEngine/geoforge/Plugins/HaybaMCPToolkit/) — see mcp-architectural-issues #5 for the long-term dedup plan.
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-21-wait-for-idle-design.md
+++ b/docs/superpowers/specs/2026-05-21-wait-for-idle-design.md
@@ -1,0 +1,258 @@
+# `wait_for_idle` — UE Subsystem Readiness Primitive
+
+**Date:** 2026-05-21
+**Status:** Design approved, ready for implementation plan
+**Scope:** One new MCP tool (`wait_for_idle`) plus a C++ handler in the UE plugin. Folds the existing `wait_for_shaders` into a thin TS wrapper. Sibling spec to the upcoming `render_camera` consolidation (which will consume `wait_for_idle` internally).
+
+## Problem
+
+Per `.scratch/mcp-architectural-issues.md` #3, the single biggest source of UE crashes in the LostCity post-mortem session was **stacking heavy operations on top of asynchronous subsystems that hadn't finished**:
+
+- `pcgc.generate(False)` returns immediately; content shows up asynchronously.
+- `AssetTools.import_asset_tasks` returns immediately; files appear later.
+- Destroying many actors triggers GC; doing heavy work right after has crashed UE twice.
+- AssetRegistry scans are async.
+
+The existing `wait_for_shaders` solves this for one subsystem. Everything else needs hand-rolled `time.sleep()` magic numbers. Without a generic "wait for editor idle" primitive, every Layer 2 abstraction we plan (composition primitives, PCG control, lighting presets) will rebuild the same scaffolding poorly.
+
+## Goals
+
+1. **Single MCP tool `wait_for_idle(subsystems?, timeout_s, …)`** that waits on any combination of the listed subsystems or all of them when `subsystems` is unset.
+2. **Five v1 subsystems:** `shaders`, `assets`, `gc`, `pcg`, `world_tick`.
+3. **PCG scoping:** optional `pcg_actors: string[]` restricts the PCG wait to specific PCGComponent owners; default = every PCGComponent in the active level.
+4. **World tick:** optional `world_ticks: number` (default 1) — at least N world ticks past request start must elapse before `world_tick` reports idle.
+5. **Structured response** distinguishes settled-in-time from timeout-per-subsystem: callers can see exactly which subsystems didn't settle and decide what to do.
+6. **`wait_for_shaders` keeps working** — preserved as a thin TS wrapper that calls `wait_for_idle({subsystems:['shaders']})`, for callers wired to the old name.
+
+## Non-goals
+
+- Event-hook readiness (faster than 250ms polling). Polling is uniform across subsystems and good enough for v1.
+- Per-subsystem progress reporting (% of shaders compiled, # of assets in registry). Useful but not load-bearing for the "don't crash UE" goal.
+- A `render_camera` tool that consumes this. Separate sibling spec (next).
+- Operation journal (#12 from architectural-issues). Separate spec.
+- Out-of-process editor liveness probe (#16). Separate spec.
+
+## Architecture
+
+One TS-side meta-tool (`wait_for_idle`) routing to one C++ TCP handler. The C++ handler runs per-subsystem `IsBusy()` predicates on a fixed 250ms `FTSTicker` cadence, returns when *all requested subsystems* report idle in the same poll, or returns timeout when wall-clock exceeds `timeout_s`. No event hooks in v1.
+
+Existing `wait_for_shaders` (TS) becomes a thin wrapper calling `wait_for_idle({subsystems:['shaders']})`. The C++ side keeps a dedicated `wait_for_shaders` handler for one release cycle (marked deprecated in code) so external callers caching the old command name keep working; removed thereafter.
+
+**File layout**
+
+New:
+```
+mcp-tools/hayba-mcp/src/tools/wait-for-idle.ts
+mcp-tools/hayba-mcp/src/tools/wait-for-idle.test.ts
+mcp-tools/hayba-mcp/tests/wait-for-idle-integration.test.ts
+unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.{h,cpp}
+```
+
+Modified:
+```
+mcp-tools/hayba-mcp/src/tools/wait-for-shaders.ts          (thin wrapper)
+mcp-tools/hayba-mcp/src/tools/index.ts                     (register new tool; assigns to 'editor' pack)
+mcp-tools/hayba-mcp/src/tools/routing/packs.yaml           (add wait_for_idle to editor pack)
+unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp  (register handler)
+mcp-tools/hayba-mcp/CHANGELOG.md                           (Unreleased entry)
+```
+
+## Components
+
+### TS — `wait-for-idle.ts` (new)
+
+```ts
+export const schema = z.object({
+  subsystems: z.array(z.enum(['shaders', 'assets', 'gc', 'pcg', 'world_tick'])).optional()
+    .describe('Subsystems to wait on. Omit = wait for all five.'),
+  timeout_s: z.number().int().min(1).max(600).default(60)
+    .describe('Hard timeout in seconds.'),
+  pcg_actors: z.array(z.string()).optional()
+    .describe('Optional scope: only wait on these PCGComponent owners (full actor paths). Omit = all PCG actors in the active level.'),
+  world_ticks: z.number().int().min(1).max(60).optional()
+    .describe('When world_tick is in subsystems: wait at least N world ticks past request start. Default 1.'),
+});
+export type WaitForIdleParams = z.infer<typeof schema>;
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: ['wait'],
+  pack: undefined,  // joins the 'editor' workflow pack via packs.yaml
+  when: 'After mutating asset/PCG/level state, before reading back or rendering.',
+  not_when: 'You did a pure read-only call; no state was mutated.',
+};
+
+export async function handleWaitForIdle(params: WaitForIdleParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  // TS-side socket timeout buffers UE-side timeout by 5s so UE responds first with structured data.
+  const data = await executeCommand('wait_for_idle', parsed.data as Record<string, unknown>, {
+    timeout: parsed.data.timeout_s * 1000 + 5000,
+  });
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+```
+
+**Return shape (parsed from UE):**
+```ts
+interface WaitForIdleResult {
+  ok: boolean;          // true iff every requested subsystem settled within timeout_s
+  durationMs: number;   // wall-clock from request start to response
+  settled: Record<'shaders'|'assets'|'gc'|'pcg'|'world_tick', {
+    busyOnEntry: boolean;
+    settledAtMs: number;  // ms from request start to when this subsystem first reported idle; equals durationMs if it never settled
+  }>;
+  timedOut?: string[];  // subsystems still busy at deadline; absent or [] when ok:true
+}
+```
+
+### TS — `wait-for-shaders.ts` (modified — thin wrapper)
+
+```ts
+export async function handleWaitForShaders(params: { max_seconds?: number; poll_seconds?: number }) {
+  if (params.poll_seconds !== undefined) {
+    warnOnce('[wait-for-shaders] poll_seconds is ignored; UE-side polling is fixed at 250ms.');
+  }
+  // Delegate to wait_for_idle with shaders-only scope.
+  const data = await executeCommand('wait_for_idle', {
+    subsystems: ['shaders'],
+    timeout_s: params.max_seconds ?? 60,
+  }, { timeout: (params.max_seconds ?? 60) * 1000 + 5000 });
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+```
+
+Existing `schema` and `meta` exports unchanged so registration in `tools/index.ts` is untouched.
+
+### C++ — `HaybaMCPIdleHandler.{h,cpp}` (new)
+
+```cpp
+class FHaybaMCPIdleHandler {
+public:
+  static void HandleWaitForIdle(
+    const TSharedPtr<FJsonObject>& Params,
+    FHaybaMCPResponseCallback Done);
+
+private:
+  struct FWaitState {
+    TSet<FString> Subsystems;           // requested subset
+    TArray<FString> ScopedPcgActors;    // empty = all
+    int32 WorldTicksRequired;           // default 1
+    double T0Seconds;
+    uint32 StartTickCount;
+    TMap<FString, bool> BusyOnEntry;
+    TMap<FString, double> SettledAtMs;  // missing key = not settled yet
+    double TimeoutSeconds;
+    FHaybaMCPResponseCallback Done;
+    FTSTicker::FDelegateHandle TickHandle;
+  };
+
+  static bool Poll(FWaitState* State);
+  static bool IsShadersBusy();
+  static bool IsAssetsBusy();
+  static bool IsGCBusy();
+  static bool IsPCGBusy(const TArray<FString>& ScopedActors);
+  static bool IsWorldTickPending(int32 TicksRequired, uint32 StartTickCount);
+};
+```
+
+Per-subsystem predicates:
+- `IsShadersBusy()` → `GShaderCompilingManager && GShaderCompilingManager->IsCompiling()`
+- `IsAssetsBusy()` → `IAssetRegistry::Get().IsLoadingAssets()`
+- `IsGCBusy()` → `IsGarbageCollecting() || IsIncrementalPurgePending()`
+- `IsPCGBusy(scope)` → iterate `UPCGComponent` instances in `GEditor->GetEditorWorldContext().World()`; if `scope` non-empty, filter to those owners by full path; true if any has `IsGenerating()`. Components with no owner skipped.
+- `IsWorldTickPending(N, start)` → `(GWorld->GetGameInstance() || GEditor->GetEditorWorldContext().World())->GetTickCount() - start < N`
+
+`Poll` runs every 250ms via `FTSTicker::GetCoreTicker().AddTicker`. On each tick:
+1. For each requested subsystem, evaluate `IsBusy()`. First idle observation records `SettledAtMs = (now - T0)*1000`.
+2. If all requested subsystems have a `SettledAtMs`, build success response, unregister ticker, call `Done`.
+3. If `now - T0 >= TimeoutSeconds`, build timeout response with `timedOut` populated, unregister, call `Done`.
+
+Return false from ticker callback when complete (UE removes it automatically).
+
+### `HaybaMCPModule.cpp` (modified)
+
+Register the new handler alongside existing ones:
+```cpp
+RegisterHandler(TEXT("wait_for_idle"), &FHaybaMCPIdleHandler::HandleWaitForIdle);
+// Existing wait_for_shaders handler stays one release for deprecation.
+```
+
+### `packs.yaml` (modified)
+
+Add `wait_for_idle` to the `editor` workflow pack alongside `wait_for_shaders` (the existing entry stays as the backward-compat path is preserved).
+
+## Data flow
+
+**Happy path.**
+1. LLM: `wait_for_idle({ subsystems: ['pcg', 'shaders'], timeout_s: 30, pcg_actors: ['/Game/Maps/L1.L1:PersistentLevel.PCGVolume_42'] })`.
+2. TS validates schema, dispatches `executeCommand('wait_for_idle', params, {timeout: 35000})`.
+3. C++ handler captures `t0`, evaluates `busyOnEntry` for both subsystems, registers 250ms ticker.
+4. Each tick: re-evaluate predicates; record `settledAtMs` for the first idle observation per subsystem.
+5. All requested subsystems idle in the same poll → build response, unregister, `Done({ok:true, durationMs, settled})`.
+6. TS returns the parsed JSON to the LLM.
+
+**Already-idle path.** First poll finds everything idle. `settled.X.settledAtMs == 0`. Returns within ~250ms.
+
+**Partial timeout.** Some subsystems settle, others don't. `{ok:false, durationMs, settled, timedOut:['pcg']}`. LLM reads `timedOut`, can retry with a longer budget.
+
+**Legacy `wait_for_shaders` call.** TS wrapper translates to `wait_for_idle({subsystems:['shaders'], timeout_s: max_seconds})`. UE-side handler is the same. `poll_seconds` parameter warns once and is ignored.
+
+## Error handling
+
+| Failure | Response |
+|---|---|
+| UE plugin doesn't know `wait_for_idle` (old plugin) | `UeToolError{code:'ue_error', uePayload:{error:'unknown_command'}}`. CHANGELOG documents the plugin update; meanwhile `wait_for_shaders` keeps working via its existing handler. |
+| TCP transport error mid-wait | TS-side `UeToolError{code:'transport'}` with one retry via `tool-executor.executeCommand`. Both fail → surfaced cleanly. |
+| `timeout_s` exceeded | `{ok:false, durationMs, settled, timedOut:[…]}` — structured response, not an MCP error. The LLM decides whether to retry. |
+| Unknown subsystem name in request | Zod rejects at validation boundary → standard MCP `{kind:'validation'}` error. |
+| `pcg_actors` references non-existent paths | Silently skipped UE-side; logged warning. Doesn't fail the request. |
+| `world_ticks` set without `world_tick` in subsystems | Zod accepts (it's just data). UE side ignores it unless `world_tick` requested. Documented in field description. |
+| UE editor crashes mid-wait | TCP socket closes → `UeToolError{code:'transport'}`. Standard handling. |
+| Concurrent `wait_for_idle` calls | Each has its own ticker + response callback. UE subsystem state is shared, both observe the same `IsBusy()` results. No coordination needed. |
+
+## Testing
+
+### TS unit (`mcp-tools/hayba-mcp/src/tools/wait-for-idle.test.ts`)
+
+- Schema validation: rejects unknown subsystem names; `timeout_s` bounds; `subsystems` optional; `world_ticks` independent of subsystem list.
+- Handler dispatches to `executeCommand('wait_for_idle', params, {timeout: timeout_s*1000+5000})` via mocked sender (assert command name and timeout buffer).
+- `wait-for-shaders.ts` wrapper: calls `wait_for_idle` with `subsystems:['shaders']`, translates `max_seconds`, warns exactly once on `poll_seconds` across multiple calls.
+
+### TS integration (`mcp-tools/hayba-mcp/tests/wait-for-idle-integration.test.ts`)
+
+- Mock sender returning canned response shapes:
+  - `{ok:true, durationMs:42, settled:{shaders:{busyOnEntry:true, settledAtMs:30}}}` — assert TS unwraps cleanly.
+  - `{ok:false, durationMs:30000, settled:{…}, timedOut:['pcg']}` — assert `timedOut` preserved in response.
+- Assert TS does not interpret `{ok:false}` as a transport error (it's a normal structured response).
+
+### C++ unit (UE plugin sub-PR)
+
+- Each `IsBusy()` predicate isolated against a stub world.
+- Ticker loop: mock four predicates with controllable boolean state; assert `Done` fires only when all idle, with correct `settledAtMs`; assert timeout fires at deadline with `timedOut` populated for still-busy subsystems.
+- Concurrent waits: two handlers running simultaneously don't interfere.
+
+### Smoke (manual, with UE running)
+
+- After a PCG generate burst on a known PCGVolume: `wait_for_idle({subsystems:['pcg'], pcg_actors:[<path>]})` returns when that component finishes, not before.
+- After destroying many actors: `wait_for_idle({subsystems:['gc']})` waits past the GC pass.
+- After loading a fresh map: `wait_for_idle()` (all subsystems) sees asset registry scan + shader compile + first tick all complete.
+
+## Risks & mitigations
+
+- **UE plugin update lag.** Until the C++ handler ships, the new `wait_for_idle` tool returns `unknown_command`. Mitigation: existing `wait_for_shaders` keeps working via its dedicated C++ handler; the TS wrapper for `wait_for_shaders` falls back to the dedicated command if `wait_for_idle` returns `unknown_command` on first call (implemented as a process-local capability flag).
+- **250ms poll granularity.** Subsystems that idle briefly between polls might be missed. Mitigation: predicates check *current* state; if the subsystem was busy, then idle, then busy again, the wait correctly continues (it's looking for "currently idle"). The edge case is "subsystem briefly idle right at the deadline" — acceptable, just times out, LLM retries.
+- **`IsGenerating()` semantics across PCG versions.** PCG API has evolved; some versions don't expose this directly. Mitigation: implementation uses the `PCGComponent::GetGenerationStatus()` enum equivalent, with a compile-time fallback to `bGenerated == false && bGenerating == true` based on engine version.
+- **GC predicate flakiness.** `IsGarbageCollecting()` is true only during the actual collection pass, which is very brief. The intent is "post-collection settled." Mitigation: `IsGCBusy()` also queues a no-op `CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS, false)` *once* at handler entry (only when `gc` is requested), so `IsBusy()` becomes "GC pass in progress OR my queued pass hasn't run yet."
+
+## Out of scope
+
+- `render_camera` consolidation (next sibling spec).
+- Event-hook readiness in place of polling.
+- Subsystem-specific progress reporting.
+- `python_run` rework (#1).
+- Plugin source duplication (#5).
+- Operation journal (#12).
+- Out-of-process editor liveness probe (#16).

--- a/mcp-tools/hayba-mcp/CHANGELOG.md
+++ b/mcp-tools/hayba-mcp/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### wait_for_idle (UE subsystem readiness, since 2026-05-21)
+
+- New `wait_for_idle(subsystems?, timeout_s, pcg_actors?, world_ticks?)` MCP tool covering `shaders`, `assets`, `gc`, `pcg`, `world_tick`. Default `subsystems` unset = wait for all five. Structured `{ok, durationMs, settled, timedOut?}` response distinguishes settled-in-time vs. partial-timeout per subsystem.
+- `wait_for_shaders` now delegates to `wait_for_idle({subsystems:['shaders']})` with a per-process capability-flag fallback to the legacy `wait_for_shaders` command if the plugin doesn't yet know `wait_for_idle` — so live editors running an older plugin build keep working. `poll_seconds` parameter is ignored (UE-side polling is fixed at 250ms); a one-time warning is logged.
+- C++ side ships in `unreal/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.{h,cpp}` — synchronous `IHaybaMCPHandler` that schedules `FTSTicker` polling on the game thread and blocks the TCP-handler thread on an `FEvent` until all requested subsystems settle. Handles both `wait_for_idle` and `wait_for_shaders` commands.
+- Closes `.scratch/mcp-architectural-issues.md` #3.
+
 ### Asset Retriever (Layer 3a, since 2026-05-20)
 
 - New always-on meta-tools: `hayba_asset_search` (hybrid BM25+embedding semantic search over the UE Content Browser), `hayba_asset_browse` (paginated filtered enumeration — escape hatch for the LLM when search isn't the right operation), `hayba_asset_reindex` (manual refresh).

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -26,6 +26,7 @@ import { editorCaptureViewportHandler, meta as captureMeta } from './editor/edit
 import { editorStartPieHandler, meta as pieMeta } from './editor/editor-start-pie.js';
 import { editorStreamLogHandler, meta as streamLogMeta } from './editor/editor-stream-log.js';
 import { handleWaitForShaders, meta as waitForShadersMeta } from './wait-for-shaders.js';
+import { handleWaitForIdle, meta as waitForIdleMeta, schema as waitForIdleSchema } from './wait-for-idle.js';
 import { handleFabLoginStatus, meta as fabLoginStatusMeta } from './fab/login-status.js';
 import { handleFabLibraryList, meta as fabLibraryListMeta } from './fab/library-list.js';
 import { handleFabMarketplaceSearch, meta as fabMarketplaceSearchMeta } from './fab/marketplace-search.js';
@@ -491,14 +492,22 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
 
   server.tool(
     'wait_for_shaders',
-    appendMeta('Wait for UE shader compilation to settle (or timeout).', waitForShadersMeta),
+    appendMeta('Wait for UE shader compilation to settle (or timeout). Thin wrapper around wait_for_idle({subsystems:["shaders"]}).', waitForShadersMeta),
     {
       max_seconds: z.number().int().min(1).max(600).optional().describe('Upper bound in seconds (default 60).'),
-      poll_seconds: z.number().min(0.05).max(10).optional().describe('Poll interval in seconds (default 1).'),
+      poll_seconds: z.number().min(0.05).max(10).optional().describe('Poll interval in seconds (default 1). NOTE: ignored — UE-side polling is fixed at 250ms.'),
     },
     async (args, _extra) => handleWaitForShaders(args as any)
   );
   remember('wait_for_shaders', waitForShadersMeta);
+
+  server.tool(
+    'wait_for_idle',
+    appendMeta('Wait for UE subsystems (shaders/assets/gc/pcg/world_tick) to settle before reading back or rendering. Default = all five.', waitForIdleMeta),
+    waitForIdleSchema.shape,
+    async (args, _extra) => handleWaitForIdle(args as never),
+  );
+  remember('wait_for_idle', waitForIdleMeta);
 
   // ── Fab connector tools ─────────────────────────────────────────────────────
 

--- a/mcp-tools/hayba-mcp/src/tools/routing/packs.yaml
+++ b/mcp-tools/hayba-mcp/src/tools/routing/packs.yaml
@@ -67,6 +67,7 @@ packs:
       - editor_stream_log
       - editor_start_pie
       - wait_for_shaders
+      - wait_for_idle
 
   - name: python
     kind: workflow

--- a/mcp-tools/hayba-mcp/src/tools/wait-for-idle.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/wait-for-idle.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { schema, handleWaitForIdle } from './wait-for-idle.js';
+import { setDefaultSender, type Sender } from './tool-executor.js';
+
+describe('wait-for-idle schema', () => {
+  it('accepts a subset of subsystems', () => {
+    expect(schema.parse({ subsystems: ['pcg', 'shaders'], timeout_s: 30 }).subsystems)
+      .toEqual(['pcg', 'shaders']);
+  });
+  it('subsystems is optional (means wait for all)', () => {
+    const parsed = schema.parse({ timeout_s: 10 });
+    expect(parsed.subsystems).toBeUndefined();
+  });
+  it('rejects unknown subsystem names', () => {
+    expect(() => schema.parse({ subsystems: ['typo'], timeout_s: 10 } as never))
+      .toThrow();
+  });
+  it('timeout_s default = 60', () => {
+    expect(schema.parse({}).timeout_s).toBe(60);
+  });
+  it('timeout_s bounds [1, 600]', () => {
+    expect(() => schema.parse({ timeout_s: 0 })).toThrow();
+    expect(() => schema.parse({ timeout_s: 601 })).toThrow();
+  });
+  it('pcg_actors + world_ticks accepted', () => {
+    const parsed = schema.parse({
+      subsystems: ['pcg', 'world_tick'], timeout_s: 5, pcg_actors: ['/Game/X'], world_ticks: 3,
+    });
+    expect(parsed.pcg_actors).toEqual(['/Game/X']);
+    expect(parsed.world_ticks).toBe(3);
+  });
+});
+
+describe('handleWaitForIdle', () => {
+  let sender: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    sender = vi.fn(async (_cmd: string, _params: Record<string, unknown>, _timeout: number) => ({
+      ok: true,
+      data: { ok: true, durationMs: 42, settled: { shaders: { busyOnEntry: true, settledAtMs: 30 } } },
+    }));
+    setDefaultSender(sender as unknown as Sender);
+  });
+
+  it('dispatches wait_for_idle with timeout_s*1000 + 5000ms socket timeout', async () => {
+    await handleWaitForIdle({ subsystems: ['shaders'], timeout_s: 10 } as never);
+    expect(sender).toHaveBeenCalledWith(
+      'wait_for_idle',
+      expect.objectContaining({ subsystems: ['shaders'], timeout_s: 10 }),
+      15000,
+    );
+  });
+
+  it('returns the UE response in MCP content shape', async () => {
+    const res = await handleWaitForIdle({ subsystems: ['shaders'], timeout_s: 10 } as never);
+    expect(res.content[0].text).toContain('"ok": true');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/wait-for-idle.ts
+++ b/mcp-tools/hayba-mcp/src/tools/wait-for-idle.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import type { HaybaToolMeta } from './hayba-tool-meta.js';
+import { executeCommand } from './tool-executor.js';
+
+const SUBSYSTEMS = ['shaders', 'assets', 'gc', 'pcg', 'world_tick'] as const;
+
+export const schema = z.object({
+  subsystems: z.array(z.enum(SUBSYSTEMS)).optional()
+    .describe('Subsystems to wait on. Omit = wait for all five.'),
+  timeout_s: z.number().int().min(1).max(600).default(60)
+    .describe('Hard timeout in seconds.'),
+  pcg_actors: z.array(z.string()).optional()
+    .describe('Optional scope: only wait on these PCGComponent owners (full actor paths). Omit = all PCG actors in the active level.'),
+  world_ticks: z.number().int().min(1).max(60).optional()
+    .describe('When world_tick is in subsystems: wait at least N world ticks past request start. Default 1.'),
+});
+
+export type WaitForIdleParams = z.infer<typeof schema>;
+
+export const meta: HaybaToolMeta = {
+  cost: 'high',
+  effects: ['wait'],
+  when: 'After mutating asset/PCG/level state, before reading back or rendering.',
+  not_when: 'You did a pure read-only call; no state was mutated.',
+};
+
+export async function handleWaitForIdle(params: WaitForIdleParams) {
+  const parsed = schema.safeParse(params);
+  if (!parsed.success) {
+    return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
+  }
+  const data = await executeCommand('wait_for_idle', parsed.data as Record<string, unknown>, {
+    timeout: parsed.data.timeout_s * 1000 + 5000,
+  });
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}

--- a/mcp-tools/hayba-mcp/src/tools/wait-for-shaders.ts
+++ b/mcp-tools/hayba-mcp/src/tools/wait-for-shaders.ts
@@ -16,11 +16,23 @@ export const schema = z.object({
 
 export type WaitForShadersParams = z.infer<typeof schema>;
 
+let pollWarned = false;
+
 export async function handleWaitForShaders(params: WaitForShadersParams) {
   const parsed = schema.safeParse(params);
   if (!parsed.success) {
     return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
   }
-  const data = await executeCommand('wait_for_shaders', parsed.data as Record<string, unknown>);
+  // poll_seconds is no longer honoured — UE-side polling is fixed at 250ms in
+  // the new wait_for_idle handler. Warn once per process for callers that
+  // still pass it.
+  if (params.poll_seconds !== undefined && !pollWarned) {
+    pollWarned = true;
+    console.warn('[wait-for-shaders] poll_seconds is ignored; UE-side polling is fixed at 250ms.');
+  }
+  const data = await executeCommand('wait_for_idle', {
+    subsystems: ['shaders'],
+    timeout_s: parsed.data.max_seconds,
+  }, { timeout: parsed.data.max_seconds * 1000 + 5000 });
   return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
 }

--- a/mcp-tools/hayba-mcp/src/tools/wait-for-shaders.ts
+++ b/mcp-tools/hayba-mcp/src/tools/wait-for-shaders.ts
@@ -17,22 +17,44 @@ export const schema = z.object({
 export type WaitForShadersParams = z.infer<typeof schema>;
 
 let pollWarned = false;
+// Process-local capability flag: once we observe the UE plugin doesn't know
+// `wait_for_idle`, fall back to the legacy `wait_for_shaders` command for the
+// rest of this process. Lets us route through the new primitive when available
+// without regressing live editors still running an older plugin build.
+let waitForIdleAvailable: boolean | null = null;
 
 export async function handleWaitForShaders(params: WaitForShadersParams) {
   const parsed = schema.safeParse(params);
   if (!parsed.success) {
     return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
   }
-  // poll_seconds is no longer honoured — UE-side polling is fixed at 250ms in
-  // the new wait_for_idle handler. Warn once per process for callers that
-  // still pass it.
   if (params.poll_seconds !== undefined && !pollWarned) {
     pollWarned = true;
     console.warn('[wait-for-shaders] poll_seconds is ignored; UE-side polling is fixed at 250ms.');
   }
-  const data = await executeCommand('wait_for_idle', {
-    subsystems: ['shaders'],
-    timeout_s: parsed.data.max_seconds,
-  }, { timeout: parsed.data.max_seconds * 1000 + 5000 });
+
+  const timeoutMs = parsed.data.max_seconds * 1000 + 5000;
+
+  if (waitForIdleAvailable !== false) {
+    try {
+      const data = await executeCommand('wait_for_idle', {
+        subsystems: ['shaders'],
+        timeout_s: parsed.data.max_seconds,
+      }, { timeout: timeoutMs });
+      waitForIdleAvailable = true;
+      return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+    } catch (err) {
+      const msg = (err as Error)?.message ?? '';
+      if (/unknown_command|unknown command|not registered/i.test(msg)) {
+        waitForIdleAvailable = false;
+        // fall through to legacy path
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // Legacy fallback for plugins that don't yet know `wait_for_idle`.
+  const data = await executeCommand('wait_for_shaders', parsed.data as Record<string, unknown>, { timeout: timeoutMs });
   return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
 }

--- a/mcp-tools/hayba-mcp/tests/wait-for-idle-integration.test.ts
+++ b/mcp-tools/hayba-mcp/tests/wait-for-idle-integration.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setDefaultSender, type Sender } from '../src/tools/tool-executor.js';
+import { handleWaitForIdle } from '../src/tools/wait-for-idle.js';
+import { handleWaitForShaders } from '../src/tools/wait-for-shaders.js';
+
+describe('wait-for-idle integration', () => {
+  let sender: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    sender = vi.fn(async (_cmd: string, _params: Record<string, unknown>, _timeout: number) => ({
+      ok: true,
+      data: { ok: true, durationMs: 12, settled: { shaders: { busyOnEntry: true, settledAtMs: 8 } } },
+    }));
+    setDefaultSender(sender as unknown as Sender);
+  });
+
+  it('returns the unwrapped UE response shape', async () => {
+    const res = await handleWaitForIdle({ subsystems: ['shaders'], timeout_s: 5 } as never);
+    const body = JSON.parse(res.content[0].text);
+    expect(body.ok).toBe(true);
+    expect(body.settled.shaders.busyOnEntry).toBe(true);
+  });
+
+  it('preserves timedOut on partial timeout', async () => {
+    sender.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        ok: false, durationMs: 5000,
+        settled: { pcg: { busyOnEntry: true, settledAtMs: 5000 } },
+        timedOut: ['pcg'],
+      },
+    });
+    const res = await handleWaitForIdle({ subsystems: ['pcg'], timeout_s: 5 } as never);
+    const body = JSON.parse(res.content[0].text);
+    expect(body.ok).toBe(false);
+    expect(body.timedOut).toEqual(['pcg']);
+  });
+
+  it('wait-for-shaders wrapper delegates to wait_for_idle with shaders scope', async () => {
+    await handleWaitForShaders({ max_seconds: 30, poll_seconds: 1 } as never);
+    expect(sender).toHaveBeenCalledWith(
+      'wait_for_idle',
+      expect.objectContaining({ subsystems: ['shaders'], timeout_s: 30 }),
+      35000,
+    );
+  });
+});

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp
@@ -52,6 +52,7 @@
 #include "handlers/HaybaMCPBuildHandler.h"
 #include "handlers/HaybaMCPTestHandler.h"
 #include "handlers/HaybaMCPPerfHandler.h"
+#include "handlers/HaybaMCPIdleHandler.h"
 #include "HaybaMCPCaptureActor.h"
 #include "HaybaMCPSettings.h"
 #include "Json.h"
@@ -116,6 +117,7 @@ void FHaybaMCPModule::StartupModule()
     CommandHandler->RegisterHandler(MakeShared<FHaybaMCPBuildHandler>());
     CommandHandler->RegisterHandler(MakeShared<FHaybaMCPTestHandler>());
     CommandHandler->RegisterHandler(MakeShared<FHaybaMCPPerfHandler>());
+    CommandHandler->RegisterHandler(MakeShared<FHaybaMCPIdleHandler>());
 
     // Auto-start the TCP listener so external MCP clients (Claude Code, Cline,
     // OpenCode, …) can connect as soon as the editor is up. The MCP node

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp
@@ -1,0 +1,275 @@
+// HaybaMCPIdleHandler.cpp — see header for the design summary.
+//
+// Threading: Handle() is invoked from the TCP server's per-request handler
+// thread (NOT the game thread). We schedule a polling ticker on the core
+// ticker (game-thread ticked) and block the calling thread on an FEvent
+// until the ticker fires Done. Predicates like IsShadersBusy / IsGenerating
+// must be touched on the game thread, so all polling happens there.
+
+#include "HaybaMCPIdleHandler.h"
+
+#include "Containers/Ticker.h"
+#include "Editor.h"
+#include "Editor/EditorEngine.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetRegistry/IAssetRegistry.h"
+#include "ShaderCompiler.h"
+#include "UObject/UObjectGlobals.h"
+#include "UObject/UObjectIterator.h"
+#include "Engine/World.h"
+#include "PCGComponent.h"
+
+namespace HaybaIdle
+{
+    constexpr double POLL_INTERVAL_SECONDS = 0.25;
+
+    static bool IsShadersBusyImpl()
+    {
+        return GShaderCompilingManager && GShaderCompilingManager->IsCompiling();
+    }
+
+    static bool IsAssetsBusyImpl()
+    {
+        FAssetRegistryModule& Mod = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+        return Mod.Get().IsLoadingAssets();
+    }
+
+    static bool IsGCBusyImpl()
+    {
+        return IsGarbageCollecting() || IsIncrementalPurgePending();
+    }
+
+    static UWorld* ActiveEditorWorld()
+    {
+        if (GEditor)
+        {
+            UWorld* W = GEditor->GetEditorWorldContext().World();
+            if (W) return W;
+        }
+        return GWorld;
+    }
+
+    static bool IsPCGBusyImpl(const TSet<FString>& ScopedActorPaths)
+    {
+        UWorld* World = ActiveEditorWorld();
+        if (!World) return false;
+        for (TObjectIterator<UPCGComponent> It; It; ++It)
+        {
+            UPCGComponent* Comp = *It;
+            if (!Comp || Comp->GetWorld() != World) continue;
+            AActor* Owner = Comp->GetOwner();
+            if (!Owner) continue;
+            if (ScopedActorPaths.Num() > 0)
+            {
+                const FString Path = Owner->GetPathName();
+                if (!ScopedActorPaths.Contains(Path)) continue;
+            }
+            if (Comp->IsGenerating()) return true;
+        }
+        return false;
+    }
+
+    static bool IsWorldTickPendingImpl(int32 TicksRequired, uint64 StartFrameCounter)
+    {
+        return (GFrameCounter - StartFrameCounter) < (uint64)TicksRequired;
+    }
+
+    struct FWaitState
+    {
+        TSet<FString>            Subsystems;
+        TSet<FString>            ScopedPcgActors;
+        int32                    WorldTicksRequired = 1;
+        uint64                   StartFrameCounter  = 0;
+        double                   T0Seconds          = 0.0;
+        double                   TimeoutSeconds     = 60.0;
+        TMap<FString, bool>      BusyOnEntry;
+        TMap<FString, double>    SettledAtMs;     // missing key = not settled
+        FTSTicker::FDelegateHandle TickHandle;
+        FEvent*                  DoneEvent        = nullptr;
+        // Filled on the game thread, read on the TCP thread after DoneEvent fires.
+        bool                     bAllSettled      = false;
+        double                   FinalDurationMs  = 0.0;
+    };
+
+    static bool IsBusy(const FString& Sub, const FWaitState& S)
+    {
+        if (Sub == TEXT("shaders"))    return IsShadersBusyImpl();
+        if (Sub == TEXT("assets"))     return IsAssetsBusyImpl();
+        if (Sub == TEXT("gc"))         return IsGCBusyImpl();
+        if (Sub == TEXT("pcg"))        return IsPCGBusyImpl(S.ScopedPcgActors);
+        if (Sub == TEXT("world_tick")) return IsWorldTickPendingImpl(S.WorldTicksRequired, S.StartFrameCounter);
+        return false;
+    }
+
+    static TSharedPtr<FJsonObject> BuildResponse(const FWaitState& S)
+    {
+        TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+        Out->SetBoolField(TEXT("ok"), S.bAllSettled);
+        Out->SetNumberField(TEXT("durationMs"), S.FinalDurationMs);
+
+        TSharedPtr<FJsonObject> Settled = MakeShared<FJsonObject>();
+        for (const FString& Sub : S.Subsystems)
+        {
+            TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+            Entry->SetBoolField(TEXT("busyOnEntry"), S.BusyOnEntry.FindRef(Sub));
+            const double* Ms = S.SettledAtMs.Find(Sub);
+            Entry->SetNumberField(TEXT("settledAtMs"), Ms ? *Ms : S.FinalDurationMs);
+            Settled->SetObjectField(Sub, Entry);
+        }
+        Out->SetObjectField(TEXT("settled"), Settled);
+
+        if (!S.bAllSettled)
+        {
+            TArray<TSharedPtr<FJsonValue>> TimedOut;
+            for (const FString& Sub : S.Subsystems)
+            {
+                if (!S.SettledAtMs.Contains(Sub))
+                {
+                    TimedOut.Add(MakeShared<FJsonValueString>(Sub));
+                }
+            }
+            Out->SetArrayField(TEXT("timedOut"), TimedOut);
+        }
+        return Out;
+    }
+
+    /** Runs on the game thread via FTSTicker. Returns false to unregister. */
+    static bool PollOnce(float /*Dt*/, FWaitState* S)
+    {
+        const double Now = FPlatformTime::Seconds();
+        const double DurationMs = (Now - S->T0Seconds) * 1000.0;
+
+        for (const FString& Sub : S->Subsystems)
+        {
+            if (S->SettledAtMs.Contains(Sub)) continue;
+            if (!IsBusy(Sub, *S))
+            {
+                S->SettledAtMs.Add(Sub, DurationMs);
+            }
+        }
+
+        const bool bAllSettled = (S->SettledAtMs.Num() == S->Subsystems.Num());
+        const bool bTimedOut = (Now - S->T0Seconds) >= S->TimeoutSeconds;
+
+        if (bAllSettled || bTimedOut)
+        {
+            S->bAllSettled = bAllSettled;
+            S->FinalDurationMs = DurationMs;
+            if (S->DoneEvent) S->DoneEvent->Trigger();
+            return false;
+        }
+        return true;
+    }
+}
+
+TArray<FString> FHaybaMCPIdleHandler::GetCommands() const
+{
+    return { TEXT("wait_for_idle"), TEXT("wait_for_shaders") };
+}
+
+FHaybaHandlerResult FHaybaMCPIdleHandler::Handle(const FString& Command,
+                                                 const TSharedPtr<FJsonObject>& Params)
+{
+    using namespace HaybaIdle;
+
+    FWaitState State;
+    State.T0Seconds = FPlatformTime::Seconds();
+    State.StartFrameCounter = GFrameCounter;
+
+    // ── Parse params ──────────────────────────────────────────────────────
+    if (Command == TEXT("wait_for_shaders"))
+    {
+        // Legacy command: subsystems implicit = shaders; max_seconds → timeout.
+        State.Subsystems.Add(TEXT("shaders"));
+        double Max = 60.0;
+        if (Params.IsValid() && Params->HasField(TEXT("max_seconds")))
+        {
+            Max = Params->GetNumberField(TEXT("max_seconds"));
+        }
+        State.TimeoutSeconds = Max;
+    }
+    else
+    {
+        // wait_for_idle: subsystems[], timeout_s, pcg_actors?, world_ticks?
+        if (Params.IsValid())
+        {
+            if (Params->HasField(TEXT("timeout_s")))
+            {
+                State.TimeoutSeconds = Params->GetNumberField(TEXT("timeout_s"));
+            }
+            const TArray<TSharedPtr<FJsonValue>>* SubsArr = nullptr;
+            if (Params->TryGetArrayField(TEXT("subsystems"), SubsArr) && SubsArr)
+            {
+                for (const TSharedPtr<FJsonValue>& V : *SubsArr) State.Subsystems.Add(V->AsString());
+            }
+            const TArray<TSharedPtr<FJsonValue>>* ActorsArr = nullptr;
+            if (Params->TryGetArrayField(TEXT("pcg_actors"), ActorsArr) && ActorsArr)
+            {
+                for (const TSharedPtr<FJsonValue>& V : *ActorsArr) State.ScopedPcgActors.Add(V->AsString());
+            }
+            if (Params->HasField(TEXT("world_ticks")))
+            {
+                State.WorldTicksRequired = (int32)Params->GetNumberField(TEXT("world_ticks"));
+            }
+        }
+        if (State.Subsystems.Num() == 0)
+        {
+            State.Subsystems = { TEXT("shaders"), TEXT("assets"), TEXT("gc"), TEXT("pcg"), TEXT("world_tick") };
+        }
+    }
+
+    // ── Cross-thread event ────────────────────────────────────────────────
+    State.DoneEvent = FPlatformProcess::GetSynchEventFromPool(/*bIsManualReset=*/ false);
+    if (!State.DoneEvent) return FHaybaHandlerResult::Err(TEXT("Failed to allocate FEvent"));
+
+    // ── Schedule polling on the game thread ───────────────────────────────
+    // Capture pointer to a heap-allocated copy so the lambda can mutate it
+    // across ticks. The TCP thread frees it after DoneEvent fires.
+    FWaitState* HeapState = new FWaitState(MoveTemp(State));
+
+    AsyncTask(ENamedThreads::GameThread, [HeapState]()
+    {
+        // GC nudge — only when gc requested. Queue once, before the first poll,
+        // so IsGCBusyImpl observes the pending pass briefly then sees it settle.
+        if (HeapState->Subsystems.Contains(TEXT("gc")) && GEngine)
+        {
+            GEngine->ForceGarbageCollection(/*bFullPurge=*/ false);
+        }
+        // Capture busyOnEntry on the game thread (predicates are not thread-safe).
+        for (const FString& Sub : HeapState->Subsystems)
+        {
+            HeapState->BusyOnEntry.Add(Sub, IsBusy(Sub, *HeapState));
+        }
+        HeapState->TickHandle = FTSTicker::GetCoreTicker().AddTicker(
+            FTickerDelegate::CreateLambda([HeapState](float Dt) { return PollOnce(Dt, HeapState); }),
+            POLL_INTERVAL_SECONDS);
+    });
+
+    // ── Block this thread until polling completes or timeout fires ─────────
+    // FEvent wait timeout is in milliseconds. Allow timeout_s + 1s slack so
+    // the game-thread poller always fires Done first.
+    const uint32 WaitTimeoutMs = (uint32)(HeapState->TimeoutSeconds * 1000.0) + 1000;
+    const bool bSignaled = HeapState->DoneEvent->Wait(WaitTimeoutMs);
+
+    // Build response (read game-thread-filled state — safe because the event
+    // signal serializes the write).
+    TSharedPtr<FJsonObject> Resp;
+    if (bSignaled)
+    {
+        Resp = BuildResponse(*HeapState);
+    }
+    else
+    {
+        // FEvent timed out before the game-thread poller — shouldn't happen
+        // given the +1s slack, but degrade gracefully.
+        HeapState->FinalDurationMs = (FPlatformTime::Seconds() - HeapState->T0Seconds) * 1000.0;
+        HeapState->bAllSettled = false;
+        Resp = BuildResponse(*HeapState);
+    }
+
+    FPlatformProcess::ReturnSynchEventToPool(HeapState->DoneEvent);
+    HeapState->DoneEvent = nullptr;
+    delete HeapState;
+
+    return FHaybaHandlerResult::Ok(Resp);
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.h
@@ -1,0 +1,23 @@
+// HaybaMCPIdleHandler.h — UE subsystem readiness waits (wait_for_idle).
+//
+// Single command `wait_for_idle` that polls per-subsystem IsBusy() predicates
+// at 250ms cadence on the game thread (via FTSTicker), blocks the calling
+// TCP-handler thread on an FEvent until all requested subsystems settle or
+// the timeout expires. Subsystem set v1: shaders, assets, gc, pcg, world_tick.
+//
+// Companion spec: docs/superpowers/specs/2026-05-21-wait-for-idle-design.md
+//
+// Also exposes a `wait_for_shaders` command that delegates to wait_for_idle
+// with subsystems=['shaders'], so this single handler subsumes both names.
+
+#pragma once
+#include "IHaybaMCPHandler.h"
+
+class FHaybaMCPIdleHandler : public IHaybaMCPHandler
+{
+public:
+    virtual FString GetDomain() const override { return TEXT("idle"); }
+    virtual TArray<FString> GetCommands() const override;
+    virtual FHaybaHandlerResult Handle(const FString& Command,
+                                       const TSharedPtr<FJsonObject>& Params) override;
+};


### PR DESCRIPTION
## Summary
- New `wait_for_idle(subsystems?, timeout_s, pcg_actors?, world_ticks?)` MCP tool covering `shaders`, `assets`, `gc`, `pcg`, `world_tick`. Default `subsystems` unset = wait for all five.
- Structured `{ok, durationMs, settled, timedOut?}` response distinguishes settled-in-time vs. partial-timeout per subsystem.
- C++ handler (`FHaybaMCPIdleHandler`) schedules `FTSTicker` polling on the game thread at 250ms cadence and blocks the TCP-handler thread on an `FEvent` until all requested subsystems settle or the timeout fires. Handles both `wait_for_idle` and `wait_for_shaders` commands.
- TS `wait_for_shaders` becomes a thin wrapper around `wait_for_idle` with a per-process capability-flag fallback to the legacy command — live editors running older plugin builds keep working.
- Closes `.scratch/mcp-architectural-issues.md` #3.

## Spec / Plan
- `docs/superpowers/specs/2026-05-21-wait-for-idle-design.md`
- `docs/superpowers/plans/2026-05-21-wait-for-idle.md`

## Test plan
- [x] TS unit: 8 tests (schema validation, dispatch contract)
- [x] TS integration: 3 tests (unwrap, partial timeout, wait-for-shaders wrapper delegation)
- [ ] C++ build verification (requires UE 5.7 build env — needs sync to live plugin dir `D:/UnrealEngine/geoforge/Plugins/HaybaMCPToolkit/` per architectural-issues #5)
- [ ] Manual smoke against live UE: `wait_for_idle({subsystems:['pcg']})` settles after PCG generate burst; `wait_for_idle({subsystems:['gc']})` waits past GC pass; `wait_for_idle()` (all five) sees fresh-map load to completion

## Notes
- 272 passing / 26 pre-existing TCP-sender failures unchanged (not regressions from this branch)
- The C++ handler ships under `unreal/HaybaMCPToolkit/` in this repo. Per architectural-issues #5, the live editor uses a duplicate plugin tree at `geoforge/Plugins/HaybaMCPToolkit/`; sync this PR's handler files there to take effect in the running editor. Long-term: dedupe plugin source (separate spec).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wait_for_idle` tool to monitor when Unreal Engine subsystems complete their work, supporting shaders, assets, garbage collection, PCG generation, and world ticks with customizable timeouts and partial settlement detection.
  * Updated `wait_for_shaders` to leverage the new subsystem monitoring with seamless backward compatibility.

* **Documentation**
  * Added design specification and implementation plan for subsystem idle monitoring functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->