### PR TITLE
Cognitive Map: tag-based grouping + color coding

### DIFF
--- a/docs/superpowers/plans/2026-05-21-cognitive-map-tag-grouping.md
+++ b/docs/superpowers/plans/2026-05-21-cognitive-map-tag-grouping.md
@@ -1,0 +1,712 @@
+# Cognitive Map — Tag-Based Grouping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded `semanticOf()` substring-matching grouping in the Cognitive Map web view with actor-tag-driven grouping, render per-cell tag chips, and color cells deterministically by their mode tag.
+
+**Architecture:** MCP server's asset retriever writes a `~/.hayba/cache/retriever-tags.json` snapshot after indexing. UE plugin's `FHaybaTagIndex` loads it lazily; `BuildUniformGrid` aggregates tags per cell (UE `Actor->Tags` first, retriever fallback). The web panel JSON gains a `tags[]` field per cell. `index.html` loads a `tag-overrides.json` palette + FNV-1a deterministic hash for unknown tags; cells fill by mode-tag color, with a chip strip below each circle, and force-layout hubs re-key by tag string.
+
+**Tech Stack:** TypeScript + vitest (MCP), Unreal C++ + Slate (plugin), HTML/D3.js (web view).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-cognitive-map-tag-grouping-design.md`
+
+---
+
+### Task 1: TS — tag-snapshot writer (TDD)
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.ts`
+- Create: `mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeTagSnapshot } from './tag-snapshot.js';
+
+describe('writeTagSnapshot', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'hayba-tag-snap-')); });
+  afterEach(()  => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('writes sorted assetPath → tags map as JSON', () => {
+    const out = join(dir, 'retriever-tags.json');
+    writeTagSnapshot(out, [
+      { path: '/Game/Foliage/SM_Pine',    tags: ['foliage', 'tree', 'conifer'] },
+      { path: '/Game/Maritime/SM_Anchor', tags: ['maritime', 'metal'] },
+    ]);
+    const parsed = JSON.parse(readFileSync(out, 'utf8'));
+    expect(Object.keys(parsed)).toEqual(['/Game/Foliage/SM_Pine', '/Game/Maritime/SM_Anchor']);
+    expect(parsed['/Game/Maritime/SM_Anchor']).toEqual(['maritime', 'metal']);
+  });
+
+  it('drops hits with no tags', () => {
+    const out = join(dir, 'snap.json');
+    writeTagSnapshot(out, [
+      { path: '/Game/A', tags: [] },
+      { path: '/Game/B', tags: ['x'] },
+    ]);
+    const parsed = JSON.parse(readFileSync(out, 'utf8'));
+    expect(Object.keys(parsed)).toEqual(['/Game/B']);
+  });
+
+  it('is idempotent on identical input', () => {
+    const out = join(dir, 'snap.json');
+    const hits = [{ path: '/Game/X', tags: ['a', 'b'] }];
+    writeTagSnapshot(out, hits);
+    const first = readFileSync(out, 'utf8');
+    writeTagSnapshot(out, hits);
+    expect(readFileSync(out, 'utf8')).toBe(first);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd D:/Hackathons/hayba/mcp-tools/hayba-mcp && npx vitest run src/tools/asset-retriever/tag-snapshot.test.ts`
+Expected: FAIL (`Cannot find module './tag-snapshot.js'`).
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.ts
+//
+// Dumps a flat { assetPath: tags[] } JSON file the UE plugin reads to
+// enrich the Cognitive Map's per-cell tag list. Sorted keys for
+// diff-friendliness; assets with zero tags are omitted to keep the file
+// small.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+export interface TagSnapshotHit {
+  path: string;
+  tags: string[];
+}
+
+export function writeTagSnapshot(outPath: string, hits: TagSnapshotHit[]): void {
+  const map: Record<string, string[]> = {};
+  for (const h of hits) {
+    if (h.tags && h.tags.length > 0) map[h.path] = h.tags;
+  }
+  const sortedKeys = Object.keys(map).sort();
+  const ordered: Record<string, string[]> = {};
+  for (const k of sortedKeys) ordered[k] = map[k];
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(ordered, null, 2) + '\n', 'utf8');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd D:/Hackathons/hayba/mcp-tools/hayba-mcp && npx vitest run src/tools/asset-retriever/tag-snapshot.test.ts`
+Expected: 3 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C D:/Hackathons/hayba add mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.ts mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.test.ts
+git -C D:/Hackathons/hayba commit -m "feat(cogmap): tag snapshot writer for asset retriever"
+```
+
+---
+
+### Task 2: TS — wire snapshot write into the asset-indexer rebuild path
+
+**Files:**
+- Modify: `mcp-tools/hayba-mcp/src/tools/asset-retriever/asset-indexer.ts` (find the function that finishes a full reindex and emit the snapshot)
+- Modify: `mcp-tools/hayba-mcp/src/tools/asset-retriever/asset-indexer.test.ts` (add one test asserting the snapshot file appears)
+
+- [ ] **Step 1: Read the existing indexer**
+
+```bash
+sed -n '1,80p' D:/Hackathons/hayba/mcp-tools/hayba-mcp/src/tools/asset-retriever/asset-indexer.ts
+```
+
+Identify the function that completes a rebuild (probably named `buildIndex`, `reindex`, or `indexAll`). It should yield the final list of hits or have access to the in-memory index of `{ path, tags }`. Locate the point right before the function returns.
+
+- [ ] **Step 2: Resolve the snapshot output path**
+
+Add this helper at the top of `asset-indexer.ts` (under the existing imports):
+
+```ts
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { writeTagSnapshot } from './tag-snapshot.js';
+
+const TAG_SNAPSHOT_PATH = join(homedir(), '.hayba', 'cache', 'retriever-tags.json');
+```
+
+- [ ] **Step 3: Emit the snapshot at end of rebuild**
+
+In the rebuild function, immediately before returning, add:
+
+```ts
+const snapshotHits = allHits.map(h => ({ path: h.path, tags: h.tags ?? [] }));
+try {
+  writeTagSnapshot(TAG_SNAPSHOT_PATH, snapshotHits);
+} catch (err) {
+  console.error('[cogmap] failed to write tag snapshot:', err);
+}
+```
+
+Adjust `allHits` to whatever the local variable is named (the array of indexed entries with `path` + `tags`). If the indexer keeps a `Map<string, AssetEntry>`, iterate that map instead. Wrap in try/catch — a failed snapshot must never break indexing.
+
+- [ ] **Step 4: Add a test**
+
+In `asset-indexer.test.ts`, add a new `it(...)` near the other rebuild tests:
+
+```ts
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+it('writes the cogmap tag snapshot after rebuild', async () => {
+  const snapPath = join(homedir(), '.hayba', 'cache', 'retriever-tags.json');
+  // best-effort cleanup so the test starts from a known state
+  try { rmSync(snapPath); } catch {}
+
+  // (set up a tiny fixture indexer with two assets — reuse the same fixture
+  // pattern as the other tests in this file)
+  await rebuildFixtureIndex();
+
+  expect(existsSync(snapPath)).toBe(true);
+  const parsed = JSON.parse(readFileSync(snapPath, 'utf8'));
+  expect(Object.values(parsed).flat().length).toBeGreaterThan(0);
+});
+```
+
+If the existing tests don't have a `rebuildFixtureIndex()` helper, instead exercise whatever the existing rebuild entrypoint is and assert `existsSync(snapPath)`.
+
+- [ ] **Step 5: Run tests**
+
+```
+cd D:/Hackathons/hayba/mcp-tools/hayba-mcp
+npx vitest run src/tools/asset-retriever/asset-indexer.test.ts
+```
+
+Expected: all pre-existing tests still pass + the new one passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C D:/Hackathons/hayba add mcp-tools/hayba-mcp/src/tools/asset-retriever/asset-indexer.ts mcp-tools/hayba-mcp/src/tools/asset-retriever/asset-indexer.test.ts
+git -C D:/Hackathons/hayba commit -m "feat(cogmap): emit retriever-tags snapshot after asset reindex"
+```
+
+---
+
+### Task 3: C++ — `FHaybaTagIndex` loader
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.cpp`
+
+- [ ] **Step 1: Header**
+
+```cpp
+// HaybaTagIndex.h — Lazy loader for the asset-retriever tag snapshot
+// (~/.hayba/cache/retriever-tags.json). Maps UE asset path → tag list.
+// Used by the Cognitive Map builder to enrich cells with semantic tags
+// when actors carry no UE Tags of their own.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FHaybaTagIndex
+{
+public:
+    /** Path resolution: %USERPROFILE%/.hayba/cache/retriever-tags.json on Windows. */
+    static FString DefaultSnapshotPath();
+
+    /** Process-wide instance. Loads on first call; subsequent calls are O(1). */
+    static FHaybaTagIndex& Get();
+
+    /** Returns empty list when the asset path is unknown or the snapshot is missing. */
+    const TArray<FString>& Lookup(const FString& AssetPath) const;
+
+    /** True iff the snapshot was successfully loaded. */
+    bool IsLoaded() const { return bLoaded; }
+
+    /** Drops the cached map and forces a reload on the next Lookup. */
+    void Invalidate();
+
+private:
+    FHaybaTagIndex() = default;
+    void EnsureLoaded();
+
+    mutable bool bLoaded = false;
+    mutable bool bLoadAttempted = false;
+    mutable TMap<FString, TArray<FString>> PathToTags;
+    static const TArray<FString> EmptyTags;
+};
+```
+
+- [ ] **Step 2: Implementation**
+
+```cpp
+// HaybaTagIndex.cpp
+#include "HaybaTagIndex.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformMisc.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+const TArray<FString> FHaybaTagIndex::EmptyTags;
+
+FString FHaybaTagIndex::DefaultSnapshotPath()
+{
+#if PLATFORM_WINDOWS
+    FString Home = FPlatformMisc::GetEnvironmentVariable(TEXT("USERPROFILE"));
+    if (Home.IsEmpty()) Home = FPaths::ProjectSavedDir();
+    return FPaths::Combine(Home, TEXT(".hayba"), TEXT("cache"), TEXT("retriever-tags.json"));
+#else
+    FString Home = FPlatformMisc::GetEnvironmentVariable(TEXT("HOME"));
+    if (Home.IsEmpty()) Home = FPaths::ProjectSavedDir();
+    return FPaths::Combine(Home, TEXT(".hayba"), TEXT("cache"), TEXT("retriever-tags.json"));
+#endif
+}
+
+FHaybaTagIndex& FHaybaTagIndex::Get()
+{
+    static FHaybaTagIndex Singleton;
+    return Singleton;
+}
+
+void FHaybaTagIndex::Invalidate()
+{
+    PathToTags.Reset();
+    bLoaded = false;
+    bLoadAttempted = false;
+}
+
+void FHaybaTagIndex::EnsureLoaded()
+{
+    if (bLoadAttempted) return;
+    bLoadAttempted = true;
+
+    const FString Path = DefaultSnapshotPath();
+    if (!IFileManager::Get().FileExists(*Path))
+    {
+        UE_LOG(LogTemp, Log, TEXT("[HaybaTagIndex] snapshot not present at %s — falling back to actor tags only"), *Path);
+        return;
+    }
+
+    FString Raw;
+    if (!FFileHelper::LoadFileToString(Raw, *Path))
+    {
+        UE_LOG(LogTemp, Warning, TEXT("[HaybaTagIndex] failed to read %s"), *Path);
+        return;
+    }
+
+    TSharedPtr<FJsonObject> Root;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Raw);
+    if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+    {
+        UE_LOG(LogTemp, Warning, TEXT("[HaybaTagIndex] %s is not valid JSON"), *Path);
+        return;
+    }
+
+    for (const auto& KV : Root->Values)
+    {
+        if (!KV.Value.IsValid() || KV.Value->Type != EJson::Array) continue;
+        TArray<FString>& Out = PathToTags.Add(KV.Key);
+        for (const TSharedPtr<FJsonValue>& V : KV.Value->AsArray())
+        {
+            FString S;
+            if (V.IsValid() && V->TryGetString(S)) Out.Add(S);
+        }
+    }
+    bLoaded = true;
+    UE_LOG(LogTemp, Log, TEXT("[HaybaTagIndex] loaded %d entries from %s"), PathToTags.Num(), *Path);
+}
+
+const TArray<FString>& FHaybaTagIndex::Lookup(const FString& AssetPath) const
+{
+    const_cast<FHaybaTagIndex*>(this)->EnsureLoaded();
+    if (const TArray<FString>* Found = PathToTags.Find(AssetPath)) return *Found;
+    return EmptyTags;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C D:/Hackathons/hayba add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.h unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.cpp
+git -C D:/Hackathons/hayba commit -m "feat(cogmap): FHaybaTagIndex lazy loader for retriever tag snapshot"
+```
+
+---
+
+### Task 4: C++ — `FHaybaCogMapCell::Tags` + per-cell aggregation
+
+**Files:**
+- Modify: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapData.h` (add `Tags` field)
+- Modify: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCogMapBuilder.cpp` (aggregate tags inside `BuildUniformGrid`)
+
+- [ ] **Step 1: Add `Tags` field to `FHaybaCogMapCell`**
+
+In `HaybaMCPSceneMapData.h`, modify the struct (currently at lines 32-40):
+
+```cpp
+struct FHaybaCogMapCell
+{
+    FBox2D Bounds = FBox2D(ForceInit);
+    FString Label;
+    EHaybaNodeSemantic Semantic = EHaybaNodeSemantic::Unknown;
+    int32 ActorCount = 0;
+    TArray<FString> DominantClasses;
+    TArray<FString> ActorLabels;
+    TArray<FString> Tags;          // NEW — top-5 tags by frequency across the cell's actors
+};
+```
+
+- [ ] **Step 2: Add the per-cell tag aggregator in the builder**
+
+In `HaybaMCPCogMapBuilder.cpp`, near the existing `DominantClasses` helper (around line 102) and before `BuildUniformGrid`, add:
+
+```cpp
+#include "HaybaTagIndex.h"
+#include "GameFramework/Actor.h"
+#include "Components/ActorComponent.h"
+
+// Aggregate up to Limit tags across the cell's actors, sorted by frequency
+// then alphabetically for stability. Prefers UE Actor->Tags; falls back to
+// the retriever snapshot indexed by the actor's primary asset path.
+TArray<FString> AggregateTagsForCell(const TArray<AActor*>& Actors, int32 Limit)
+{
+    TMap<FString, int32> Counts;
+
+    auto Bump = [&Counts](const FString& Tag)
+    {
+        if (!Tag.IsEmpty()) Counts.FindOrAdd(Tag)++;
+    };
+
+    const FHaybaTagIndex& Index = FHaybaTagIndex::Get();
+
+    for (AActor* A : Actors)
+    {
+        if (!A) continue;
+        bool bHadUETag = false;
+        for (const FName& T : A->Tags) { Bump(T.ToString()); bHadUETag = true; }
+        if (bHadUETag) continue;
+
+        // Fallback: resolve the actor's source-asset path via its root component's UObject, if any.
+        FString AssetPath;
+        if (UObject* SrcAsset = A->GetClass()) AssetPath = SrcAsset->GetPathName();
+        if (!AssetPath.IsEmpty())
+        {
+            for (const FString& T : Index.Lookup(AssetPath)) Bump(T);
+        }
+    }
+
+    TArray<TPair<FString, int32>> Sorted;
+    for (const auto& KV : Counts) Sorted.Add(KV);
+    Sorted.Sort([](const TPair<FString,int32>& A, const TPair<FString,int32>& B)
+    {
+        if (A.Value != B.Value) return A.Value > B.Value;
+        return A.Key < B.Key;
+    });
+
+    TArray<FString> Out;
+    Out.Reserve(Limit);
+    for (int32 i = 0; i < FMath::Min(Limit, Sorted.Num()); ++i) Out.Add(Sorted[i].Key);
+    return Out;
+}
+```
+
+- [ ] **Step 3: Call the aggregator inside the cell loop**
+
+In `BuildUniformGrid` (around line 159-167), modify the per-bin block:
+
+```cpp
+FHaybaCogMapCell Cell;
+Cell.Bounds = FBox2D(
+    FVector2D(Bounds.Min.X + GX * CellSize.X,     Bounds.Min.Y + GY * CellSize.Y),
+    FVector2D(Bounds.Min.X + (GX+1) * CellSize.X, Bounds.Min.Y + (GY+1) * CellSize.Y));
+Cell.ActorCount = Bin.Num();
+Cell.DominantClasses = DominantClasses(Bin, /*Limit=*/5);
+Cell.Tags           = AggregateTagsForCell(Bin, /*Limit=*/5);   // NEW
+ClassifyDominant(Cell.DominantClasses, Cell.Label, Cell.Semantic);
+for (AActor* A : Bin) Cell.ActorLabels.Add(A->GetActorLabel());
+Cells.Add(MoveTemp(Cell));
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C D:/Hackathons/hayba add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapData.h unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCogMapBuilder.cpp
+git -C D:/Hackathons/hayba commit -m "feat(cogmap): aggregate per-cell tags from UE Tags + retriever index"
+```
+
+---
+
+### Task 5: C++ — Emit `tags[]` in the cog-map JSON payload
+
+**Files:**
+- Modify: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapWebPanel.cpp` (the JSON builder around lines 103-119)
+
+- [ ] **Step 1: Add a tags array to each cell's JSON**
+
+Replace the loop body (currently lines 104-117) with:
+
+```cpp
+for (int32 i = 0; i < Cells.Num(); ++i)
+{
+    const FHaybaCogMapCell& C = Cells[i];
+    if (i) J += TEXT(",");
+    J += FString::Printf(TEXT("{\"label\":\"%s\",\"count\":%d,\"bounds\":{\"min\":[%.3f,%.3f],\"max\":[%.3f,%.3f]},\"dominant\":["),
+        *EscStr(C.Label), C.ActorCount,
+        C.Bounds.Min.X, C.Bounds.Min.Y, C.Bounds.Max.X, C.Bounds.Max.Y);
+    for (int32 d = 0; d < C.DominantClasses.Num(); ++d)
+    {
+        if (d) J += TEXT(",");
+        J += TEXT("\"") + EscStr(C.DominantClasses[d]) + TEXT("\"");
+    }
+    J += TEXT("],\"tags\":[");
+    for (int32 t = 0; t < C.Tags.Num(); ++t)
+    {
+        if (t) J += TEXT(",");
+        J += TEXT("\"") + EscStr(C.Tags[t]) + TEXT("\"");
+    }
+    J += TEXT("]}");
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C D:/Hackathons/hayba add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapWebPanel.cpp
+git -C D:/Hackathons/hayba commit -m "feat(cogmap): include tags[] in scene-map JSON payload"
+```
+
+---
+
+### Task 6: D3 — `tag-overrides.json` + `colorForTag()` + chip strip + hub re-keying
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Resources/cognitive-map/tag-overrides.json`
+- Modify: `unreal/HaybaMCPToolkit/Resources/cognitive-map/index.html`
+
+- [ ] **Step 1: Add the overrides file**
+
+```json
+{
+  "maritime":   "hsl(210, 60%, 50%)",
+  "foliage":    "hsl(120, 50%, 45%)",
+  "urban":      "hsl(280, 30%, 55%)",
+  "light":      "hsl(50, 75%, 60%)",
+  "character":  "hsl(15, 65%, 55%)",
+  "vehicle":    "hsl(0, 60%, 50%)",
+  "interior":   "hsl(30, 40%, 50%)",
+  "industrial": "hsl(200, 20%, 45%)",
+  "natural":    "hsl(95, 45%, 50%)",
+  "rock":       "hsl(25, 25%, 45%)",
+  "water":      "hsl(195, 70%, 55%)",
+  "sky":        "hsl(220, 70%, 70%)",
+  "tech":       "hsl(180, 55%, 50%)",
+  "magic":      "hsl(290, 70%, 60%)",
+  "weapon":     "hsl(355, 50%, 45%)"
+}
+```
+
+- [ ] **Step 2: Add the tag colorizer to index.html**
+
+At the top of the `<script>` block in `index.html` (before `semanticOf` at line ~95), add:
+
+```html
+<script>
+let TAG_OVERRIDES = {};
+fetch('tag-overrides.json').then(r => r.ok ? r.json() : {}).then(o => { TAG_OVERRIDES = o; render(); });
+
+// FNV-1a 32-bit hash. Deterministic per tag string.
+function fnv1a(str) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < str.length; ++i) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h;
+}
+
+function colorForTag(tag) {
+  if (!tag) return 'hsl(0, 0%, 60%)';      // muted gray for tagless cells
+  if (TAG_OVERRIDES[tag]) return TAG_OVERRIDES[tag];
+  const hue = fnv1a(tag) % 360;
+  return `hsl(${hue}, 55%, 55%)`;
+}
+</script>
+```
+
+Adjust the existing `<script>` block — these go inside it, not in a new tag.
+
+- [ ] **Step 3: Replace `semanticOf`-driven cell color + hub keying**
+
+In the cell rendering code, replace whatever `.fill(...)` call colors the leaf cell with:
+
+```js
+.attr('fill', c => colorForTag((c.tags && c.tags[0]) || null))
+```
+
+Then locate the `families` Map (around line 144) that groups by `semanticOf(c.label)`. Replace its keying:
+
+```js
+const families = new Map(); // tag → { node, cells:[] }
+cells.forEach(c => {
+  const key = (c.tags && c.tags[0]) ? c.tags[0] : '_untagged';
+  if (!families.has(key)) {
+    families.set(key, {
+      node: { id: 'hub:' + key, isHub: true, tag: key, color: colorForTag(key === '_untagged' ? null : key) },
+      cells: []
+    });
+  }
+  families.get(key).cells.push(c);
+});
+```
+
+Wherever hub nodes get their fill color from `palette[sem]`, change to `d.color`.
+
+- [ ] **Step 4: Render the per-cell chip strip**
+
+Locate the SVG group that contains each leaf circle (look for the `<circle>` append on cells). After the circle's `append('circle')...` call, append a chip strip group:
+
+```js
+const chipR = 3;
+const chipGap = 2;
+cellGroup.each(function(c) {
+  const g = d3.select(this);
+  const chips = (c.tags || []).slice(0, 5);
+  const totalW = chips.length * (chipR * 2 + chipGap) - chipGap;
+  const startX = -totalW / 2;
+  const chipY  = (c.radius || 8) + chipR + 4;
+  g.selectAll('circle.chip').remove();
+  g.selectAll('circle.chip').data(chips).enter().append('circle')
+    .attr('class', 'chip')
+    .attr('cx', (_, i) => startX + i * (chipR * 2 + chipGap) + chipR)
+    .attr('cy', chipY)
+    .attr('r', chipR)
+    .attr('fill', t => colorForTag(t))
+    .append('title').text(t => t);
+});
+```
+
+Use the actual variable name for the per-cell group from the existing code (likely `cellGroup`, `nodeG`, or similar — read the file to confirm). The `c.radius || 8` fallback matches whatever the existing leaf-circle radius logic produces.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C D:/Hackathons/hayba add unreal/HaybaMCPToolkit/Resources/cognitive-map/tag-overrides.json unreal/HaybaMCPToolkit/Resources/cognitive-map/index.html
+git -C D:/Hackathons/hayba commit -m "feat(cogmap): tag-keyed hubs, deterministic colors, chip strip per cell"
+```
+
+---
+
+### Task 7: Smoke verification + manual visual check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: TS smoke**
+
+```
+cd D:/Hackathons/hayba/mcp-tools/hayba-mcp
+npx vitest run src/tools/asset-retriever
+```
+
+Expected: all asset-retriever tests pass, including the new `tag-snapshot.test.ts` + the indexer test that checks the snapshot file appears.
+
+- [ ] **Step 2: Manual UE side (record in PR body)**
+
+After the user opens the Unreal editor and rebuilds modules:
+
+1. Run `mcp__hayba-toolkit__hayba_asset_reindex` from Claude — confirms `~/.hayba/cache/retriever-tags.json` is written.
+2. Open `Window → Hayba MCP` (or wherever the Cognitive Map panel lives), trigger the cog-map build.
+3. Verify visually:
+   - Each cell circle has 0-5 small colored chip dots below it.
+   - Hover over a chip → tooltip shows the tag name.
+   - Cells with no tags render as muted gray with no chips.
+   - The same tag appears as the same color across different cells (e.g. anything maritime is the same blue).
+   - Force-layout hubs cluster by tag, not by hardcoded semantic.
+
+- [ ] **Step 3: Commit nothing** (manual verification — no diff)
+
+---
+
+### Task 8: Push branch + open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git -C D:/Hackathons/hayba push -u origin spec/cogmap-tag-grouping
+```
+
+The branch was created earlier when the spec was committed; subsequent code commits live on the same branch.
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base main --head spec/cogmap-tag-grouping \
+  --title "Cognitive Map: tag-based grouping + color coding" \
+  --body "$(cat <<'EOF'
+## Summary
+- MCP server writes `~/.hayba/cache/retriever-tags.json` after asset reindex.
+- UE plugin loads it via `FHaybaTagIndex`; per-cell tag aggregation prefers UE `Actor->Tags` and falls back to the retriever snapshot.
+- Web view (`Resources/cognitive-map/index.html`) gains a `tag-overrides.json` palette + FNV-1a deterministic hash for unknown tags.
+- Cells fill by mode-tag color; chip strip below each cell shows the top-5 tags; force-layout hubs re-keyed by tag.
+
+Implements `docs/superpowers/specs/2026-05-21-cognitive-map-tag-grouping-design.md`.
+
+## Test plan
+- [x] vitest src/tools/asset-retriever/tag-snapshot.test.ts (3/3)
+- [x] vitest src/tools/asset-retriever/asset-indexer.test.ts (snapshot-file assertion)
+- [ ] Manual: reindex → snapshot present at ~/.hayba/cache/retriever-tags.json
+- [ ] Manual: cog-map cells now show chip strips
+- [ ] Manual: same tag → same color across cells
+- [ ] Manual: hubs cluster by tag instead of hardcoded semantic
+
+## Scope cuts (v2)
+- Tag filter/search UI on the webview
+- Click-tag-to-isolate behavior
+- In-editor overrides editor (v1 = edit the JSON)
+- Stale-snapshot detection
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+
+| Spec section | Covered by |
+|---|---|
+| Snapshot writer `~/.hayba/cache/retriever-tags.json` | T1 |
+| Snapshot wired into reindex path | T2 |
+| `FHaybaTagIndex` lazy loader | T3 |
+| `FHaybaCogMapCell.Tags` field | T4 step 1 |
+| Per-cell aggregation (UE Tags first, retriever fallback) | T4 steps 2-3 |
+| JSON payload includes `tags[]` | T5 |
+| `tag-overrides.json` (~15 hand-pinned) | T6 step 1 |
+| Deterministic `colorForTag` w/ FNV-1a fallback | T6 step 2 |
+| Cell fill = mode-tag color | T6 step 3 |
+| Force-layout hubs re-keyed by tag | T6 step 3 |
+| Chip strip rendering | T6 step 4 |
+| Smoke + visual verification | T7 |
+
+**Out-of-scope items correctly deferred:** tag filter, click-isolate, in-editor overrides editor, stale-snapshot detection — none have implementation steps.
+
+**Placeholder scan:** every step has the actual code/command. The only blanks are the existing-variable-name lookups in T2 (`allHits`) and T6 step 4 (cell group var) — both flagged explicitly with "read the file" instructions and exact patterns to match.
+
+**Type consistency:** `Tags: TArray<FString>` is the same name in `HaybaMCPSceneMapData.h` (T4), the JSON emitter (`C.Tags`, T5), and the JS reader (`c.tags`, T6). `FHaybaTagIndex::Lookup` returns `const TArray<FString>&` consistent with how T4's aggregator iterates it. The `colorForTag(null)` muted-gray fallback in T6 step 2 matches the chip-strip behavior in step 4 (no chips rendered when `c.tags` is empty).

--- a/docs/superpowers/plans/2026-05-21-slivers-a-ts-runtime.md
+++ b/docs/superpowers/plans/2026-05-21-slivers-a-ts-runtime.md
@@ -1,0 +1,2129 @@
+# Slivers v1 Plan A — TS Runtime + MCP Tools + frame_target
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the Sliver runtime, four always-on MCP tools (`hayba_sliver_{list,get,run,import}`), and one bundled sliver (`com.hayba.composition.frame_target`). After this plan, an LLM can list, fetch, execute, and import slivers without any UE plugin work.
+
+**Architecture:** TS-side discriminated-union `SliverSpec` validated by Zod, executor functions registered against `executor.kind` strings, runtime with per-invocation cycle detection + max depth + side-effect aggregation. Specs live as JSON in `%APPDATA%/Hayba/slivers/`. Built-in specs ship inside the package and are copied to disk on first run if missing. MCP tool surface is added to `ALWAYS_ON_META` and registered alongside the existing asset-retriever tools.
+
+**Tech Stack:** TypeScript 5, Vitest, Zod, `@modelcontextprotocol/sdk`. Node 22 (the repo's `package.json` engines). No UE-side work in this plan.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-21-slivers-design.md`.
+
+---
+
+## File Structure
+
+```
+mcp-tools/hayba-mcp/
+├── src/
+│   ├── slivers/
+│   │   ├── types.ts                         # SliverSpec, SliverParam discriminated union, errors
+│   │   ├── spec-schema.ts                   # Zod schema mirroring types.ts for JSON validation
+│   │   ├── registry.ts                      # executor registration by kind
+│   │   ├── runtime.ts                       # runSliver(id, params, ctx) with cycle/depth guards
+│   │   ├── loader.ts                        # reads + writes %APPDATA%/Hayba/slivers/*.sliver.json
+│   │   ├── index.ts                         # setupSliverSystem() facade
+│   │   ├── composition/
+│   │   │   └── frame_target.ts              # pure executor; returns camera_transform
+│   │   ├── specs/
+│   │   │   └── com.hayba.composition.frame_target.sliver.json
+│   │   ├── types.test.ts
+│   │   ├── spec-schema.test.ts
+│   │   ├── registry.test.ts
+│   │   ├── runtime.test.ts
+│   │   ├── loader.test.ts
+│   │   └── composition/
+│   │       └── frame_target.test.ts
+│   ├── tools/
+│   │   └── sliver/
+│   │       ├── list.ts                      # hayba_sliver_list handler + schema
+│   │       ├── get.ts                       # hayba_sliver_get handler + schema
+│   │       ├── run.ts                       # hayba_sliver_run handler + schema
+│   │       ├── import.ts                    # hayba_sliver_import handler + schema
+│   │       ├── list.test.ts
+│   │       ├── get.test.ts
+│   │       ├── run.test.ts
+│   │       └── import.test.ts
+│   └── tools/routing/register.ts            # modified: add slivers to ALWAYS_ON_META + wire 4 tools
+└── package.json                             # modified: build:assets copies sliver specs
+```
+
+Each file has one responsibility. Tests live next to source per the existing repo convention (`*.test.ts` siblings).
+
+---
+
+### Task 1: Sliver type definitions
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/slivers/types.ts`
+- Test: `mcp-tools/hayba-mcp/src/slivers/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/types.test.ts
+import { describe, it, expect } from 'vitest';
+import { SliverCycleError, SliverDepthError, SliverNotFoundError, SliverValidationError } from './types.js';
+
+describe('sliver error types', () => {
+  it('SliverCycleError carries the offending id and the call stack', () => {
+    const err = new SliverCycleError('com.hayba.a', ['com.hayba.b', 'com.hayba.a']);
+    expect(err.name).toBe('SliverCycleError');
+    expect(err.id).toBe('com.hayba.a');
+    expect(err.stack_ids).toEqual(['com.hayba.b', 'com.hayba.a']);
+    expect(err.message).toContain('com.hayba.a');
+  });
+
+  it('SliverDepthError reports the depth that was exceeded', () => {
+    const err = new SliverDepthError(8);
+    expect(err.maxDepth).toBe(8);
+    expect(err.message).toContain('8');
+  });
+
+  it('SliverNotFoundError carries the missing id', () => {
+    expect(new SliverNotFoundError('com.x.y').id).toBe('com.x.y');
+  });
+
+  it('SliverValidationError keeps the human reason', () => {
+    expect(new SliverValidationError('missing required param "target"').message).toContain('target');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/types.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the types module**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/types.ts
+//
+// Sliver type definitions. The runtime, loader, registry, and MCP tools
+// all consume these. Discriminated-union params live here; the Zod
+// equivalent is mirrored in spec-schema.ts for JSON validation.
+
+export type SliverParamBase = {
+  id: string;
+  label?: string;
+  required?: boolean;
+};
+
+export type SliverParamFloat   = SliverParamBase & { type: 'float';     range?: [number, number]; step?: number; default?: number };
+export type SliverParamInt     = SliverParamBase & { type: 'int';       range?: [number, number]; step?: number; default?: number };
+export type SliverParamBool    = SliverParamBase & { type: 'bool';                                                default?: boolean };
+export type SliverParamString  = SliverParamBase & { type: 'string';    maxLength?: number;                       default?: string };
+export type SliverParamEnum    = SliverParamBase & { type: 'enum';      options: Array<{ value: string; label?: string }>; default?: string };
+export type SliverParamColor   = SliverParamBase & { type: 'color';                                               default?: string };  // '#RRGGBB'
+export type SliverParamActor   = SliverParamBase & { type: 'actor_ref'; class_filter?: string };
+export type SliverParamAsset   = SliverParamBase & { type: 'asset_ref'; class_filter?: string };
+export type SliverParamVec3    = SliverParamBase & { type: 'vector3';   range?: Array<[number, number]>;          default?: [number, number, number] };
+export type SliverParamXform   = SliverParamBase & { type: 'transform'; default?: { location: [number, number, number]; rotation: [number, number, number]; scale: [number, number, number] } };
+
+export type SliverParam =
+  | SliverParamFloat | SliverParamInt | SliverParamBool | SliverParamString
+  | SliverParamEnum | SliverParamColor | SliverParamActor | SliverParamAsset
+  | SliverParamVec3 | SliverParamXform;
+
+export interface SliverDeterminism {
+  pure: boolean;
+  declared_outputs: string[];
+  side_effects: string[];
+  seed_param: string | null;
+}
+
+export interface SliverSpec {
+  id: string;
+  version: string;
+  category: string;
+  title: string;
+  description: string;
+  author: string;
+  params: SliverParam[];
+  executor: { kind: string };
+  determinism: SliverDeterminism;
+}
+
+export type SliverParamValues = Record<string, unknown>;
+
+export interface SliverRunResult {
+  ok: boolean;
+  outputs: Record<string, unknown>;
+  side_effects: string[];
+  durationMs: number;
+  error?: string;
+}
+
+/** Context threaded through a runSliver call. Mostly the runtime needs it; executors may read it. */
+export interface SliverContext {
+  /** Reverse-DNS ids in the current call stack (oldest → newest). */
+  stack: string[];
+  /** Current depth = stack.length. Compared against maxDepth. */
+  maxDepth: number;
+  /** Lets executors call other slivers. */
+  runSliver: (id: string, params: SliverParamValues) => Promise<SliverRunResult>;
+}
+
+/** Executor function signature. Pure or mutating per the spec's determinism block. */
+export type SliverExecutor = (
+  params: SliverParamValues,
+  ctx: SliverContext,
+) => Promise<Record<string, unknown>>;
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+export class SliverCycleError extends Error {
+  readonly name = 'SliverCycleError';
+  constructor(public readonly id: string, public readonly stack_ids: string[]) {
+    super(`Sliver "${id}" re-entered its own call stack: ${stack_ids.join(' → ')}`);
+  }
+}
+
+export class SliverDepthError extends Error {
+  readonly name = 'SliverDepthError';
+  constructor(public readonly maxDepth: number) {
+    super(`Sliver call depth exceeded maxDepth=${maxDepth}`);
+  }
+}
+
+export class SliverNotFoundError extends Error {
+  readonly name = 'SliverNotFoundError';
+  constructor(public readonly id: string) {
+    super(`No installed sliver with id "${id}"`);
+  }
+}
+
+export class SliverValidationError extends Error {
+  readonly name = 'SliverValidationError';
+  constructor(message: string) {
+    super(message);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/types.test.ts`
+Expected: 4 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/slivers/types.ts mcp-tools/hayba-mcp/src/slivers/types.test.ts
+git commit -m "feat(slivers): type definitions for spec, params, runtime, errors"
+```
+
+---
+
+### Task 2: Zod schema for JSON spec validation
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/slivers/spec-schema.ts`
+- Test: `mcp-tools/hayba-mcp/src/slivers/spec-schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/spec-schema.test.ts
+import { describe, it, expect } from 'vitest';
+import { sliverSpecSchema, parseSliverSpec } from './spec-schema.js';
+
+const valid = {
+  id: 'com.hayba.composition.frame_target',
+  version: '1.0.0',
+  category: 'composition',
+  title: 'Frame Target',
+  description: 'Compute a camera transform.',
+  author: 'core',
+  params: [
+    { id: 'target', type: 'actor_ref', required: true },
+    { id: 'distance', type: 'float', range: [1, 100], default: 10 },
+  ],
+  executor: { kind: 'composition.frame_target' },
+  determinism: { pure: true, declared_outputs: ['camera_transform'], side_effects: [], seed_param: null },
+};
+
+describe('sliver spec schema', () => {
+  it('accepts a valid spec', () => {
+    expect(() => sliverSpecSchema.parse(valid)).not.toThrow();
+  });
+
+  it('parseSliverSpec returns ok=true on valid input', () => {
+    const r = parseSliverSpec(valid);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.spec.id).toBe(valid.id);
+  });
+
+  it('parseSliverSpec returns ok=false with reason on bad input', () => {
+    const r = parseSliverSpec({ ...valid, id: '' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/id/i);
+  });
+
+  it('rejects ids that are not reverse-DNS', () => {
+    const r = parseSliverSpec({ ...valid, id: 'frame_target' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown param types', () => {
+    const r = parseSliverSpec({
+      ...valid,
+      params: [{ id: 'x', type: 'banana' as unknown as 'float' }],
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects duplicate param ids', () => {
+    const r = parseSliverSpec({
+      ...valid,
+      params: [
+        { id: 'a', type: 'float' },
+        { id: 'a', type: 'int' },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/duplicate/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/spec-schema.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the schema module**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/spec-schema.ts
+//
+// Zod schema mirroring the TS types in types.ts. Used to validate JSON
+// specs loaded from disk and from URL imports. The discriminated union
+// on `type` matches the SliverParam shape exactly.
+
+import { z } from 'zod';
+import type { SliverSpec } from './types.js';
+
+const reverseDns = /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*){2,}$/;
+
+const rangePair = z.tuple([z.number(), z.number()]);
+
+const paramBase = { id: z.string().min(1), label: z.string().optional(), required: z.boolean().optional() };
+
+const paramFloat   = z.object({ ...paramBase, type: z.literal('float'),     range: rangePair.optional(), step: z.number().optional(), default: z.number().optional() });
+const paramInt     = z.object({ ...paramBase, type: z.literal('int'),       range: rangePair.optional(), step: z.number().optional(), default: z.number().int().optional() });
+const paramBool    = z.object({ ...paramBase, type: z.literal('bool'),      default: z.boolean().optional() });
+const paramString  = z.object({ ...paramBase, type: z.literal('string'),    maxLength: z.number().int().positive().optional(), default: z.string().optional() });
+const paramEnum    = z.object({ ...paramBase, type: z.literal('enum'),      options: z.array(z.object({ value: z.string(), label: z.string().optional() })).min(1), default: z.string().optional() });
+const paramColor   = z.object({ ...paramBase, type: z.literal('color'),     default: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional() });
+const paramActor   = z.object({ ...paramBase, type: z.literal('actor_ref'), class_filter: z.string().optional() });
+const paramAsset   = z.object({ ...paramBase, type: z.literal('asset_ref'), class_filter: z.string().optional() });
+const paramVec3    = z.object({ ...paramBase, type: z.literal('vector3'),   range: z.array(rangePair).length(3).optional(), default: z.tuple([z.number(), z.number(), z.number()]).optional() });
+const paramXform   = z.object({ ...paramBase, type: z.literal('transform'), default: z.object({
+  location: z.tuple([z.number(), z.number(), z.number()]),
+  rotation: z.tuple([z.number(), z.number(), z.number()]),
+  scale:    z.tuple([z.number(), z.number(), z.number()]),
+}).optional() });
+
+const param = z.discriminatedUnion('type', [
+  paramFloat, paramInt, paramBool, paramString, paramEnum,
+  paramColor, paramActor, paramAsset, paramVec3, paramXform,
+]);
+
+const determinism = z.object({
+  pure: z.boolean(),
+  declared_outputs: z.array(z.string()),
+  side_effects: z.array(z.string()),
+  seed_param: z.string().nullable(),
+});
+
+export const sliverSpecSchema = z.object({
+  id: z.string().regex(reverseDns, 'id must be reverse-DNS like com.hayba.composition.frame_target'),
+  version: z.string().regex(/^\d+\.\d+\.\d+$/, 'version must be semver MAJOR.MINOR.PATCH'),
+  category: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string(),
+  author: z.string().min(1),
+  params: z.array(param).superRefine((arr, ctx) => {
+    const seen = new Set<string>();
+    for (const p of arr) {
+      if (seen.has(p.id)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `duplicate param id "${p.id}"` });
+      }
+      seen.add(p.id);
+    }
+  }),
+  executor: z.object({ kind: z.string().min(1) }),
+  determinism,
+});
+
+export type ParseResult =
+  | { ok: true; spec: SliverSpec }
+  | { ok: false; reason: string };
+
+export function parseSliverSpec(input: unknown): ParseResult {
+  const r = sliverSpecSchema.safeParse(input);
+  if (r.success) return { ok: true, spec: r.data as SliverSpec };
+  const first = r.error.issues[0];
+  const path = first.path.join('.') || '(root)';
+  return { ok: false, reason: `${path}: ${first.message}` };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/spec-schema.test.ts`
+Expected: 6 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/slivers/spec-schema.ts mcp-tools/hayba-mcp/src/slivers/spec-schema.test.ts
+git commit -m "feat(slivers): zod schema for spec JSON validation"
+```
+
+---
+
+### Task 3: Executor registry
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/slivers/registry.ts`
+- Test: `mcp-tools/hayba-mcp/src/slivers/registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/registry.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ExecutorRegistry } from './registry.js';
+import type { SliverExecutor } from './types.js';
+
+describe('ExecutorRegistry', () => {
+  let reg: ExecutorRegistry;
+  beforeEach(() => { reg = new ExecutorRegistry(); });
+
+  it('register + get round-trips', () => {
+    const fn: SliverExecutor = async () => ({ ok: true });
+    reg.register('composition.frame_target', fn);
+    expect(reg.get('composition.frame_target')).toBe(fn);
+  });
+
+  it('returns undefined for unknown kind', () => {
+    expect(reg.get('does.not.exist')).toBeUndefined();
+  });
+
+  it('throws on duplicate registration', () => {
+    const fn: SliverExecutor = async () => ({});
+    reg.register('k', fn);
+    expect(() => reg.register('k', fn)).toThrow(/already registered/);
+  });
+
+  it('lists registered kinds', () => {
+    reg.register('a', async () => ({}));
+    reg.register('b', async () => ({}));
+    expect(reg.kinds().sort()).toEqual(['a', 'b']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/registry.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the registry**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/registry.ts
+//
+// Maps executor.kind strings to executor functions. Each category
+// (composition, lighting, pcg_diff, …) registers one entry per concrete
+// sliver. Slivers loaded from disk look up their executor here at run
+// time; a missing kind is a clear "executor not bundled" error.
+
+import type { SliverExecutor } from './types.js';
+
+export class ExecutorRegistry {
+  private readonly byKind = new Map<string, SliverExecutor>();
+
+  register(kind: string, executor: SliverExecutor): void {
+    if (this.byKind.has(kind)) {
+      throw new Error(`Executor kind "${kind}" already registered`);
+    }
+    this.byKind.set(kind, executor);
+  }
+
+  get(kind: string): SliverExecutor | undefined {
+    return this.byKind.get(kind);
+  }
+
+  kinds(): string[] {
+    return [...this.byKind.keys()];
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/registry.test.ts`
+Expected: 4 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/slivers/registry.ts mcp-tools/hayba-mcp/src/slivers/registry.test.ts
+git commit -m "feat(slivers): executor registry keyed by executor.kind"
+```
+
+---
+
+### Task 4: Param validator (used by runtime)
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/slivers/param-validator.ts`
+- Test: `mcp-tools/hayba-mcp/src/slivers/param-validator.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/param-validator.test.ts
+import { describe, it, expect } from 'vitest';
+import { validateAndCoerceParams } from './param-validator.js';
+import type { SliverParam } from './types.js';
+
+const params: SliverParam[] = [
+  { id: 'distance', type: 'float', range: [1, 100], default: 10 },
+  { id: 'pick',     type: 'enum',  options: [{ value: 'a' }, { value: 'b' }], default: 'a' },
+  { id: 'on',       type: 'bool',  default: false },
+  { id: 'target',   type: 'actor_ref', required: true },
+];
+
+describe('validateAndCoerceParams', () => {
+  it('fills defaults when values are omitted', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.values).toEqual({ distance: 10, pick: 'a', on: false, target: '/Game/X.X' });
+  });
+
+  it('fails when a required param is missing', () => {
+    const r = validateAndCoerceParams(params, { distance: 5 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/target/);
+  });
+
+  it('rejects out-of-range floats', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X', distance: 999 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/distance/);
+  });
+
+  it('rejects enum values not in options', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X', pick: 'z' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/pick/);
+  });
+
+  it('rejects wrong types', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X', distance: 'big' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown param ids', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X', wat: 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/wat/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/param-validator.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the validator**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/param-validator.ts
+//
+// Runtime validation + default-filling for a SliverParam[] against a
+// caller-supplied values bag. Centralised so the MCP `run` tool and
+// internal runSliver calls share one code path.
+
+import type { SliverParam, SliverParamValues } from './types.js';
+
+export type ValidateResult =
+  | { ok: true; values: SliverParamValues }
+  | { ok: false; reason: string };
+
+export function validateAndCoerceParams(
+  params: SliverParam[],
+  input: SliverParamValues,
+): ValidateResult {
+  const known = new Set(params.map(p => p.id));
+  for (const k of Object.keys(input)) {
+    if (!known.has(k)) return { ok: false, reason: `unknown param "${k}"` };
+  }
+
+  const out: SliverParamValues = {};
+  for (const p of params) {
+    const provided = Object.prototype.hasOwnProperty.call(input, p.id);
+    let v = provided ? input[p.id] : (('default' in p ? (p as { default?: unknown }).default : undefined));
+
+    if (v === undefined) {
+      if (p.required) return { ok: false, reason: `missing required param "${p.id}"` };
+      continue;
+    }
+
+    const err = checkParam(p, v);
+    if (err) return { ok: false, reason: `param "${p.id}": ${err}` };
+    out[p.id] = v;
+  }
+  return { ok: true, values: out };
+}
+
+function checkParam(p: SliverParam, v: unknown): string | null {
+  switch (p.type) {
+    case 'float':
+    case 'int': {
+      if (typeof v !== 'number' || Number.isNaN(v)) return `expected number, got ${typeof v}`;
+      if (p.type === 'int' && !Number.isInteger(v)) return 'expected integer';
+      if (p.range) {
+        const [lo, hi] = p.range;
+        if (v < lo || v > hi) return `out of range [${lo}, ${hi}]`;
+      }
+      return null;
+    }
+    case 'bool':
+      return typeof v === 'boolean' ? null : `expected boolean, got ${typeof v}`;
+    case 'string':
+      if (typeof v !== 'string') return `expected string, got ${typeof v}`;
+      if (p.maxLength != null && v.length > p.maxLength) return `exceeds maxLength=${p.maxLength}`;
+      return null;
+    case 'enum':
+      if (typeof v !== 'string') return 'expected string';
+      return p.options.some(o => o.value === v) ? null : `not in options`;
+    case 'color':
+      return typeof v === 'string' && /^#[0-9a-fA-F]{6}$/.test(v) ? null : 'expected "#RRGGBB" hex';
+    case 'actor_ref':
+    case 'asset_ref':
+      return typeof v === 'string' && v.length > 0 ? null : 'expected non-empty path string';
+    case 'vector3':
+      if (!Array.isArray(v) || v.length !== 3 || !v.every(n => typeof n === 'number')) return 'expected [x,y,z] number tuple';
+      return null;
+    case 'transform':
+      if (typeof v !== 'object' || v === null) return 'expected object';
+      // shallow check; the executor is trusted to deep-validate if it cares
+      return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/param-validator.test.ts`
+Expected: 6 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/slivers/param-validator.ts mcp-tools/hayba-mcp/src/slivers/param-validator.test.ts
+git commit -m "feat(slivers): runtime param validator with defaults + ranges"
+```
+
+---
+
+### Task 5: Sliver runtime (runSliver with cycle detection)
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/slivers/runtime.ts`
+- Test: `mcp-tools/hayba-mcp/src/slivers/runtime.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/runtime.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ExecutorRegistry } from './registry.js';
+import { SliverRuntime } from './runtime.js';
+import type { SliverSpec, SliverExecutor } from './types.js';
+
+function makeSpec(id: string, kind: string, extra: Partial<SliverSpec> = {}): SliverSpec {
+  return {
+    id,
+    version: '1.0.0',
+    category: 'test',
+    title: id,
+    description: '',
+    author: 'test',
+    params: [],
+    executor: { kind },
+    determinism: { pure: true, declared_outputs: ['v'], side_effects: [], seed_param: null },
+    ...extra,
+  };
+}
+
+describe('SliverRuntime.runSliver', () => {
+  let registry: ExecutorRegistry;
+  let runtime: SliverRuntime;
+  let specs: Map<string, SliverSpec>;
+
+  beforeEach(() => {
+    registry = new ExecutorRegistry();
+    specs = new Map();
+    runtime = new SliverRuntime({
+      registry,
+      getSpec: (id) => specs.get(id),
+      maxDepth: 8,
+    });
+  });
+
+  it('returns the executor output and durationMs', async () => {
+    specs.set('com.t.a', makeSpec('com.t.a', 'k.a'));
+    registry.register('k.a', async () => ({ v: 42 }));
+    const r = await runtime.runSliver('com.t.a', {});
+    expect(r.ok).toBe(true);
+    expect(r.outputs).toEqual({ v: 42 });
+    expect(r.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns SliverNotFoundError shape when spec is missing', async () => {
+    const r = await runtime.runSliver('com.t.missing', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/com\.t\.missing/);
+  });
+
+  it('returns error when executor.kind is not registered', async () => {
+    specs.set('com.t.x', makeSpec('com.t.x', 'k.unregistered'));
+    const r = await runtime.runSliver('com.t.x', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/k\.unregistered/);
+  });
+
+  it('validates params against the spec', async () => {
+    specs.set('com.t.p', makeSpec('com.t.p', 'k.p', {
+      params: [{ id: 'x', type: 'float', range: [0, 1] }],
+    }));
+    registry.register('k.p', async () => ({}));
+    const r = await runtime.runSliver('com.t.p', { x: 5 });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/out of range/);
+  });
+
+  it('aggregates declared side_effects into the result', async () => {
+    specs.set('com.t.s', makeSpec('com.t.s', 'k.s', {
+      determinism: { pure: false, declared_outputs: [], side_effects: ['lighting_change'], seed_param: null },
+    }));
+    registry.register('k.s', async () => ({}));
+    const r = await runtime.runSliver('com.t.s', {});
+    expect(r.side_effects).toEqual(['lighting_change']);
+  });
+
+  it('detects direct cycles (sliver calls itself)', async () => {
+    specs.set('com.t.cyc', makeSpec('com.t.cyc', 'k.cyc'));
+    const exec: SliverExecutor = async (_p, ctx) => {
+      await ctx.runSliver('com.t.cyc', {});
+      return {};
+    };
+    registry.register('k.cyc', exec);
+    const r = await runtime.runSliver('com.t.cyc', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/cycle/i);
+  });
+
+  it('detects indirect cycles (a → b → a)', async () => {
+    specs.set('com.t.a', makeSpec('com.t.a', 'k.a'));
+    specs.set('com.t.b', makeSpec('com.t.b', 'k.b'));
+    registry.register('k.a', async (_p, ctx) => { await ctx.runSliver('com.t.b', {}); return {}; });
+    registry.register('k.b', async (_p, ctx) => { await ctx.runSliver('com.t.a', {}); return {}; });
+    const r = await runtime.runSliver('com.t.a', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/cycle/i);
+  });
+
+  it('enforces maxDepth', async () => {
+    const small = new SliverRuntime({ registry, getSpec: (id) => specs.get(id), maxDepth: 2 });
+    specs.set('com.t.deep', makeSpec('com.t.deep', 'k.deep'));
+    let i = 0;
+    registry.register('k.deep', async (_p, ctx) => {
+      if (i++ < 5) await ctx.runSliver('com.t.deep2', {});
+      return {};
+    });
+    specs.set('com.t.deep2', makeSpec('com.t.deep2', 'k.deep2'));
+    registry.register('k.deep2', async (_p, ctx) => {
+      if (i++ < 5) await ctx.runSliver('com.t.deep', {});
+      return {};
+    });
+    const r = await small.runSliver('com.t.deep', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/depth/i);
+  });
+
+  it('allows the same sliver to be called sequentially (no false cycle)', async () => {
+    specs.set('com.t.leaf', makeSpec('com.t.leaf', 'k.leaf'));
+    specs.set('com.t.par',  makeSpec('com.t.par',  'k.par'));
+    registry.register('k.leaf', async () => ({ v: 1 }));
+    registry.register('k.par', async (_p, ctx) => {
+      const a = await ctx.runSliver('com.t.leaf', {});
+      const b = await ctx.runSliver('com.t.leaf', {});
+      return { a: a.outputs.v, b: b.outputs.v };
+    });
+    const r = await runtime.runSliver('com.t.par', {});
+    expect(r.ok).toBe(true);
+    expect(r.outputs).toEqual({ a: 1, b: 1 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/runtime.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the runtime**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/runtime.ts
+//
+// SliverRuntime.runSliver — single entry point for executing any sliver.
+// Walks: lookup spec → validate params → resolve executor → cycle/depth
+// guard → execute → collect outputs + side_effects → return.
+
+import {
+  SliverCycleError, SliverDepthError, SliverNotFoundError, SliverValidationError,
+  type SliverParamValues, type SliverRunResult, type SliverSpec, type SliverContext,
+} from './types.js';
+import type { ExecutorRegistry } from './registry.js';
+import { validateAndCoerceParams } from './param-validator.js';
+
+export interface SliverRuntimeOpts {
+  registry: ExecutorRegistry;
+  getSpec: (id: string) => SliverSpec | undefined;
+  maxDepth?: number;
+}
+
+export class SliverRuntime {
+  private readonly registry: ExecutorRegistry;
+  private readonly getSpec: (id: string) => SliverSpec | undefined;
+  private readonly maxDepth: number;
+
+  constructor(opts: SliverRuntimeOpts) {
+    this.registry = opts.registry;
+    this.getSpec = opts.getSpec;
+    this.maxDepth = opts.maxDepth ?? 8;
+  }
+
+  runSliver(id: string, params: SliverParamValues): Promise<SliverRunResult> {
+    return this.runInternal(id, params, []);
+  }
+
+  private async runInternal(
+    id: string,
+    params: SliverParamValues,
+    stack: string[],
+  ): Promise<SliverRunResult> {
+    const t0 = performance.now();
+    try {
+      if (stack.length >= this.maxDepth) throw new SliverDepthError(this.maxDepth);
+      if (stack.includes(id)) throw new SliverCycleError(id, [...stack, id]);
+
+      const spec = this.getSpec(id);
+      if (!spec) throw new SliverNotFoundError(id);
+
+      const executor = this.registry.get(spec.executor.kind);
+      if (!executor) throw new SliverValidationError(`executor.kind "${spec.executor.kind}" not registered`);
+
+      const v = validateAndCoerceParams(spec.params, params);
+      if (!v.ok) throw new SliverValidationError(v.reason);
+
+      const newStack = [...stack, id];
+      const ctx: SliverContext = {
+        stack: newStack,
+        maxDepth: this.maxDepth,
+        runSliver: (childId, childParams) => this.runInternal(childId, childParams, newStack),
+      };
+
+      const outputs = await executor(v.values, ctx);
+
+      return {
+        ok: true,
+        outputs,
+        side_effects: [...spec.determinism.side_effects],
+        durationMs: Math.round(performance.now() - t0),
+      };
+    } catch (e) {
+      return {
+        ok: false,
+        outputs: {},
+        side_effects: [],
+        durationMs: Math.round(performance.now() - t0),
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/runtime.test.ts`
+Expected: 9 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/slivers/runtime.ts mcp-tools/hayba-mcp/src/slivers/runtime.test.ts
+git commit -m "feat(slivers): runSliver with cycle detection, depth limit, side-effect aggregation"
+```
+
+---
+
+### Task 6: Spec loader (disk read + bundled fallback)
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/slivers/loader.ts`
+- Test: `mcp-tools/hayba-mcp/src/slivers/loader.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/loader.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SliverLoader } from './loader.js';
+
+const validSpec = {
+  id: 'com.test.demo',
+  version: '1.0.0',
+  category: 'test',
+  title: 'Demo',
+  description: '',
+  author: 'test',
+  params: [],
+  executor: { kind: 'test.demo' },
+  determinism: { pure: true, declared_outputs: [], side_effects: [], seed_param: null },
+};
+
+describe('SliverLoader', () => {
+  let userDir: string;
+  let bundledDir: string;
+
+  beforeEach(() => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sliver-user-'));
+    bundledDir = mkdtempSync(join(tmpdir(), 'hayba-sliver-bundled-'));
+  });
+  afterEach(() => {
+    rmSync(userDir, { recursive: true, force: true });
+    rmSync(bundledDir, { recursive: true, force: true });
+  });
+
+  it('loads valid specs from userDir', async () => {
+    writeFileSync(join(userDir, 'com.test.demo.sliver.json'), JSON.stringify(validSpec));
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(loader.list().map(s => s.id)).toEqual(['com.test.demo']);
+    expect(loader.get('com.test.demo')?.title).toBe('Demo');
+  });
+
+  it('seeds userDir from bundledDir on first reload if userDir lacks the spec', async () => {
+    writeFileSync(join(bundledDir, 'com.test.demo.sliver.json'), JSON.stringify(validSpec));
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(existsSync(join(userDir, 'com.test.demo.sliver.json'))).toBe(true);
+    expect(loader.get('com.test.demo')).toBeDefined();
+  });
+
+  it('userDir wins over bundledDir when both have the same id', async () => {
+    writeFileSync(join(bundledDir, 'com.test.demo.sliver.json'), JSON.stringify(validSpec));
+    writeFileSync(join(userDir, 'com.test.demo.sliver.json'), JSON.stringify({ ...validSpec, title: 'User Override' }));
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(loader.get('com.test.demo')?.title).toBe('User Override');
+  });
+
+  it('skips and logs invalid specs without failing the whole reload', async () => {
+    writeFileSync(join(userDir, 'good.sliver.json'), JSON.stringify(validSpec));
+    writeFileSync(join(userDir, 'bad.sliver.json'), '{ not valid json');
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(loader.list().length).toBe(1);
+    expect(loader.errors().length).toBe(1);
+    expect(loader.errors()[0]).toMatch(/bad\.sliver\.json/);
+  });
+
+  it('install writes a spec to userDir and adds it to the in-memory map', async () => {
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    const r = loader.install(validSpec);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.id).toBe('com.test.demo');
+    expect(existsSync(join(userDir, 'com.test.demo.sliver.json'))).toBe(true);
+    expect(loader.get('com.test.demo')).toBeDefined();
+  });
+
+  it('install rejects malformed specs', async () => {
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    const r = loader.install({ ...validSpec, id: 'not-reverse-dns' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('ignores non-sliver json files', async () => {
+    writeFileSync(join(userDir, 'com.test.demo.preset.json'), JSON.stringify({ distance: 5 }));
+    writeFileSync(join(userDir, 'README.md'), '# slivers');
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(loader.list()).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/loader.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the loader**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/loader.ts
+//
+// SliverLoader — reads *.sliver.json from %APPDATA%/Hayba/slivers/
+// (userDir), seeding from the package's bundled specs (bundledDir) on
+// first run. Validates with parseSliverSpec; bad files are skipped and
+// reported via errors() so the MCP server keeps booting.
+//
+// "install" writes a new spec to userDir and updates the in-memory map.
+
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { SliverSpec } from './types.js';
+import { parseSliverSpec } from './spec-schema.js';
+
+export interface SliverLoaderOpts {
+  /** Absolute path to %APPDATA%/Hayba/slivers/ (or test override). */
+  userDir: string;
+  /** Absolute path to the package's bundled specs (dist/slivers/specs/). */
+  bundledDir: string;
+}
+
+export type InstallResult =
+  | { ok: true; id: string; path: string }
+  | { ok: false; reason: string };
+
+const SUFFIX = '.sliver.json';
+
+export class SliverLoader {
+  private readonly userDir: string;
+  private readonly bundledDir: string;
+  private specs = new Map<string, SliverSpec>();
+  private loadErrors: string[] = [];
+
+  constructor(opts: SliverLoaderOpts) {
+    this.userDir = opts.userDir;
+    this.bundledDir = opts.bundledDir;
+  }
+
+  /** Seed (idempotent) then full reload from userDir. Call at startup or after import. */
+  async reload(): Promise<void> {
+    this.ensureDir(this.userDir);
+    this.seedFromBundled();
+    this.specs.clear();
+    this.loadErrors = [];
+    if (!existsSync(this.userDir)) return;
+    for (const name of readdirSync(this.userDir)) {
+      if (!name.endsWith(SUFFIX)) continue;
+      const fullPath = join(this.userDir, name);
+      try {
+        const raw = readFileSync(fullPath, 'utf8');
+        const json = JSON.parse(raw);
+        const parsed = parseSliverSpec(json);
+        if (!parsed.ok) {
+          this.loadErrors.push(`${name}: ${parsed.reason}`);
+          continue;
+        }
+        this.specs.set(parsed.spec.id, parsed.spec);
+      } catch (e) {
+        this.loadErrors.push(`${name}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  }
+
+  list(): SliverSpec[] { return [...this.specs.values()]; }
+  get(id: string): SliverSpec | undefined { return this.specs.get(id); }
+  errors(): string[] { return [...this.loadErrors]; }
+
+  install(specInput: unknown): InstallResult {
+    const parsed = parseSliverSpec(specInput);
+    if (!parsed.ok) return { ok: false, reason: parsed.reason };
+    this.ensureDir(this.userDir);
+    const path = join(this.userDir, `${parsed.spec.id}${SUFFIX}`);
+    writeFileSync(path, JSON.stringify(parsed.spec, null, 2));
+    this.specs.set(parsed.spec.id, parsed.spec);
+    return { ok: true, id: parsed.spec.id, path };
+  }
+
+  private ensureDir(dir: string): void {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+
+  private seedFromBundled(): void {
+    if (!existsSync(this.bundledDir)) return;
+    if (!statSync(this.bundledDir).isDirectory()) return;
+    for (const name of readdirSync(this.bundledDir)) {
+      if (!name.endsWith(SUFFIX)) continue;
+      const target = join(this.userDir, name);
+      if (existsSync(target)) continue;
+      copyFileSync(join(this.bundledDir, name), target);
+    }
+  }
+}
+
+/** Default user dir resolver — %APPDATA%/Hayba/slivers on Windows, ~/.hayba/slivers elsewhere. */
+export function defaultUserSliversDir(): string {
+  const base = process.env.APPDATA ?? join(process.env.HOME ?? '.', '.hayba');
+  return join(base, 'Hayba', 'slivers');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/loader.test.ts`
+Expected: 7 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/slivers/loader.ts mcp-tools/hayba-mcp/src/slivers/loader.test.ts
+git commit -m "feat(slivers): disk loader with bundled-spec seeding and install"
+```
+
+---
+
+### Task 7: `frame_target` executor + bundled spec
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/slivers/composition/frame_target.ts`
+- Create: `mcp-tools/hayba-mcp/src/slivers/composition/frame_target.test.ts`
+- Create: `mcp-tools/hayba-mcp/src/slivers/specs/com.hayba.composition.frame_target.sliver.json`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/composition/frame_target.test.ts
+import { describe, it, expect } from 'vitest';
+import { frameTargetExecutor, COMPOSITION_FRAME_TARGET_KIND } from './frame_target.js';
+import type { SliverContext } from '../types.js';
+
+const ctxStub: SliverContext = { stack: [], maxDepth: 8, runSliver: async () => ({ ok: true, outputs: {}, side_effects: [], durationMs: 0 }) };
+
+describe('frameTargetExecutor', () => {
+  it('returns a camera_transform object with location, rotation, and fov', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/Heroes/SK_Hero.SK_Hero',
+      distance: 10,
+      height: 2,
+      fov: 70,
+      yaw_deg: 0,
+    }, ctxStub);
+    expect(out).toHaveProperty('camera_transform');
+    const t = out.camera_transform as { location: number[]; rotation: number[]; fov: number };
+    expect(t.location).toHaveLength(3);
+    expect(t.rotation).toHaveLength(3);
+    expect(t.fov).toBe(70);
+  });
+
+  it('at yaw=0 places the camera on +X axis at the given distance', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/X.X', distance: 10, height: 0, fov: 70, yaw_deg: 0,
+    }, ctxStub) as { camera_transform: { location: [number, number, number] } };
+    expect(out.camera_transform.location[0]).toBeCloseTo(1000, 1); // 10m → 1000 UE units
+    expect(out.camera_transform.location[1]).toBeCloseTo(0, 1);
+  });
+
+  it('at yaw=90 places the camera on +Y axis', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/X.X', distance: 10, height: 0, fov: 70, yaw_deg: 90,
+    }, ctxStub) as { camera_transform: { location: [number, number, number] } };
+    expect(out.camera_transform.location[0]).toBeCloseTo(0, 1);
+    expect(out.camera_transform.location[1]).toBeCloseTo(1000, 1);
+  });
+
+  it('applies the height offset to Z (meters → centimetres)', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/X.X', distance: 10, height: 3, fov: 70, yaw_deg: 0,
+    }, ctxStub) as { camera_transform: { location: [number, number, number] } };
+    expect(out.camera_transform.location[2]).toBeCloseTo(300, 1);
+  });
+
+  it('points yaw toward the origin (camera at +X looks toward −X)', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/X.X', distance: 10, height: 0, fov: 70, yaw_deg: 0,
+    }, ctxStub) as { camera_transform: { rotation: [number, number, number] } };
+    // rotation in [pitch, yaw, roll] degrees per UE convention
+    expect(out.camera_transform.rotation[1]).toBeCloseTo(180, 1);
+  });
+
+  it('exports the registry kind as a constant', () => {
+    expect(COMPOSITION_FRAME_TARGET_KIND).toBe('composition.frame_target');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/composition/frame_target.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the executor**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/composition/frame_target.ts
+//
+// Pure executor: given a target actor path + distance/height/fov/orbit,
+// returns a camera_transform pointing at the target's origin from a
+// position on the orbit circle around it. Coordinates returned in UE
+// units (centimetres); the caller (render_camera or similar) consumes
+// the transform as-is.
+//
+// We don't resolve the actor's actual location here — that requires a
+// UE round-trip. v1 frames toward the world origin from a relative
+// offset; the LLM/agent is responsible for combining with the actor's
+// world location if needed. A v2 could call a hayba_actor_location
+// subroutine via ctx.runSliver.
+
+import type { SliverExecutor } from '../types.js';
+
+export const COMPOSITION_FRAME_TARGET_KIND = 'composition.frame_target';
+
+interface FrameTargetParams {
+  target: string;
+  distance: number;
+  height: number;
+  fov: number;
+  yaw_deg: number;
+}
+
+export const frameTargetExecutor: SliverExecutor = async (rawParams) => {
+  const p = rawParams as unknown as FrameTargetParams;
+  const M_TO_UE = 100;          // 1 m = 100 UE units
+  const yawRad = (p.yaw_deg * Math.PI) / 180;
+  const r = p.distance * M_TO_UE;
+
+  const x = Math.cos(yawRad) * r;
+  const y = Math.sin(yawRad) * r;
+  const z = p.height * M_TO_UE;
+
+  // Camera looks at origin: yaw is +180 from the position angle.
+  const cameraYawDeg = (p.yaw_deg + 180) % 360;
+  // Simple pitch toward the target accounting for height.
+  const pitchDeg = Math.atan2(-z, r) * (180 / Math.PI);
+
+  return {
+    camera_transform: {
+      location: [x, y, z],
+      rotation: [pitchDeg, cameraYawDeg, 0],   // [pitch, yaw, roll]
+      fov: p.fov,
+    },
+  };
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/composition/frame_target.test.ts`
+Expected: 6 passing.
+
+- [ ] **Step 5: Create the bundled JSON spec**
+
+```json
+// mcp-tools/hayba-mcp/src/slivers/specs/com.hayba.composition.frame_target.sliver.json
+{
+  "id": "com.hayba.composition.frame_target",
+  "version": "1.0.0",
+  "category": "composition",
+  "title": "Frame Target",
+  "description": "Compute a camera transform that frames a target actor from a given orbit angle, distance, and height offset.",
+  "author": "core",
+  "params": [
+    { "id": "target",   "type": "actor_ref", "label": "Target",            "required": true },
+    { "id": "distance", "type": "float",     "label": "Distance (m)",      "range": [1, 100],  "default": 10 },
+    { "id": "height",   "type": "float",     "label": "Height offset (m)", "range": [-10, 50], "default": 2 },
+    { "id": "fov",      "type": "float",     "label": "Field of view (deg)","range": [20, 120], "default": 70 },
+    { "id": "yaw_deg",  "type": "float",     "label": "Orbit angle (deg)", "range": [0, 360],  "default": 45 }
+  ],
+  "executor": { "kind": "composition.frame_target" },
+  "determinism": {
+    "pure": true,
+    "declared_outputs": ["camera_transform"],
+    "side_effects": [],
+    "seed_param": null
+  }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/slivers/composition/ mcp-tools/hayba-mcp/src/slivers/specs/
+git commit -m "feat(slivers): frame_target executor + bundled spec"
+```
+
+---
+
+### Task 8: `setupSliverSystem` facade
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/slivers/index.ts`
+- Test: `mcp-tools/hayba-mcp/src/slivers/index.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/index.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from './index.js';
+
+describe('setupSliverSystem', () => {
+  let userDir: string;
+  let bundledDir: string;
+
+  beforeEach(() => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sliver-sys-u-'));
+    bundledDir = mkdtempSync(join(tmpdir(), 'hayba-sliver-sys-b-'));
+  });
+  afterEach(() => {
+    rmSync(userDir, { recursive: true, force: true });
+    rmSync(bundledDir, { recursive: true, force: true });
+  });
+
+  it('wires loader + registry + runtime and registers built-in executors', async () => {
+    const sys = await setupSliverSystem({ userDir, bundledDir, maxDepth: 4 });
+    expect(sys.registry.kinds()).toContain('composition.frame_target');
+    expect(sys.runtime).toBeDefined();
+    expect(sys.loader).toBeDefined();
+  });
+
+  it('seeds the bundled frame_target spec into userDir when bundledDir contains it', async () => {
+    const { copyFileSync, mkdirSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    mkdirSync(bundledDir, { recursive: true });
+    copyFileSync(
+      resolve('src/slivers/specs/com.hayba.composition.frame_target.sliver.json'),
+      join(bundledDir, 'com.hayba.composition.frame_target.sliver.json'),
+    );
+    const sys = await setupSliverSystem({ userDir, bundledDir, maxDepth: 4 });
+    expect(sys.loader.get('com.hayba.composition.frame_target')).toBeDefined();
+
+    const r = await sys.runtime.runSliver('com.hayba.composition.frame_target', { target: '/Game/X.X' });
+    expect(r.ok).toBe(true);
+    expect(r.outputs).toHaveProperty('camera_transform');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/index.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the facade**
+
+```ts
+// mcp-tools/hayba-mcp/src/slivers/index.ts
+//
+// One-shot wiring: builds the registry, registers built-in executors,
+// constructs the loader (which seeds + reads userDir), constructs the
+// runtime. Caller (tools/routing/register.ts) holds the returned handle
+// for use by the MCP sliver tools.
+
+import { ExecutorRegistry } from './registry.js';
+import { SliverLoader, defaultUserSliversDir } from './loader.js';
+import { SliverRuntime } from './runtime.js';
+import { COMPOSITION_FRAME_TARGET_KIND, frameTargetExecutor } from './composition/frame_target.js';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface SliverSystem {
+  registry: ExecutorRegistry;
+  loader: SliverLoader;
+  runtime: SliverRuntime;
+}
+
+export interface SetupOpts {
+  userDir?: string;
+  bundledDir?: string;
+  maxDepth?: number;
+}
+
+export async function setupSliverSystem(opts: SetupOpts = {}): Promise<SliverSystem> {
+  const registry = new ExecutorRegistry();
+  registry.register(COMPOSITION_FRAME_TARGET_KIND, frameTargetExecutor);
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const loader = new SliverLoader({
+    userDir: opts.userDir ?? defaultUserSliversDir(),
+    bundledDir: opts.bundledDir ?? resolve(__dirname, 'specs'),
+  });
+  await loader.reload();
+
+  const runtime = new SliverRuntime({
+    registry,
+    getSpec: (id) => loader.get(id),
+    maxDepth: opts.maxDepth ?? 8,
+  });
+
+  return { registry, loader, runtime };
+}
+
+export type { SliverSpec, SliverRunResult, SliverParam, SliverParamValues } from './types.js';
+export { SliverLoader, defaultUserSliversDir } from './loader.js';
+export { SliverRuntime } from './runtime.js';
+export { ExecutorRegistry } from './registry.js';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/slivers/index.test.ts`
+Expected: 2 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/slivers/index.ts mcp-tools/hayba-mcp/src/slivers/index.test.ts
+git commit -m "feat(slivers): setupSliverSystem facade wiring registry + loader + runtime"
+```
+
+---
+
+### Task 9: `hayba_sliver_list` MCP tool
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/tools/sliver/list.ts`
+- Test: `mcp-tools/hayba-mcp/src/tools/sliver/list.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/sliver/list.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from '../../slivers/index.js';
+import { sliverListHandler } from './list.js';
+
+describe('hayba_sliver_list', () => {
+  let userDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-list-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+  });
+  afterEach(() => { rmSync(userDir, { recursive: true, force: true }); });
+
+  it('returns all installed slivers', async () => {
+    const r = await sliverListHandler({}, { loader: sys.loader });
+    expect(r.slivers.length).toBeGreaterThan(0);
+    expect(r.slivers[0]).toMatchObject({
+      id: 'com.hayba.composition.frame_target',
+      category: 'composition',
+    });
+  });
+
+  it('filters by category', async () => {
+    const r = await sliverListHandler({ category: 'composition' }, { loader: sys.loader });
+    expect(r.slivers.every(s => s.category === 'composition')).toBe(true);
+    const empty = await sliverListHandler({ category: 'does_not_exist' }, { loader: sys.loader });
+    expect(empty.slivers).toEqual([]);
+  });
+
+  it('filters by namespace prefix', async () => {
+    const r = await sliverListHandler({ namespace: 'com.hayba' }, { loader: sys.loader });
+    expect(r.slivers.every(s => s.id.startsWith('com.hayba.'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/tools/sliver/list.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the handler**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/sliver/list.ts
+import { z } from 'zod';
+import type { SliverLoader } from '../../slivers/loader.js';
+
+export const sliverListSchema = {
+  category: z.string().optional(),
+  namespace: z.string().optional(),
+};
+
+export interface SliverListCtx { loader: SliverLoader; }
+export interface SliverSummary { id: string; title: string; category: string; version: string; }
+export interface SliverListResult { slivers: SliverSummary[]; }
+
+export async function sliverListHandler(
+  args: { category?: string; namespace?: string },
+  ctx: SliverListCtx,
+): Promise<SliverListResult> {
+  const slivers = ctx.loader.list()
+    .filter(s => !args.category || s.category === args.category)
+    .filter(s => !args.namespace || s.id.startsWith(args.namespace + '.') || s.id === args.namespace)
+    .map(s => ({ id: s.id, title: s.title, category: s.category, version: s.version }));
+  return { slivers };
+}
+
+export const meta = {
+  cost: 'low' as const,
+  effects: ['read'],
+  when: 'You want to discover which Slivers (deterministic abstractions) are installed.',
+  not_when: 'You already know the sliver id and just want its full spec — use hayba_sliver_get.',
+  pack: 'core',
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/tools/sliver/list.test.ts`
+Expected: 3 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/tools/sliver/list.ts mcp-tools/hayba-mcp/src/tools/sliver/list.test.ts
+git commit -m "feat(slivers): hayba_sliver_list MCP tool"
+```
+
+---
+
+### Task 10: `hayba_sliver_get` MCP tool
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/tools/sliver/get.ts`
+- Test: `mcp-tools/hayba-mcp/src/tools/sliver/get.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/sliver/get.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from '../../slivers/index.js';
+import { sliverGetHandler } from './get.js';
+
+describe('hayba_sliver_get', () => {
+  let userDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-get-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+  });
+  afterEach(() => { rmSync(userDir, { recursive: true, force: true }); });
+
+  it('returns the full spec for a known id', async () => {
+    const r = await sliverGetHandler({ id: 'com.hayba.composition.frame_target' }, { loader: sys.loader });
+    expect(r.found).toBe(true);
+    if (r.found) {
+      expect(r.spec.id).toBe('com.hayba.composition.frame_target');
+      expect(r.spec.params.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns found=false for unknown id', async () => {
+    const r = await sliverGetHandler({ id: 'com.nope.missing' }, { loader: sys.loader });
+    expect(r.found).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/tools/sliver/get.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Create the handler**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/sliver/get.ts
+import { z } from 'zod';
+import type { SliverLoader } from '../../slivers/loader.js';
+import type { SliverSpec } from '../../slivers/types.js';
+
+export const sliverGetSchema = { id: z.string().min(1) };
+
+export interface SliverGetCtx { loader: SliverLoader; }
+export type SliverGetResult =
+  | { found: true; spec: SliverSpec }
+  | { found: false; id: string };
+
+export async function sliverGetHandler(
+  args: { id: string },
+  ctx: SliverGetCtx,
+): Promise<SliverGetResult> {
+  const spec = ctx.loader.get(args.id);
+  if (!spec) return { found: false, id: args.id };
+  return { found: true, spec };
+}
+
+export const meta = {
+  cost: 'low' as const,
+  effects: ['read'],
+  when: 'You have a sliver id and need its full spec — param schema, determinism block, executor kind.',
+  not_when: 'You want to enumerate slivers — use hayba_sliver_list.',
+  pack: 'core',
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/tools/sliver/get.test.ts`
+Expected: 2 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/tools/sliver/get.ts mcp-tools/hayba-mcp/src/tools/sliver/get.test.ts
+git commit -m "feat(slivers): hayba_sliver_get MCP tool"
+```
+
+---
+
+### Task 11: `hayba_sliver_run` MCP tool
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/tools/sliver/run.ts`
+- Test: `mcp-tools/hayba-mcp/src/tools/sliver/run.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/sliver/run.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from '../../slivers/index.js';
+import { sliverRunHandler } from './run.js';
+
+describe('hayba_sliver_run', () => {
+  let userDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-run-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+  });
+  afterEach(() => { rmSync(userDir, { recursive: true, force: true }); });
+
+  it('executes a known sliver and returns ok=true with outputs', async () => {
+    const r = await sliverRunHandler(
+      { id: 'com.hayba.composition.frame_target', params: { target: '/Game/X.X' } },
+      { runtime: sys.runtime },
+    );
+    expect(r.ok).toBe(true);
+    expect(r.outputs).toHaveProperty('camera_transform');
+    expect(typeof r.durationMs).toBe('number');
+  });
+
+  it('returns ok=false with error message when sliver id is unknown', async () => {
+    const r = await sliverRunHandler(
+      { id: 'com.nope.missing', params: {} },
+      { runtime: sys.runtime },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/missing/);
+  });
+
+  it('returns ok=false when params fail validation', async () => {
+    const r = await sliverRunHandler(
+      { id: 'com.hayba.composition.frame_target', params: { target: '/Game/X.X', distance: 9999 } },
+      { runtime: sys.runtime },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/distance/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/tools/sliver/run.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Create the handler**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/sliver/run.ts
+import { z } from 'zod';
+import type { SliverRuntime } from '../../slivers/runtime.js';
+import type { SliverRunResult } from '../../slivers/types.js';
+
+export const sliverRunSchema = {
+  id: z.string().min(1),
+  params: z.record(z.unknown()).default({}),
+};
+
+export interface SliverRunCtx { runtime: SliverRuntime; }
+
+export async function sliverRunHandler(
+  args: { id: string; params: Record<string, unknown> },
+  ctx: SliverRunCtx,
+): Promise<SliverRunResult> {
+  return ctx.runtime.runSliver(args.id, args.params ?? {});
+}
+
+export const meta = {
+  cost: 'medium' as const,
+  effects: ['varies-by-sliver'],
+  when: 'You want to execute a sliver with concrete parameter values. Returns outputs + declared side_effects.',
+  not_when: 'You only need to read the spec — use hayba_sliver_get.',
+  pack: 'core',
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/tools/sliver/run.test.ts`
+Expected: 3 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/tools/sliver/run.ts mcp-tools/hayba-mcp/src/tools/sliver/run.test.ts
+git commit -m "feat(slivers): hayba_sliver_run MCP tool"
+```
+
+---
+
+### Task 12: `hayba_sliver_import` MCP tool
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/tools/sliver/import.ts`
+- Test: `mcp-tools/hayba-mcp/src/tools/sliver/import.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/sliver/import.test.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from '../../slivers/index.js';
+import { sliverImportHandler } from './import.js';
+
+const sample = {
+  id: 'com.example.cool.thing',
+  version: '1.0.0',
+  category: 'demo',
+  title: 'Cool Thing',
+  description: 'demo',
+  author: 'example',
+  params: [],
+  executor: { kind: 'demo.cool' },
+  determinism: { pure: true, declared_outputs: [], side_effects: [], seed_param: null },
+};
+
+describe('hayba_sliver_import', () => {
+  let userDir: string;
+  let srcDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-imp-u-'));
+    srcDir  = mkdtempSync(join(tmpdir(), 'hayba-sl-imp-s-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+  });
+  afterEach(() => {
+    rmSync(userDir, { recursive: true, force: true });
+    rmSync(srcDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('imports a local file path and installs it to userDir', async () => {
+    const p = join(srcDir, 'cool.sliver.json');
+    writeFileSync(p, JSON.stringify(sample));
+    const r = await sliverImportHandler({ source: p }, { loader: sys.loader });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.id).toBe('com.example.cool.thing');
+      expect(existsSync(join(userDir, 'com.example.cool.thing.sliver.json'))).toBe(true);
+    }
+    expect(sys.loader.get('com.example.cool.thing')).toBeDefined();
+  });
+
+  it('imports an https URL via fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(sample), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const r = await sliverImportHandler({ source: 'https://example.com/cool.sliver.json' }, { loader: sys.loader });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects sources that are not file paths or https URLs', async () => {
+    const r = await sliverImportHandler({ source: 'ftp://example.com/x' }, { loader: sys.loader });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/source/i);
+  });
+
+  it('rejects malformed JSON content', async () => {
+    const p = join(srcDir, 'bad.sliver.json');
+    writeFileSync(p, '{ not json');
+    const r = await sliverImportHandler({ source: p }, { loader: sys.loader });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects specs that fail schema validation', async () => {
+    const p = join(srcDir, 'bad.sliver.json');
+    writeFileSync(p, JSON.stringify({ ...sample, id: 'not-reverse-dns' }));
+    const r = await sliverImportHandler({ source: p }, { loader: sys.loader });
+    expect(r.ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/tools/sliver/import.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Create the handler**
+
+```ts
+// mcp-tools/hayba-mcp/src/tools/sliver/import.ts
+//
+// hayba_sliver_import — accepts either an absolute file path or an
+// https URL, fetches the JSON, validates against the sliver schema,
+// installs into userDir. Returns the installed id or a clear reason on
+// failure. No network sandbox; trust is social — the LLM's caller (or
+// the user) is responsible for vetting URLs.
+
+import { z } from 'zod';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import type { SliverLoader } from '../../slivers/loader.js';
+
+export const sliverImportSchema = { source: z.string().min(1) };
+
+export interface SliverImportCtx { loader: SliverLoader; }
+export type SliverImportResult =
+  | { ok: true; id: string; path: string; source: string }
+  | { ok: false; reason: string };
+
+export async function sliverImportHandler(
+  args: { source: string },
+  ctx: SliverImportCtx,
+): Promise<SliverImportResult> {
+  let raw: string;
+  try {
+    if (/^https?:\/\//i.test(args.source)) {
+      const resp = await fetch(args.source);
+      if (!resp.ok) return { ok: false, reason: `fetch ${args.source} → HTTP ${resp.status}` };
+      raw = await resp.text();
+    } else if (existsSync(args.source) && statSync(args.source).isFile()) {
+      raw = readFileSync(args.source, 'utf8');
+    } else {
+      return { ok: false, reason: `source must be an existing file path or an http(s) URL: "${args.source}"` };
+    }
+  } catch (e) {
+    return { ok: false, reason: `read source: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); }
+  catch (e) { return { ok: false, reason: `invalid JSON: ${e instanceof Error ? e.message : String(e)}` }; }
+
+  const result = ctx.loader.install(parsed);
+  if (!result.ok) return { ok: false, reason: result.reason };
+  return { ok: true, id: result.id, path: result.path, source: args.source };
+}
+
+export const meta = {
+  cost: 'medium' as const,
+  effects: ['filesystem_write'],
+  when: 'You want to install a sliver from a local file path or an http(s) URL into the user sliver library.',
+  not_when: 'You only want to run an already-installed sliver — use hayba_sliver_run.',
+  pack: 'core',
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/tools/sliver/import.test.ts`
+Expected: 5 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/tools/sliver/import.ts mcp-tools/hayba-mcp/src/tools/sliver/import.test.ts
+git commit -m "feat(slivers): hayba_sliver_import MCP tool with file + URL support"
+```
+
+---
+
+### Task 13: Wire sliver tools into routing/register.ts
+
+**Files:**
+- Modify: `mcp-tools/hayba-mcp/src/tools/routing/register.ts`
+
+- [ ] **Step 1: Add imports**
+
+Open `mcp-tools/hayba-mcp/src/tools/routing/register.ts`. Find the import block ending around line 27 (the last `asset-retriever/meta-tools/reindex.js` import). After it, add:
+
+```ts
+import { setupSliverSystem, type SliverSystem } from '../../slivers/index.js';
+import { sliverListHandler, sliverListSchema } from '../sliver/list.js';
+import { sliverGetHandler,  sliverGetSchema  } from '../sliver/get.js';
+import { sliverRunHandler,  sliverRunSchema  } from '../sliver/run.js';
+import { sliverImportHandler, sliverImportSchema } from '../sliver/import.js';
+```
+
+- [ ] **Step 2: Add sliver ids to ALWAYS_ON_META**
+
+Find the `ALWAYS_ON_META = new Set<string>([...])` block. Append these four ids inside the set, after `'hayba_asset_reindex'`:
+
+```ts
+  'hayba_sliver_list',
+  'hayba_sliver_get',
+  'hayba_sliver_run',
+  'hayba_sliver_import',
+```
+
+- [ ] **Step 3: Extend RoutingHandle to expose the sliver system**
+
+Find `export interface RoutingHandle { ... }`. Add one field:
+
+```ts
+  slivers: SliverSystem;
+```
+
+- [ ] **Step 4: Set up the sliver system + register the four tools**
+
+Inside `registerDeferredRouting`, locate the asset-retriever block (`// ── Asset retriever (Layer 3a) ─────────────...`). Immediately *after* the closing of that block's last `server.tool(...)` (the `hayba_asset_reindex` registration) and *before* `// ── Always-load packs from settings ──────────`, add:
+
+```ts
+  // ── Slivers (Layer 2 — deterministic abstractions) ─────────────────────────
+  const slivers = await setupSliverSystem();
+  for (const err of slivers.loader.errors()) {
+    console.warn(`[slivers] load error: ${err}`);
+  }
+
+  server.tool(
+    'hayba_sliver_list',
+    'List installed Slivers (deterministic abstractions). Optional category or namespace filter.',
+    sliverListSchema,
+    async (args: { category?: string; namespace?: string }) => {
+      const r = await sliverListHandler(args, { loader: slivers.loader });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'hayba_sliver_get',
+    'Get the full spec (params + determinism + executor) of an installed sliver by id.',
+    sliverGetSchema,
+    async (args: { id: string }) => {
+      const r = await sliverGetHandler(args, { loader: slivers.loader });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'hayba_sliver_run',
+    'Execute a sliver with concrete parameter values. Returns outputs + declared side_effects + durationMs.',
+    sliverRunSchema,
+    async (args: { id: string; params: Record<string, unknown> }) => {
+      const r = await sliverRunHandler(args, { runtime: slivers.runtime });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'hayba_sliver_import',
+    'Install a sliver from a local file path or an http(s) URL into the user sliver library.',
+    sliverImportSchema,
+    async (args: { source: string }) => {
+      const r = await sliverImportHandler(args, { loader: slivers.loader });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+```
+
+- [ ] **Step 5: Return `slivers` in the RoutingHandle**
+
+Find the `return { registry, index, retriever, ... };` at the bottom of `registerDeferredRouting`. Add `slivers,` to the returned object so it matches the extended interface.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `cd mcp-tools/hayba-mcp && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `cd mcp-tools/hayba-mcp && npm test`
+Expected: all green (existing + new sliver tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/tools/routing/register.ts
+git commit -m "feat(slivers): wire 4 sliver tools into deferred routing + ALWAYS_ON_META"
+```
+
+---
+
+### Task 14: build:assets copies bundled sliver specs to dist
+
+**Files:**
+- Modify: `mcp-tools/hayba-mcp/package.json`
+
+- [ ] **Step 1: Update the build:assets script**
+
+Open `mcp-tools/hayba-mcp/package.json`. Find the `"build:assets"` line. Replace its value with a script that copies *both* `packs.yaml` and every `*.sliver.json` under `src/slivers/specs/` to `dist/slivers/specs/`:
+
+```json
+    "build:assets": "node -e \"import('node:fs').then(fs=>{fs.mkdirSync('dist/tools/routing',{recursive:true});fs.copyFileSync('src/tools/routing/packs.yaml','dist/tools/routing/packs.yaml');fs.mkdirSync('dist/slivers/specs',{recursive:true});for(const f of fs.readdirSync('src/slivers/specs')){if(f.endsWith('.sliver.json'))fs.copyFileSync('src/slivers/specs/'+f,'dist/slivers/specs/'+f)}console.error('[build:assets] copied packs.yaml + sliver specs')})\"",
+```
+
+- [ ] **Step 2: Run the build**
+
+Run: `cd mcp-tools/hayba-mcp && npm run build:server`
+Expected: tsc succeeds; `[build:assets] copied packs.yaml + sliver specs` printed.
+
+- [ ] **Step 3: Verify both artifacts exist**
+
+Run: `cd mcp-tools/hayba-mcp && ls dist/slivers/specs/ && ls dist/tools/routing/packs.yaml`
+Expected: `com.hayba.composition.frame_target.sliver.json` listed; `packs.yaml` path resolves.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/package.json
+git commit -m "build(slivers): copy bundled sliver specs to dist on build"
+```
+
+---
+
+### Task 15: Integration smoke test against compiled dist
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/.scratch/verify-slivers.mjs` (not committed; ephemeral verification)
+
+- [ ] **Step 1: Write the smoke driver**
+
+```js
+// mcp-tools/hayba-mcp/.scratch/verify-slivers.mjs
+// Drives the compiled sliver subsystem end-to-end without spinning up
+// the full MCP server. Mirrors how registerDeferredRouting will use it.
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from '../dist/slivers/index.js';
+
+const userDir = mkdtempSync(join(tmpdir(), 'hayba-sliver-smoke-'));
+try {
+  const sys = await setupSliverSystem({ userDir });
+  console.log('registered kinds:', sys.registry.kinds());
+  console.log('installed slivers:', sys.loader.list().map(s => s.id));
+  const r = await sys.runtime.runSliver('com.hayba.composition.frame_target', {
+    target: '/Game/X.X', distance: 12, height: 1.5, fov: 60, yaw_deg: 30,
+  });
+  console.log('run result:', JSON.stringify(r, null, 2));
+  if (!r.ok) process.exit(1);
+} finally {
+  rmSync(userDir, { recursive: true, force: true });
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cd mcp-tools/hayba-mcp && node .scratch/verify-slivers.mjs`
+Expected:
+- `registered kinds: [ 'composition.frame_target' ]`
+- `installed slivers: [ 'com.hayba.composition.frame_target' ]`
+- `run result` shows `"ok": true` and a `camera_transform` object.
+
+- [ ] **Step 3: No commit (scratch artifact)**
+
+`.scratch/` is gitignored per repo convention. Leave the file or delete it — it does not commit.
+
+---
+
+### Task 16: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/slivers-design-spec`
+(or whichever branch this implementation lives on — if it's a fresh branch, create one with `git checkout -b feat/slivers-a-ts-runtime` first and push that.)
+
+- [ ] **Step 2: Open the PR via gh**
+
+```bash
+gh pr create --title "Slivers v1 plan A: TS runtime + 4 MCP tools + frame_target" --body "$(cat <<'EOF'
+## Summary
+- Sliver runtime (types, zod schema, registry, runtime with cycle/depth guards, loader with bundled-seed)
+- Four always-on MCP tools: hayba_sliver_{list,get,run,import}
+- First bundled sliver: com.hayba.composition.frame_target (pure, returns camera_transform)
+- build:assets now copies sliver specs to dist
+
+Implements Plan A of the Slivers v1 spec
+(docs/superpowers/specs/2026-05-21-slivers-design.md). No UE plugin
+work in this PR — Plans B (UE Slivers UI) and C (time_of_day + lighting
+handler) follow.
+
+## Test plan
+- [ ] npm test (mcp-tools/hayba-mcp) all green
+- [ ] npm run build:server succeeds, dist/slivers/specs/ contains the bundled spec
+- [ ] .scratch/verify-slivers.mjs prints ok=true with a sensible camera_transform
+- [ ] Manual: in a running MCP client, hayba_sliver_list returns frame_target; hayba_sliver_run with valid params returns a transform
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review Notes (post-write)
+
+**Spec coverage check:**
+
+| Spec section | Covered by |
+|---|---|
+| Identity (reverse-DNS regex) | Task 2 (`reverseDns` regex in schema) |
+| Storage layout (%APPDATA%/Hayba/slivers/) | Task 6 (`defaultUserSliversDir`) |
+| Param types (all 10) | Task 1 (TS) + Task 2 (Zod) + Task 4 (validator) |
+| Determinism contract fields | Task 1 (types), Task 2 (schema), Task 5 (side_effect aggregation) |
+| Composability + cycle detection + max depth | Task 5 (`runtime.test.ts` covers direct/indirect cycles + depth + sequential reuse) |
+| MCP surface (4 tools) | Tasks 9–13 |
+| ALWAYS_ON_META addition | Task 13 |
+| Bundled spec shipping | Task 7 (json) + Task 14 (build copy) |
+| URL import | Task 12 (https branch + fetch test) |
+| Convention-only determinism | Implicit — no verifier in this plan, matches spec's v1 stance |
+
+**Out of scope (correctly deferred):**
+- UE Slivers tab UI → Plan B
+- `time_of_day` + UE lighting handler → Plan C
+- `sliver_draft` AI authoring tool → Phase 5
+- Per-sliver `.preset.json` save/load → covered when UE UI ships (Plan B)
+- `sliver_verify` determinism enforcement → v2
+
+**Placeholder scan:** No TBDs, every code step contains the actual code, every test contains real assertions, every command has expected output.
+
+**Type consistency check:** `SliverSpec.executor.kind` (string) flows through types.ts → spec-schema.ts → runtime.ts → registry.ts → composition/frame_target.ts (`COMPOSITION_FRAME_TARGET_KIND = 'composition.frame_target'`) consistently. `SliverRunResult` shape matches between runtime.ts, run.ts handler, and the smoke test assertion.

--- a/docs/superpowers/plans/2026-05-21-slivers-b-ue-ui.md
+++ b/docs/superpowers/plans/2026-05-21-slivers-b-ue-ui.md
@@ -1,0 +1,1952 @@
+# Slivers v1 Plan B — UE Plugin Slivers Tab
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the user-facing UE plugin Slivers tab — a Slate dockable panel that lists installed slivers, renders sliders/inputs from each spec, lets the user run the sliver, and shows the result. After this plan, a user can pick `Window → Slivers`, select `Frame Target`, scrub the `distance` and `yaw_deg` sliders, hit Run, and see the camera_transform JSON come back.
+
+**Architecture:** UE plugin opens a Slate `SSliversPanel` from a dock tab. The panel reads sliver specs from `%APPDATA%/Hayba/slivers/*.sliver.json` (same directory the MCP server uses — UE just re-parses the JSON in C++). When the user clicks Run, the plugin sends an HTTP POST to a new MCP-server endpoint (`localhost:3091/sliver/run`) and renders the response. A small `UHaybaSliverSettings` UDeveloperSettings holds the MCP URL.
+
+**Tech Stack:** UE 5.7 Slate + Editor (`SCompoundWidget`, `FGlobalTabmanager`, `FWorkspaceMenuStructure`), `Json`/`JsonUtilities` modules for spec parsing, `HTTP` module for the MCP round-trip. TS side: minor addition to `mcp-tools/hayba-mcp/src/dashboard/server.ts` (or equivalent existing Express setup) to expose 4 sliver routes.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-21-slivers-design.md` — section "UE plugin — Slivers tab".
+**Companion plans:** Plan A (TS runtime, PR #217 — shipped) defines the JSON spec shape and the MCP tools. Plan C (time_of_day + lighting handler) will add the second sliver but is independent of this UI work.
+
+---
+
+## Scope cuts vs the spec (intentional, deferred to v2)
+
+| Spec item | v1 status |
+|---|---|
+| All 10 param widget types | v1 ships 6 (Float, Int, Bool, String, Enum, ActorRef). Vector3 / Color / Transform / AssetRef widgets → v2 |
+| `SliverRunMode: AutoDebounced250ms` | Manual only in v1 |
+| Per-sliver `Save preset` button + `.preset.json` files | Deferred |
+| Rich output preview (parse `camera_transform`, etc.) | v1 shows raw JSON in a read-only text panel |
+| Live sliver list refresh on disk change | v1 has a manual "Refresh" button |
+| `MaxSliverDepth` config | Server-side default (8) only; no UI surface |
+
+Each cut is small and additive — v2 extends the existing widget registry without restructuring.
+
+---
+
+## Architectural decisions (locked)
+
+1. **UI shell:** Slate dockable tab via `FGlobalTabmanager::Get()->RegisterNomadTabSpawner`, opened from `Window → Slivers`. Not UMG / Editor Utility Widget. Pure C++ keeps it editor-only, no runtime UMG dependency.
+
+2. **Spec parsing:** UE plugin re-implements `parseSliverSpec` in C++ (small — discriminated union over `type` strings, lift fields from `FJsonObject`). UE reads from the same `%APPDATA%/Hayba/slivers/` directory the MCP server seeds. No coupling beyond the on-disk JSON shape.
+
+3. **Sliver execution:** new HTTP endpoint on the MCP server. UE plugin posts JSON to `http://localhost:3091/sliver/run` and parses the response. Port + host configurable via `UHaybaSliverSettings`. No new IPC primitive; UE already uses the `HTTP` module elsewhere for asset downloads.
+
+4. **Param widget extensibility:** `SSliverParamWidget` is an abstract Slate widget. Each concrete type registers a factory at module startup. Adding `vector3` later = one new file + one registration line.
+
+5. **No actor picker dropdown in v1.** `ActorRef` widget is a `SEditableTextBox` plus a small "Pick from selection" button that fills it from `GEditor->GetSelectedActors()`. The full `SObjectPropertyEntryBox` integration is v2 — it requires `PropertyEditor` module wiring that's worth its own task.
+
+---
+
+## File Structure
+
+```
+mcp-tools/hayba-mcp/
+├── src/
+│   └── http/
+│       ├── sliver-routes.ts             # Express router: /sliver/{list,get,run,import}
+│       ├── sliver-routes.test.ts
+│       └── server.ts                    # Tiny Express bootstrap (port from env, default 3091)
+├── package.json                          # modified: add "start:http" + "main" hint if needed
+└── src/index.ts                          # modified: start HTTP server alongside MCP stdio
+
+unreal/HaybaMCPToolkit/
+├── HaybaMCPToolkit.uplugin               # modified: add "Slate", "SlateCore", "EditorStyle", "HTTP", "Json", "JsonUtilities" deps if missing
+├── Source/HaybaMCPToolkit/
+│   ├── HaybaMCPToolkit.Build.cs          # modified: add modules listed above
+│   ├── Public/Slivers/
+│   │   └── HaybaSliverSettings.h         # UDeveloperSettings — MCP URL/port
+│   ├── Private/Slivers/
+│   │   ├── HaybaSliverSettings.cpp
+│   │   ├── HaybaSliverTypes.h            # C++ mirror of SliverSpec/SliverParam discriminated union
+│   │   ├── HaybaSliverTypes.cpp          # ParseSliverSpec(FJsonObject) + reverse-DNS validator
+│   │   ├── HaybaSliverLoader.h           # Reads %APPDATA%/Hayba/slivers/*.sliver.json
+│   │   ├── HaybaSliverLoader.cpp
+│   │   ├── HaybaSliverClient.h           # HTTP client (POST /sliver/run etc.)
+│   │   ├── HaybaSliverClient.cpp
+│   │   ├── SSliversPanel.h               # Top-level Slate widget: list + detail split
+│   │   ├── SSliversPanel.cpp
+│   │   ├── SSliverDetailPanel.h          # Param widgets + Run + output
+│   │   ├── SSliverDetailPanel.cpp
+│   │   ├── SSliverParamWidget.h          # Abstract base + factory registry
+│   │   ├── SSliverParamWidget.cpp
+│   │   ├── SSliverParamFloat.h/.cpp      # Float slider
+│   │   ├── SSliverParamInt.h/.cpp        # Int slider
+│   │   ├── SSliverParamBool.h/.cpp       # Checkbox
+│   │   ├── SSliverParamString.h/.cpp     # Text input
+│   │   ├── SSliverParamEnum.h/.cpp       # Dropdown
+│   │   ├── SSliverParamActorRef.h/.cpp   # Text + "Pick from selection" button
+│   │   └── HaybaSliverTabRegistration.cpp # Registers nomad tab + Window menu entry
+│   └── HaybaMCPModule.cpp                 # modified: call HaybaSliver_RegisterTab on StartupModule
+```
+
+Each Slate widget is one .h/.cpp pair with one responsibility. Param widgets share a base class with a factory map keyed by the spec's `type` string.
+
+---
+
+### Task 1: TS-side — sliver routes module (TDD)
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/http/sliver-routes.ts`
+- Create: `mcp-tools/hayba-mcp/src/http/sliver-routes.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mcp-tools/hayba-mcp/src/http/sliver-routes.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { setupSliverSystem } from '../slivers/index.js';
+import { mountSliverRoutes } from './sliver-routes.js';
+
+describe('sliver HTTP routes', () => {
+  let userDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+  let server: Server;
+  let url: string;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-http-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+    const app = express();
+    app.use(express.json());
+    mountSliverRoutes(app, sys);
+    server = app.listen(0);
+    const port = (server.address() as AddressInfo).port;
+    url = `http://127.0.0.1:${port}`;
+  });
+  afterEach(() => {
+    server.close();
+    rmSync(userDir, { recursive: true, force: true });
+  });
+
+  it('GET /sliver/list returns installed slivers', async () => {
+    const r = await fetch(`${url}/sliver/list`);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.slivers.length).toBeGreaterThan(0);
+    expect(body.slivers[0].id).toBe('com.hayba.composition.frame_target');
+  });
+
+  it('GET /sliver/list?category=composition filters', async () => {
+    const r = await fetch(`${url}/sliver/list?category=composition`);
+    const body = await r.json();
+    expect(body.slivers.every((s: { category: string }) => s.category === 'composition')).toBe(true);
+  });
+
+  it('GET /sliver/get?id=... returns the full spec', async () => {
+    const r = await fetch(`${url}/sliver/get?id=com.hayba.composition.frame_target`);
+    const body = await r.json();
+    expect(body.found).toBe(true);
+    expect(body.spec.params.length).toBeGreaterThan(0);
+  });
+
+  it('POST /sliver/run executes and returns outputs', async () => {
+    const r = await fetch(`${url}/sliver/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: 'com.hayba.composition.frame_target', params: { target: '/Game/X.X' } }),
+    });
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.ok).toBe(true);
+    expect(body.outputs).toHaveProperty('camera_transform');
+  });
+
+  it('POST /sliver/run returns ok=false on validation failure', async () => {
+    const r = await fetch(`${url}/sliver/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: 'com.hayba.composition.frame_target', params: { target: '/Game/X.X', distance: 9999 } }),
+    });
+    const body = await r.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/distance/);
+  });
+
+  it('POST /sliver/import installs from a JSON body', async () => {
+    const spec = {
+      id: 'com.test.http.demo',
+      version: '1.0.0',
+      category: 'demo',
+      title: 'HTTP Demo',
+      description: '',
+      author: 'test',
+      params: [],
+      executor: { kind: 'demo.http' },
+      determinism: { pure: true, declared_outputs: [], side_effects: [], seed_param: null },
+    };
+    const r = await fetch(`${url}/sliver/import`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ spec }),
+    });
+    const body = await r.json();
+    expect(body.ok).toBe(true);
+    expect(sys.loader.get('com.test.http.demo')).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/http/sliver-routes.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Create the routes module**
+
+```ts
+// mcp-tools/hayba-mcp/src/http/sliver-routes.ts
+//
+// Express router exposing the four sliver tools over HTTP. Used by the
+// UE plugin's Slivers panel; the LLM-facing MCP tools (hayba_sliver_*)
+// remain stdio-based via the MCP server. Both surfaces share the same
+// SliverSystem so installed slivers are visible from either side.
+
+import type { Express, Request, Response } from 'express';
+import type { SliverSystem } from '../slivers/index.js';
+import { sliverListHandler } from '../tools/sliver/list.js';
+import { sliverGetHandler }  from '../tools/sliver/get.js';
+import { sliverRunHandler }  from '../tools/sliver/run.js';
+
+export function mountSliverRoutes(app: Express, sys: SliverSystem): void {
+  app.get('/sliver/list', async (req: Request, res: Response) => {
+    const r = await sliverListHandler({
+      category: typeof req.query.category === 'string' ? req.query.category : undefined,
+      namespace: typeof req.query.namespace === 'string' ? req.query.namespace : undefined,
+    }, { loader: sys.loader });
+    res.json(r);
+  });
+
+  app.get('/sliver/get', async (req: Request, res: Response) => {
+    if (typeof req.query.id !== 'string' || !req.query.id) {
+      res.status(400).json({ error: 'missing id' });
+      return;
+    }
+    const r = await sliverGetHandler({ id: req.query.id }, { loader: sys.loader });
+    res.json(r);
+  });
+
+  app.post('/sliver/run', async (req: Request, res: Response) => {
+    const body = req.body as { id?: unknown; params?: unknown };
+    if (typeof body.id !== 'string' || !body.id) {
+      res.status(400).json({ error: 'missing id' });
+      return;
+    }
+    const r = await sliverRunHandler({
+      id: body.id,
+      params: (body.params && typeof body.params === 'object' ? body.params : {}) as Record<string, unknown>,
+    }, { runtime: sys.runtime });
+    res.json(r);
+  });
+
+  app.post('/sliver/import', async (req: Request, res: Response) => {
+    const body = req.body as { spec?: unknown };
+    if (!body.spec || typeof body.spec !== 'object') {
+      res.status(400).json({ error: 'missing spec' });
+      return;
+    }
+    const r = sys.loader.install(body.spec);
+    res.json(r);
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mcp-tools/hayba-mcp && npx vitest run src/http/sliver-routes.test.ts`
+Expected: 6 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/http/sliver-routes.ts mcp-tools/hayba-mcp/src/http/sliver-routes.test.ts
+git commit -m "feat(slivers): HTTP routes exposing list/get/run/import to UE plugin"
+```
+
+---
+
+### Task 2: TS-side — HTTP server bootstrap + index.ts wiring
+
+**Files:**
+- Create: `mcp-tools/hayba-mcp/src/http/server.ts`
+- Modify: `mcp-tools/hayba-mcp/src/index.ts` (start the HTTP server alongside the MCP stdio server)
+
+- [ ] **Step 1: Read `mcp-tools/hayba-mcp/src/index.ts`**
+
+Identify where `registerDeferredRouting` is called and where the returned `RoutingHandle` is available. The new HTTP server needs `routingHandle.slivers` (the `SliverSystem`).
+
+- [ ] **Step 2: Create the HTTP bootstrap**
+
+```ts
+// mcp-tools/hayba-mcp/src/http/server.ts
+//
+// Tiny Express bootstrap. Port comes from env HAYBA_MCP_HTTP_PORT, or
+// 3091 by default. Bound to 127.0.0.1 only — local-machine traffic
+// only, never exposed to the network.
+
+import express from 'express';
+import type { Server } from 'node:http';
+import type { SliverSystem } from '../slivers/index.js';
+import { mountSliverRoutes } from './sliver-routes.js';
+
+export function startHttpServer(slivers: SliverSystem): Server {
+  const app = express();
+  app.use(express.json({ limit: '1mb' }));
+  mountSliverRoutes(app, slivers);
+  const port = Number(process.env.HAYBA_MCP_HTTP_PORT ?? 3091);
+  const server = app.listen(port, '127.0.0.1', () => {
+    console.error(`[hayba-mcp] HTTP listening on 127.0.0.1:${port}`);
+  });
+  return server;
+}
+```
+
+- [ ] **Step 3: Wire into index.ts**
+
+Add the import:
+
+```ts
+import { startHttpServer } from './http/server.js';
+```
+
+After `registerDeferredRouting(...)` resolves (the line where the `RoutingHandle` is captured), add:
+
+```ts
+startHttpServer(routingHandle.slivers);
+```
+
+Use the actual variable name the existing code uses for the routing handle — read the file first to find it.
+
+- [ ] **Step 4: Verify build + smoke**
+
+```bash
+cd mcp-tools/hayba-mcp
+npm run build:server
+# Start the server in the background:
+node dist/index.js &
+HAYBA_PID=$!
+sleep 1
+# Hit the endpoint:
+curl -s http://127.0.0.1:3091/sliver/list | head -c 200
+echo
+kill $HAYBA_PID
+```
+
+Expected: `{"slivers":[{"id":"com.hayba.composition.frame_target",...}]}`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp-tools/hayba-mcp/src/http/server.ts mcp-tools/hayba-mcp/src/index.ts
+git commit -m "feat(slivers): start HTTP server on 127.0.0.1:3091 for UE plugin"
+```
+
+---
+
+### Task 3: UE — Build.cs dependencies + plugin manifest
+
+**Files:**
+- Modify: `unreal/HaybaMCPToolkit/HaybaMCPToolkit.uplugin`
+- Modify: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/HaybaMCPToolkit.Build.cs`
+
+- [ ] **Step 1: Read both files**
+
+Identify the current module dependency list. The plugin already depends on Core/CoreUObject/Engine/Editor (verify). It needs to add: `Slate`, `SlateCore`, `EditorStyle`, `EditorWidgets`, `WorkspaceMenuStructure`, `ToolMenus`, `InputCore`, `HTTP`, `Json`, `JsonUtilities`, `DeveloperSettings`, `UnrealEd`. Skip any already present.
+
+- [ ] **Step 2: Update Build.cs**
+
+In the `PublicDependencyModuleNames.AddRange(new string[] { ... })` block (or `PrivateDependencyModuleNames` if the existing pattern uses that), add the missing modules. Keep alphabetical order if the existing file does. Example final state for the Private list:
+
+```csharp
+PrivateDependencyModuleNames.AddRange(new string[] {
+    "Core", "CoreUObject", "Engine", "Slate", "SlateCore",
+    "EditorStyle", "EditorWidgets", "WorkspaceMenuStructure",
+    "ToolMenus", "InputCore", "HTTP", "Json", "JsonUtilities",
+    "DeveloperSettings", "UnrealEd",
+    // ... existing deps preserved
+});
+```
+
+- [ ] **Step 3: Verify the plugin still compiles**
+
+Run from a shell that can build UE (the user may need to do this from the editor; document it as a manual step):
+
+```
+The user opens Unreal Editor. On first open after this change UE will
+prompt "Modules out of date, rebuild?" — click Yes.
+```
+
+The agent cannot build UE itself; mark this as a manual verification step in the report.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/HaybaMCPToolkit.uplugin unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/HaybaMCPToolkit.Build.cs
+git commit -m "build(slivers): add Slate + HTTP + Json + Editor module deps for Slivers tab"
+```
+
+---
+
+### Task 4: UE — `UHaybaSliverSettings` UDeveloperSettings
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/Slivers/HaybaSliverSettings.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverSettings.cpp`
+
+- [ ] **Step 1: Header**
+
+```cpp
+// HaybaSliverSettings.h — DeveloperSettings exposing the MCP HTTP URL
+// and the Slivers tab run mode. Lives in Project Settings → Plugins →
+// Hayba MCP → Slivers. Per-project (DefaultEditor.ini).
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "HaybaSliverSettings.generated.h"
+
+UENUM(BlueprintType)
+enum class EHaybaSliverRunMode : uint8
+{
+    Manual           UMETA(DisplayName = "Manual"),
+    // AutoDebounced — v2; placeholder enum value keeps the future widget render flat.
+    AutoDebounced250 UMETA(DisplayName = "Auto (debounced 250 ms) — v2 only"),
+};
+
+UCLASS(config = EditorPerProjectUserSettings, defaultconfig, meta = (DisplayName = "Hayba Slivers"))
+class HAYBAMCPTOOLKIT_API UHaybaSliverSettings : public UDeveloperSettings
+{
+    GENERATED_BODY()
+public:
+    UHaybaSliverSettings();
+
+    /** Base URL of the MCP server's HTTP listener. Set by hayba-mcp on startup; default matches its default port. */
+    UPROPERTY(EditAnywhere, config, Category = "Hayba Slivers")
+    FString McpHttpBaseUrl;
+
+    /** v1 ships Manual only. AutoDebounced lands in v2. */
+    UPROPERTY(EditAnywhere, config, Category = "Hayba Slivers")
+    EHaybaSliverRunMode RunMode;
+
+    /** Maximum recursion depth when slivers call each other. */
+    UPROPERTY(EditAnywhere, config, Category = "Hayba Slivers", meta = (ClampMin = "1", ClampMax = "32"))
+    int32 MaxSliverDepth;
+
+    static const UHaybaSliverSettings* GetChecked();
+};
+```
+
+- [ ] **Step 2: Implementation**
+
+```cpp
+// HaybaSliverSettings.cpp
+#include "Slivers/HaybaSliverSettings.h"
+
+UHaybaSliverSettings::UHaybaSliverSettings()
+    : McpHttpBaseUrl(TEXT("http://127.0.0.1:3091"))
+    , RunMode(EHaybaSliverRunMode::Manual)
+    , MaxSliverDepth(8)
+{}
+
+const UHaybaSliverSettings* UHaybaSliverSettings::GetChecked()
+{
+    const UHaybaSliverSettings* S = GetDefault<UHaybaSliverSettings>();
+    check(S);
+    return S;
+}
+```
+
+- [ ] **Step 3: Manual verification (after Task 12 wires the tab open)**
+
+Document: After implementing this task the settings are not visible until UE is rebuilt. They will appear under Project Settings → Plugins → Hayba Slivers once the plugin is reloaded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/Slivers/HaybaSliverSettings.h \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverSettings.cpp
+git commit -m "feat(slivers): UHaybaSliverSettings (MCP URL, run mode, max depth)"
+```
+
+---
+
+### Task 5: UE — `FHaybaSliverSpec` C++ types + JSON parser
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.cpp`
+
+- [ ] **Step 1: Header — mirror the TS shapes in plain C++ structs**
+
+```cpp
+// HaybaSliverTypes.h — C++ mirror of the on-disk SliverSpec JSON shape.
+// Only the v1 param types are decoded (Float, Int, Bool, String, Enum,
+// ActorRef); other type strings parse into FHaybaSliverParam with
+// Type=Unsupported and are surfaced by the panel as "not yet supported".
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Templates/SharedPointer.h"
+
+class FJsonObject;
+
+enum class EHaybaSliverParamType : uint8
+{
+    Float,
+    Int,
+    Bool,
+    String,
+    Enum,
+    ActorRef,
+    Unsupported,
+};
+
+struct FHaybaSliverEnumOption
+{
+    FString Value;
+    FString Label;
+};
+
+struct FHaybaSliverParam
+{
+    FString Id;
+    FString Label;
+    bool bRequired = false;
+    EHaybaSliverParamType Type = EHaybaSliverParamType::Unsupported;
+    FString OriginalTypeString;   // verbatim from JSON, used for the Unsupported message
+
+    // Numeric (float / int)
+    TOptional<double> RangeMin;
+    TOptional<double> RangeMax;
+    TOptional<double> DefaultNumber;
+
+    // Bool
+    TOptional<bool>   DefaultBool;
+
+    // String / Enum / ActorRef
+    TOptional<FString> DefaultString;
+    TArray<FHaybaSliverEnumOption> EnumOptions;
+
+    // ActorRef
+    FString ClassFilter;
+};
+
+struct FHaybaSliverDeterminism
+{
+    bool bPure = true;
+    TArray<FString> DeclaredOutputs;
+    TArray<FString> SideEffects;
+    TOptional<FString> SeedParam;
+};
+
+struct FHaybaSliverSpec
+{
+    FString Id;
+    FString Version;
+    FString Category;
+    FString Title;
+    FString Description;
+    FString Author;
+    FString ExecutorKind;
+    TArray<FHaybaSliverParam> Params;
+    FHaybaSliverDeterminism Determinism;
+};
+
+/** Returns true and fills OutSpec on success; false and OutError on validation failure. */
+bool ParseHaybaSliverSpec(const TSharedRef<FJsonObject>& In, FHaybaSliverSpec& OutSpec, FString& OutError);
+
+/** Reverse-DNS check: at least 3 dot-separated segments, lowercase + underscores. */
+bool IsReverseDnsId(const FString& Id);
+```
+
+- [ ] **Step 2: Implementation**
+
+```cpp
+// HaybaSliverTypes.cpp
+#include "Slivers/HaybaSliverTypes.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Internationalization/Regex.h"
+
+bool IsReverseDnsId(const FString& Id)
+{
+    // Mirrors src/slivers/spec-schema.ts: ^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*){2,}$
+    const FRegexPattern Pattern(TEXT("^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*){2,}$"));
+    FRegexMatcher M(Pattern, Id);
+    return M.FindNext();
+}
+
+static bool ParseRange(const TSharedPtr<FJsonValue>& V, TOptional<double>& OutMin, TOptional<double>& OutMax)
+{
+    if (!V.IsValid() || V->Type != EJson::Array) return false;
+    const TArray<TSharedPtr<FJsonValue>>& A = V->AsArray();
+    if (A.Num() != 2) return false;
+    OutMin = A[0]->AsNumber();
+    OutMax = A[1]->AsNumber();
+    return true;
+}
+
+static EHaybaSliverParamType ParamTypeFromString(const FString& S)
+{
+    if (S == TEXT("float"))     return EHaybaSliverParamType::Float;
+    if (S == TEXT("int"))       return EHaybaSliverParamType::Int;
+    if (S == TEXT("bool"))      return EHaybaSliverParamType::Bool;
+    if (S == TEXT("string"))    return EHaybaSliverParamType::String;
+    if (S == TEXT("enum"))      return EHaybaSliverParamType::Enum;
+    if (S == TEXT("actor_ref")) return EHaybaSliverParamType::ActorRef;
+    return EHaybaSliverParamType::Unsupported;
+}
+
+static bool ParseParam(const TSharedPtr<FJsonObject>& Obj, FHaybaSliverParam& Out, FString& OutError)
+{
+    if (!Obj->TryGetStringField(TEXT("id"), Out.Id) || Out.Id.IsEmpty())
+    { OutError = TEXT("param missing id"); return false; }
+    Obj->TryGetStringField(TEXT("label"), Out.Label);
+    Obj->TryGetBoolField(TEXT("required"), Out.bRequired);
+
+    FString TypeStr;
+    if (!Obj->TryGetStringField(TEXT("type"), TypeStr))
+    { OutError = FString::Printf(TEXT("param %s missing type"), *Out.Id); return false; }
+    Out.OriginalTypeString = TypeStr;
+    Out.Type = ParamTypeFromString(TypeStr);
+
+    // Range
+    if (Out.Type == EHaybaSliverParamType::Float || Out.Type == EHaybaSliverParamType::Int)
+    {
+        const TArray<TSharedPtr<FJsonValue>>* RangeArr = nullptr;
+        if (Obj->TryGetArrayField(TEXT("range"), RangeArr) && RangeArr && RangeArr->Num() == 2)
+        {
+            Out.RangeMin = (*RangeArr)[0]->AsNumber();
+            Out.RangeMax = (*RangeArr)[1]->AsNumber();
+        }
+        double DefNum;
+        if (Obj->TryGetNumberField(TEXT("default"), DefNum)) Out.DefaultNumber = DefNum;
+    }
+    if (Out.Type == EHaybaSliverParamType::Bool)
+    {
+        bool DefB;
+        if (Obj->TryGetBoolField(TEXT("default"), DefB)) Out.DefaultBool = DefB;
+    }
+    if (Out.Type == EHaybaSliverParamType::String || Out.Type == EHaybaSliverParamType::Enum || Out.Type == EHaybaSliverParamType::ActorRef)
+    {
+        FString DefS;
+        if (Obj->TryGetStringField(TEXT("default"), DefS)) Out.DefaultString = DefS;
+    }
+    if (Out.Type == EHaybaSliverParamType::Enum)
+    {
+        const TArray<TSharedPtr<FJsonValue>>* OptArr = nullptr;
+        if (Obj->TryGetArrayField(TEXT("options"), OptArr) && OptArr)
+        {
+            for (const TSharedPtr<FJsonValue>& Opt : *OptArr)
+            {
+                if (Opt->Type != EJson::Object) continue;
+                FHaybaSliverEnumOption O;
+                Opt->AsObject()->TryGetStringField(TEXT("value"), O.Value);
+                Opt->AsObject()->TryGetStringField(TEXT("label"), O.Label);
+                Out.EnumOptions.Add(O);
+            }
+        }
+    }
+    if (Out.Type == EHaybaSliverParamType::ActorRef)
+    {
+        Obj->TryGetStringField(TEXT("class_filter"), Out.ClassFilter);
+    }
+    return true;
+}
+
+bool ParseHaybaSliverSpec(const TSharedRef<FJsonObject>& In, FHaybaSliverSpec& OutSpec, FString& OutError)
+{
+    if (!In->TryGetStringField(TEXT("id"), OutSpec.Id) || !IsReverseDnsId(OutSpec.Id))
+    { OutError = TEXT("invalid or missing reverse-DNS id"); return false; }
+    if (!In->TryGetStringField(TEXT("version"), OutSpec.Version))   { OutError = TEXT("missing version"); return false; }
+    if (!In->TryGetStringField(TEXT("category"), OutSpec.Category)) { OutError = TEXT("missing category"); return false; }
+    if (!In->TryGetStringField(TEXT("title"), OutSpec.Title))       { OutError = TEXT("missing title"); return false; }
+    In->TryGetStringField(TEXT("description"), OutSpec.Description);
+    if (!In->TryGetStringField(TEXT("author"), OutSpec.Author))     { OutError = TEXT("missing author"); return false; }
+
+    const TSharedPtr<FJsonObject>* ExecObj = nullptr;
+    if (!In->TryGetObjectField(TEXT("executor"), ExecObj) || !(*ExecObj)->TryGetStringField(TEXT("kind"), OutSpec.ExecutorKind))
+    { OutError = TEXT("missing executor.kind"); return false; }
+
+    const TArray<TSharedPtr<FJsonValue>>* ParamsArr = nullptr;
+    if (In->TryGetArrayField(TEXT("params"), ParamsArr) && ParamsArr)
+    {
+        TSet<FString> SeenIds;
+        for (const TSharedPtr<FJsonValue>& V : *ParamsArr)
+        {
+            if (V->Type != EJson::Object) continue;
+            FHaybaSliverParam P;
+            FString Err;
+            if (!ParseParam(V->AsObject(), P, Err)) { OutError = Err; return false; }
+            if (SeenIds.Contains(P.Id)) { OutError = FString::Printf(TEXT("duplicate param id \"%s\""), *P.Id); return false; }
+            SeenIds.Add(P.Id);
+            OutSpec.Params.Add(P);
+        }
+    }
+
+    const TSharedPtr<FJsonObject>* DetObj = nullptr;
+    if (In->TryGetObjectField(TEXT("determinism"), DetObj))
+    {
+        (*DetObj)->TryGetBoolField(TEXT("pure"), OutSpec.Determinism.bPure);
+        const TArray<TSharedPtr<FJsonValue>>* Outs = nullptr;
+        if ((*DetObj)->TryGetArrayField(TEXT("declared_outputs"), Outs) && Outs)
+            for (const TSharedPtr<FJsonValue>& V : *Outs) OutSpec.Determinism.DeclaredOutputs.Add(V->AsString());
+        const TArray<TSharedPtr<FJsonValue>>* Effects = nullptr;
+        if ((*DetObj)->TryGetArrayField(TEXT("side_effects"), Effects) && Effects)
+            for (const TSharedPtr<FJsonValue>& V : *Effects) OutSpec.Determinism.SideEffects.Add(V->AsString());
+        FString Seed;
+        if ((*DetObj)->TryGetStringField(TEXT("seed_param"), Seed) && !Seed.IsEmpty())
+            OutSpec.Determinism.SeedParam = Seed;
+    }
+    return true;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+No UE-side runtime test framework is wired up in this plugin (verify by reading any existing `*Test*.cpp` — likely absent). Skip a separate test; the integration smoke in Task 13 covers the parser end-to-end.
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.h \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.cpp
+git commit -m "feat(slivers): C++ FHaybaSliverSpec + JSON parser (v1 param types)"
+```
+
+---
+
+### Task 6: UE — `FHaybaSliverLoader` (disk read)
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.cpp`
+
+- [ ] **Step 1: Header**
+
+```cpp
+// HaybaSliverLoader.h — Scans %APPDATA%/Hayba/slivers/*.sliver.json,
+// parses each one into FHaybaSliverSpec, exposes a flat list + lookup.
+// Cheap to refresh on demand (no watcher; the panel exposes a Refresh
+// button).
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Slivers/HaybaSliverTypes.h"
+
+class FHaybaSliverLoader
+{
+public:
+    /** %APPDATA%/Hayba/slivers on Windows, $HOME/.hayba/Hayba/slivers elsewhere. */
+    static FString DefaultUserSliversDir();
+
+    /** Reads + parses every *.sliver.json in UserDir. Replaces in-memory state. */
+    void Refresh(const FString& UserDir);
+
+    const TArray<FHaybaSliverSpec>& List() const { return Specs; }
+    const FHaybaSliverSpec* Find(const FString& Id) const;
+    const TArray<FString>& Errors() const { return LoadErrors; }
+
+private:
+    TArray<FHaybaSliverSpec> Specs;
+    TArray<FString> LoadErrors;
+};
+```
+
+- [ ] **Step 2: Implementation**
+
+```cpp
+// HaybaSliverLoader.cpp
+#include "Slivers/HaybaSliverLoader.h"
+
+#include "Dom/JsonObject.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+FString FHaybaSliverLoader::DefaultUserSliversDir()
+{
+#if PLATFORM_WINDOWS
+    FString Appdata = FPlatformMisc::GetEnvironmentVariable(TEXT("APPDATA"));
+    if (Appdata.IsEmpty()) Appdata = FPaths::ProjectSavedDir();
+    return FPaths::Combine(Appdata, TEXT("Hayba"), TEXT("slivers"));
+#else
+    FString Home = FPlatformMisc::GetEnvironmentVariable(TEXT("HOME"));
+    if (Home.IsEmpty()) Home = FPaths::ProjectSavedDir();
+    return FPaths::Combine(Home, TEXT(".hayba"), TEXT("Hayba"), TEXT("slivers"));
+#endif
+}
+
+void FHaybaSliverLoader::Refresh(const FString& UserDir)
+{
+    Specs.Reset();
+    LoadErrors.Reset();
+
+    if (!IFileManager::Get().DirectoryExists(*UserDir)) return;
+
+    TArray<FString> Files;
+    IFileManager::Get().FindFiles(Files, *FPaths::Combine(UserDir, TEXT("*.sliver.json")), /*Files*/true, /*Dirs*/false);
+
+    for (const FString& Name : Files)
+    {
+        const FString Full = FPaths::Combine(UserDir, Name);
+        FString Raw;
+        if (!FFileHelper::LoadFileToString(Raw, *Full))
+        { LoadErrors.Add(FString::Printf(TEXT("%s: failed to read"), *Name)); continue; }
+
+        TSharedPtr<FJsonObject> Obj;
+        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Raw);
+        if (!FJsonSerializer::Deserialize(Reader, Obj) || !Obj.IsValid())
+        { LoadErrors.Add(FString::Printf(TEXT("%s: invalid JSON"), *Name)); continue; }
+
+        FHaybaSliverSpec Spec;
+        FString Err;
+        if (!ParseHaybaSliverSpec(Obj.ToSharedRef(), Spec, Err))
+        { LoadErrors.Add(FString::Printf(TEXT("%s: %s"), *Name, *Err)); continue; }
+
+        Specs.Add(MoveTemp(Spec));
+    }
+}
+
+const FHaybaSliverSpec* FHaybaSliverLoader::Find(const FString& Id) const
+{
+    for (const FHaybaSliverSpec& S : Specs) if (S.Id == Id) return &S;
+    return nullptr;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.h \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.cpp
+git commit -m "feat(slivers): FHaybaSliverLoader reads %APPDATA%/Hayba/slivers"
+```
+
+---
+
+### Task 7: UE — `FHaybaSliverClient` HTTP client
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverClient.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverClient.cpp`
+
+- [ ] **Step 1: Header**
+
+```cpp
+// HaybaSliverClient.h — Thin HTTP client over the MCP server's
+// /sliver/run endpoint. Async: caller passes a completion delegate
+// fired on the game thread.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+DECLARE_DELEGATE_TwoParams(FHaybaSliverRunCallback, bool /*bOk*/, const FString& /*JsonResponseOrError*/);
+
+class FHaybaSliverClient
+{
+public:
+    /** POST /sliver/run with the given id + params (JSON-serialised). */
+    static void RunSliver(
+        const FString& BaseUrl,
+        const FString& Id,
+        const FString& ParamsJson,
+        FHaybaSliverRunCallback OnDone);
+};
+```
+
+- [ ] **Step 2: Implementation**
+
+```cpp
+// HaybaSliverClient.cpp
+#include "Slivers/HaybaSliverClient.h"
+
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+
+void FHaybaSliverClient::RunSliver(
+    const FString& BaseUrl,
+    const FString& Id,
+    const FString& ParamsJson,
+    FHaybaSliverRunCallback OnDone)
+{
+    const FString Url = BaseUrl + TEXT("/sliver/run");
+    const FString Body = FString::Printf(TEXT("{\"id\":\"%s\",\"params\":%s}"), *Id, *ParamsJson);
+
+    const TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Req = FHttpModule::Get().CreateRequest();
+    Req->SetVerb(TEXT("POST"));
+    Req->SetURL(Url);
+    Req->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+    Req->SetContentAsString(Body);
+
+    Req->OnProcessRequestComplete().BindLambda(
+        [OnDone](FHttpRequestPtr, FHttpResponsePtr Resp, bool bSucceeded)
+        {
+            if (!bSucceeded || !Resp.IsValid())
+            { OnDone.ExecuteIfBound(false, TEXT("HTTP request failed")); return; }
+            const int32 Code = Resp->GetResponseCode();
+            const FString Content = Resp->GetContentAsString();
+            OnDone.ExecuteIfBound(Code >= 200 && Code < 300, Content);
+        });
+    Req->ProcessRequest();
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverClient.h \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverClient.cpp
+git commit -m "feat(slivers): FHaybaSliverClient HTTP wrapper for /sliver/run"
+```
+
+---
+
+### Task 8: UE — `SSliverParamWidget` base + factory
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.cpp`
+
+- [ ] **Step 1: Header — abstract base + factory map**
+
+```cpp
+// SSliverParamWidget.h — Abstract base for every param widget. Each
+// concrete widget knows how to (a) render a Slate row for one param
+// and (b) report its current value back to the panel when Run is
+// pressed.
+//
+// Widgets register themselves at module startup via
+// FSliverParamWidgetRegistry::Register("float", &Make).
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Slivers/HaybaSliverTypes.h"
+
+class SSliverParamWidget : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamWidget) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs) { Param = InArgs._Param; }
+
+    /** JSON fragment for this param's current value: e.g. `12.5`, `"hello"`, `true`. */
+    virtual FString GetValueAsJson() const = 0;
+
+    const FHaybaSliverParam& GetParam() const { return Param; }
+
+protected:
+    FHaybaSliverParam Param;
+};
+
+class FSliverParamWidgetRegistry
+{
+public:
+    using FFactory = TFunction<TSharedRef<SSliverParamWidget>(const FHaybaSliverParam&)>;
+
+    static FSliverParamWidgetRegistry& Get();
+    void Register(EHaybaSliverParamType Type, FFactory Make);
+    TSharedRef<SSliverParamWidget> Create(const FHaybaSliverParam& Param) const;
+
+private:
+    TMap<EHaybaSliverParamType, FFactory> Factories;
+};
+
+/** Called once on module startup to register all built-in widgets. */
+void HaybaSliver_RegisterBuiltinParamWidgets();
+```
+
+- [ ] **Step 2: Implementation skeleton + an "unsupported" fallback widget**
+
+```cpp
+// SSliverParamWidget.cpp
+#include "Slivers/SSliverParamWidget.h"
+
+#include "Widgets/Text/STextBlock.h"
+
+namespace
+{
+    class SUnsupportedParamWidget : public SSliverParamWidget
+    {
+    public:
+        SLATE_BEGIN_ARGS(SUnsupportedParamWidget) {}
+            SLATE_ARGUMENT(FHaybaSliverParam, Param)
+        SLATE_END_ARGS()
+
+        void Construct(const FArguments& InArgs)
+        {
+            SSliverParamWidget::FArguments BaseArgs;
+            BaseArgs._Param = InArgs._Param;
+            SSliverParamWidget::Construct(BaseArgs);
+
+            ChildSlot
+            [
+                SNew(STextBlock).Text(FText::FromString(FString::Printf(
+                    TEXT("[unsupported param type: %s]"), *Param.OriginalTypeString)))
+            ];
+        }
+
+        virtual FString GetValueAsJson() const override { return TEXT("null"); }
+    };
+}
+
+FSliverParamWidgetRegistry& FSliverParamWidgetRegistry::Get()
+{
+    static FSliverParamWidgetRegistry Singleton;
+    return Singleton;
+}
+
+void FSliverParamWidgetRegistry::Register(EHaybaSliverParamType Type, FFactory Make)
+{
+    Factories.Add(Type, MoveTemp(Make));
+}
+
+TSharedRef<SSliverParamWidget> FSliverParamWidgetRegistry::Create(const FHaybaSliverParam& Param) const
+{
+    if (const FFactory* F = Factories.Find(Param.Type)) return (*F)(Param);
+    return SNew(SUnsupportedParamWidget).Param(Param);
+}
+```
+
+The `HaybaSliver_RegisterBuiltinParamWidgets` function is defined in Task 11 once all widgets exist.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.h \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.cpp
+git commit -m "feat(slivers): SSliverParamWidget base + factory registry + unsupported fallback"
+```
+
+---
+
+### Task 9: UE — Float + Int + Bool param widgets
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamFloat.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamFloat.cpp`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamInt.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamInt.cpp`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamBool.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamBool.cpp`
+
+- [ ] **Step 1: Float — `SSpinBox<float>` with min/max from `RangeMin/Max`**
+
+```cpp
+// SSliverParamFloat.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamFloat : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamFloat) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    float Value = 0.f;
+};
+```
+
+```cpp
+// SSliverParamFloat.cpp
+#include "Slivers/SSliverParamFloat.h"
+#include "Widgets/Input/SSpinBox.h"
+
+void SSliverParamFloat::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    Value = static_cast<float>(Param.DefaultNumber.Get(0.0));
+
+    auto Spin = SNew(SSpinBox<float>)
+        .Value_Lambda([this]() { return Value; })
+        .OnValueChanged_Lambda([this](float V) { Value = V; });
+    if (Param.RangeMin.IsSet()) Spin->SetMinValue(static_cast<float>(Param.RangeMin.GetValue()));
+    if (Param.RangeMax.IsSet()) Spin->SetMaxValue(static_cast<float>(Param.RangeMax.GetValue()));
+
+    ChildSlot [ Spin ];
+}
+
+FString SSliverParamFloat::GetValueAsJson() const
+{
+    return FString::SanitizeFloat(Value);
+}
+```
+
+- [ ] **Step 2: Int — same shape with `SSpinBox<int32>`**
+
+```cpp
+// SSliverParamInt.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamInt : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamInt) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    int32 Value = 0;
+};
+```
+
+```cpp
+// SSliverParamInt.cpp
+#include "Slivers/SSliverParamInt.h"
+#include "Widgets/Input/SSpinBox.h"
+
+void SSliverParamInt::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    Value = static_cast<int32>(Param.DefaultNumber.Get(0.0));
+
+    auto Spin = SNew(SSpinBox<int32>)
+        .Value_Lambda([this]() { return Value; })
+        .OnValueChanged_Lambda([this](int32 V) { Value = V; });
+    if (Param.RangeMin.IsSet()) Spin->SetMinValue(static_cast<int32>(Param.RangeMin.GetValue()));
+    if (Param.RangeMax.IsSet()) Spin->SetMaxValue(static_cast<int32>(Param.RangeMax.GetValue()));
+
+    ChildSlot [ Spin ];
+}
+
+FString SSliverParamInt::GetValueAsJson() const { return FString::FromInt(Value); }
+```
+
+- [ ] **Step 3: Bool — `SCheckBox`**
+
+```cpp
+// SSliverParamBool.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamBool : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamBool) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    bool bValue = false;
+};
+```
+
+```cpp
+// SSliverParamBool.cpp
+#include "Slivers/SSliverParamBool.h"
+#include "Widgets/Input/SCheckBox.h"
+
+void SSliverParamBool::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    bValue = Param.DefaultBool.Get(false);
+
+    ChildSlot
+    [
+        SNew(SCheckBox)
+        .IsChecked_Lambda([this]() { return bValue ? ECheckBoxState::Checked : ECheckBoxState::Unchecked; })
+        .OnCheckStateChanged_Lambda([this](ECheckBoxState S) { bValue = (S == ECheckBoxState::Checked); })
+    ];
+}
+
+FString SSliverParamBool::GetValueAsJson() const { return bValue ? TEXT("true") : TEXT("false"); }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamFloat.* \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamInt.* \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamBool.*
+git commit -m "feat(slivers): Float / Int / Bool Slate param widgets"
+```
+
+---
+
+### Task 10: UE — String + Enum + ActorRef param widgets
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamString.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamString.cpp`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamEnum.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamEnum.cpp`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamActorRef.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamActorRef.cpp`
+
+- [ ] **Step 1: String — `SEditableTextBox`**
+
+```cpp
+// SSliverParamString.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamString : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamString) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    FString Value;
+};
+```
+
+```cpp
+// SSliverParamString.cpp
+#include "Slivers/SSliverParamString.h"
+#include "Widgets/Input/SEditableTextBox.h"
+
+static FString JsonEscape(const FString& In)
+{
+    FString S = In;
+    S.ReplaceInline(TEXT("\\"), TEXT("\\\\"));
+    S.ReplaceInline(TEXT("\""), TEXT("\\\""));
+    S.ReplaceInline(TEXT("\n"), TEXT("\\n"));
+    S.ReplaceInline(TEXT("\r"), TEXT("\\r"));
+    S.ReplaceInline(TEXT("\t"), TEXT("\\t"));
+    return S;
+}
+
+void SSliverParamString::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    Value = Param.DefaultString.Get(FString());
+
+    ChildSlot
+    [
+        SNew(SEditableTextBox)
+        .Text_Lambda([this]() { return FText::FromString(Value); })
+        .OnTextChanged_Lambda([this](const FText& T) { Value = T.ToString(); })
+    ];
+}
+
+FString SSliverParamString::GetValueAsJson() const
+{
+    return FString::Printf(TEXT("\"%s\""), *JsonEscape(Value));
+}
+```
+
+- [ ] **Step 2: Enum — `SComboBox<TSharedPtr<FString>>`**
+
+```cpp
+// SSliverParamEnum.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+#include "Widgets/Input/SComboBox.h"
+
+class SSliverParamEnum : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamEnum) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    TArray<TSharedPtr<FString>> Options;
+    TSharedPtr<FString> Selected;
+};
+```
+
+```cpp
+// SSliverParamEnum.cpp
+#include "Slivers/SSliverParamEnum.h"
+#include "Widgets/Text/STextBlock.h"
+
+static FString JsonEscape2(const FString& In)
+{
+    FString S = In;
+    S.ReplaceInline(TEXT("\\"), TEXT("\\\\"));
+    S.ReplaceInline(TEXT("\""), TEXT("\\\""));
+    return S;
+}
+
+void SSliverParamEnum::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    for (const FHaybaSliverEnumOption& O : Param.EnumOptions)
+        Options.Add(MakeShared<FString>(O.Value));
+
+    const FString Def = Param.DefaultString.Get(Options.Num() > 0 ? *Options[0] : FString());
+    for (const TSharedPtr<FString>& Opt : Options) if (*Opt == Def) { Selected = Opt; break; }
+    if (!Selected.IsValid() && Options.Num() > 0) Selected = Options[0];
+
+    ChildSlot
+    [
+        SNew(SComboBox<TSharedPtr<FString>>)
+        .OptionsSource(&Options)
+        .OnGenerateWidget_Lambda([](TSharedPtr<FString> Item)
+        { return SNew(STextBlock).Text(FText::FromString(*Item)); })
+        .OnSelectionChanged_Lambda([this](TSharedPtr<FString> Item, ESelectInfo::Type)
+        { Selected = Item; })
+        .InitiallySelectedItem(Selected)
+        [
+            SNew(STextBlock).Text_Lambda([this]()
+            { return Selected.IsValid() ? FText::FromString(*Selected) : FText::GetEmpty(); })
+        ]
+    ];
+}
+
+FString SSliverParamEnum::GetValueAsJson() const
+{
+    if (!Selected.IsValid()) return TEXT("null");
+    return FString::Printf(TEXT("\"%s\""), *JsonEscape2(*Selected));
+}
+```
+
+- [ ] **Step 3: ActorRef — text box + "Pick from selection" button**
+
+```cpp
+// SSliverParamActorRef.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamActorRef : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamActorRef) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    FString Value;
+    FReply OnPickFromSelection();
+};
+```
+
+```cpp
+// SSliverParamActorRef.cpp
+#include "Slivers/SSliverParamActorRef.h"
+#include "Editor.h"
+#include "GameFramework/Actor.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+
+static FString JsonEscapeA(const FString& In)
+{
+    FString S = In;
+    S.ReplaceInline(TEXT("\\"), TEXT("\\\\"));
+    S.ReplaceInline(TEXT("\""), TEXT("\\\""));
+    return S;
+}
+
+void SSliverParamActorRef::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    Value = Param.DefaultString.Get(FString());
+
+    ChildSlot
+    [
+        SNew(SHorizontalBox)
+        + SHorizontalBox::Slot().FillWidth(1.0f).Padding(2)
+        [
+            SNew(SEditableTextBox)
+            .Text_Lambda([this]() { return FText::FromString(Value); })
+            .OnTextChanged_Lambda([this](const FText& T) { Value = T.ToString(); })
+        ]
+        + SHorizontalBox::Slot().AutoWidth().Padding(2)
+        [
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Pick from selection")))
+            .OnClicked(this, &SSliverParamActorRef::OnPickFromSelection)
+        ]
+    ];
+}
+
+FReply SSliverParamActorRef::OnPickFromSelection()
+{
+    if (!GEditor) return FReply::Handled();
+    TArray<AActor*> Sel;
+    GEditor->GetSelectedActors()->GetSelectedObjects<AActor>(Sel);
+    if (Sel.Num() > 0 && Sel[0]) Value = Sel[0]->GetPathName();
+    return FReply::Handled();
+}
+
+FString SSliverParamActorRef::GetValueAsJson() const
+{
+    return FString::Printf(TEXT("\"%s\""), *JsonEscapeA(Value));
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamString.* \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamEnum.* \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamActorRef.*
+git commit -m "feat(slivers): String / Enum / ActorRef Slate param widgets"
+```
+
+---
+
+### Task 11: UE — Register all built-in param widget factories
+
+**Files:**
+- Modify: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.cpp` (or add a new file `HaybaSliverParamWidgetRegistration.cpp`)
+
+- [ ] **Step 1: Implement `HaybaSliver_RegisterBuiltinParamWidgets`**
+
+Add at the end of `SSliverParamWidget.cpp`:
+
+```cpp
+#include "Slivers/SSliverParamFloat.h"
+#include "Slivers/SSliverParamInt.h"
+#include "Slivers/SSliverParamBool.h"
+#include "Slivers/SSliverParamString.h"
+#include "Slivers/SSliverParamEnum.h"
+#include "Slivers/SSliverParamActorRef.h"
+
+void HaybaSliver_RegisterBuiltinParamWidgets()
+{
+    FSliverParamWidgetRegistry& R = FSliverParamWidgetRegistry::Get();
+    R.Register(EHaybaSliverParamType::Float,    [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamFloat).Param(P); });
+    R.Register(EHaybaSliverParamType::Int,      [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamInt).Param(P); });
+    R.Register(EHaybaSliverParamType::Bool,     [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamBool).Param(P); });
+    R.Register(EHaybaSliverParamType::String,   [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamString).Param(P); });
+    R.Register(EHaybaSliverParamType::Enum,     [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamEnum).Param(P); });
+    R.Register(EHaybaSliverParamType::ActorRef, [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamActorRef).Param(P); });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.cpp
+git commit -m "feat(slivers): register built-in param widget factories"
+```
+
+---
+
+### Task 12: UE — `SSliverDetailPanel` (param widgets + Run + output)
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverDetailPanel.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverDetailPanel.cpp`
+
+- [ ] **Step 1: Header**
+
+```cpp
+// SSliverDetailPanel.h — Shows a single sliver: title, description,
+// generated param widgets, Run button, output text box.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Slivers/HaybaSliverTypes.h"
+#include "Slivers/SSliverParamWidget.h"
+#include "Widgets/SCompoundWidget.h"
+
+class SMultiLineEditableTextBox;
+
+class SSliverDetailPanel : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverDetailPanel) {}
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+
+    /** Switch the panel to display + run this spec. Resets all param widgets. */
+    void SetSpec(const FHaybaSliverSpec& InSpec);
+
+private:
+    FHaybaSliverSpec Spec;
+    TArray<TSharedRef<SSliverParamWidget>> ParamWidgets;
+    TSharedPtr<SMultiLineEditableTextBox> OutputBox;
+    TSharedPtr<class SVerticalBox> ParamBox;
+    TSharedPtr<class STextBlock> TitleText;
+    TSharedPtr<class STextBlock> DescriptionText;
+    bool bRunning = false;
+
+    FReply OnRunClicked();
+    FString BuildParamsJson() const;
+    void RebuildParamUI();
+};
+```
+
+- [ ] **Step 2: Implementation**
+
+```cpp
+// SSliverDetailPanel.cpp
+#include "Slivers/SSliverDetailPanel.h"
+
+#include "Slivers/HaybaSliverClient.h"
+#include "Slivers/HaybaSliverSettings.h"
+#include "Async/Async.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SMultiLineEditableTextBox.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+
+void SSliverDetailPanel::Construct(const FArguments& InArgs)
+{
+    ChildSlot
+    [
+        SNew(SVerticalBox)
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [ SAssignNew(TitleText, STextBlock) ]
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [ SAssignNew(DescriptionText, STextBlock) ]
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [ SAssignNew(ParamBox, SVerticalBox) ]
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Run")))
+            .OnClicked(this, &SSliverDetailPanel::OnRunClicked)
+        ]
+        + SVerticalBox::Slot().FillHeight(1.0f).Padding(4)
+        [
+            SNew(SBorder)
+            [
+                SAssignNew(OutputBox, SMultiLineEditableTextBox)
+                .IsReadOnly(true)
+                .Text(FText::FromString(TEXT("(no run yet)")))
+            ]
+        ]
+    ];
+}
+
+void SSliverDetailPanel::SetSpec(const FHaybaSliverSpec& InSpec)
+{
+    Spec = InSpec;
+    if (TitleText)       TitleText->SetText(FText::FromString(Spec.Title + TEXT("  (") + Spec.Id + TEXT(")")));
+    if (DescriptionText) DescriptionText->SetText(FText::FromString(Spec.Description));
+    if (OutputBox)       OutputBox->SetText(FText::FromString(TEXT("(no run yet)")));
+    RebuildParamUI();
+}
+
+void SSliverDetailPanel::RebuildParamUI()
+{
+    if (!ParamBox.IsValid()) return;
+    ParamBox->ClearChildren();
+    ParamWidgets.Reset();
+
+    for (const FHaybaSliverParam& P : Spec.Params)
+    {
+        TSharedRef<SSliverParamWidget> W = FSliverParamWidgetRegistry::Get().Create(P);
+        ParamWidgets.Add(W);
+
+        const FString LabelText = (!P.Label.IsEmpty() ? P.Label : P.Id) + (P.bRequired ? TEXT(" *") : TEXT(""));
+        ParamBox->AddSlot().AutoHeight().Padding(2)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().FillWidth(0.4f).VAlign(VAlign_Center)
+            [ SNew(STextBlock).Text(FText::FromString(LabelText)) ]
+            + SHorizontalBox::Slot().FillWidth(0.6f)
+            [ W ]
+        ];
+    }
+}
+
+FString SSliverDetailPanel::BuildParamsJson() const
+{
+    TArray<FString> Parts;
+    for (const TSharedRef<SSliverParamWidget>& W : ParamWidgets)
+    {
+        const FString Id = W->GetParam().Id;
+        FString Esc = Id; Esc.ReplaceInline(TEXT("\""), TEXT("\\\""));
+        Parts.Add(FString::Printf(TEXT("\"%s\":%s"), *Esc, *W->GetValueAsJson()));
+    }
+    return TEXT("{") + FString::Join(Parts, TEXT(",")) + TEXT("}");
+}
+
+FReply SSliverDetailPanel::OnRunClicked()
+{
+    if (bRunning) return FReply::Handled();
+    bRunning = true;
+    if (OutputBox) OutputBox->SetText(FText::FromString(TEXT("(running…)")));
+
+    const UHaybaSliverSettings* S = UHaybaSliverSettings::GetChecked();
+    const FString BaseUrl = S->McpHttpBaseUrl;
+    const FString Id = Spec.Id;
+    const FString ParamsJson = BuildParamsJson();
+
+    FHaybaSliverRunCallback OnDone = FHaybaSliverRunCallback::CreateLambda(
+        [this](bool bOk, const FString& Body)
+        {
+            AsyncTask(ENamedThreads::GameThread, [this, bOk, Body]()
+            {
+                bRunning = false;
+                if (OutputBox)
+                {
+                    OutputBox->SetText(FText::FromString(bOk ? Body : (TEXT("HTTP error:\n") + Body)));
+                }
+            });
+        });
+
+    FHaybaSliverClient::RunSliver(BaseUrl, Id, ParamsJson, OnDone);
+    return FReply::Handled();
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverDetailPanel.h \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverDetailPanel.cpp
+git commit -m "feat(slivers): SSliverDetailPanel — params, Run, output"
+```
+
+---
+
+### Task 13: UE — `SSliversPanel` (list + detail split) + tab registration
+
+**Files:**
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliversPanel.h`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliversPanel.cpp`
+- Create: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTabRegistration.cpp`
+- Modify: `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp` (call `HaybaSliver_RegisterTab` + `HaybaSliver_RegisterBuiltinParamWidgets` on StartupModule, unregister on ShutdownModule)
+
+- [ ] **Step 1: SSliversPanel header**
+
+```cpp
+// SSliversPanel.h — Top-level Slate panel: list of installed slivers
+// on the left, SSliverDetailPanel on the right.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Slivers/HaybaSliverLoader.h"
+#include "Slivers/SSliverDetailPanel.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/Views/SListView.h"
+
+class SSliversPanel : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliversPanel) {}
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+
+private:
+    FHaybaSliverLoader Loader;
+    TArray<TSharedPtr<FHaybaSliverSpec>> ListItems;
+    TSharedPtr<SListView<TSharedPtr<FHaybaSliverSpec>>> ListView;
+    TSharedPtr<SSliverDetailPanel> DetailPanel;
+
+    void Refresh();
+    FReply OnRefreshClicked() { Refresh(); return FReply::Handled(); }
+    TSharedRef<ITableRow> OnGenerateRow(TSharedPtr<FHaybaSliverSpec> Item, const TSharedRef<STableViewBase>& Owner);
+    void OnSelectionChanged(TSharedPtr<FHaybaSliverSpec> Item, ESelectInfo::Type);
+};
+```
+
+- [ ] **Step 2: SSliversPanel implementation**
+
+```cpp
+// SSliversPanel.cpp
+#include "Slivers/SSliversPanel.h"
+
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Layout/SSplitter.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Views/STableRow.h"
+
+void SSliversPanel::Construct(const FArguments& InArgs)
+{
+    ChildSlot
+    [
+        SNew(SVerticalBox)
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().AutoWidth().Padding(2)
+            [
+                SNew(SButton)
+                .Text(FText::FromString(TEXT("Refresh")))
+                .OnClicked(this, &SSliversPanel::OnRefreshClicked)
+            ]
+            + SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center).Padding(8, 0)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("Slivers (deterministic abstractions)")))
+            ]
+        ]
+        + SVerticalBox::Slot().FillHeight(1.0f)
+        [
+            SNew(SSplitter)
+            + SSplitter::Slot().Value(0.3f)
+            [
+                SAssignNew(ListView, SListView<TSharedPtr<FHaybaSliverSpec>>)
+                .ListItemsSource(&ListItems)
+                .OnGenerateRow(this, &SSliversPanel::OnGenerateRow)
+                .OnSelectionChanged(this, &SSliversPanel::OnSelectionChanged)
+                .SelectionMode(ESelectionMode::Single)
+            ]
+            + SSplitter::Slot().Value(0.7f)
+            [
+                SAssignNew(DetailPanel, SSliverDetailPanel)
+            ]
+        ]
+    ];
+
+    Refresh();
+}
+
+void SSliversPanel::Refresh()
+{
+    Loader.Refresh(FHaybaSliverLoader::DefaultUserSliversDir());
+    ListItems.Reset();
+    for (const FHaybaSliverSpec& S : Loader.List())
+        ListItems.Add(MakeShared<FHaybaSliverSpec>(S));
+    if (ListView) ListView->RequestListRefresh();
+}
+
+TSharedRef<ITableRow> SSliversPanel::OnGenerateRow(TSharedPtr<FHaybaSliverSpec> Item, const TSharedRef<STableViewBase>& Owner)
+{
+    const FString DisplayText = Item.IsValid()
+        ? FString::Printf(TEXT("%s   [%s]"), *Item->Title, *Item->Category)
+        : FString();
+    return SNew(STableRow<TSharedPtr<FHaybaSliverSpec>>, Owner)
+        [ SNew(STextBlock).Text(FText::FromString(DisplayText)) ];
+}
+
+void SSliversPanel::OnSelectionChanged(TSharedPtr<FHaybaSliverSpec> Item, ESelectInfo::Type)
+{
+    if (Item.IsValid() && DetailPanel) DetailPanel->SetSpec(*Item);
+}
+```
+
+- [ ] **Step 3: Tab registration**
+
+```cpp
+// HaybaSliverTabRegistration.cpp — Registers the Slivers nomad tab and
+// the Window menu entry. Public callable: HaybaSliver_RegisterTab() /
+// HaybaSliver_UnregisterTab().
+
+#include "Slivers/SSliversPanel.h"
+
+#include "Framework/Application/SlateApplication.h"
+#include "Framework/Docking/TabManager.h"
+#include "Widgets/Docking/SDockTab.h"
+#include "WorkspaceMenuStructure.h"
+#include "WorkspaceMenuStructureModule.h"
+
+static const FName SliversTabName(TEXT("HaybaSlivers"));
+
+static TSharedRef<SDockTab> SpawnSliversTab(const FSpawnTabArgs&)
+{
+    return SNew(SDockTab)
+        .TabRole(ETabRole::NomadTab)
+        .Label(NSLOCTEXT("HaybaSlivers", "TabLabel", "Slivers"))
+        [
+            SNew(SSliversPanel)
+        ];
+}
+
+void HaybaSliver_RegisterTab()
+{
+    FGlobalTabmanager::Get()->RegisterNomadTabSpawner(SliversTabName, FOnSpawnTab::CreateStatic(&SpawnSliversTab))
+        .SetDisplayName(NSLOCTEXT("HaybaSlivers", "TabTitle", "Slivers"))
+        .SetTooltipText(NSLOCTEXT("HaybaSlivers", "TabTooltip", "Hayba Slivers — deterministic abstractions"))
+        .SetGroup(WorkspaceMenu::GetMenuStructure().GetToolsCategory());
+}
+
+void HaybaSliver_UnregisterTab()
+{
+    if (FSlateApplication::IsInitialized())
+        FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(SliversTabName);
+}
+```
+
+- [ ] **Step 4: Wire startup/shutdown in `HaybaMCPModule.cpp`**
+
+Read `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp`. Find `StartupModule()` and `ShutdownModule()`. At the bottom of `StartupModule`, add:
+
+```cpp
+extern void HaybaSliver_RegisterTab();
+extern void HaybaSliver_RegisterBuiltinParamWidgets();
+HaybaSliver_RegisterBuiltinParamWidgets();
+HaybaSliver_RegisterTab();
+```
+
+At the top of `ShutdownModule`, add:
+
+```cpp
+extern void HaybaSliver_UnregisterTab();
+HaybaSliver_UnregisterTab();
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliversPanel.h \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliversPanel.cpp \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTabRegistration.cpp \
+        unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp
+git commit -m "feat(slivers): SSliversPanel + Window → Slivers tab registration"
+```
+
+---
+
+### Task 14: End-to-end smoke verification
+
+**Files:** none (manual verification — record results in PR description)
+
+- [ ] **Step 1: TS-side smoke**
+
+```bash
+cd mcp-tools/hayba-mcp && npm run build:server
+node dist/index.js &
+sleep 1
+curl -s http://127.0.0.1:3091/sliver/list
+curl -s -X POST http://127.0.0.1:3091/sliver/run \
+  -H 'content-type: application/json' \
+  -d '{"id":"com.hayba.composition.frame_target","params":{"target":"/Game/X.X","distance":12,"height":1.5,"fov":60,"yaw_deg":30}}'
+kill %1
+```
+
+Expect: list returns frame_target; run returns `"ok":true` with a `camera_transform`.
+
+- [ ] **Step 2: UE-side smoke (manual, requires the user)**
+
+Document the steps in the PR body for the user to perform:
+
+1. Open Unreal Editor on the live geoforge project. When prompted "Modules out of date, rebuild?" — click Yes.
+2. Start the MCP server (it must be running for the panel to talk to it): the user runs Claude Code as normal, which spawns `hayba-mcp`.
+3. In the editor: `Window → Slivers`. The Slivers panel appears as a dock tab.
+4. The left list shows `Frame Target  [composition]`. Click it.
+5. The right pane shows: title, description, five labelled rows (target text+button, distance spinner, height spinner, fov spinner, yaw_deg spinner).
+6. Pick any actor in the level → click "Pick from selection" → the `target` text field fills with its path.
+7. Drag the `distance` spinner to 15. Drag `yaw_deg` to 90.
+8. Click Run. The output text box shows the JSON response (`ok: true`, `camera_transform.location` approximately `[0, 1500, 200]`, `fov: 70`).
+
+- [ ] **Step 3: Commit nothing** (manual verification — no diff)
+
+---
+
+### Task 15: Push branch + open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/slivers-b-ue-ui
+```
+
+(Create the branch before any code work: `git checkout -b feat/slivers-b-ue-ui` from main or from the merged Plan A tip.)
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base main --head feat/slivers-b-ue-ui \
+  --title "Slivers v1 plan B: UE Slivers tab + HTTP routes" \
+  --body "$(cat <<'EOF'
+## Summary
+- New Slate dockable tab `Window → Slivers` listing every installed sliver and rendering its param widgets.
+- Six param widgets shipped: Float, Int, Bool, String, Enum, ActorRef (covers frame_target and the time_of_day to-be-shipped in Plan C).
+- New MCP-server HTTP endpoint on 127.0.0.1:3091 with /sliver/{list,get,run,import}; UE plugin posts to /sliver/run.
+- C++-side sliver spec parser + loader + HTTP client wired in.
+- UHaybaSliverSettings (Project Settings → Plugins → Hayba Slivers) for the MCP URL + RunMode + MaxSliverDepth.
+
+Implements Plan B of the Slivers v1 spec
+(docs/superpowers/specs/2026-05-21-slivers-design.md). Builds on Plan A
+(#217). Plan C (time_of_day + lighting handler) is next.
+
+## Scope cuts deferred to v2
+- AutoDebounced run mode (Manual only in v1)
+- Save preset
+- Rich output preview (raw JSON in v1)
+- Vector3 / Color / Transform / AssetRef widgets
+- Live disk-watcher (manual Refresh button only)
+
+## Test plan
+- [x] vitest src/http/sliver-routes.test.ts — 6/6 green
+- [x] node dist/index.js starts the HTTP listener on 127.0.0.1:3091
+- [x] curl /sliver/list returns frame_target
+- [x] curl /sliver/run returns ok:true with camera_transform
+- [ ] Editor rebuilds modules cleanly on first launch
+- [ ] Window → Slivers opens the panel
+- [ ] Clicking Frame Target shows 5 param widgets
+- [ ] Pick from selection fills the target field
+- [ ] Run posts to the MCP server and shows the JSON response
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+
+| Spec section | Covered by |
+|---|---|
+| UE plugin Slivers tab | Tasks 12, 13 |
+| Left rail grouped (by category) | Task 13 lists by title + category column; full grouping deferred |
+| Generic widget renderer per `params[]` | Tasks 8-11 (factory + 6 widgets) |
+| Per-project settings (`SliverRunMode`, `MaxSliverDepth`) | Task 4 |
+| Save preset → sibling `.preset.json` | Deferred (documented) |
+| MCP execution path | Tasks 1-2 (HTTP routes) + Task 7 (UE client) + Task 12 (Run button wiring) |
+| actor_ref scene picker | Task 10 ("Pick from selection" simplified) |
+| asset_ref Content Browser picker | Deferred |
+
+**Out-of-scope items correctly deferred:**
+- Vector3 / Color / Transform / AssetRef widgets (post-mortem #1 + future slivers will need them — v2)
+- AutoDebounced run mode (needs FTSTicker + a debounce primitive — small but additive)
+- Live disk watcher (FDirectoryWatcher; nice-to-have, not blocker)
+- Output rich preview (per-sliver result type; v2 builds on JSON)
+
+**Placeholder scan:** Every code step contains the actual code, every command has expected output, no TBDs.
+
+**Type consistency:** `EHaybaSliverParamType` enum values match the JSON `type` strings (`float` / `int` / etc.) consistently from parser (Task 5) through factory keys (Task 8) through registrations (Task 11). `GetValueAsJson()` is the same virtual signature across all six widget tasks. `UHaybaSliverSettings::McpHttpBaseUrl` is the single source consumed by `SSliverDetailPanel::OnRunClicked` via `FHaybaSliverClient::RunSliver`.
+
+**Cross-plan consistency:** All routes added in Tasks 1-2 are read by URLs Tasks 7+12 use. The bundled `frame_target` spec from Plan A is what the loader (Task 6) finds and the panel (Task 13) lists.

--- a/docs/superpowers/specs/2026-05-21-cognitive-map-tag-grouping-design.md
+++ b/docs/superpowers/specs/2026-05-21-cognitive-map-tag-grouping-design.md
@@ -1,0 +1,162 @@
+# Cognitive Map — Tag-Based Grouping & Color Coding
+
+**Date:** 2026-05-21
+**Status:** Approved (brainstorm)
+**Touches:** `mcp-tools/hayba-mcp`, `unreal/HaybaMCPToolkit`
+
+## Problem
+
+The Cognitive Map web view (`HaybaMCPSceneMapWebPanel` + `Resources/cognitive-map/index.html`) groups scene cells by a hardcoded `Semantic` enum derived from substring matches on cell labels (`"tree" → forest`, `"building" → urban`). Two failures:
+
+1. **No tags surface in the UI.** Cells render as plain circles with no chips, no per-cell tag readout.
+2. **Grouping is wrong.** The substring heuristic produces broken hubs — a lantern goes to `Light` instead of joining the `maritime/dock/props` cluster it actually belongs to.
+
+## Goal
+
+Replace semantic-enum-driven grouping with **actor-tag-driven grouping**, and surface tags directly on each cell as colored chips. Color is deterministic per tag so blue = `maritime` across sessions; recognition becomes free after a few uses.
+
+## Architecture
+
+Three small additions across the existing pipeline — no new processes, no new IPC.
+
+```
+[MCP server reindex] ── writes ──> ~/.hayba/cache/retriever-tags.json
+                                        │
+                                        │ loaded on first scene-map build
+                                        ▼
+[UE scene-map builder]  reads ──> FHaybaTagIndex (assetPath → tags[])
+                                        │
+                                        │ aggregates per cell (UE Tags first, retriever fallback)
+                                        ▼
+[FHaybaCogMapCell.Tags] ── JSON ──> Resources/cognitive-map/index.html
+                                        │
+                                        │ tag-overrides.json + deterministic hash
+                                        ▼
+                              cell fill color + tag chip strip
+```
+
+### Tag source priority (UE Tags first, retriever fallback)
+
+For each actor in a cell:
+1. Read `Actor->Tags` (UE built-in `TArray<FName>`). If non-empty, use it.
+2. Else lookup the actor's source asset path in `FHaybaTagIndex`. If found, use its tags.
+3. Else contribute no tags.
+
+Aggregation per cell: count tag frequency across all actors, keep top 5 sorted by count (ties broken alphabetically for determinism).
+
+### Color resolution
+
+```
+colorForTag(tag):
+    if tag in tagOverrides:   return tagOverrides[tag]
+    hue = fnv1a32(tag) % 360
+    return hsl(hue, 55%, 55%)
+```
+
+- `tag-overrides.json` ships with ~15 hand-pinned mappings for the most common worldbuilding tags so they don't drift onto visually-similar hues. Example entries: `maritime → hsl(210, 60%, 50%)`, `foliage → hsl(120, 50%, 45%)`, `urban → hsl(280, 30%, 55%)`.
+- Cells with zero tags render in muted gray (`hsl(0, 0%, 60%)`).
+
+### Cell rendering
+
+- **Fill:** `colorForTag(cell.tags[0])` — the mode tag (most common).
+- **Chip strip:** rendered below the circle as up to 5 small filled dots (radius 3px) + text label visible on hover. Chip color uses the same `colorForTag` resolver, so a cell with mixed tags shows its mode color and the chip dots reveal the mix.
+- **Hub anchors:** the force-layout's clustering "anchor" nodes are now keyed by tag string instead of the old `Semantic` enum value. Cells with the same mode tag gravitate to the same hub.
+
+## Components / file plan
+
+| File | Status | Purpose |
+|---|---|---|
+| `mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.ts` | new (~20 lines) | After indexing, write `~/.hayba/cache/retriever-tags.json` as `{ "<assetPath>": ["<tag1>", ...] }` |
+| `mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.test.ts` | new | vitest: snapshot writer correctness + stable ordering |
+| `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.h` | new | C++ class wrapping the on-disk snapshot, lazy-loaded |
+| `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.cpp` | new | Loader + `Lookup(assetPath) → TArray<FString>` |
+| `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapData.h` | modify | Add `TArray<FString> Tags` to `FHaybaCogMapCell` |
+| `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapBuilder.cpp` (or equivalent) | modify | Per-actor tag aggregation; serialize `tags` into the JSON payload |
+| `unreal/HaybaMCPToolkit/Resources/cognitive-map/tag-overrides.json` | new | ~15 hand-pinned `{tag: hsl}` entries |
+| `unreal/HaybaMCPToolkit/Resources/cognitive-map/index.html` | modify | Load overrides, implement `colorForTag()`, render chip strips, re-key hubs by tag |
+
+Snapshot path resolution in the UE plugin: `FPlatformProcess::UserHomeDir() / ".hayba/cache/retriever-tags.json"` (Windows: `%USERPROFILE%\.hayba\cache\retriever-tags.json`).
+
+## Data shapes
+
+### Snapshot file (`~/.hayba/cache/retriever-tags.json`)
+
+```json
+{
+  "/Game/Maritime/SM_Anchor": ["maritime", "metal", "rusted", "anchor"],
+  "/Game/Foliage/SM_Pine": ["foliage", "tree", "conifer", "outdoor"]
+}
+```
+
+Sorted keys for diff-friendliness. Tags array preserves the order returned by the indexer.
+
+### Updated `FHaybaCogMapCell` JSON
+
+```json
+{
+  "bounds": {"min": [x, y], "max": [x, y]},
+  "label": "dense_forest_zone_A",
+  "count": 47,
+  "dominant": ["BP_Tree_Pine", "BP_Grass_Cluster"],
+  "semantic": "Foliage",
+  "tags": ["foliage", "tree", "outdoor", "natural", "vegetation"]
+}
+```
+
+The legacy `semantic` field stays — keeps the fallback path working and avoids breaking any client that already reads it.
+
+### `tag-overrides.json`
+
+```json
+{
+  "maritime":   "hsl(210, 60%, 50%)",
+  "foliage":    "hsl(120, 50%, 45%)",
+  "urban":      "hsl(280, 30%, 55%)",
+  "light":      "hsl(50, 75%, 60%)",
+  "character":  "hsl(15, 65%, 55%)",
+  "vehicle":    "hsl(0, 60%, 50%)",
+  "interior":   "hsl(30, 40%, 50%)",
+  "industrial": "hsl(200, 20%, 45%)",
+  "natural":    "hsl(95, 45%, 50%)",
+  "rock":       "hsl(25, 25%, 45%)",
+  "water":      "hsl(195, 70%, 55%)",
+  "sky":        "hsl(220, 70%, 70%)",
+  "tech":       "hsl(180, 55%, 50%)",
+  "magic":      "hsl(290, 70%, 60%)",
+  "weapon":     "hsl(355, 50%, 45%)"
+}
+```
+
+15 entries; editable. Anything outside this map gets a deterministic hash-derived hue.
+
+## Error handling
+
+- **Snapshot file missing** → log a single warning, fall back to the existing semantic-enum coloring. No regression — the panel just looks the way it did before this work.
+- **Snapshot malformed JSON** → same fallback, error logged.
+- **Cell with zero tags after aggregation** → muted gray fill, no chips, no hub anchor (cell drifts free in the layout).
+- **Stale snapshot** (assets reindexed but plugin not restarted) → no detection in v1; the user re-runs the reindex tool and reopens the panel when groups feel wrong.
+
+## Testing
+
+- **TS:** vitest on `tag-snapshot.ts` — writes correct shape, stable key ordering, idempotent on re-run.
+- **C++:** no test framework in the plugin; rely on integration smoke per existing convention.
+- **Visual (manual):** capture before/after screenshots on a known scene with three categories (forest / maritime / mixed). Verify:
+  1. Tag chips render under cells
+  2. Same tag has same color across cells
+  3. Hubs form by tag, not by hardcoded semantic
+  4. Cells with no tags render gray and don't anchor to any hub
+
+## Out of scope (deferred)
+
+- Tag filter/search UI on the webview
+- Click-tag-to-isolate behavior
+- Hand-pinned override editor inside UE (v1 = edit the JSON directly)
+- Stale-snapshot detection (file mtime check + auto-reload)
+- Per-tag legend panel — overrides are static, so a legend isn't strictly needed; can land in v2
+
+## Non-goals
+
+- Replacing the force-layout algorithm
+- Changing the cell-extraction logic (which actors get bucketed into which cell)
+- Restructuring `FHaybaCogMapCell` beyond the one new field
+- Touching the asset retriever's indexing logic (we only add a small write step at the end)

--- a/docs/superpowers/specs/2026-05-21-slivers-design.md
+++ b/docs/superpowers/specs/2026-05-21-slivers-design.md
@@ -1,0 +1,264 @@
+# Slivers — User-Authorable Deterministic Abstractions
+
+**Status:** Draft v1
+**Date:** 2026-05-21
+**Owner:** saracensaray
+**Related:** Gemini three-layer architecture (Layer 2 — Deterministic Abstraction); `.scratch/mcp-architectural-issues.md` items #8, #9, #10, #11, #12
+
+## Problem
+
+The Hayba MCP toolkit ships verified plumbing for Layer 2 (`wait_for_idle`, `render_camera`) but no Layer 2 *primitives*. Gemini's architectural guidance is explicit: the LLM must never emit raw coordinates, fluid dynamics, or geometric intersections — it must emit bounded parameters that deterministic compiled code resolves. We have nothing in that shape today.
+
+Building one-off C++ tools for every Layer 2 need (PCG diff, ASP constraint, lighting preset, frame_target, time_of_day, …) scales linearly with the design space. We need a **container format** that lets us ship many deterministic abstractions cheaply, with a consistent LLM-facing schema and a consistent user-facing tuning UI.
+
+## Concept: Slivers
+
+A **Sliver** is a small, parameterized, deterministic abstraction with:
+
+- A declared parameter schema (the dials the user/LLM can turn)
+- A deterministic executor (the code that consumes params and produces output)
+- A declared determinism contract (purity, declared outputs, declared side effects)
+- A generic slider/widget UI rendered in the UE plugin Details panel
+- A portable JSON spec that's shareable as a single file
+
+The LLM emits intent ("frame the hero from above"); the user (or the LLM) selects a sliver and provides params; the sliver's deterministic executor produces the result. Sliders let the human close the spatial-reasoning gap LLMs can't.
+
+This is the operational form of Voyager's "executable skill library" cited by Gemini, adapted for an in-editor MCP context.
+
+## Goals
+
+- One container format covers every Layer 2 category we'll ship (composition, lighting, PCG diff, sim params, ASP constraint, visibility queries, executable skills).
+- Adding a new category = new TS executor module + new param-widget registration. No new UI framework, no new tool wiring per sliver.
+- A sliver is shareable as a single JSON file. Importable from local path or URL. No registry server.
+- The LLM's discovery surface stays small — sliver tooling lives in `ALWAYS_ON_META` (4 tools) and slivers themselves are discovered via `hayba_sliver_list`, not by registering each as an MCP tool.
+- Determinism is documented and conventional in v1, with a path to verifier-enforced determinism in v2.
+
+## Non-goals (v1)
+
+- No node editor. Slivers are authored as JSON + TS. The "graph" of sliver-calls-sliver is implicit in code, not visual.
+- No public registry/database. Sharing is file + URL + optional GitHub blessed-slivers repo (deferred).
+- No AI authoring loop (`sliver_draft`). Hand-authored only in v1.
+- No sandbox / determinism enforcement. Convention only.
+- No per-sliver MCP tool registration. All sliver execution flows through `hayba_sliver_run`.
+
+## Architecture
+
+### Identity & namespacing
+
+Sliver IDs are **reverse-DNS** strings, e.g. `com.hayba.composition.frame_target`, `com.saracensaray.world.coastal_town`.
+
+- Eliminates collision risk on URL import from untrusted authors.
+- The `com.hayba.*` namespace is reserved for core/blessed slivers.
+- Community slivers use the author's chosen domain or handle namespace.
+- IDs are case-sensitive and use lowercase + dots.
+
+### Storage layout
+
+```
+%APPDATA%\Hayba\slivers\
+  com.hayba.composition.frame_target.sliver.json
+  com.hayba.composition.frame_target.preset.json   (optional, per-sliver saved presets)
+  com.hayba.lighting.time_of_day.sliver.json
+  com.saracensaray.world.coastal_town.sliver.json
+```
+
+Per-user, cross-project. The UE plugin and MCP server both read from this directory.
+
+TS executors ship inside the MCP server:
+
+```
+mcp-tools/hayba-mcp/src/slivers/
+  registry.ts                          # category → executor lookup
+  types.ts                             # SliverSpec, SliverParam, SliverOutput, etc.
+  runtime.ts                           # runSliver(id, params) → output (with cycle detection)
+  loader.ts                            # reads %APPDATA%\Hayba\slivers\*.sliver.json
+  composition/
+    frame_target.ts
+  lighting/
+    time_of_day.ts
+```
+
+Each TS executor registers itself with the runtime against an `executor.kind` string. The JSON spec is the LLM/UI-facing contract; the TS is the implementation. Loading a sliver whose `executor.kind` isn't registered yields a clear error at list/run time.
+
+### Sliver JSON spec v1
+
+```jsonc
+{
+  "id": "com.hayba.composition.frame_target",
+  "version": "1.0.0",
+  "category": "composition",
+  "title": "Frame Target",
+  "description": "Compute a camera transform that frames an actor from a given orbit angle, distance, and height offset.",
+  "author": "core",
+
+  "params": [
+    {
+      "id": "target",
+      "type": "actor_ref",
+      "label": "Target",
+      "required": true
+    },
+    {
+      "id": "distance",
+      "type": "float",
+      "label": "Distance (m)",
+      "range": [1, 100],
+      "default": 10
+    },
+    {
+      "id": "height",
+      "type": "float",
+      "label": "Height offset (m)",
+      "range": [-10, 50],
+      "default": 2
+    },
+    {
+      "id": "fov",
+      "type": "float",
+      "label": "Field of view (deg)",
+      "range": [20, 120],
+      "default": 70
+    },
+    {
+      "id": "yaw_deg",
+      "type": "float",
+      "label": "Orbit angle (deg)",
+      "range": [0, 360],
+      "default": 45
+    }
+  ],
+
+  "executor": {
+    "kind": "composition.frame_target"
+  },
+
+  "determinism": {
+    "pure": true,
+    "declared_outputs": ["camera_transform"],
+    "side_effects": [],
+    "seed_param": null
+  }
+}
+```
+
+### Param types (v1)
+
+| Type | Widget | Notes |
+|---|---|---|
+| `float` | slider | `range: [min, max]`, optional `step` |
+| `int` | slider | integer step |
+| `bool` | checkbox | |
+| `string` | text input | optional `maxLength` |
+| `enum` | dropdown | `options: [{value, label}]` |
+| `color` | color picker | sRGB hex string in/out |
+| `actor_ref` | scene actor picker (UE-side) | optional `class_filter` |
+| `asset_ref` | Content Browser picker (UE-side) | optional `class_filter` |
+| `vector3` | three-float widget | optional `range` per axis |
+| `transform` | location + rotation + scale composite widget | |
+
+Adding a param type = (1) extend the discriminated union in `types.ts`, (2) add a widget in the UE plugin Details panel, (3) document. This is the explicit extensibility seam.
+
+### Determinism contract
+
+A sliver declares:
+
+- `pure: bool` — true means same params → same output, no observable side effects. False means it mutates editor state (spawns actors, changes lighting, etc.).
+- `declared_outputs: string[]` — names of fields the executor returns. The runtime validates the executor's return value matches this set.
+- `side_effects: string[]` — vocabulary of declared mutations: `actor_spawn`, `actor_modify`, `asset_load`, `asset_create`, `lighting_change`, `pcg_generate`, etc. Used by the future dependency-DAG.
+- `seed_param: string | null` — name of the param that seeds any RNG. If non-null, the runtime requires the executor to be deterministic given the same seed.
+
+V1 is **convention only** — we document, we don't enforce. Trust authors; rely on social review for blessed slivers. V2 ships `hayba_sliver_verify` that re-runs with the same params and diffs outputs.
+
+### Composability (sliver calls sliver)
+
+A TS executor is an `async (params) => output` function. It can `await runSliver(id, params)` to compose primitives. Example: a hypothetical `com.hayba.world.coastal_town` executor might call `com.hayba.lighting.time_of_day` internally to pin the lighting for its preview render.
+
+Guardrails:
+
+- **Cycle detection** via per-invocation call stack (Set of IDs). Throws `SliverCycleError` if a sliver re-enters its own call stack.
+- **Max depth** = 8 by default. Configurable via UE plugin setting `MaxSliverDepth`.
+- **Output binding** — callers consume outputs by name from `declared_outputs[]`. Schema mismatch throws at runtime.
+- **Side-effect aggregation** — the runtime accumulates `side_effects[]` across the call tree and returns them in the top-level result, so the caller can see what was actually touched.
+
+Sliver-to-sliver edges form the foundation of the dependency-DAG (phase 3): the runtime can record these edges, and downstream dirty-flag propagation can walk them.
+
+### MCP tool surface
+
+Four tools added to `ALWAYS_ON_META` (joining the existing 10):
+
+| Tool | Signature | Behavior |
+|---|---|---|
+| `hayba_sliver_list` | `{ category?, namespace? }` → `{ slivers: [{id, title, category, version}] }` | Lists installed slivers from `%APPDATA%\Hayba\slivers\`. Optional filters. |
+| `hayba_sliver_get` | `{ id }` → `{ spec, last_params? }` | Full JSON spec + most-recently-used param values if any. |
+| `hayba_sliver_run` | `{ id, params }` → `{ ok, outputs, side_effects, durationMs, error? }` | Validates params against spec, dispatches to executor, returns outputs. |
+| `hayba_sliver_import` | `{ source: file_path \| url }` → `{ id, installed }` | Fetches, validates against JSON schema, installs to `%APPDATA%\Hayba\slivers\`. |
+
+Slivers themselves are **not** registered as MCP tools — the LLM discovers them via `hayba_sliver_list` and invokes via `hayba_sliver_run`. This keeps the LLM's tool surface bounded regardless of how many slivers exist.
+
+### UE plugin — Slivers tab
+
+New tab in the existing Hayba Details panel:
+
+- **Left rail:** installed slivers, grouped by category (collapsible)
+- **Right pane:** selected sliver — title, description, generated param widgets (one per `params[]` entry), "Run" button, last-run output preview
+- **Preset row:** "Save preset" writes `<sliver_id>.preset.json` next to the spec; "Load preset" dropdown lists saved presets
+- **Settings (plugin settings panel, not per-sliver):**
+  - `SliverRunMode: Manual | AutoDebounced250ms`
+  - `MaxSliverDepth: int (default 8)`
+
+Auto-debounced mode re-runs the sliver 250ms after the last slider change. Manual requires "Run" click. Per-project setting; lets users opt into the live feel for cheap slivers and opt out for heavy ones (full tectonics re-runs).
+
+### Sharing — v1 mechanics, v2 ecosystem
+
+V1:
+
+- A sliver is a single `.sliver.json` file. Self-contained, copy-paste-able, attach-to-email-able.
+- `hayba_sliver_import` accepts a local path or URL. URL import validates schema before installing and warns on first import per author: *"This sliver will execute on your machine. Source: <url>. Author: <id>. Proceed?"*
+- Trust model is social, not platform — same as installing a UE plugin. No sandbox claim.
+
+V2 (deferred):
+
+- A `blessed-slivers` GitHub repo bundled with the toolkit. Pull requests = de facto review.
+- Optional manifest with `dependencies: [other sliver IDs]` for slivers that compose others.
+- Possible registry server if the social/git model proves insufficient.
+
+## V1 categories and shipped slivers
+
+| Category | First sliver | Executor | Determinism |
+|---|---|---|---|
+| `composition` | `com.hayba.composition.frame_target` | Computes camera transform from actor bounds + orbit + distance + height + FOV. Pure math, returns `camera_transform`. | `pure: true` |
+| `lighting` | `com.hayba.lighting.time_of_day` | Atomic update of DirectionalLight angle + intensity, SkyLight intensity, SkyAtmosphere sun rotation, ExpHeightFog scattering, PostProcess exposure compensation, from a single `time_of_day: [0..1]` param. | `pure: false`, `side_effects: ['lighting_change']` |
+
+These two prove the format generalizes (one pure return-value sliver, one mutating side-effect sliver) without hand-wave.
+
+## Phase plan
+
+1. **v1 ship (this design):** runtime + JSON spec + UE Slivers tab + 4 MCP tools + `frame_target` + `time_of_day`. One PR.
+2. `pcg_diff` category — Gemini's headline Layer 2 primitive. PCG graph param overrides via JSON patch.
+3. Dependency-DAG + dirty-flag — leverages the sliver-call graph already being recorded by the runtime.
+4. `sim_params` category — `tectonics_init` sliver, pairs with the in-flight baking-pipeline rework.
+5. `com.hayba.sliver_draft` AI authoring tool — LLM generates draft slivers from intent, saves to `%APPDATA%\Hayba\slivers\draft\` for user promotion.
+6. `visibility` category — `is_visible`, `frustum_query`. Composes naturally with `composition`.
+7. `asp_constraint` category — heaviest swing. ASP solver for urban/cultural layouts.
+8. URL import polish + blessed-slivers GitHub repo seeded with the first 5+ categories.
+
+## Risks & open questions
+
+- **Convention-only determinism may be too loose.** A community sliver claiming `pure: true` but secretly mutating state could break the DAG once we ship it. Mitigation: v2 `sliver_verify`; until then, trust author + blessed-repo PR review.
+- **`actor_ref` and `asset_ref` widgets require UE-side picker UI.** That's plugin work, not pure TS. Scope this honestly in the implementation plan.
+- **Composability + side effects = surprising rollback semantics.** If `coastal_town` calls `time_of_day` mid-execution and then errors, lighting stays changed. V1 accepts this — no transaction layer. V2 could add the operation journal (post-mortem #12) and use it for rollback.
+- **Reverse-DNS IDs are unfun to type.** Acceptable trade-off for unambiguous URL import. UE picker uses `title` for display; reverse-DNS is only seen in JSON and CLI.
+
+## Out of scope
+
+- Public registry, moderation, sandboxing of community slivers (v2+).
+- Visual node editor (intentionally rejected — see "Non-goals").
+- Sliver versioning beyond semver string in JSON (no migration tooling in v1).
+- Cross-engine slivers (UE-only; Unity/Godot not considered).
+
+## Success criteria
+
+- Both shipped slivers are usable end-to-end from the UE Slivers tab without restarting the editor.
+- The LLM can list, fetch, and execute slivers using only the 4 always-on tools.
+- Adding a third category requires changes only in `mcp-tools/hayba-mcp/src/slivers/<new-category>/` and the UE param-widget registry — no MCP tool surface changes, no spec changes.
+- One sliver imported from a local path via `hayba_sliver_import` works identically to a built-in one.

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build:dashboard && tsc && npm run build:assets",
     "build:dashboard": "cd dashboard && npm install && npm run build && cd ..",
     "build:server": "tsc && npm run build:assets",
-    "build:assets": "node -e \"import('node:fs').then(fs=>{fs.mkdirSync('dist/tools/routing',{recursive:true});fs.copyFileSync('src/tools/routing/packs.yaml','dist/tools/routing/packs.yaml');console.error('[build:assets] copied packs.yaml')})\"",
+    "build:assets": "node -e \"import('node:fs').then(fs=>{fs.mkdirSync('dist/tools/routing',{recursive:true});fs.copyFileSync('src/tools/routing/packs.yaml','dist/tools/routing/packs.yaml');fs.mkdirSync('dist/slivers/specs',{recursive:true});for(const f of fs.readdirSync('src/slivers/specs')){if(f.endsWith('.sliver.json'))fs.copyFileSync('src/slivers/specs/'+f,'dist/slivers/specs/'+f)}console.error('[build:assets] copied packs.yaml + sliver specs')})\"",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/mcp-tools/hayba-mcp/src/http/server.ts
+++ b/mcp-tools/hayba-mcp/src/http/server.ts
@@ -1,0 +1,32 @@
+//
+// Bootstraps a minimal Express HTTP server alongside the MCP stdio server.
+// Used by the UE plugin's Slivers panel to call sliver list/get/run/import
+// without going through the MCP transport. Logs go to stderr so they don't
+// corrupt the MCP stdio (stdout) channel.
+//
+// Binds to 127.0.0.1 only — never expose to the network.
+
+import express from 'express';
+import type { Server } from 'node:http';
+import type { SliverSystem } from '../slivers/index.js';
+import { mountSliverRoutes } from './sliver-routes.js';
+
+export function startHttpServer(slivers: SliverSystem): Server {
+  const app = express();
+  app.use(express.json({ limit: '1mb' }));
+
+  mountSliverRoutes(app, slivers);
+
+  const port = Number(process.env.HAYBA_MCP_HTTP_PORT ?? 3091);
+  const host = '127.0.0.1';
+
+  const server = app.listen(port, host, () => {
+    console.error(`Hayba HTTP server listening on http://${host}:${port}`);
+  });
+
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    console.error(`Hayba HTTP server error: ${err.code ?? ''} ${err.message}`);
+  });
+
+  return server;
+}

--- a/mcp-tools/hayba-mcp/src/http/sliver-routes.test.ts
+++ b/mcp-tools/hayba-mcp/src/http/sliver-routes.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { setupSliverSystem } from '../slivers/index.js';
+import { mountSliverRoutes } from './sliver-routes.js';
+
+describe('sliver HTTP routes', () => {
+  let userDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+  let server: Server;
+  let url: string;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-http-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+    const app = express();
+    app.use(express.json());
+    mountSliverRoutes(app, sys);
+    server = app.listen(0);
+    const port = (server.address() as AddressInfo).port;
+    url = `http://127.0.0.1:${port}`;
+  });
+  afterEach(() => {
+    server.close();
+    rmSync(userDir, { recursive: true, force: true });
+  });
+
+  it('GET /sliver/list returns installed slivers', async () => {
+    const r = await fetch(`${url}/sliver/list`);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.slivers.length).toBeGreaterThan(0);
+    expect(body.slivers[0].id).toBe('com.hayba.composition.frame_target');
+  });
+
+  it('GET /sliver/list?category=composition filters', async () => {
+    const r = await fetch(`${url}/sliver/list?category=composition`);
+    const body = await r.json();
+    expect(body.slivers.every((s: { category: string }) => s.category === 'composition')).toBe(true);
+  });
+
+  it('GET /sliver/get?id=... returns the full spec', async () => {
+    const r = await fetch(`${url}/sliver/get?id=com.hayba.composition.frame_target`);
+    const body = await r.json();
+    expect(body.found).toBe(true);
+    expect(body.spec.params.length).toBeGreaterThan(0);
+  });
+
+  it('POST /sliver/run executes and returns outputs', async () => {
+    const r = await fetch(`${url}/sliver/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: 'com.hayba.composition.frame_target', params: { target: '/Game/X.X' } }),
+    });
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.ok).toBe(true);
+    expect(body.outputs).toHaveProperty('camera_transform');
+  });
+
+  it('POST /sliver/run returns ok=false on validation failure', async () => {
+    const r = await fetch(`${url}/sliver/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: 'com.hayba.composition.frame_target', params: { target: '/Game/X.X', distance: 9999 } }),
+    });
+    const body = await r.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/distance/);
+  });
+
+  it('POST /sliver/import installs from a JSON body', async () => {
+    const spec = {
+      id: 'com.test.http.demo',
+      version: '1.0.0',
+      category: 'demo',
+      title: 'HTTP Demo',
+      description: '',
+      author: 'test',
+      params: [],
+      executor: { kind: 'demo.http' },
+      determinism: { pure: true, declared_outputs: [], side_effects: [], seed_param: null },
+    };
+    const r = await fetch(`${url}/sliver/import`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ spec }),
+    });
+    const body = await r.json();
+    expect(body.ok).toBe(true);
+    expect(sys.loader.get('com.test.http.demo')).toBeDefined();
+  });
+});

--- a/mcp-tools/hayba-mcp/src/http/sliver-routes.ts
+++ b/mcp-tools/hayba-mcp/src/http/sliver-routes.ts
@@ -1,0 +1,53 @@
+//
+// Express router exposing the four sliver tools over HTTP. Used by the
+// UE plugin's Slivers panel; the LLM-facing MCP tools (hayba_sliver_*)
+// remain stdio-based via the MCP server. Both surfaces share the same
+// SliverSystem so installed slivers are visible from either side.
+
+import type { Express, Request, Response } from 'express';
+import type { SliverSystem } from '../slivers/index.js';
+import { sliverListHandler } from '../tools/sliver/list.js';
+import { sliverGetHandler }  from '../tools/sliver/get.js';
+import { sliverRunHandler }  from '../tools/sliver/run.js';
+
+export function mountSliverRoutes(app: Express, sys: SliverSystem): void {
+  app.get('/sliver/list', async (req: Request, res: Response) => {
+    const r = await sliverListHandler({
+      category: typeof req.query.category === 'string' ? req.query.category : undefined,
+      namespace: typeof req.query.namespace === 'string' ? req.query.namespace : undefined,
+    }, { loader: sys.loader });
+    res.json(r);
+  });
+
+  app.get('/sliver/get', async (req: Request, res: Response) => {
+    if (typeof req.query.id !== 'string' || !req.query.id) {
+      res.status(400).json({ error: 'missing id' });
+      return;
+    }
+    const r = await sliverGetHandler({ id: req.query.id }, { loader: sys.loader });
+    res.json(r);
+  });
+
+  app.post('/sliver/run', async (req: Request, res: Response) => {
+    const body = req.body as { id?: unknown; params?: unknown };
+    if (typeof body.id !== 'string' || !body.id) {
+      res.status(400).json({ error: 'missing id' });
+      return;
+    }
+    const r = await sliverRunHandler({
+      id: body.id,
+      params: (body.params && typeof body.params === 'object' ? body.params : {}) as Record<string, unknown>,
+    }, { runtime: sys.runtime });
+    res.json(r);
+  });
+
+  app.post('/sliver/import', async (req: Request, res: Response) => {
+    const body = req.body as { spec?: unknown };
+    if (!body.spec || typeof body.spec !== 'object') {
+      res.status(400).json({ error: 'missing spec' });
+      return;
+    }
+    const r = sys.loader.install(body.spec);
+    res.json(r);
+  });
+}

--- a/mcp-tools/hayba-mcp/src/index.ts
+++ b/mcp-tools/hayba-mcp/src/index.ts
@@ -5,6 +5,7 @@ import { config } from './config.js';
 import { listCatalogResources, readCatalogResource } from './resources.js';
 import { registerTools } from './tools/index.js';
 import { startDashboard } from './dashboard/server.js';
+import { startHttpServer } from './http/server.js';
 import { pingSidecar } from './tools/visual/sidecar-client.js';
 
 // ── MCP server setup ─────────────────────────────────────────────────────────
@@ -34,10 +35,16 @@ async function main() {
   // until the worldbuilding-hub roadmap reaches the terrain integration phase.
   // Must complete before server.connect — γ-hybrid routing registers its
   // meta-tools asynchronously and the MCP SDK rejects post-connect registration.
-  await registerTools(server, {});
+  const routing = await registerTools(server, {});
 
   await startDashboard(config.dashboardPort, '127.0.0.1');
   console.error(`Dashboard: http://127.0.0.1:${config.dashboardPort}`);
+
+  // HTTP server for the UE plugin (Slivers panel). Stdio remains the primary
+  // MCP transport — this is a parallel surface for the same SliverSystem.
+  if (routing?.slivers) {
+    startHttpServer(routing.slivers);
+  }
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/mcp-tools/hayba-mcp/src/slivers/composition/frame_target.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/composition/frame_target.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { frameTargetExecutor, COMPOSITION_FRAME_TARGET_KIND } from './frame_target.js';
+import type { SliverContext } from '../types.js';
+
+const ctxStub: SliverContext = { stack: [], maxDepth: 8, runSliver: async () => ({ ok: true, outputs: {}, side_effects: [], durationMs: 0 }) };
+
+describe('frameTargetExecutor', () => {
+  it('returns a camera_transform object with location, rotation, and fov', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/Heroes/SK_Hero.SK_Hero',
+      distance: 10,
+      height: 2,
+      fov: 70,
+      yaw_deg: 0,
+    }, ctxStub);
+    expect(out).toHaveProperty('camera_transform');
+    const t = out.camera_transform as { location: number[]; rotation: number[]; fov: number };
+    expect(t.location).toHaveLength(3);
+    expect(t.rotation).toHaveLength(3);
+    expect(t.fov).toBe(70);
+  });
+
+  it('at yaw=0 places the camera on +X axis at the given distance', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/X.X', distance: 10, height: 0, fov: 70, yaw_deg: 0,
+    }, ctxStub) as { camera_transform: { location: [number, number, number] } };
+    expect(out.camera_transform.location[0]).toBeCloseTo(1000, 1); // 10m → 1000 UE units
+    expect(out.camera_transform.location[1]).toBeCloseTo(0, 1);
+  });
+
+  it('at yaw=90 places the camera on +Y axis', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/X.X', distance: 10, height: 0, fov: 70, yaw_deg: 90,
+    }, ctxStub) as { camera_transform: { location: [number, number, number] } };
+    expect(out.camera_transform.location[0]).toBeCloseTo(0, 1);
+    expect(out.camera_transform.location[1]).toBeCloseTo(1000, 1);
+  });
+
+  it('applies the height offset to Z (meters → centimetres)', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/X.X', distance: 10, height: 3, fov: 70, yaw_deg: 0,
+    }, ctxStub) as { camera_transform: { location: [number, number, number] } };
+    expect(out.camera_transform.location[2]).toBeCloseTo(300, 1);
+  });
+
+  it('points yaw toward the origin (camera at +X looks toward −X)', async () => {
+    const out = await frameTargetExecutor({
+      target: '/Game/X.X', distance: 10, height: 0, fov: 70, yaw_deg: 0,
+    }, ctxStub) as { camera_transform: { rotation: [number, number, number] } };
+    // rotation in [pitch, yaw, roll] degrees per UE convention
+    expect(out.camera_transform.rotation[1]).toBeCloseTo(180, 1);
+  });
+
+  it('exports the registry kind as a constant', () => {
+    expect(COMPOSITION_FRAME_TARGET_KIND).toBe('composition.frame_target');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/slivers/composition/frame_target.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/composition/frame_target.ts
@@ -1,0 +1,49 @@
+// mcp-tools/hayba-mcp/src/slivers/composition/frame_target.ts
+//
+// Pure executor: given a target actor path + distance/height/fov/orbit,
+// returns a camera_transform pointing at the target's origin from a
+// position on the orbit circle around it. Coordinates returned in UE
+// units (centimetres); the caller (render_camera or similar) consumes
+// the transform as-is.
+//
+// We don't resolve the actor's actual location here — that requires a
+// UE round-trip. v1 frames toward the world origin from a relative
+// offset; the LLM/agent is responsible for combining with the actor's
+// world location if needed. A v2 could call a hayba_actor_location
+// subroutine via ctx.runSliver.
+
+import type { SliverExecutor } from '../types.js';
+
+export const COMPOSITION_FRAME_TARGET_KIND = 'composition.frame_target';
+
+interface FrameTargetParams {
+  target: string;
+  distance: number;
+  height: number;
+  fov: number;
+  yaw_deg: number;
+}
+
+export const frameTargetExecutor: SliverExecutor = async (rawParams) => {
+  const p = rawParams as unknown as FrameTargetParams;
+  const M_TO_UE = 100;          // 1 m = 100 UE units
+  const yawRad = (p.yaw_deg * Math.PI) / 180;
+  const r = p.distance * M_TO_UE;
+
+  const x = Math.cos(yawRad) * r;
+  const y = Math.sin(yawRad) * r;
+  const z = p.height * M_TO_UE;
+
+  // Camera looks at origin: yaw is +180 from the position angle.
+  const cameraYawDeg = (p.yaw_deg + 180) % 360;
+  // Simple pitch toward the target accounting for height.
+  const pitchDeg = Math.atan2(-z, r) * (180 / Math.PI);
+
+  return {
+    camera_transform: {
+      location: [x, y, z],
+      rotation: [pitchDeg, cameraYawDeg, 0],   // [pitch, yaw, roll]
+      fov: p.fov,
+    },
+  };
+};

--- a/mcp-tools/hayba-mcp/src/slivers/index.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/index.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from './index.js';
+
+describe('setupSliverSystem', () => {
+  let userDir: string;
+  let bundledDir: string;
+
+  beforeEach(() => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sliver-sys-u-'));
+    bundledDir = mkdtempSync(join(tmpdir(), 'hayba-sliver-sys-b-'));
+  });
+  afterEach(() => {
+    rmSync(userDir, { recursive: true, force: true });
+    rmSync(bundledDir, { recursive: true, force: true });
+  });
+
+  it('wires loader + registry + runtime and registers built-in executors', async () => {
+    const sys = await setupSliverSystem({ userDir, bundledDir, maxDepth: 4 });
+    expect(sys.registry.kinds()).toContain('composition.frame_target');
+    expect(sys.runtime).toBeDefined();
+    expect(sys.loader).toBeDefined();
+  });
+
+  it('seeds the bundled frame_target spec into userDir when bundledDir contains it', async () => {
+    const { copyFileSync, mkdirSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    mkdirSync(bundledDir, { recursive: true });
+    copyFileSync(
+      resolve('src/slivers/specs/com.hayba.composition.frame_target.sliver.json'),
+      join(bundledDir, 'com.hayba.composition.frame_target.sliver.json'),
+    );
+    const sys = await setupSliverSystem({ userDir, bundledDir, maxDepth: 4 });
+    expect(sys.loader.get('com.hayba.composition.frame_target')).toBeDefined();
+
+    const r = await sys.runtime.runSliver('com.hayba.composition.frame_target', { target: '/Game/X.X' });
+    expect(r.ok).toBe(true);
+    expect(r.outputs).toHaveProperty('camera_transform');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/slivers/index.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/index.ts
@@ -1,0 +1,49 @@
+//
+// One-shot wiring: builds the registry, registers built-in executors,
+// constructs the loader (which seeds + reads userDir), constructs the
+// runtime. Caller (tools/routing/register.ts) holds the returned handle
+// for use by the MCP sliver tools.
+
+import { ExecutorRegistry } from './registry.js';
+import { SliverLoader, defaultUserSliversDir } from './loader.js';
+import { SliverRuntime } from './runtime.js';
+import { COMPOSITION_FRAME_TARGET_KIND, frameTargetExecutor } from './composition/frame_target.js';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface SliverSystem {
+  registry: ExecutorRegistry;
+  loader: SliverLoader;
+  runtime: SliverRuntime;
+}
+
+export interface SetupOpts {
+  userDir?: string;
+  bundledDir?: string;
+  maxDepth?: number;
+}
+
+export async function setupSliverSystem(opts: SetupOpts = {}): Promise<SliverSystem> {
+  const registry = new ExecutorRegistry();
+  registry.register(COMPOSITION_FRAME_TARGET_KIND, frameTargetExecutor);
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const loader = new SliverLoader({
+    userDir: opts.userDir ?? defaultUserSliversDir(),
+    bundledDir: opts.bundledDir ?? resolve(__dirname, 'specs'),
+  });
+  await loader.reload();
+
+  const runtime = new SliverRuntime({
+    registry,
+    getSpec: (id) => loader.get(id),
+    maxDepth: opts.maxDepth ?? 8,
+  });
+
+  return { registry, loader, runtime };
+}
+
+export type { SliverSpec, SliverRunResult, SliverParam, SliverParamValues } from './types.js';
+export { SliverLoader, defaultUserSliversDir } from './loader.js';
+export { SliverRuntime } from './runtime.js';
+export { ExecutorRegistry } from './registry.js';

--- a/mcp-tools/hayba-mcp/src/slivers/loader.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/loader.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SliverLoader } from './loader.js';
+
+const validSpec = {
+  id: 'com.test.demo',
+  version: '1.0.0',
+  category: 'test',
+  title: 'Demo',
+  description: '',
+  author: 'test',
+  params: [],
+  executor: { kind: 'test.demo' },
+  determinism: { pure: true, declared_outputs: [], side_effects: [], seed_param: null },
+};
+
+describe('SliverLoader', () => {
+  let userDir: string;
+  let bundledDir: string;
+
+  beforeEach(() => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sliver-user-'));
+    bundledDir = mkdtempSync(join(tmpdir(), 'hayba-sliver-bundled-'));
+  });
+  afterEach(() => {
+    rmSync(userDir, { recursive: true, force: true });
+    rmSync(bundledDir, { recursive: true, force: true });
+  });
+
+  it('loads valid specs from userDir', async () => {
+    writeFileSync(join(userDir, 'com.test.demo.sliver.json'), JSON.stringify(validSpec));
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(loader.list().map(s => s.id)).toEqual(['com.test.demo']);
+    expect(loader.get('com.test.demo')?.title).toBe('Demo');
+  });
+
+  it('seeds userDir from bundledDir on first reload if userDir lacks the spec', async () => {
+    writeFileSync(join(bundledDir, 'com.test.demo.sliver.json'), JSON.stringify(validSpec));
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(existsSync(join(userDir, 'com.test.demo.sliver.json'))).toBe(true);
+    expect(loader.get('com.test.demo')).toBeDefined();
+  });
+
+  it('userDir wins over bundledDir when both have the same id', async () => {
+    writeFileSync(join(bundledDir, 'com.test.demo.sliver.json'), JSON.stringify(validSpec));
+    writeFileSync(join(userDir, 'com.test.demo.sliver.json'), JSON.stringify({ ...validSpec, title: 'User Override' }));
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(loader.get('com.test.demo')?.title).toBe('User Override');
+  });
+
+  it('skips and logs invalid specs without failing the whole reload', async () => {
+    writeFileSync(join(userDir, 'good.sliver.json'), JSON.stringify(validSpec));
+    writeFileSync(join(userDir, 'bad.sliver.json'), '{ not valid json');
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(loader.list().length).toBe(1);
+    expect(loader.errors().length).toBe(1);
+    expect(loader.errors()[0]).toMatch(/bad\.sliver\.json/);
+  });
+
+  it('install writes a spec to userDir and adds it to the in-memory map', async () => {
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    const r = loader.install(validSpec);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.id).toBe('com.test.demo');
+    expect(existsSync(join(userDir, 'com.test.demo.sliver.json'))).toBe(true);
+    expect(loader.get('com.test.demo')).toBeDefined();
+  });
+
+  it('install rejects malformed specs', async () => {
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    const r = loader.install({ ...validSpec, id: 'not-reverse-dns' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('ignores non-sliver json files', async () => {
+    writeFileSync(join(userDir, 'com.test.demo.preset.json'), JSON.stringify({ distance: 5 }));
+    writeFileSync(join(userDir, 'README.md'), '# slivers');
+    const loader = new SliverLoader({ userDir, bundledDir });
+    await loader.reload();
+    expect(loader.list()).toEqual([]);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/slivers/loader.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/loader.ts
@@ -1,0 +1,98 @@
+// mcp-tools/hayba-mcp/src/slivers/loader.ts
+//
+// SliverLoader — reads *.sliver.json from %APPDATA%/Hayba/slivers/
+// (userDir), seeding from the package's bundled specs (bundledDir) on
+// first run. Validates with parseSliverSpec; bad files are skipped and
+// reported via errors() so the MCP server keeps booting.
+//
+// "install" writes a new spec to userDir and updates the in-memory map.
+
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { SliverSpec } from './types.js';
+import { parseSliverSpec } from './spec-schema.js';
+
+export interface SliverLoaderOpts {
+  /** Absolute path to %APPDATA%/Hayba/slivers/ (or test override). */
+  userDir: string;
+  /** Absolute path to the package's bundled specs (dist/slivers/specs/). */
+  bundledDir: string;
+}
+
+export type InstallResult =
+  | { ok: true; id: string; path: string }
+  | { ok: false; reason: string };
+
+const SUFFIX = '.sliver.json';
+
+export class SliverLoader {
+  private readonly userDir: string;
+  private readonly bundledDir: string;
+  private specs = new Map<string, SliverSpec>();
+  private loadErrors: string[] = [];
+
+  constructor(opts: SliverLoaderOpts) {
+    this.userDir = opts.userDir;
+    this.bundledDir = opts.bundledDir;
+  }
+
+  /** Seed (idempotent) then full reload from userDir. Call at startup or after import. */
+  async reload(): Promise<void> {
+    this.ensureDir(this.userDir);
+    this.seedFromBundled();
+    this.specs.clear();
+    this.loadErrors = [];
+    if (!existsSync(this.userDir)) return;
+    for (const name of readdirSync(this.userDir)) {
+      if (!name.endsWith(SUFFIX)) continue;
+      const fullPath = join(this.userDir, name);
+      try {
+        const raw = readFileSync(fullPath, 'utf8');
+        const json = JSON.parse(raw);
+        const parsed = parseSliverSpec(json);
+        if (!parsed.ok) {
+          this.loadErrors.push(`${name}: ${parsed.reason}`);
+          continue;
+        }
+        this.specs.set(parsed.spec.id, parsed.spec);
+      } catch (e) {
+        this.loadErrors.push(`${name}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  }
+
+  list(): SliverSpec[] { return [...this.specs.values()]; }
+  get(id: string): SliverSpec | undefined { return this.specs.get(id); }
+  errors(): string[] { return [...this.loadErrors]; }
+
+  install(specInput: unknown): InstallResult {
+    const parsed = parseSliverSpec(specInput);
+    if (!parsed.ok) return { ok: false, reason: parsed.reason };
+    this.ensureDir(this.userDir);
+    const path = join(this.userDir, `${parsed.spec.id}${SUFFIX}`);
+    writeFileSync(path, JSON.stringify(parsed.spec, null, 2));
+    this.specs.set(parsed.spec.id, parsed.spec);
+    return { ok: true, id: parsed.spec.id, path };
+  }
+
+  private ensureDir(dir: string): void {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+
+  private seedFromBundled(): void {
+    if (!existsSync(this.bundledDir)) return;
+    if (!statSync(this.bundledDir).isDirectory()) return;
+    for (const name of readdirSync(this.bundledDir)) {
+      if (!name.endsWith(SUFFIX)) continue;
+      const target = join(this.userDir, name);
+      if (existsSync(target)) continue;
+      copyFileSync(join(this.bundledDir, name), target);
+    }
+  }
+}
+
+/** Default user dir resolver — %APPDATA%/Hayba/slivers on Windows, ~/.hayba/slivers elsewhere. */
+export function defaultUserSliversDir(): string {
+  const base = process.env.APPDATA ?? join(process.env.HOME ?? '.', '.hayba');
+  return join(base, 'Hayba', 'slivers');
+}

--- a/mcp-tools/hayba-mcp/src/slivers/param-validator.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/param-validator.test.ts
@@ -1,0 +1,48 @@
+// mcp-tools/hayba-mcp/src/slivers/param-validator.test.ts
+import { describe, it, expect } from 'vitest';
+import { validateAndCoerceParams } from './param-validator.js';
+import type { SliverParam } from './types.js';
+
+const params: SliverParam[] = [
+  { id: 'distance', type: 'float', range: [1, 100], default: 10 },
+  { id: 'pick',     type: 'enum',  options: [{ value: 'a' }, { value: 'b' }], default: 'a' },
+  { id: 'on',       type: 'bool',  default: false },
+  { id: 'target',   type: 'actor_ref', required: true },
+];
+
+describe('validateAndCoerceParams', () => {
+  it('fills defaults when values are omitted', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.values).toEqual({ distance: 10, pick: 'a', on: false, target: '/Game/X.X' });
+  });
+
+  it('fails when a required param is missing', () => {
+    const r = validateAndCoerceParams(params, { distance: 5 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/target/);
+  });
+
+  it('rejects out-of-range floats', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X', distance: 999 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/distance/);
+  });
+
+  it('rejects enum values not in options', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X', pick: 'z' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/pick/);
+  });
+
+  it('rejects wrong types', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X', distance: 'big' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown param ids', () => {
+    const r = validateAndCoerceParams(params, { target: '/Game/X.X', wat: 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/wat/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/slivers/param-validator.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/param-validator.ts
@@ -1,0 +1,73 @@
+// mcp-tools/hayba-mcp/src/slivers/param-validator.ts
+//
+// Runtime validation + default-filling for a SliverParam[] against a
+// caller-supplied values bag. Centralised so the MCP `run` tool and
+// internal runSliver calls share one code path.
+
+import type { SliverParam, SliverParamValues } from './types.js';
+
+export type ValidateResult =
+  | { ok: true; values: SliverParamValues }
+  | { ok: false; reason: string };
+
+export function validateAndCoerceParams(
+  params: SliverParam[],
+  input: SliverParamValues,
+): ValidateResult {
+  const known = new Set(params.map(p => p.id));
+  for (const k of Object.keys(input)) {
+    if (!known.has(k)) return { ok: false, reason: `unknown param "${k}"` };
+  }
+
+  const out: SliverParamValues = {};
+  for (const p of params) {
+    const provided = Object.prototype.hasOwnProperty.call(input, p.id);
+    let v = provided ? input[p.id] : (('default' in p ? (p as { default?: unknown }).default : undefined));
+
+    if (v === undefined) {
+      if (p.required) return { ok: false, reason: `missing required param "${p.id}"` };
+      continue;
+    }
+
+    const err = checkParam(p, v);
+    if (err) return { ok: false, reason: `param "${p.id}": ${err}` };
+    out[p.id] = v;
+  }
+  return { ok: true, values: out };
+}
+
+function checkParam(p: SliverParam, v: unknown): string | null {
+  switch (p.type) {
+    case 'float':
+    case 'int': {
+      if (typeof v !== 'number' || Number.isNaN(v)) return `expected number, got ${typeof v}`;
+      if (p.type === 'int' && !Number.isInteger(v)) return 'expected integer';
+      if (p.range) {
+        const [lo, hi] = p.range;
+        if (v < lo || v > hi) return `out of range [${lo}, ${hi}]`;
+      }
+      return null;
+    }
+    case 'bool':
+      return typeof v === 'boolean' ? null : `expected boolean, got ${typeof v}`;
+    case 'string':
+      if (typeof v !== 'string') return `expected string, got ${typeof v}`;
+      if (p.maxLength != null && v.length > p.maxLength) return `exceeds maxLength=${p.maxLength}`;
+      return null;
+    case 'enum':
+      if (typeof v !== 'string') return 'expected string';
+      return p.options.some(o => o.value === v) ? null : `not in options`;
+    case 'color':
+      return typeof v === 'string' && /^#[0-9a-fA-F]{6}$/.test(v) ? null : 'expected "#RRGGBB" hex';
+    case 'actor_ref':
+    case 'asset_ref':
+      return typeof v === 'string' && v.length > 0 ? null : 'expected non-empty path string';
+    case 'vector3':
+      if (!Array.isArray(v) || v.length !== 3 || !v.every(n => typeof n === 'number')) return 'expected [x,y,z] number tuple';
+      return null;
+    case 'transform':
+      if (typeof v !== 'object' || v === null) return 'expected object';
+      // shallow check; the executor is trusted to deep-validate if it cares
+      return null;
+  }
+}

--- a/mcp-tools/hayba-mcp/src/slivers/registry.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/registry.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ExecutorRegistry } from './registry.js';
+import type { SliverExecutor } from './types.js';
+
+describe('ExecutorRegistry', () => {
+  let reg: ExecutorRegistry;
+  beforeEach(() => { reg = new ExecutorRegistry(); });
+
+  it('register + get round-trips', () => {
+    const fn: SliverExecutor = async () => ({ ok: true });
+    reg.register('composition.frame_target', fn);
+    expect(reg.get('composition.frame_target')).toBe(fn);
+  });
+
+  it('returns undefined for unknown kind', () => {
+    expect(reg.get('does.not.exist')).toBeUndefined();
+  });
+
+  it('throws on duplicate registration', () => {
+    const fn: SliverExecutor = async () => ({});
+    reg.register('k', fn);
+    expect(() => reg.register('k', fn)).toThrow(/already registered/);
+  });
+
+  it('lists registered kinds', () => {
+    reg.register('a', async () => ({}));
+    reg.register('b', async () => ({}));
+    expect(reg.kinds().sort()).toEqual(['a', 'b']);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/slivers/registry.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/registry.ts
@@ -1,0 +1,26 @@
+//
+// Maps executor.kind strings to executor functions. Each category
+// (composition, lighting, pcg_diff, …) registers one entry per concrete
+// sliver. Slivers loaded from disk look up their executor here at run
+// time; a missing kind is a clear "executor not bundled" error.
+
+import type { SliverExecutor } from './types.js';
+
+export class ExecutorRegistry {
+  private readonly byKind = new Map<string, SliverExecutor>();
+
+  register(kind: string, executor: SliverExecutor): void {
+    if (this.byKind.has(kind)) {
+      throw new Error(`Executor kind "${kind}" already registered`);
+    }
+    this.byKind.set(kind, executor);
+  }
+
+  get(kind: string): SliverExecutor | undefined {
+    return this.byKind.get(kind);
+  }
+
+  kinds(): string[] {
+    return [...this.byKind.keys()];
+  }
+}

--- a/mcp-tools/hayba-mcp/src/slivers/runtime.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/runtime.test.ts
@@ -128,4 +128,20 @@ describe('SliverRuntime.runSliver', () => {
     expect(r.ok).toBe(true);
     expect(r.outputs).toEqual({ a: 1, b: 1 });
   });
+
+  it('aggregates side_effects across the call tree (parent + child) and dedupes', async () => {
+    specs.set('com.t.parent', makeSpec('com.t.parent', 'k.parent', {
+      determinism: { pure: false, declared_outputs: [], side_effects: ['actor_spawn'], seed_param: null },
+    }));
+    specs.set('com.t.child', makeSpec('com.t.child', 'k.child', {
+      determinism: { pure: false, declared_outputs: [], side_effects: ['lighting_change', 'actor_spawn'], seed_param: null },
+    }));
+    registry.register('k.parent', async (_p, ctx) => { await ctx.runSliver('com.t.child', {}); return {}; });
+    registry.register('k.child', async () => ({}));
+
+    const r = await runtime.runSliver('com.t.parent', {});
+    expect(r.ok).toBe(true);
+    expect(r.side_effects).toEqual(['actor_spawn', 'lighting_change']);
+    // 'actor_spawn' appears in both parent and child — should appear once, in first-seen order
+  });
 });

--- a/mcp-tools/hayba-mcp/src/slivers/runtime.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/runtime.test.ts
@@ -1,0 +1,131 @@
+// mcp-tools/hayba-mcp/src/slivers/runtime.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ExecutorRegistry } from './registry.js';
+import { SliverRuntime } from './runtime.js';
+import type { SliverSpec, SliverExecutor } from './types.js';
+
+function makeSpec(id: string, kind: string, extra: Partial<SliverSpec> = {}): SliverSpec {
+  return {
+    id,
+    version: '1.0.0',
+    category: 'test',
+    title: id,
+    description: '',
+    author: 'test',
+    params: [],
+    executor: { kind },
+    determinism: { pure: true, declared_outputs: ['v'], side_effects: [], seed_param: null },
+    ...extra,
+  };
+}
+
+describe('SliverRuntime.runSliver', () => {
+  let registry: ExecutorRegistry;
+  let runtime: SliverRuntime;
+  let specs: Map<string, SliverSpec>;
+
+  beforeEach(() => {
+    registry = new ExecutorRegistry();
+    specs = new Map();
+    runtime = new SliverRuntime({
+      registry,
+      getSpec: (id) => specs.get(id),
+      maxDepth: 8,
+    });
+  });
+
+  it('returns the executor output and durationMs', async () => {
+    specs.set('com.t.a', makeSpec('com.t.a', 'k.a'));
+    registry.register('k.a', async () => ({ v: 42 }));
+    const r = await runtime.runSliver('com.t.a', {});
+    expect(r.ok).toBe(true);
+    expect(r.outputs).toEqual({ v: 42 });
+    expect(r.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns SliverNotFoundError shape when spec is missing', async () => {
+    const r = await runtime.runSliver('com.t.missing', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/com\.t\.missing/);
+  });
+
+  it('returns error when executor.kind is not registered', async () => {
+    specs.set('com.t.x', makeSpec('com.t.x', 'k.unregistered'));
+    const r = await runtime.runSliver('com.t.x', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/k\.unregistered/);
+  });
+
+  it('validates params against the spec', async () => {
+    specs.set('com.t.p', makeSpec('com.t.p', 'k.p', {
+      params: [{ id: 'x', type: 'float', range: [0, 1] }],
+    }));
+    registry.register('k.p', async () => ({}));
+    const r = await runtime.runSliver('com.t.p', { x: 5 });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/out of range/);
+  });
+
+  it('aggregates declared side_effects into the result', async () => {
+    specs.set('com.t.s', makeSpec('com.t.s', 'k.s', {
+      determinism: { pure: false, declared_outputs: [], side_effects: ['lighting_change'], seed_param: null },
+    }));
+    registry.register('k.s', async () => ({}));
+    const r = await runtime.runSliver('com.t.s', {});
+    expect(r.side_effects).toEqual(['lighting_change']);
+  });
+
+  it('detects direct cycles (sliver calls itself)', async () => {
+    specs.set('com.t.cyc', makeSpec('com.t.cyc', 'k.cyc'));
+    const exec: SliverExecutor = async (_p, ctx) => {
+      await ctx.runSliver('com.t.cyc', {});
+      return {};
+    };
+    registry.register('k.cyc', exec);
+    const r = await runtime.runSliver('com.t.cyc', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/cycle/i);
+  });
+
+  it('detects indirect cycles (a → b → a)', async () => {
+    specs.set('com.t.a', makeSpec('com.t.a', 'k.a'));
+    specs.set('com.t.b', makeSpec('com.t.b', 'k.b'));
+    registry.register('k.a', async (_p, ctx) => { await ctx.runSliver('com.t.b', {}); return {}; });
+    registry.register('k.b', async (_p, ctx) => { await ctx.runSliver('com.t.a', {}); return {}; });
+    const r = await runtime.runSliver('com.t.a', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/cycle/i);
+  });
+
+  it('enforces maxDepth', async () => {
+    const small = new SliverRuntime({ registry, getSpec: (id) => specs.get(id), maxDepth: 2 });
+    specs.set('com.t.deep', makeSpec('com.t.deep', 'k.deep'));
+    let i = 0;
+    registry.register('k.deep', async (_p, ctx) => {
+      if (i++ < 5) await ctx.runSliver('com.t.deep2', {});
+      return {};
+    });
+    specs.set('com.t.deep2', makeSpec('com.t.deep2', 'k.deep2'));
+    registry.register('k.deep2', async (_p, ctx) => {
+      if (i++ < 5) await ctx.runSliver('com.t.deep', {});
+      return {};
+    });
+    const r = await small.runSliver('com.t.deep', {});
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/depth/i);
+  });
+
+  it('allows the same sliver to be called sequentially (no false cycle)', async () => {
+    specs.set('com.t.leaf', makeSpec('com.t.leaf', 'k.leaf'));
+    specs.set('com.t.par',  makeSpec('com.t.par',  'k.par'));
+    registry.register('k.leaf', async () => ({ v: 1 }));
+    registry.register('k.par', async (_p, ctx) => {
+      const a = await ctx.runSliver('com.t.leaf', {});
+      const b = await ctx.runSliver('com.t.leaf', {});
+      return { a: a.outputs.v, b: b.outputs.v };
+    });
+    const r = await runtime.runSliver('com.t.par', {});
+    expect(r.ok).toBe(true);
+    expect(r.outputs).toEqual({ a: 1, b: 1 });
+  });
+});

--- a/mcp-tools/hayba-mcp/src/slivers/runtime.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/runtime.ts
@@ -1,0 +1,149 @@
+// mcp-tools/hayba-mcp/src/slivers/runtime.ts
+//
+// SliverRuntime.runSliver — single entry point for executing any sliver.
+// Walks: lookup spec → validate params → resolve executor → cycle/depth
+// guard → execute → collect outputs + side_effects → return.
+//
+// Design note: cycle and depth errors are thrown without being caught by
+// inner runInternal frames — they propagate all the way to the root call's
+// catch block. This ensures that an executor which calls ctx.runSliver and
+// gets a cycle/depth error will not silently succeed after the nested await.
+
+import {
+  SliverCycleError, SliverDepthError, SliverNotFoundError, SliverValidationError,
+  type SliverParamValues, type SliverRunResult, type SliverSpec, type SliverContext,
+} from './types.js';
+import type { ExecutorRegistry } from './registry.js';
+import { validateAndCoerceParams } from './param-validator.js';
+
+export interface SliverRuntimeOpts {
+  registry: ExecutorRegistry;
+  getSpec: (id: string) => SliverSpec | undefined;
+  maxDepth?: number;
+}
+
+/** Marker so the root catch knows these should remain unhandled at inner frames. */
+const STRUCTURAL_ERRORS = [SliverCycleError, SliverDepthError] as const;
+
+function isStructural(e: unknown): e is SliverCycleError | SliverDepthError {
+  return STRUCTURAL_ERRORS.some(Cls => e instanceof Cls);
+}
+
+export class SliverRuntime {
+  private readonly registry: ExecutorRegistry;
+  private readonly getSpec: (id: string) => SliverSpec | undefined;
+  private readonly maxDepth: number;
+
+  constructor(opts: SliverRuntimeOpts) {
+    this.registry = opts.registry;
+    this.getSpec = opts.getSpec;
+    this.maxDepth = opts.maxDepth ?? 8;
+  }
+
+  /** Public entry point. Always resolves (never rejects). */
+  runSliver(id: string, params: SliverParamValues): Promise<SliverRunResult> {
+    return this.runRoot(id, params, []);
+  }
+
+  /**
+   * Root frame: wraps _runFrame in a try/catch that converts ALL errors
+   * (including cycle/depth that bubble up from deep frames) into a result.
+   */
+  private async runRoot(
+    id: string,
+    params: SliverParamValues,
+    stack: string[],
+  ): Promise<SliverRunResult> {
+    const t0 = performance.now();
+    try {
+      const outputs = await this._runFrame(id, params, stack);
+      return {
+        ok: true,
+        outputs,
+        side_effects: this._getSideEffects(id, stack),
+        durationMs: Math.round(performance.now() - t0),
+      };
+    } catch (e) {
+      return {
+        ok: false,
+        outputs: {},
+        side_effects: [],
+        durationMs: Math.round(performance.now() - t0),
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  }
+
+  /**
+   * Inner frame: throws on all errors (structural and non-structural).
+   * Structural errors (cycle/depth) bubble through executor awaits unchanged.
+   * Non-structural errors bubble up to the nearest runRoot catch.
+   */
+  private async _runFrame(
+    id: string,
+    params: SliverParamValues,
+    stack: string[],
+  ): Promise<Record<string, unknown>> {
+    if (stack.length >= this.maxDepth) throw new SliverDepthError(this.maxDepth);
+    if (stack.includes(id)) throw new SliverCycleError(id, [...stack, id]);
+
+    const spec = this.getSpec(id);
+    if (!spec) throw new SliverNotFoundError(id);
+
+    const executor = this.registry.get(spec.executor.kind);
+    if (!executor) throw new SliverValidationError(`executor.kind "${spec.executor.kind}" not registered`);
+
+    const v = validateAndCoerceParams(spec.params, params);
+    if (!v.ok) throw new SliverValidationError(v.reason);
+
+    const newStack = [...stack, id];
+    const ctx: SliverContext = {
+      stack: newStack,
+      maxDepth: this.maxDepth,
+      runSliver: (childId, childParams) =>
+        this._runChildSliver(childId, childParams, newStack),
+    };
+
+    return await executor(v.values, ctx);
+  }
+
+  /**
+   * Called by ctx.runSliver inside executors. Structural errors (cycle/depth)
+   * are re-thrown so they escape the executor's try/catch and reach the root.
+   * Non-structural errors are wrapped in a SliverRunResult.
+   */
+  private async _runChildSliver(
+    id: string,
+    params: SliverParamValues,
+    stack: string[],
+  ): Promise<SliverRunResult> {
+    const t0 = performance.now();
+    try {
+      const outputs = await this._runFrame(id, params, stack);
+      const spec = this.getSpec(id);
+      return {
+        ok: true,
+        outputs,
+        side_effects: spec ? [...spec.determinism.side_effects] : [],
+        durationMs: Math.round(performance.now() - t0),
+      };
+    } catch (e) {
+      // Structural errors must not be swallowed here — re-throw so they
+      // propagate through the executor's await chain to the root catch.
+      if (isStructural(e)) throw e;
+      return {
+        ok: false,
+        outputs: {},
+        side_effects: [],
+        durationMs: Math.round(performance.now() - t0),
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  }
+
+  /** Retrieves side_effects from the spec after a successful run. */
+  private _getSideEffects(id: string, _stack: string[]): string[] {
+    const spec = this.getSpec(id);
+    return spec ? [...spec.determinism.side_effects] : [];
+  }
+}

--- a/mcp-tools/hayba-mcp/src/slivers/runtime.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/runtime.ts
@@ -48,6 +48,8 @@ export class SliverRuntime {
   /**
    * Root frame: wraps _runFrame in a try/catch that converts ALL errors
    * (including cycle/depth that bubble up from deep frames) into a result.
+   * A shared `effects` array is passed down through the call tree so all
+   * frames (root + children) accumulate into a single list.
    */
   private async runRoot(
     id: string,
@@ -55,12 +57,13 @@ export class SliverRuntime {
     stack: string[],
   ): Promise<SliverRunResult> {
     const t0 = performance.now();
+    const effects: string[] = [];
     try {
-      const outputs = await this._runFrame(id, params, stack);
+      const outputs = await this._runFrame(id, params, stack, effects);
       return {
         ok: true,
         outputs,
-        side_effects: this._getSideEffects(id, stack),
+        side_effects: dedup(effects),
         durationMs: Math.round(performance.now() - t0),
       };
     } catch (e) {
@@ -78,11 +81,14 @@ export class SliverRuntime {
    * Inner frame: throws on all errors (structural and non-structural).
    * Structural errors (cycle/depth) bubble through executor awaits unchanged.
    * Non-structural errors bubble up to the nearest runRoot catch.
+   * Pushes this spec's side_effects into the shared `effects` array before
+   * executing, so they are recorded even if the executor triggers a child.
    */
   private async _runFrame(
     id: string,
     params: SliverParamValues,
     stack: string[],
+    effects: string[],
   ): Promise<Record<string, unknown>> {
     if (stack.length >= this.maxDepth) throw new SliverDepthError(this.maxDepth);
     if (stack.includes(id)) throw new SliverCycleError(id, [...stack, id]);
@@ -96,12 +102,15 @@ export class SliverRuntime {
     const v = validateAndCoerceParams(spec.params, params);
     if (!v.ok) throw new SliverValidationError(v.reason);
 
+    // Record this frame's side_effects into the shared accumulator.
+    for (const e of spec.determinism.side_effects) effects.push(e);
+
     const newStack = [...stack, id];
     const ctx: SliverContext = {
       stack: newStack,
       maxDepth: this.maxDepth,
       runSliver: (childId, childParams) =>
-        this._runChildSliver(childId, childParams, newStack),
+        this._runChildSliver(childId, childParams, newStack, effects),
     };
 
     return await executor(v.values, ctx);
@@ -111,15 +120,18 @@ export class SliverRuntime {
    * Called by ctx.runSliver inside executors. Structural errors (cycle/depth)
    * are re-thrown so they escape the executor's try/catch and reach the root.
    * Non-structural errors are wrapped in a SliverRunResult.
+   * The shared `effects` array is threaded through so child side_effects are
+   * collected into the root accumulator.
    */
   private async _runChildSliver(
     id: string,
     params: SliverParamValues,
     stack: string[],
+    effects: string[],
   ): Promise<SliverRunResult> {
     const t0 = performance.now();
     try {
-      const outputs = await this._runFrame(id, params, stack);
+      const outputs = await this._runFrame(id, params, stack, effects);
       const spec = this.getSpec(id);
       return {
         ok: true,
@@ -140,10 +152,14 @@ export class SliverRuntime {
       };
     }
   }
+}
 
-  /** Retrieves side_effects from the spec after a successful run. */
-  private _getSideEffects(id: string, _stack: string[]): string[] {
-    const spec = this.getSpec(id);
-    return spec ? [...spec.determinism.side_effects] : [];
+/** Deduplicate a string array preserving first-seen order. */
+function dedup(arr: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const s of arr) {
+    if (!seen.has(s)) { seen.add(s); out.push(s); }
   }
+  return out;
 }

--- a/mcp-tools/hayba-mcp/src/slivers/spec-schema.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/spec-schema.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { sliverSpecSchema, parseSliverSpec } from './spec-schema.js';
+
+const valid = {
+  id: 'com.hayba.composition.frame_target',
+  version: '1.0.0',
+  category: 'composition',
+  title: 'Frame Target',
+  description: 'Compute a camera transform.',
+  author: 'core',
+  params: [
+    { id: 'target', type: 'actor_ref', required: true },
+    { id: 'distance', type: 'float', range: [1, 100], default: 10 },
+  ],
+  executor: { kind: 'composition.frame_target' },
+  determinism: { pure: true, declared_outputs: ['camera_transform'], side_effects: [], seed_param: null },
+};
+
+describe('sliver spec schema', () => {
+  it('accepts a valid spec', () => {
+    expect(() => sliverSpecSchema.parse(valid)).not.toThrow();
+  });
+
+  it('parseSliverSpec returns ok=true on valid input', () => {
+    const r = parseSliverSpec(valid);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.spec.id).toBe(valid.id);
+  });
+
+  it('parseSliverSpec returns ok=false with reason on bad input', () => {
+    const r = parseSliverSpec({ ...valid, id: '' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/id/i);
+  });
+
+  it('rejects ids that are not reverse-DNS', () => {
+    const r = parseSliverSpec({ ...valid, id: 'frame_target' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects unknown param types', () => {
+    const r = parseSliverSpec({
+      ...valid,
+      params: [{ id: 'x', type: 'banana' as unknown as 'float' }],
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects duplicate param ids', () => {
+    const r = parseSliverSpec({
+      ...valid,
+      params: [
+        { id: 'a', type: 'float' },
+        { id: 'a', type: 'int' },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/duplicate/i);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/slivers/spec-schema.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/spec-schema.ts
@@ -1,0 +1,71 @@
+// Zod schema mirroring the TS types in types.ts. Used to validate JSON
+// specs loaded from disk and from URL imports. The discriminated union
+// on `type` matches the SliverParam shape exactly.
+
+import { z } from 'zod';
+import type { SliverSpec } from './types.js';
+
+const reverseDns = /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*){2,}$/;
+
+const rangePair = z.tuple([z.number(), z.number()]);
+
+const paramBase = { id: z.string().min(1), label: z.string().optional(), required: z.boolean().optional() };
+
+const paramFloat   = z.object({ ...paramBase, type: z.literal('float'),     range: rangePair.optional(), step: z.number().optional(), default: z.number().optional() });
+const paramInt     = z.object({ ...paramBase, type: z.literal('int'),       range: rangePair.optional(), step: z.number().optional(), default: z.number().int().optional() });
+const paramBool    = z.object({ ...paramBase, type: z.literal('bool'),      default: z.boolean().optional() });
+const paramString  = z.object({ ...paramBase, type: z.literal('string'),    maxLength: z.number().int().positive().optional(), default: z.string().optional() });
+const paramEnum    = z.object({ ...paramBase, type: z.literal('enum'),      options: z.array(z.object({ value: z.string(), label: z.string().optional() })).min(1), default: z.string().optional() });
+const paramColor   = z.object({ ...paramBase, type: z.literal('color'),     default: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional() });
+const paramActor   = z.object({ ...paramBase, type: z.literal('actor_ref'), class_filter: z.string().optional() });
+const paramAsset   = z.object({ ...paramBase, type: z.literal('asset_ref'), class_filter: z.string().optional() });
+const paramVec3    = z.object({ ...paramBase, type: z.literal('vector3'),   range: z.array(rangePair).length(3).optional(), default: z.tuple([z.number(), z.number(), z.number()]).optional() });
+const paramXform   = z.object({ ...paramBase, type: z.literal('transform'), default: z.object({
+  location: z.tuple([z.number(), z.number(), z.number()]),
+  rotation: z.tuple([z.number(), z.number(), z.number()]),
+  scale:    z.tuple([z.number(), z.number(), z.number()]),
+}).optional() });
+
+const param = z.discriminatedUnion('type', [
+  paramFloat, paramInt, paramBool, paramString, paramEnum,
+  paramColor, paramActor, paramAsset, paramVec3, paramXform,
+]);
+
+const determinism = z.object({
+  pure: z.boolean(),
+  declared_outputs: z.array(z.string()),
+  side_effects: z.array(z.string()),
+  seed_param: z.string().nullable(),
+});
+
+export const sliverSpecSchema = z.object({
+  id: z.string().regex(reverseDns, 'id must be reverse-DNS like com.hayba.composition.frame_target'),
+  version: z.string().regex(/^\d+\.\d+\.\d+$/, 'version must be semver MAJOR.MINOR.PATCH'),
+  category: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string(),
+  author: z.string().min(1),
+  params: z.array(param).superRefine((arr, ctx) => {
+    const seen = new Set<string>();
+    for (const p of arr) {
+      if (seen.has(p.id)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `duplicate param id "${p.id}"` });
+      }
+      seen.add(p.id);
+    }
+  }),
+  executor: z.object({ kind: z.string().min(1) }),
+  determinism,
+});
+
+export type ParseResult =
+  | { ok: true; spec: SliverSpec }
+  | { ok: false; reason: string };
+
+export function parseSliverSpec(input: unknown): ParseResult {
+  const r = sliverSpecSchema.safeParse(input);
+  if (r.success) return { ok: true, spec: r.data as SliverSpec };
+  const first = r.error.issues[0];
+  const path = first.path.join('.') || '(root)';
+  return { ok: false, reason: `${path}: ${first.message}` };
+}

--- a/mcp-tools/hayba-mcp/src/slivers/specs/com.hayba.composition.frame_target.sliver.json
+++ b/mcp-tools/hayba-mcp/src/slivers/specs/com.hayba.composition.frame_target.sliver.json
@@ -1,0 +1,22 @@
+{
+  "id": "com.hayba.composition.frame_target",
+  "version": "1.0.0",
+  "category": "composition",
+  "title": "Frame Target",
+  "description": "Compute a camera transform that frames a target actor from a given orbit angle, distance, and height offset.",
+  "author": "core",
+  "params": [
+    { "id": "target",   "type": "actor_ref", "label": "Target",            "required": true },
+    { "id": "distance", "type": "float",     "label": "Distance (m)",      "range": [1, 100],  "default": 10 },
+    { "id": "height",   "type": "float",     "label": "Height offset (m)", "range": [-10, 50], "default": 2 },
+    { "id": "fov",      "type": "float",     "label": "Field of view (deg)","range": [20, 120], "default": 70 },
+    { "id": "yaw_deg",  "type": "float",     "label": "Orbit angle (deg)", "range": [0, 360],  "default": 45 }
+  ],
+  "executor": { "kind": "composition.frame_target" },
+  "determinism": {
+    "pure": true,
+    "declared_outputs": ["camera_transform"],
+    "side_effects": [],
+    "seed_param": null
+  }
+}

--- a/mcp-tools/hayba-mcp/src/slivers/types.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/types.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { SliverCycleError, SliverDepthError, SliverNotFoundError, SliverValidationError } from './types.js';
+
+describe('sliver error types', () => {
+  it('SliverCycleError carries the offending id and the call stack', () => {
+    const err = new SliverCycleError('com.hayba.a', ['com.hayba.b', 'com.hayba.a']);
+    expect(err.name).toBe('SliverCycleError');
+    expect(err.id).toBe('com.hayba.a');
+    expect(err.stack_ids).toEqual(['com.hayba.b', 'com.hayba.a']);
+    expect(err.message).toContain('com.hayba.a');
+  });
+
+  it('SliverDepthError reports the depth that was exceeded', () => {
+    const err = new SliverDepthError(8);
+    expect(err.maxDepth).toBe(8);
+    expect(err.message).toContain('8');
+  });
+
+  it('SliverNotFoundError carries the missing id', () => {
+    expect(new SliverNotFoundError('com.x.y').id).toBe('com.x.y');
+  });
+
+  it('SliverValidationError keeps the human reason', () => {
+    expect(new SliverValidationError('missing required param "target"').message).toContain('target');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/slivers/types.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/types.ts
@@ -76,7 +76,7 @@ export type SliverExecutor = (
 export class SliverCycleError extends Error {
   readonly name = 'SliverCycleError';
   constructor(public readonly id: string, public readonly stack_ids: string[]) {
-    super(`Sliver "${id}" re-entered its own call stack: ${stack_ids.join(' → ')}`);
+    super(`Sliver cycle detected — "${id}" re-entered its own call stack: ${stack_ids.join(' → ')}`);
   }
 }
 

--- a/mcp-tools/hayba-mcp/src/slivers/types.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/types.ts
@@ -1,0 +1,102 @@
+// mcp-tools/hayba-mcp/src/slivers/types.ts
+//
+// Sliver type definitions. The runtime, loader, registry, and MCP tools
+// all consume these. Discriminated-union params live here; the Zod
+// equivalent is mirrored in spec-schema.ts for JSON validation.
+
+export type SliverParamBase = {
+  id: string;
+  label?: string;
+  required?: boolean;
+};
+
+export type SliverParamFloat   = SliverParamBase & { type: 'float';     range?: [number, number]; step?: number; default?: number };
+export type SliverParamInt     = SliverParamBase & { type: 'int';       range?: [number, number]; step?: number; default?: number };
+export type SliverParamBool    = SliverParamBase & { type: 'bool';                                                default?: boolean };
+export type SliverParamString  = SliverParamBase & { type: 'string';    maxLength?: number;                       default?: string };
+export type SliverParamEnum    = SliverParamBase & { type: 'enum';      options: Array<{ value: string; label?: string }>; default?: string };
+export type SliverParamColor   = SliverParamBase & { type: 'color';                                               default?: string };  // '#RRGGBB'
+export type SliverParamActor   = SliverParamBase & { type: 'actor_ref'; class_filter?: string };
+export type SliverParamAsset   = SliverParamBase & { type: 'asset_ref'; class_filter?: string };
+export type SliverParamVec3    = SliverParamBase & { type: 'vector3';   range?: Array<[number, number]>;          default?: [number, number, number] };
+export type SliverParamXform   = SliverParamBase & { type: 'transform'; default?: { location: [number, number, number]; rotation: [number, number, number]; scale: [number, number, number] } };
+
+export type SliverParam =
+  | SliverParamFloat | SliverParamInt | SliverParamBool | SliverParamString
+  | SliverParamEnum | SliverParamColor | SliverParamActor | SliverParamAsset
+  | SliverParamVec3 | SliverParamXform;
+
+export interface SliverDeterminism {
+  pure: boolean;
+  declared_outputs: string[];
+  side_effects: string[];
+  seed_param: string | null;
+}
+
+export interface SliverSpec {
+  id: string;
+  version: string;
+  category: string;
+  title: string;
+  description: string;
+  author: string;
+  params: SliverParam[];
+  executor: { kind: string };
+  determinism: SliverDeterminism;
+}
+
+export type SliverParamValues = Record<string, unknown>;
+
+export interface SliverRunResult {
+  ok: boolean;
+  outputs: Record<string, unknown>;
+  side_effects: string[];
+  durationMs: number;
+  error?: string;
+}
+
+/** Context threaded through a runSliver call. Mostly the runtime needs it; executors may read it. */
+export interface SliverContext {
+  /** Reverse-DNS ids in the current call stack (oldest → newest). */
+  stack: string[];
+  /** Current depth = stack.length. Compared against maxDepth. */
+  maxDepth: number;
+  /** Lets executors call other slivers. */
+  runSliver: (id: string, params: SliverParamValues) => Promise<SliverRunResult>;
+}
+
+/** Executor function signature. Pure or mutating per the spec's determinism block. */
+export type SliverExecutor = (
+  params: SliverParamValues,
+  ctx: SliverContext,
+) => Promise<Record<string, unknown>>;
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+export class SliverCycleError extends Error {
+  readonly name = 'SliverCycleError';
+  constructor(public readonly id: string, public readonly stack_ids: string[]) {
+    super(`Sliver "${id}" re-entered its own call stack: ${stack_ids.join(' → ')}`);
+  }
+}
+
+export class SliverDepthError extends Error {
+  readonly name = 'SliverDepthError';
+  constructor(public readonly maxDepth: number) {
+    super(`Sliver call depth exceeded maxDepth=${maxDepth}`);
+  }
+}
+
+export class SliverNotFoundError extends Error {
+  readonly name = 'SliverNotFoundError';
+  constructor(public readonly id: string) {
+    super(`No installed sliver with id "${id}"`);
+  }
+}
+
+export class SliverValidationError extends Error {
+  readonly name = 'SliverValidationError';
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-retriever/asset-indexer.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-retriever/asset-indexer.test.ts
@@ -1,5 +1,22 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { AssetIndexer } from './asset-indexer.js';
+
+let tmpDir: string;
+let snapPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'hayba-tagsnap-'));
+  snapPath = join(tmpDir, 'retriever-tags.json');
+  process.env.HAYBA_TAG_SNAPSHOT_PATH = snapPath;
+});
+
+afterEach(() => {
+  delete process.env.HAYBA_TAG_SNAPSHOT_PATH;
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
 
 describe('AssetIndexer', () => {
   it('uses describe_assets when available', async () => {
@@ -46,5 +63,22 @@ describe('AssetIndexer', () => {
     const r1 = await idx.build();
     const r2 = await idx.build();
     expect(r1.snapshotHash).toBe(r2.snapshotHash);
+  });
+
+  it('writes retriever-tags snapshot after build', async () => {
+    const dispatch = vi.fn(async () => ({
+      assets: [
+        { path: '/Game/Foo/SM_Rock', name: 'SM_Rock', class: 'StaticMesh', tags: ['rock', 'nature'], lastModified: 1 },
+        { path: '/Game/Bar/SM_Tree', name: 'SM_Tree', class: 'StaticMesh', tags: ['tree'], lastModified: 2 },
+        { path: '/Game/Baz/SM_Empty', name: 'SM_Empty', class: 'StaticMesh', tags: [], lastModified: 3 },
+      ],
+    }));
+    const idx = new AssetIndexer(dispatch);
+    await idx.build();
+    expect(existsSync(snapPath)).toBe(true);
+    const parsed = JSON.parse(readFileSync(snapPath, 'utf8'));
+    expect(parsed['/Game/Foo/SM_Rock']).toEqual(['rock', 'nature']);
+    expect(parsed['/Game/Bar/SM_Tree']).toEqual(['tree']);
+    expect(parsed['/Game/Baz/SM_Empty']).toBeUndefined();
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/asset-retriever/asset-indexer.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-retriever/asset-indexer.ts
@@ -1,5 +1,13 @@
 import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { inferSource, type AssetDoc } from './types.js';
+import { writeTagSnapshot } from './tag-snapshot.js';
+
+function tagSnapshotPath(): string {
+  return process.env.HAYBA_TAG_SNAPSHOT_PATH
+    ?? join(homedir(), '.hayba', 'cache', 'retriever-tags.json');
+}
 
 export type Dispatch = (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
 
@@ -24,10 +32,11 @@ export class AssetIndexer {
 
   async build(opts: { forceRefresh?: boolean } = {}): Promise<BuildResult> {
     void opts.forceRefresh;
+    let result: BuildResult;
     try {
       const r = await this.dispatch('describe_assets', { path: '/Game/' }) as DescribeAssetsResponse;
       const docs = r.assets.map(a => normalize(a));
-      return { docs, snapshotHash: hashDocs(docs), fallbackUsed: false };
+      result = { docs, snapshotHash: hashDocs(docs), fallbackUsed: false };
     } catch (e) {
       if (/unknown_command/i.test((e as Error).message)) {
         if (!this.fallbackWarned) {
@@ -39,10 +48,18 @@ export class AssetIndexer {
           const path = typeof a === 'string' ? a : a.path;
           return normalize({ path });
         });
-        return { docs, snapshotHash: hashDocs(docs), fallbackUsed: true };
+        result = { docs, snapshotHash: hashDocs(docs), fallbackUsed: true };
+      } else {
+        throw e;
       }
-      throw e;
     }
+    const snapshotHits = result.docs.map(d => ({ path: d.path, tags: d.tags ?? [] }));
+    try {
+      writeTagSnapshot(tagSnapshotPath(), snapshotHits);
+    } catch (err) {
+      console.error('[cogmap] failed to write tag snapshot:', err);
+    }
+    return result;
   }
 
   async describeDelta(paths: string[]): Promise<AssetDoc[]> {

--- a/mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.test.ts
@@ -1,0 +1,42 @@
+// mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeTagSnapshot } from './tag-snapshot.js';
+
+describe('writeTagSnapshot', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'hayba-tag-snap-')); });
+  afterEach(()  => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('writes sorted assetPath → tags map as JSON', () => {
+    const out = join(dir, 'retriever-tags.json');
+    writeTagSnapshot(out, [
+      { path: '/Game/Foliage/SM_Pine',    tags: ['foliage', 'tree', 'conifer'] },
+      { path: '/Game/Maritime/SM_Anchor', tags: ['maritime', 'metal'] },
+    ]);
+    const parsed = JSON.parse(readFileSync(out, 'utf8'));
+    expect(Object.keys(parsed)).toEqual(['/Game/Foliage/SM_Pine', '/Game/Maritime/SM_Anchor']);
+    expect(parsed['/Game/Maritime/SM_Anchor']).toEqual(['maritime', 'metal']);
+  });
+
+  it('drops hits with no tags', () => {
+    const out = join(dir, 'snap.json');
+    writeTagSnapshot(out, [
+      { path: '/Game/A', tags: [] },
+      { path: '/Game/B', tags: ['x'] },
+    ]);
+    const parsed = JSON.parse(readFileSync(out, 'utf8'));
+    expect(Object.keys(parsed)).toEqual(['/Game/B']);
+  });
+
+  it('is idempotent on identical input', () => {
+    const out = join(dir, 'snap.json');
+    const hits = [{ path: '/Game/X', tags: ['a', 'b'] }];
+    writeTagSnapshot(out, hits);
+    const first = readFileSync(out, 'utf8');
+    writeTagSnapshot(out, hits);
+    expect(readFileSync(out, 'utf8')).toBe(first);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.ts
@@ -5,7 +5,7 @@
 // diff-friendliness; assets with zero tags are omitted to keep the file
 // small.
 
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 export interface TagSnapshotHit {
@@ -21,6 +21,13 @@ export function writeTagSnapshot(outPath: string, hits: TagSnapshotHit[]): void 
   const sortedKeys = Object.keys(map).sort();
   const ordered: Record<string, string[]> = {};
   for (const k of sortedKeys) ordered[k] = map[k];
-  mkdirSync(dirname(outPath), { recursive: true });
-  writeFileSync(outPath, JSON.stringify(ordered, null, 2) + '\n', 'utf8');
+  const payload = JSON.stringify(ordered, null, 2) + '\n';
+  const tmpPath = outPath + '.tmp';
+  try {
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(tmpPath, payload, 'utf8');
+    renameSync(tmpPath, outPath);
+  } catch (err) {
+    throw new Error(`writeTagSnapshot: failed to write ${outPath}: ${(err as Error).message}`);
+  }
 }

--- a/mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.ts
@@ -1,0 +1,26 @@
+// mcp-tools/hayba-mcp/src/tools/asset-retriever/tag-snapshot.ts
+//
+// Dumps a flat { assetPath: tags[] } JSON file the UE plugin reads to
+// enrich the Cognitive Map's per-cell tag list. Sorted keys for
+// diff-friendliness; assets with zero tags are omitted to keep the file
+// small.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+export interface TagSnapshotHit {
+  path: string;
+  tags: string[];
+}
+
+export function writeTagSnapshot(outPath: string, hits: TagSnapshotHit[]): void {
+  const map: Record<string, string[]> = {};
+  for (const h of hits) {
+    if (h.tags && h.tags.length > 0) map[h.path] = h.tags;
+  }
+  const sortedKeys = Object.keys(map).sort();
+  const ordered: Record<string, string[]> = {};
+  for (const k of sortedKeys) ordered[k] = map[k];
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(ordered, null, 2) + '\n', 'utf8');
+}

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -8,7 +8,7 @@ import { installToolStreamMirror } from './tool-stream-mirror.js';
 import { installLiveSender, executeCommand } from './tool-executor.js';
 import { registerToolMeta } from './tool-meta-registry.js';
 import { readSettings } from './routing/settings-watcher.js';
-import { registerDeferredRouting, ALWAYS_ON_META, type CapturedTool } from './routing/register.js';
+import { registerDeferredRouting, ALWAYS_ON_META, type CapturedTool, type RoutingHandle } from './routing/register.js';
 
 // ── Code Mode meta-tools (always-on) ──────────────────────────────────────────
 import { listToolCategoriesHandler, meta as listMeta } from './code-mode/list-tool-categories.js';
@@ -123,7 +123,7 @@ import { analyzeConventionsHandler } from './hayba-analyze-conventions.js';
 // as a typed shim so registerTools' signature doesn't churn for callers.
 type SessionManagerStub = Record<string, unknown>;
 
-export async function registerTools(server: McpServer, session: SessionManagerStub): Promise<void> {
+export async function registerTools(server: McpServer, session: SessionManagerStub): Promise<RoutingHandle | null> {
   const settings = readSettings();
   if (settings.toolRouting === 'deferred') {
     // γ-hybrid: capture every server.tool(...) call into a descriptor map
@@ -175,11 +175,12 @@ export async function registerTools(server: McpServer, session: SessionManagerSt
     // sequence server.connect() after every server.tool() call has happened
     // — McpServer rejects late registrations with "Cannot register
     // capabilities after connecting to transport".
-    await registerDeferredRouting(server, captured);
-    return;
+    const handle = await registerDeferredRouting(server, captured);
+    return handle;
   }
 
   registerToolsCore(server, session);
+  return null;
 }
 
 /**

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -25,6 +25,11 @@ import { AssetRetriever, setDefaultRetriever } from '../asset-retriever/asset-re
 import { assetSearchHandler, assetSearchSchema } from '../asset-retriever/meta-tools/search.js';
 import { assetBrowseHandler, assetBrowseSchema } from '../asset-retriever/meta-tools/browse.js';
 import { assetReindexHandler, assetReindexSchema } from '../asset-retriever/meta-tools/reindex.js';
+import { setupSliverSystem, type SliverSystem } from '../../slivers/index.js';
+import { sliverListHandler, sliverListSchema } from '../sliver/list.js';
+import { sliverGetHandler,  sliverGetSchema  } from '../sliver/get.js';
+import { sliverRunHandler,  sliverRunSchema  } from '../sliver/run.js';
+import { sliverImportHandler, sliverImportSchema } from '../sliver/import.js';
 
 /** Tools registered by registerDeferredRouting itself — skip in shim re-register. */
 export const ALWAYS_ON_META = new Set<string>([
@@ -38,6 +43,10 @@ export const ALWAYS_ON_META = new Set<string>([
   'hayba_asset_search',
   'hayba_asset_browse',
   'hayba_asset_reindex',
+  'hayba_sliver_list',
+  'hayba_sliver_get',
+  'hayba_sliver_run',
+  'hayba_sliver_import',
 ]);
 
 export interface CapturedTool {
@@ -55,6 +64,7 @@ export interface RoutingHandle {
   registry: PackRegistry;
   index: ToolIndex;
   retriever: AssetRetriever;
+  slivers: SliverSystem;
   /** Trigger autoload — wire to `check_ue_status.onConnected`. */
   onUeConnected: () => Promise<void>;
 }
@@ -281,6 +291,52 @@ export async function registerDeferredRouting(
     },
   );
 
+  // ── Slivers (Layer 2 — deterministic abstractions) ─────────────────────────
+  const slivers = await setupSliverSystem();
+  for (const err of slivers.loader.errors()) {
+    console.warn(`[slivers] load error: ${err}`);
+  }
+
+  server.tool(
+    'hayba_sliver_list',
+    'List installed Slivers (deterministic abstractions). Optional category or namespace filter.',
+    sliverListSchema,
+    async (args: { category?: string; namespace?: string }) => {
+      const r = await sliverListHandler(args, { loader: slivers.loader });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'hayba_sliver_get',
+    'Get the full spec (params + determinism + executor) of an installed sliver by id.',
+    sliverGetSchema,
+    async (args: { id: string }) => {
+      const r = await sliverGetHandler(args, { loader: slivers.loader });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'hayba_sliver_run',
+    'Execute a sliver with concrete parameter values. Returns outputs + declared side_effects + durationMs.',
+    sliverRunSchema,
+    async (args: { id: string; params: Record<string, unknown> }) => {
+      const r = await sliverRunHandler(args, { runtime: slivers.runtime });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'hayba_sliver_import',
+    'Install a sliver from a local file path or an http(s) URL into the user sliver library.',
+    sliverImportSchema,
+    async (args: { source: string }) => {
+      const r = await sliverImportHandler(args, { loader: slivers.loader });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
   // ── Always-load packs from settings ────────────────────────────────────────
   for (const name of settings.alwaysLoadPacks) {
     const r = await registry.loadPack(name);
@@ -293,6 +349,7 @@ export async function registerDeferredRouting(
     registry,
     index,
     retriever,
+    slivers,
     onUeConnected: () => registry.maybeAutoLoad('ue_connected'),
   };
 }

--- a/mcp-tools/hayba-mcp/src/tools/sliver/get.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sliver/get.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from '../../slivers/index.js';
+import { sliverGetHandler } from './get.js';
+
+describe('hayba_sliver_get', () => {
+  let userDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-get-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+  });
+  afterEach(() => { rmSync(userDir, { recursive: true, force: true }); });
+
+  it('returns the full spec for a known id', async () => {
+    const r = await sliverGetHandler({ id: 'com.hayba.composition.frame_target' }, { loader: sys.loader });
+    expect(r.found).toBe(true);
+    if (r.found) {
+      expect(r.spec.id).toBe('com.hayba.composition.frame_target');
+      expect(r.spec.params.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns found=false for unknown id', async () => {
+    const r = await sliverGetHandler({ id: 'com.nope.missing' }, { loader: sys.loader });
+    expect(r.found).toBe(false);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/sliver/get.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sliver/get.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import type { SliverLoader } from '../../slivers/loader.js';
+import type { SliverSpec } from '../../slivers/types.js';
+
+export const sliverGetSchema = { id: z.string().min(1) };
+
+export interface SliverGetCtx { loader: SliverLoader; }
+export type SliverGetResult =
+  | { found: true; spec: SliverSpec }
+  | { found: false; id: string };
+
+export async function sliverGetHandler(
+  args: { id: string },
+  ctx: SliverGetCtx,
+): Promise<SliverGetResult> {
+  const spec = ctx.loader.get(args.id);
+  if (!spec) return { found: false, id: args.id };
+  return { found: true, spec };
+}
+
+export const meta = {
+  cost: 'low' as const,
+  effects: ['read'],
+  when: 'You have a sliver id and need its full spec — param schema, determinism block, executor kind.',
+  not_when: 'You want to enumerate slivers — use hayba_sliver_list.',
+  pack: 'core',
+};

--- a/mcp-tools/hayba-mcp/src/tools/sliver/import.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sliver/import.test.ts
@@ -1,0 +1,77 @@
+// mcp-tools/hayba-mcp/src/tools/sliver/import.test.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from '../../slivers/index.js';
+import { sliverImportHandler } from './import.js';
+
+const sample = {
+  id: 'com.example.cool.thing',
+  version: '1.0.0',
+  category: 'demo',
+  title: 'Cool Thing',
+  description: 'demo',
+  author: 'example',
+  params: [],
+  executor: { kind: 'demo.cool' },
+  determinism: { pure: true, declared_outputs: [], side_effects: [], seed_param: null },
+};
+
+describe('hayba_sliver_import', () => {
+  let userDir: string;
+  let srcDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-imp-u-'));
+    srcDir  = mkdtempSync(join(tmpdir(), 'hayba-sl-imp-s-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+  });
+  afterEach(() => {
+    rmSync(userDir, { recursive: true, force: true });
+    rmSync(srcDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('imports a local file path and installs it to userDir', async () => {
+    const p = join(srcDir, 'cool.sliver.json');
+    writeFileSync(p, JSON.stringify(sample));
+    const r = await sliverImportHandler({ source: p }, { loader: sys.loader });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.id).toBe('com.example.cool.thing');
+      expect(existsSync(join(userDir, 'com.example.cool.thing.sliver.json'))).toBe(true);
+    }
+    expect(sys.loader.get('com.example.cool.thing')).toBeDefined();
+  });
+
+  it('imports an https URL via fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(sample), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const r = await sliverImportHandler({ source: 'https://example.com/cool.sliver.json' }, { loader: sys.loader });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects sources that are not file paths or https URLs', async () => {
+    const r = await sliverImportHandler({ source: 'ftp://example.com/x' }, { loader: sys.loader });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/source/i);
+  });
+
+  it('rejects malformed JSON content', async () => {
+    const p = join(srcDir, 'bad.sliver.json');
+    writeFileSync(p, '{ not json');
+    const r = await sliverImportHandler({ source: p }, { loader: sys.loader });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects specs that fail schema validation', async () => {
+    const p = join(srcDir, 'bad.sliver.json');
+    writeFileSync(p, JSON.stringify({ ...sample, id: 'not-reverse-dns' }));
+    const r = await sliverImportHandler({ source: p }, { loader: sys.loader });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/sliver/import.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sliver/import.ts
@@ -1,0 +1,54 @@
+// mcp-tools/hayba-mcp/src/tools/sliver/import.ts
+//
+// hayba_sliver_import — accepts either an absolute file path or an
+// https URL, fetches the JSON, validates against the sliver schema,
+// installs into userDir. Returns the installed id or a clear reason on
+// failure. No network sandbox; trust is social — the LLM's caller (or
+// the user) is responsible for vetting URLs.
+
+import { z } from 'zod';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import type { SliverLoader } from '../../slivers/loader.js';
+
+export const sliverImportSchema = { source: z.string().min(1) };
+
+export interface SliverImportCtx { loader: SliverLoader; }
+export type SliverImportResult =
+  | { ok: true; id: string; path: string; source: string }
+  | { ok: false; reason: string };
+
+export async function sliverImportHandler(
+  args: { source: string },
+  ctx: SliverImportCtx,
+): Promise<SliverImportResult> {
+  let raw: string;
+  try {
+    if (/^https?:\/\//i.test(args.source)) {
+      const resp = await fetch(args.source);
+      if (!resp.ok) return { ok: false, reason: `fetch ${args.source} → HTTP ${resp.status}` };
+      raw = await resp.text();
+    } else if (existsSync(args.source) && statSync(args.source).isFile()) {
+      raw = readFileSync(args.source, 'utf8');
+    } else {
+      return { ok: false, reason: `source must be an existing file path or an http(s) URL: "${args.source}"` };
+    }
+  } catch (e) {
+    return { ok: false, reason: `read source: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); }
+  catch (e) { return { ok: false, reason: `invalid JSON: ${e instanceof Error ? e.message : String(e)}` }; }
+
+  const result = ctx.loader.install(parsed);
+  if (!result.ok) return { ok: false, reason: result.reason };
+  return { ok: true, id: result.id, path: result.path, source: args.source };
+}
+
+export const meta = {
+  cost: 'medium' as const,
+  effects: ['filesystem_write'],
+  when: 'You want to install a sliver from a local file path or an http(s) URL into the user sliver library.',
+  not_when: 'You only want to run an already-installed sliver — use hayba_sliver_run.',
+  pack: 'core',
+};

--- a/mcp-tools/hayba-mcp/src/tools/sliver/list.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sliver/list.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from '../../slivers/index.js';
+import { sliverListHandler } from './list.js';
+
+describe('hayba_sliver_list', () => {
+  let userDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-list-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+  });
+  afterEach(() => { rmSync(userDir, { recursive: true, force: true }); });
+
+  it('returns all installed slivers', async () => {
+    const r = await sliverListHandler({}, { loader: sys.loader });
+    expect(r.slivers.length).toBeGreaterThan(0);
+    expect(r.slivers[0]).toMatchObject({
+      id: 'com.hayba.composition.frame_target',
+      category: 'composition',
+    });
+  });
+
+  it('filters by category', async () => {
+    const r = await sliverListHandler({ category: 'composition' }, { loader: sys.loader });
+    expect(r.slivers.every(s => s.category === 'composition')).toBe(true);
+    const empty = await sliverListHandler({ category: 'does_not_exist' }, { loader: sys.loader });
+    expect(empty.slivers).toEqual([]);
+  });
+
+  it('filters by namespace prefix', async () => {
+    const r = await sliverListHandler({ namespace: 'com.hayba' }, { loader: sys.loader });
+    expect(r.slivers.every(s => s.id.startsWith('com.hayba.'))).toBe(true);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/sliver/list.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sliver/list.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import type { SliverLoader } from '../../slivers/loader.js';
+
+export const sliverListSchema = {
+  category: z.string().optional(),
+  namespace: z.string().optional(),
+};
+
+export interface SliverListCtx { loader: SliverLoader; }
+export interface SliverSummary { id: string; title: string; category: string; version: string; }
+export interface SliverListResult { slivers: SliverSummary[]; }
+
+export async function sliverListHandler(
+  args: { category?: string; namespace?: string },
+  ctx: SliverListCtx,
+): Promise<SliverListResult> {
+  const slivers = ctx.loader.list()
+    .filter(s => !args.category || s.category === args.category)
+    .filter(s => !args.namespace || s.id.startsWith(args.namespace + '.') || s.id === args.namespace)
+    .map(s => ({ id: s.id, title: s.title, category: s.category, version: s.version }));
+  return { slivers };
+}
+
+export const meta = {
+  cost: 'low' as const,
+  effects: ['read'],
+  when: 'You want to discover which Slivers (deterministic abstractions) are installed.',
+  not_when: 'You already know the sliver id and just want its full spec — use hayba_sliver_get.',
+  pack: 'core',
+};

--- a/mcp-tools/hayba-mcp/src/tools/sliver/run.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sliver/run.test.ts
@@ -1,0 +1,46 @@
+// mcp-tools/hayba-mcp/src/tools/sliver/run.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setupSliverSystem } from '../../slivers/index.js';
+import { sliverRunHandler } from './run.js';
+
+describe('hayba_sliver_run', () => {
+  let userDir: string;
+  let sys: Awaited<ReturnType<typeof setupSliverSystem>>;
+
+  beforeEach(async () => {
+    userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-run-'));
+    sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
+  });
+  afterEach(() => { rmSync(userDir, { recursive: true, force: true }); });
+
+  it('executes a known sliver and returns ok=true with outputs', async () => {
+    const r = await sliverRunHandler(
+      { id: 'com.hayba.composition.frame_target', params: { target: '/Game/X.X' } },
+      { runtime: sys.runtime },
+    );
+    expect(r.ok).toBe(true);
+    expect(r.outputs).toHaveProperty('camera_transform');
+    expect(typeof r.durationMs).toBe('number');
+  });
+
+  it('returns ok=false with error message when sliver id is unknown', async () => {
+    const r = await sliverRunHandler(
+      { id: 'com.nope.missing', params: {} },
+      { runtime: sys.runtime },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/missing/);
+  });
+
+  it('returns ok=false when params fail validation', async () => {
+    const r = await sliverRunHandler(
+      { id: 'com.hayba.composition.frame_target', params: { target: '/Game/X.X', distance: 9999 } },
+      { runtime: sys.runtime },
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/distance/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/sliver/run.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sliver/run.ts
@@ -1,0 +1,26 @@
+// mcp-tools/hayba-mcp/src/tools/sliver/run.ts
+import { z } from 'zod';
+import type { SliverRuntime } from '../../slivers/runtime.js';
+import type { SliverRunResult } from '../../slivers/types.js';
+
+export const sliverRunSchema = {
+  id: z.string().min(1),
+  params: z.record(z.unknown()).default({}),
+};
+
+export interface SliverRunCtx { runtime: SliverRuntime; }
+
+export async function sliverRunHandler(
+  args: { id: string; params: Record<string, unknown> },
+  ctx: SliverRunCtx,
+): Promise<SliverRunResult> {
+  return ctx.runtime.runSliver(args.id, args.params ?? {});
+}
+
+export const meta = {
+  cost: 'medium' as const,
+  effects: ['varies-by-sliver'],
+  when: 'You want to execute a sliver with concrete parameter values. Returns outputs + declared side_effects.',
+  not_when: 'You only need to read the spec — use hayba_sliver_get.',
+  pack: 'core',
+};

--- a/unreal/HaybaMCPToolkit/Resources/cognitive-map/index.html
+++ b/unreal/HaybaMCPToolkit/Resources/cognitive-map/index.html
@@ -78,6 +78,34 @@
     //   root  ── semantic-category hub  ── cell leaf
     // Force-directed layout, drag-able nodes, responsive resize.
 
+    // ── Tag-based coloring ───────────────────────────────────────────────
+    // Tag overrides are hand-pinned in tag-overrides.json (broad families
+    // like "maritime", "foliage", etc.). Anything not in the overrides
+    // table is hashed deterministically so the same tag string always
+    // resolves to the same hue across runs and cells.
+    let TAG_OVERRIDES = {};
+    fetch('tag-overrides.json')
+      .then(r => r.ok ? r.json() : {})
+      .then(o => { TAG_OVERRIDES = o; render(); })
+      .catch(() => { /* tolerate missing overrides — fall back to hash */ });
+
+    // FNV-1a 32-bit hash. Deterministic per tag string.
+    function fnv1a(str) {
+      let h = 2166136261 >>> 0;
+      for (let i = 0; i < str.length; ++i) {
+        h ^= str.charCodeAt(i);
+        h = Math.imul(h, 16777619) >>> 0;
+      }
+      return h;
+    }
+
+    function colorForTag(tag) {
+      if (!tag) return 'hsl(0, 0%, 60%)';      // muted gray for tagless cells
+      if (TAG_OVERRIDES[tag]) return TAG_OVERRIDES[tag];
+      const hue = fnv1a(tag) % 360;
+      return `hsl(${hue}, 55%, 55%)`;
+    }
+
     const PALETTE = {
       forest:     '#4caf6c',
       meadow:     '#7bb867',
@@ -140,31 +168,36 @@
       const root = { id: 'root', kind: 'root', label: 'level', color: '#cfd5e6', r: 30, x: 0, y: 0, vx: 0, vy: 0 };
       nodes.push(root);
 
-      // 2. Hubs per semantic family.
-      const families = new Map(); // semantic → {node, cells:[]}
+      // 2. Hubs per tag family. Cells are keyed by their first (mode) tag;
+      //    anything without tags lands in a single '_untagged' hub. Once
+      //    Task 5 wires cell.tags through the JSON payload this groups
+      //    cells by real tag families instead of the old hardcoded semantic
+      //    table.
+      const families = new Map(); // tag → {node, cells:[]}
       for (const c of cells) {
-        const sem = semanticOf(c.label);
-        if (!families.has(sem)) {
+        const key = (c.tags && c.tags[0]) ? c.tags[0] : '_untagged';
+        if (!families.has(key)) {
           const hub = {
-            id: 'hub:' + sem, kind: 'hub', label: sem,
-            color: PALETTE[sem] || fallbackColor,
+            id: 'hub:' + key, kind: 'hub', label: key,
+            color: colorForTag(key === '_untagged' ? null : key),
             r: 16, x: 0, y: 0, vx: 0, vy: 0, data: { cellCount: 0, actorCount: 0 },
           };
           nodes.push(hub);
           edges.push({ source: 'root', target: hub.id });
-          families.set(sem, { node: hub, cells: [] });
+          families.set(key, { node: hub, cells: [] });
         }
-        families.get(sem).cells.push(c);
+        families.get(key).cells.push(c);
       }
 
       // 3. Cell leaves under each hub.
-      for (const [sem, fam] of families) {
+      for (const [key, fam] of families) {
         fam.node.data.cellCount = fam.cells.length;
         for (const c of fam.cells) {
           fam.node.data.actorCount += c.count;
           const cellNode = {
-            id: 'cell:' + sem + ':' + c.label + ':' + (c.bounds.min[0]) + ':' + (c.bounds.min[1]),
-            kind: 'cell', label: c.label, color: PALETTE[sem] || fallbackColor,
+            id: 'cell:' + key + ':' + c.label + ':' + (c.bounds.min[0]) + ':' + (c.bounds.min[1]),
+            kind: 'cell', label: c.label,
+            color: colorForTag((c.tags && c.tags[0]) || null),
             // Radius scales with sqrt(actor count) so a 100-actor cell is
             // ~10× a 1-actor cell but big areas don't dominate.
             r: 6 + Math.sqrt(c.count) * 1.5,
@@ -290,11 +323,46 @@
         const body = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
         body.setAttribute('class', 'body');
         body.setAttribute('r', n.r);
+        // Fill leaf cells with their tag color. Root/hub keep the dark
+        // panel fill from CSS so the colored stroke reads as a ring.
+        if (n.kind === 'cell') body.setAttribute('fill', n.color);
         g.appendChild(body);
+
+        // Per-cell chip strip: up to 5 small dots, one per tag, colored
+        // with the same deterministic tag palette. Renders as a horizontal
+        // row centered just below the cell circle. Tooltips on each chip
+        // show the tag name. Tagless cells get no chips.
+        if (n.kind === 'cell') {
+          const chips = (n.data && n.data.tags) ? n.data.tags.slice(0, 5) : [];
+          if (chips.length) {
+            const chipR = 3;
+            const chipGap = 2;
+            const totalW = chips.length * (chipR * 2 + chipGap) - chipGap;
+            const startX = -totalW / 2;
+            const chipY  = n.r + chipR + 4;
+            for (let i = 0; i < chips.length; ++i) {
+              const t = chips[i];
+              const chip = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+              chip.setAttribute('class', 'chip');
+              chip.setAttribute('cx', startX + i * (chipR * 2 + chipGap) + chipR);
+              chip.setAttribute('cy', chipY);
+              chip.setAttribute('r', chipR);
+              chip.setAttribute('fill', colorForTag(t));
+              const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+              title.textContent = t;
+              chip.appendChild(title);
+              g.appendChild(chip);
+            }
+          }
+        }
 
         const txt = document.createElementNS('http://www.w3.org/2000/svg', 'text');
         txt.setAttribute('text-anchor', 'middle');
-        txt.setAttribute('dy', n.r + 14);
+        // Cells reserve ~14px below for the chip strip; nudge the label down
+        // so the count doesn't collide with the chips.
+        const labelDy = (n.kind === 'cell' && n.data && n.data.tags && n.data.tags.length)
+          ? n.r + 24 : n.r + 14;
+        txt.setAttribute('dy', labelDy);
         txt.setAttribute('font-size', n.kind === 'root' ? 14 : (n.kind === 'hub' ? 12 : 10));
         txt.textContent = n.kind === 'cell'
           ? `${n.data.count}`     // tight leaves: just the count, hover for detail

--- a/unreal/HaybaMCPToolkit/Resources/cognitive-map/index.html
+++ b/unreal/HaybaMCPToolkit/Resources/cognitive-map/index.html
@@ -86,7 +86,7 @@
     let TAG_OVERRIDES = {};
     fetch('tag-overrides.json')
       .then(r => r.ok ? r.json() : {})
-      .then(o => { TAG_OVERRIDES = o; render(); })
+      .then(o => { TAG_OVERRIDES = o; if (cells && cells.length) { buildGraph(cells); render(); } })
       .catch(() => { /* tolerate missing overrides — fall back to hash */ });
 
     // FNV-1a 32-bit hash. Deterministic per tag string.
@@ -104,39 +104,6 @@
       if (TAG_OVERRIDES[tag]) return TAG_OVERRIDES[tag];
       const hue = fnv1a(tag) % 360;
       return `hsl(${hue}, 55%, 55%)`;
-    }
-
-    const PALETTE = {
-      forest:     '#4caf6c',
-      meadow:     '#7bb867',
-      brush:      '#5fa462',
-      urban:      '#8c93b0',
-      lighting:   '#e6c155',
-      triggers:   '#5cb6ee',
-      characters: '#f57777',
-      geology:    '#b58e6a',
-      terrain:    '#a98a5e',
-      water:      '#4d9ed6',
-      mixed:      '#9aa0ad',
-    };
-    const fallbackColor = '#9aa0ad';
-    function semanticOf(label) {
-      // Map a cell's label back to its broad semantic family for coloring.
-      for (const k of Object.keys(PALETTE)) if (label === k) return k;
-      // Heuristic fallback by substring (matches the C++ name table).
-      const map = [
-        [['tree','foliage'], 'forest'], [['grass'], 'meadow'], [['bush'], 'brush'],
-        [['building','wall','floor','house'], 'urban'],
-        [['light','lamp'], 'lighting'],
-        [['character','pawn'], 'characters'],
-        [['trigger','volume'], 'triggers'],
-        [['rock','cliff','boulder'], 'geology'],
-        [['water','river','ocean'], 'water'],
-        [['landscape','terrain'], 'terrain'],
-      ];
-      for (const [keys, sem] of map) for (const k of keys)
-        if (label.toLowerCase().includes(k)) return sem;
-      return 'mixed';
     }
 
     const svg     = document.getElementById('svg');

--- a/unreal/HaybaMCPToolkit/Resources/cognitive-map/tag-overrides.json
+++ b/unreal/HaybaMCPToolkit/Resources/cognitive-map/tag-overrides.json
@@ -1,0 +1,17 @@
+{
+  "maritime":   "hsl(210, 60%, 50%)",
+  "foliage":    "hsl(120, 50%, 45%)",
+  "urban":      "hsl(280, 30%, 55%)",
+  "light":      "hsl(50, 75%, 60%)",
+  "character":  "hsl(15, 65%, 55%)",
+  "vehicle":    "hsl(0, 60%, 50%)",
+  "interior":   "hsl(30, 40%, 50%)",
+  "industrial": "hsl(200, 20%, 45%)",
+  "natural":    "hsl(95, 45%, 50%)",
+  "rock":       "hsl(25, 25%, 45%)",
+  "water":      "hsl(195, 70%, 55%)",
+  "sky":        "hsl(220, 70%, 70%)",
+  "tech":       "hsl(180, 55%, 50%)",
+  "magic":      "hsl(290, 70%, 60%)",
+  "weapon":     "hsl(355, 50%, 45%)"
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/HaybaMCPToolkit.Build.cs
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/HaybaMCPToolkit.Build.cs
@@ -15,7 +15,7 @@ public class HaybaMCPToolkit : ModuleRules
 
         PublicDependencyModuleNames.AddRange(new string[] {
             "Core", "CoreUObject", "Engine", "Slate", "SlateCore",
-            "EditorStyle", "InputCore", "EnhancedInput",
+            "EditorStyle", "EditorWidgets", "InputCore", "EnhancedInput",
             "UMG"
         });
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCogMapBuilder.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCogMapBuilder.cpp
@@ -8,6 +8,8 @@
 #include "Engine/Brush.h"
 #include "EngineUtils.h"
 #include "GameFramework/Actor.h"
+#include "Components/ActorComponent.h"
+#include "HaybaTagIndex.h"
 #include "Landscape.h"
 #include "LandscapeStreamingProxy.h"
 
@@ -116,6 +118,50 @@ namespace
         return Out;
     }
 
+    // Aggregate up to Limit tags across the cell's actors, sorted by frequency
+    // then alphabetically for stability. Prefers UE Actor->Tags; falls back to
+    // the retriever snapshot indexed by the actor's primary asset path.
+    TArray<FString> AggregateTagsForCell(const TArray<AActor*>& Actors, int32 Limit)
+    {
+        TMap<FString, int32> Counts;
+
+        auto Bump = [&Counts](const FString& Tag)
+        {
+            if (!Tag.IsEmpty()) Counts.FindOrAdd(Tag)++;
+        };
+
+        const FHaybaTagIndex& Index = FHaybaTagIndex::Get();
+
+        for (AActor* A : Actors)
+        {
+            if (!A) continue;
+            bool bHadUETag = false;
+            for (const FName& T : A->Tags) { Bump(T.ToString()); bHadUETag = true; }
+            if (bHadUETag) continue;
+
+            // Fallback: resolve the actor's source-asset path via its root component's UObject, if any.
+            FString AssetPath;
+            if (UObject* SrcAsset = A->GetClass()) AssetPath = SrcAsset->GetPathName();
+            if (!AssetPath.IsEmpty())
+            {
+                for (const FString& T : Index.Lookup(AssetPath)) Bump(T);
+            }
+        }
+
+        TArray<TPair<FString, int32>> Sorted;
+        for (const auto& KV : Counts) Sorted.Add(KV);
+        Sorted.Sort([](const TPair<FString,int32>& A, const TPair<FString,int32>& B)
+        {
+            if (A.Value != B.Value) return A.Value > B.Value;
+            return A.Key < B.Key;
+        });
+
+        TArray<FString> Out;
+        Out.Reserve(Limit);
+        for (int32 i = 0; i < FMath::Min(Limit, Sorted.Num()); ++i) Out.Add(Sorted[i].Key);
+        return Out;
+    }
+
     // Uniform 2D grid fallback. Divides the bounding XY of all actors into a
     // GridSize × GridSize lattice and keeps non-empty bins as cells.
     TArray<FHaybaCogMapCell> BuildUniformGrid(const TArray<AActor*>& Actors, int32 GridSize)
@@ -162,6 +208,7 @@ namespace
                 FVector2D(Bounds.Min.X + (GX+1) * CellSize.X, Bounds.Min.Y + (GY+1) * CellSize.Y));
             Cell.ActorCount = Bin.Num();
             Cell.DominantClasses = DominantClasses(Bin, /*Limit=*/5);
+            Cell.Tags = AggregateTagsForCell(Bin, /*Limit=*/5);
             ClassifyDominant(Cell.DominantClasses, Cell.Label, Cell.Semantic);
             for (AActor* A : Bin) Cell.ActorLabels.Add(A->GetActorLabel());
             Cells.Add(MoveTemp(Cell));

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCogMapBuilder.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCogMapBuilder.cpp
@@ -12,6 +12,9 @@
 #include "HaybaTagIndex.h"
 #include "Landscape.h"
 #include "LandscapeStreamingProxy.h"
+#include "Misc/PackageName.h"
+#include "Components/StaticMeshComponent.h"
+#include "Engine/StaticMesh.h"
 
 namespace
 {
@@ -139,12 +142,33 @@ namespace
             for (const FName& T : A->Tags) { Bump(T.ToString()); bHadUETag = true; }
             if (bHadUETag) continue;
 
-            // Fallback: resolve the actor's source-asset path via its root component's UObject, if any.
+            // For BP actors, GetClass()->GetPathName() returns "/Game/Foo/BP_X.BP_X_C".
+            // Convert back to the asset path the retriever indexed ("/Game/Foo/BP_X").
             FString AssetPath;
-            if (UObject* SrcAsset = A->GetClass()) AssetPath = SrcAsset->GetPathName();
-            if (!AssetPath.IsEmpty())
+            if (UClass* Cls = A->GetClass())
+            {
+                AssetPath = Cls->GetPathName();
+                if (AssetPath.EndsWith(TEXT("_C")))
+                {
+                    AssetPath = FPackageName::ObjectPathToPackageName(AssetPath);
+                }
+            }
+            // Native classes resolve to "/Script/Engine.X" — Lookup will simply miss for those.
+            // v1 accepts the miss; v2 may walk components for the underlying mesh asset.
+            if (!AssetPath.IsEmpty() && !AssetPath.StartsWith(TEXT("/Script/")))
             {
                 for (const FString& T : Index.Lookup(AssetPath)) Bump(T);
+            }
+
+            // Additional fallback: look up the static mesh asset on the actor's mesh
+            // component, if any. Catches AStaticMeshActor and similar where the class
+            // path lives in /Script/ but the content asset is the mesh.
+            if (UStaticMeshComponent* SMC = A->FindComponentByClass<UStaticMeshComponent>())
+            {
+                if (UStaticMesh* Mesh = SMC->GetStaticMesh())
+                {
+                    for (const FString& T : Index.Lookup(Mesh->GetPathName())) Bump(T);
+                }
             }
         }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp
@@ -170,10 +170,18 @@ void FHaybaMCPModule::StartupModule()
                 true));
         }
     }));
+
+    extern void HaybaSliver_RegisterTab();
+    extern void HaybaSliver_RegisterBuiltinParamWidgets();
+    HaybaSliver_RegisterBuiltinParamWidgets();
+    HaybaSliver_RegisterTab();
 }
 
 void FHaybaMCPModule::ShutdownModule()
 {
+    extern void HaybaSliver_UnregisterTab();
+    HaybaSliver_UnregisterTab();
+
     auto& TM = FGlobalTabmanager::Get();
     TM->UnregisterNomadTabSpawner(TabMain);
     StopTcpServer();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapData.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapData.h
@@ -37,6 +37,7 @@ struct FHaybaCogMapCell
     int32 ActorCount = 0;
     TArray<FString> DominantClasses;       // top 5 class names by count
     TArray<FString> ActorLabels;           // for click-to-select
+    TArray<FString> Tags;                  // NEW — top-5 tags by frequency across the cell's actors
 };
 
 /** Minimal quadtree storing node index + position so splits can redistribute. */

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapWebPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSceneMapWebPanel.cpp
@@ -113,6 +113,12 @@ FString SHaybaMCPSceneMapWebPanel::CellsToJson() const
             if (d) J += TEXT(",");
             J += TEXT("\"") + EscStr(C.DominantClasses[d]) + TEXT("\"");
         }
+        J += TEXT("],\"tags\":[");
+        for (int32 t = 0; t < C.Tags.Num(); ++t)
+        {
+            if (t) J += TEXT(",");
+            J += TEXT("\"") + EscStr(C.Tags[t]) + TEXT("\"");
+        }
         J += TEXT("]}");
     }
     J += TEXT("]}");

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.cpp
@@ -1,0 +1,87 @@
+// HaybaTagIndex.cpp
+#include "HaybaTagIndex.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformMisc.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+const TArray<FString> FHaybaTagIndex::EmptyTags;
+
+FString FHaybaTagIndex::DefaultSnapshotPath()
+{
+#if PLATFORM_WINDOWS
+    FString Home = FPlatformMisc::GetEnvironmentVariable(TEXT("USERPROFILE"));
+    if (Home.IsEmpty()) Home = FPaths::ProjectSavedDir();
+    return FPaths::Combine(Home, TEXT(".hayba"), TEXT("cache"), TEXT("retriever-tags.json"));
+#else
+    FString Home = FPlatformMisc::GetEnvironmentVariable(TEXT("HOME"));
+    if (Home.IsEmpty()) Home = FPaths::ProjectSavedDir();
+    return FPaths::Combine(Home, TEXT(".hayba"), TEXT("cache"), TEXT("retriever-tags.json"));
+#endif
+}
+
+FHaybaTagIndex& FHaybaTagIndex::Get()
+{
+    static FHaybaTagIndex Singleton;
+    return Singleton;
+}
+
+void FHaybaTagIndex::Invalidate()
+{
+    PathToTags.Reset();
+    bLoaded = false;
+    bLoadAttempted = false;
+}
+
+void FHaybaTagIndex::EnsureLoaded()
+{
+    if (bLoadAttempted) return;
+    bLoadAttempted = true;
+
+    const FString Path = DefaultSnapshotPath();
+    if (!IFileManager::Get().FileExists(*Path))
+    {
+        UE_LOG(LogTemp, Log, TEXT("[HaybaTagIndex] snapshot not present at %s — falling back to actor tags only"), *Path);
+        return;
+    }
+
+    FString Raw;
+    if (!FFileHelper::LoadFileToString(Raw, *Path))
+    {
+        UE_LOG(LogTemp, Warning, TEXT("[HaybaTagIndex] failed to read %s"), *Path);
+        return;
+    }
+
+    TSharedPtr<FJsonObject> Root;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Raw);
+    if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+    {
+        UE_LOG(LogTemp, Warning, TEXT("[HaybaTagIndex] %s is not valid JSON"), *Path);
+        return;
+    }
+
+    for (const auto& KV : Root->Values)
+    {
+        if (!KV.Value.IsValid() || KV.Value->Type != EJson::Array) continue;
+        TArray<FString>& Out = PathToTags.Add(KV.Key);
+        for (const TSharedPtr<FJsonValue>& V : KV.Value->AsArray())
+        {
+            FString S;
+            if (V.IsValid() && V->TryGetString(S)) Out.Add(S);
+        }
+    }
+    bLoaded = true;
+    UE_LOG(LogTemp, Log, TEXT("[HaybaTagIndex] loaded %d entries from %s"), PathToTags.Num(), *Path);
+}
+
+const TArray<FString>& FHaybaTagIndex::Lookup(const FString& AssetPath) const
+{
+    const_cast<FHaybaTagIndex*>(this)->EnsureLoaded();
+    if (const TArray<FString>* Found = PathToTags.Find(AssetPath)) return *Found;
+    return EmptyTags;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaTagIndex.h
@@ -1,0 +1,36 @@
+// HaybaTagIndex.h — Lazy loader for the asset-retriever tag snapshot
+// (~/.hayba/cache/retriever-tags.json). Maps UE asset path → tag list.
+// Used by the Cognitive Map builder to enrich cells with semantic tags
+// when actors carry no UE Tags of their own.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FHaybaTagIndex
+{
+public:
+    /** Path resolution: %USERPROFILE%/.hayba/cache/retriever-tags.json on Windows. */
+    static FString DefaultSnapshotPath();
+
+    /** Process-wide instance. Loads on first call; subsequent calls are O(1). */
+    static FHaybaTagIndex& Get();
+
+    /** Returns empty list when the asset path is unknown or the snapshot is missing. */
+    const TArray<FString>& Lookup(const FString& AssetPath) const;
+
+    /** True iff the snapshot was successfully loaded. */
+    bool IsLoaded() const { return bLoaded; }
+
+    /** Drops the cached map and forces a reload on the next Lookup. */
+    void Invalidate();
+
+private:
+    FHaybaTagIndex() = default;
+    void EnsureLoaded();
+
+    mutable bool bLoaded = false;
+    mutable bool bLoadAttempted = false;
+    mutable TMap<FString, TArray<FString>> PathToTags;
+    static const TArray<FString> EmptyTags;
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverClient.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverClient.cpp
@@ -1,0 +1,33 @@
+// HaybaSliverClient.cpp
+#include "Slivers/HaybaSliverClient.h"
+
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+
+void FHaybaSliverClient::RunSliver(
+    const FString& BaseUrl,
+    const FString& Id,
+    const FString& ParamsJson,
+    FHaybaSliverRunCallback OnDone)
+{
+    const FString Url = BaseUrl + TEXT("/sliver/run");
+    const FString Body = FString::Printf(TEXT("{\"id\":\"%s\",\"params\":%s}"), *Id, *ParamsJson);
+
+    const TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Req = FHttpModule::Get().CreateRequest();
+    Req->SetVerb(TEXT("POST"));
+    Req->SetURL(Url);
+    Req->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+    Req->SetContentAsString(Body);
+
+    Req->OnProcessRequestComplete().BindLambda(
+        [OnDone](FHttpRequestPtr, FHttpResponsePtr Resp, bool bSucceeded)
+        {
+            if (!bSucceeded || !Resp.IsValid())
+            { OnDone.ExecuteIfBound(false, TEXT("HTTP request failed")); return; }
+            const int32 Code = Resp->GetResponseCode();
+            const FString Content = Resp->GetContentAsString();
+            OnDone.ExecuteIfBound(Code >= 200 && Code < 300, Content);
+        });
+    Req->ProcessRequest();
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverClient.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverClient.h
@@ -1,0 +1,20 @@
+// HaybaSliverClient.h — Thin HTTP client over the MCP server's
+// /sliver/run endpoint. Async: caller passes a completion delegate
+// fired on the game thread.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+DECLARE_DELEGATE_TwoParams(FHaybaSliverRunCallback, bool /*bOk*/, const FString& /*JsonResponseOrError*/);
+
+class FHaybaSliverClient
+{
+public:
+    /** POST /sliver/run with the given id + params (JSON-serialised). */
+    static void RunSliver(
+        const FString& BaseUrl,
+        const FString& Id,
+        const FString& ParamsJson,
+        FHaybaSliverRunCallback OnDone);
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.cpp
@@ -1,0 +1,59 @@
+// HaybaSliverLoader.cpp
+#include "Slivers/HaybaSliverLoader.h"
+
+#include "Dom/JsonObject.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+FString FHaybaSliverLoader::DefaultUserSliversDir()
+{
+#if PLATFORM_WINDOWS
+    FString Appdata = FPlatformMisc::GetEnvironmentVariable(TEXT("APPDATA"));
+    if (Appdata.IsEmpty()) Appdata = FPaths::ProjectSavedDir();
+    return FPaths::Combine(Appdata, TEXT("Hayba"), TEXT("slivers"));
+#else
+    FString Home = FPlatformMisc::GetEnvironmentVariable(TEXT("HOME"));
+    if (Home.IsEmpty()) Home = FPaths::ProjectSavedDir();
+    return FPaths::Combine(Home, TEXT(".hayba"), TEXT("Hayba"), TEXT("slivers"));
+#endif
+}
+
+void FHaybaSliverLoader::Refresh(const FString& UserDir)
+{
+    Specs.Reset();
+    LoadErrors.Reset();
+
+    if (!IFileManager::Get().DirectoryExists(*UserDir)) return;
+
+    TArray<FString> Files;
+    IFileManager::Get().FindFiles(Files, *FPaths::Combine(UserDir, TEXT("*.sliver.json")), /*Files*/true, /*Dirs*/false);
+
+    for (const FString& Name : Files)
+    {
+        const FString Full = FPaths::Combine(UserDir, Name);
+        FString Raw;
+        if (!FFileHelper::LoadFileToString(Raw, *Full))
+        { LoadErrors.Add(FString::Printf(TEXT("%s: failed to read"), *Name)); continue; }
+
+        TSharedPtr<FJsonObject> Obj;
+        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Raw);
+        if (!FJsonSerializer::Deserialize(Reader, Obj) || !Obj.IsValid())
+        { LoadErrors.Add(FString::Printf(TEXT("%s: invalid JSON"), *Name)); continue; }
+
+        FHaybaSliverSpec Spec;
+        FString Err;
+        if (!ParseHaybaSliverSpec(Obj.ToSharedRef(), Spec, Err))
+        { LoadErrors.Add(FString::Printf(TEXT("%s: %s"), *Name, *Err)); continue; }
+
+        Specs.Add(MoveTemp(Spec));
+    }
+}
+
+const FHaybaSliverSpec* FHaybaSliverLoader::Find(const FString& Id) const
+{
+    for (const FHaybaSliverSpec& S : Specs) if (S.Id == Id) return &S;
+    return nullptr;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.cpp
@@ -3,6 +3,8 @@
 
 #include "Dom/JsonObject.h"
 #include "HAL/PlatformProcess.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformMisc.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 #include "Serialization/JsonReader.h"

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverLoader.h
@@ -1,0 +1,27 @@
+// HaybaSliverLoader.h — Scans %APPDATA%/Hayba/slivers/*.sliver.json,
+// parses each one into FHaybaSliverSpec, exposes a flat list + lookup.
+// Cheap to refresh on demand (no watcher; the panel exposes a Refresh
+// button).
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Slivers/HaybaSliverTypes.h"
+
+class FHaybaSliverLoader
+{
+public:
+    /** %APPDATA%/Hayba/slivers on Windows, $HOME/.hayba/Hayba/slivers elsewhere. */
+    static FString DefaultUserSliversDir();
+
+    /** Reads + parses every *.sliver.json in UserDir. Replaces in-memory state. */
+    void Refresh(const FString& UserDir);
+
+    const TArray<FHaybaSliverSpec>& List() const { return Specs; }
+    const FHaybaSliverSpec* Find(const FString& Id) const;
+    const TArray<FString>& Errors() const { return LoadErrors; }
+
+private:
+    TArray<FHaybaSliverSpec> Specs;
+    TArray<FString> LoadErrors;
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverSettings.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverSettings.cpp
@@ -1,0 +1,15 @@
+// HaybaSliverSettings.cpp
+#include "Slivers/HaybaSliverSettings.h"
+
+UHaybaSliverSettings::UHaybaSliverSettings()
+    : McpHttpBaseUrl(TEXT("http://127.0.0.1:3091"))
+    , RunMode(EHaybaSliverRunMode::Manual)
+    , MaxSliverDepth(8)
+{}
+
+const UHaybaSliverSettings* UHaybaSliverSettings::GetChecked()
+{
+    const UHaybaSliverSettings* S = GetDefault<UHaybaSliverSettings>();
+    check(S);
+    return S;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTabRegistration.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTabRegistration.cpp
@@ -1,0 +1,37 @@
+// HaybaSliverTabRegistration.cpp — Registers the Slivers nomad tab and
+// the Window menu entry. Public callable: HaybaSliver_RegisterTab() /
+// HaybaSliver_UnregisterTab().
+
+#include "Slivers/SSliversPanel.h"
+
+#include "Framework/Application/SlateApplication.h"
+#include "Framework/Docking/TabManager.h"
+#include "Widgets/Docking/SDockTab.h"
+#include "WorkspaceMenuStructure.h"
+#include "WorkspaceMenuStructureModule.h"
+
+static const FName SliversTabName(TEXT("HaybaSlivers"));
+
+static TSharedRef<SDockTab> SpawnSliversTab(const FSpawnTabArgs&)
+{
+    return SNew(SDockTab)
+        .TabRole(ETabRole::NomadTab)
+        .Label(NSLOCTEXT("HaybaSlivers", "TabLabel", "Slivers"))
+        [
+            SNew(SSliversPanel)
+        ];
+}
+
+void HaybaSliver_RegisterTab()
+{
+    FGlobalTabmanager::Get()->RegisterNomadTabSpawner(SliversTabName, FOnSpawnTab::CreateStatic(&SpawnSliversTab))
+        .SetDisplayName(NSLOCTEXT("HaybaSlivers", "TabTitle", "Slivers"))
+        .SetTooltipText(NSLOCTEXT("HaybaSlivers", "TabTooltip", "Hayba Slivers — deterministic abstractions"))
+        .SetGroup(WorkspaceMenu::GetMenuStructure().GetToolsCategory());
+}
+
+void HaybaSliver_UnregisterTab()
+{
+    if (FSlateApplication::IsInitialized())
+        FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(SliversTabName);
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.cpp
@@ -1,0 +1,139 @@
+// HaybaSliverTypes.cpp
+#include "Slivers/HaybaSliverTypes.h"
+
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Internationalization/Regex.h"
+
+bool IsReverseDnsId(const FString& Id)
+{
+    // Mirrors src/slivers/spec-schema.ts: ^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*){2,}$
+    const FRegexPattern Pattern(TEXT("^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*){2,}$"));
+    FRegexMatcher M(Pattern, Id);
+    return M.FindNext();
+}
+
+static bool ParseRange(const TSharedPtr<FJsonValue>& V, TOptional<double>& OutMin, TOptional<double>& OutMax)
+{
+    if (!V.IsValid() || V->Type != EJson::Array) return false;
+    const TArray<TSharedPtr<FJsonValue>>& A = V->AsArray();
+    if (A.Num() != 2) return false;
+    OutMin = A[0]->AsNumber();
+    OutMax = A[1]->AsNumber();
+    return true;
+}
+
+static EHaybaSliverParamType ParamTypeFromString(const FString& S)
+{
+    if (S == TEXT("float"))     return EHaybaSliverParamType::Float;
+    if (S == TEXT("int"))       return EHaybaSliverParamType::Int;
+    if (S == TEXT("bool"))      return EHaybaSliverParamType::Bool;
+    if (S == TEXT("string"))    return EHaybaSliverParamType::String;
+    if (S == TEXT("enum"))      return EHaybaSliverParamType::Enum;
+    if (S == TEXT("actor_ref")) return EHaybaSliverParamType::ActorRef;
+    return EHaybaSliverParamType::Unsupported;
+}
+
+static bool ParseParam(const TSharedPtr<FJsonObject>& Obj, FHaybaSliverParam& Out, FString& OutError)
+{
+    if (!Obj->TryGetStringField(TEXT("id"), Out.Id) || Out.Id.IsEmpty())
+    { OutError = TEXT("param missing id"); return false; }
+    Obj->TryGetStringField(TEXT("label"), Out.Label);
+    Obj->TryGetBoolField(TEXT("required"), Out.bRequired);
+
+    FString TypeStr;
+    if (!Obj->TryGetStringField(TEXT("type"), TypeStr))
+    { OutError = FString::Printf(TEXT("param %s missing type"), *Out.Id); return false; }
+    Out.OriginalTypeString = TypeStr;
+    Out.Type = ParamTypeFromString(TypeStr);
+
+    // Range
+    if (Out.Type == EHaybaSliverParamType::Float || Out.Type == EHaybaSliverParamType::Int)
+    {
+        const TArray<TSharedPtr<FJsonValue>>* RangeArr = nullptr;
+        if (Obj->TryGetArrayField(TEXT("range"), RangeArr) && RangeArr && RangeArr->Num() == 2)
+        {
+            Out.RangeMin = (*RangeArr)[0]->AsNumber();
+            Out.RangeMax = (*RangeArr)[1]->AsNumber();
+        }
+        double DefNum;
+        if (Obj->TryGetNumberField(TEXT("default"), DefNum)) Out.DefaultNumber = DefNum;
+    }
+    if (Out.Type == EHaybaSliverParamType::Bool)
+    {
+        bool DefB;
+        if (Obj->TryGetBoolField(TEXT("default"), DefB)) Out.DefaultBool = DefB;
+    }
+    if (Out.Type == EHaybaSliverParamType::String || Out.Type == EHaybaSliverParamType::Enum || Out.Type == EHaybaSliverParamType::ActorRef)
+    {
+        FString DefS;
+        if (Obj->TryGetStringField(TEXT("default"), DefS)) Out.DefaultString = DefS;
+    }
+    if (Out.Type == EHaybaSliverParamType::Enum)
+    {
+        const TArray<TSharedPtr<FJsonValue>>* OptArr = nullptr;
+        if (Obj->TryGetArrayField(TEXT("options"), OptArr) && OptArr)
+        {
+            for (const TSharedPtr<FJsonValue>& Opt : *OptArr)
+            {
+                if (Opt->Type != EJson::Object) continue;
+                FHaybaSliverEnumOption O;
+                Opt->AsObject()->TryGetStringField(TEXT("value"), O.Value);
+                Opt->AsObject()->TryGetStringField(TEXT("label"), O.Label);
+                Out.EnumOptions.Add(O);
+            }
+        }
+    }
+    if (Out.Type == EHaybaSliverParamType::ActorRef)
+    {
+        Obj->TryGetStringField(TEXT("class_filter"), Out.ClassFilter);
+    }
+    return true;
+}
+
+bool ParseHaybaSliverSpec(const TSharedRef<FJsonObject>& In, FHaybaSliverSpec& OutSpec, FString& OutError)
+{
+    if (!In->TryGetStringField(TEXT("id"), OutSpec.Id) || !IsReverseDnsId(OutSpec.Id))
+    { OutError = TEXT("invalid or missing reverse-DNS id"); return false; }
+    if (!In->TryGetStringField(TEXT("version"), OutSpec.Version))   { OutError = TEXT("missing version"); return false; }
+    if (!In->TryGetStringField(TEXT("category"), OutSpec.Category)) { OutError = TEXT("missing category"); return false; }
+    if (!In->TryGetStringField(TEXT("title"), OutSpec.Title))       { OutError = TEXT("missing title"); return false; }
+    In->TryGetStringField(TEXT("description"), OutSpec.Description);
+    if (!In->TryGetStringField(TEXT("author"), OutSpec.Author))     { OutError = TEXT("missing author"); return false; }
+
+    const TSharedPtr<FJsonObject>* ExecObj = nullptr;
+    if (!In->TryGetObjectField(TEXT("executor"), ExecObj) || !(*ExecObj)->TryGetStringField(TEXT("kind"), OutSpec.ExecutorKind))
+    { OutError = TEXT("missing executor.kind"); return false; }
+
+    const TArray<TSharedPtr<FJsonValue>>* ParamsArr = nullptr;
+    if (In->TryGetArrayField(TEXT("params"), ParamsArr) && ParamsArr)
+    {
+        TSet<FString> SeenIds;
+        for (const TSharedPtr<FJsonValue>& V : *ParamsArr)
+        {
+            if (V->Type != EJson::Object) continue;
+            FHaybaSliverParam P;
+            FString Err;
+            if (!ParseParam(V->AsObject(), P, Err)) { OutError = Err; return false; }
+            if (SeenIds.Contains(P.Id)) { OutError = FString::Printf(TEXT("duplicate param id \"%s\""), *P.Id); return false; }
+            SeenIds.Add(P.Id);
+            OutSpec.Params.Add(P);
+        }
+    }
+
+    const TSharedPtr<FJsonObject>* DetObj = nullptr;
+    if (In->TryGetObjectField(TEXT("determinism"), DetObj))
+    {
+        (*DetObj)->TryGetBoolField(TEXT("pure"), OutSpec.Determinism.bPure);
+        const TArray<TSharedPtr<FJsonValue>>* Outs = nullptr;
+        if ((*DetObj)->TryGetArrayField(TEXT("declared_outputs"), Outs) && Outs)
+            for (const TSharedPtr<FJsonValue>& V : *Outs) OutSpec.Determinism.DeclaredOutputs.Add(V->AsString());
+        const TArray<TSharedPtr<FJsonValue>>* Effects = nullptr;
+        if ((*DetObj)->TryGetArrayField(TEXT("side_effects"), Effects) && Effects)
+            for (const TSharedPtr<FJsonValue>& V : *Effects) OutSpec.Determinism.SideEffects.Add(V->AsString());
+        FString Seed;
+        if ((*DetObj)->TryGetStringField(TEXT("seed_param"), Seed) && !Seed.IsEmpty())
+            OutSpec.Determinism.SeedParam = Seed;
+    }
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.cpp
@@ -13,16 +13,6 @@ bool IsReverseDnsId(const FString& Id)
     return M.FindNext();
 }
 
-static bool ParseRange(const TSharedPtr<FJsonValue>& V, TOptional<double>& OutMin, TOptional<double>& OutMax)
-{
-    if (!V.IsValid() || V->Type != EJson::Array) return false;
-    const TArray<TSharedPtr<FJsonValue>>& A = V->AsArray();
-    if (A.Num() != 2) return false;
-    OutMin = A[0]->AsNumber();
-    OutMax = A[1]->AsNumber();
-    return true;
-}
-
 static EHaybaSliverParamType ParamTypeFromString(const FString& S)
 {
     if (S == TEXT("float"))     return EHaybaSliverParamType::Float;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/HaybaSliverTypes.h
@@ -1,0 +1,79 @@
+// HaybaSliverTypes.h — C++ mirror of the on-disk SliverSpec JSON shape.
+// Only the v1 param types are decoded (Float, Int, Bool, String, Enum,
+// ActorRef); other type strings parse into FHaybaSliverParam with
+// Type=Unsupported and are surfaced by the panel as "not yet supported".
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Templates/SharedPointer.h"
+
+class FJsonObject;
+
+enum class EHaybaSliverParamType : uint8
+{
+    Float,
+    Int,
+    Bool,
+    String,
+    Enum,
+    ActorRef,
+    Unsupported,
+};
+
+struct FHaybaSliverEnumOption
+{
+    FString Value;
+    FString Label;
+};
+
+struct FHaybaSliverParam
+{
+    FString Id;
+    FString Label;
+    bool bRequired = false;
+    EHaybaSliverParamType Type = EHaybaSliverParamType::Unsupported;
+    FString OriginalTypeString;   // verbatim from JSON, used for the Unsupported message
+
+    // Numeric (float / int)
+    TOptional<double> RangeMin;
+    TOptional<double> RangeMax;
+    TOptional<double> DefaultNumber;
+
+    // Bool
+    TOptional<bool>   DefaultBool;
+
+    // String / Enum / ActorRef
+    TOptional<FString> DefaultString;
+    TArray<FHaybaSliverEnumOption> EnumOptions;
+
+    // ActorRef
+    FString ClassFilter;
+};
+
+struct FHaybaSliverDeterminism
+{
+    bool bPure = true;
+    TArray<FString> DeclaredOutputs;
+    TArray<FString> SideEffects;
+    TOptional<FString> SeedParam;
+};
+
+struct FHaybaSliverSpec
+{
+    FString Id;
+    FString Version;
+    FString Category;
+    FString Title;
+    FString Description;
+    FString Author;
+    FString ExecutorKind;
+    TArray<FHaybaSliverParam> Params;
+    FHaybaSliverDeterminism Determinism;
+};
+
+/** Returns true and fills OutSpec on success; false and OutError on validation failure. */
+bool ParseHaybaSliverSpec(const TSharedRef<FJsonObject>& In, FHaybaSliverSpec& OutSpec, FString& OutError);
+
+/** Reverse-DNS check: at least 3 dot-separated segments, lowercase + underscores. */
+bool IsReverseDnsId(const FString& Id);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverDetailPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverDetailPanel.cpp
@@ -1,0 +1,112 @@
+// SSliverDetailPanel.cpp
+#include "Slivers/SSliverDetailPanel.h"
+
+#include "Slivers/HaybaSliverClient.h"
+#include "Slivers/HaybaSliverSettings.h"
+#include "Async/Async.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SMultiLineEditableTextBox.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+
+void SSliverDetailPanel::Construct(const FArguments& InArgs)
+{
+    ChildSlot
+    [
+        SNew(SVerticalBox)
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [ SAssignNew(TitleText, STextBlock) ]
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [ SAssignNew(DescriptionText, STextBlock) ]
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [ SAssignNew(ParamBox, SVerticalBox) ]
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Run")))
+            .OnClicked(this, &SSliverDetailPanel::OnRunClicked)
+        ]
+        + SVerticalBox::Slot().FillHeight(1.0f).Padding(4)
+        [
+            SNew(SBorder)
+            [
+                SAssignNew(OutputBox, SMultiLineEditableTextBox)
+                .IsReadOnly(true)
+                .Text(FText::FromString(TEXT("(no run yet)")))
+            ]
+        ]
+    ];
+}
+
+void SSliverDetailPanel::SetSpec(const FHaybaSliverSpec& InSpec)
+{
+    Spec = InSpec;
+    if (TitleText)       TitleText->SetText(FText::FromString(Spec.Title + TEXT("  (") + Spec.Id + TEXT(")")));
+    if (DescriptionText) DescriptionText->SetText(FText::FromString(Spec.Description));
+    if (OutputBox)       OutputBox->SetText(FText::FromString(TEXT("(no run yet)")));
+    RebuildParamUI();
+}
+
+void SSliverDetailPanel::RebuildParamUI()
+{
+    if (!ParamBox.IsValid()) return;
+    ParamBox->ClearChildren();
+    ParamWidgets.Reset();
+
+    for (const FHaybaSliverParam& P : Spec.Params)
+    {
+        TSharedRef<SSliverParamWidget> W = FSliverParamWidgetRegistry::Get().Create(P);
+        ParamWidgets.Add(W);
+
+        const FString LabelText = (!P.Label.IsEmpty() ? P.Label : P.Id) + (P.bRequired ? TEXT(" *") : TEXT(""));
+        ParamBox->AddSlot().AutoHeight().Padding(2)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().FillWidth(0.4f).VAlign(VAlign_Center)
+            [ SNew(STextBlock).Text(FText::FromString(LabelText)) ]
+            + SHorizontalBox::Slot().FillWidth(0.6f)
+            [ W ]
+        ];
+    }
+}
+
+FString SSliverDetailPanel::BuildParamsJson() const
+{
+    TArray<FString> Parts;
+    for (const TSharedRef<SSliverParamWidget>& W : ParamWidgets)
+    {
+        const FString Id = W->GetParam().Id;
+        FString Esc = Id; Esc.ReplaceInline(TEXT("\""), TEXT("\\\""));
+        Parts.Add(FString::Printf(TEXT("\"%s\":%s"), *Esc, *W->GetValueAsJson()));
+    }
+    return TEXT("{") + FString::Join(Parts, TEXT(",")) + TEXT("}");
+}
+
+FReply SSliverDetailPanel::OnRunClicked()
+{
+    if (bRunning) return FReply::Handled();
+    bRunning = true;
+    if (OutputBox) OutputBox->SetText(FText::FromString(TEXT("(running…)")));
+
+    const UHaybaSliverSettings* S = UHaybaSliverSettings::GetChecked();
+    const FString BaseUrl = S->McpHttpBaseUrl;
+    const FString Id = Spec.Id;
+    const FString ParamsJson = BuildParamsJson();
+
+    FHaybaSliverRunCallback OnDone = FHaybaSliverRunCallback::CreateLambda(
+        [this](bool bOk, const FString& Body)
+        {
+            AsyncTask(ENamedThreads::GameThread, [this, bOk, Body]()
+            {
+                bRunning = false;
+                if (OutputBox)
+                {
+                    OutputBox->SetText(FText::FromString(bOk ? Body : (TEXT("HTTP error:\n") + Body)));
+                }
+            });
+        });
+
+    FHaybaSliverClient::RunSliver(BaseUrl, Id, ParamsJson, OnDone);
+    return FReply::Handled();
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverDetailPanel.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverDetailPanel.h
@@ -1,0 +1,35 @@
+// SSliverDetailPanel.h — Shows a single sliver: title, description,
+// generated param widgets, Run button, output text box.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Slivers/HaybaSliverTypes.h"
+#include "Slivers/SSliverParamWidget.h"
+#include "Widgets/SCompoundWidget.h"
+
+class SMultiLineEditableTextBox;
+
+class SSliverDetailPanel : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverDetailPanel) {}
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+
+    /** Switch the panel to display + run this spec. Resets all param widgets. */
+    void SetSpec(const FHaybaSliverSpec& InSpec);
+
+private:
+    FHaybaSliverSpec Spec;
+    TArray<TSharedRef<SSliverParamWidget>> ParamWidgets;
+    TSharedPtr<SMultiLineEditableTextBox> OutputBox;
+    TSharedPtr<class SVerticalBox> ParamBox;
+    TSharedPtr<class STextBlock> TitleText;
+    TSharedPtr<class STextBlock> DescriptionText;
+    bool bRunning = false;
+
+    FReply OnRunClicked();
+    FString BuildParamsJson() const;
+    void RebuildParamUI();
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamActorRef.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamActorRef.cpp
@@ -1,0 +1,57 @@
+// SSliverParamActorRef.cpp
+#include "Slivers/SSliverParamActorRef.h"
+#include "Editor.h"
+#include "GameFramework/Actor.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+
+static FString JsonEscapeA(const FString& In)
+{
+    FString S = In;
+    S.ReplaceInline(TEXT("\\"), TEXT("\\\\"));
+    S.ReplaceInline(TEXT("\""), TEXT("\\\""));
+    return S;
+}
+
+void SSliverParamActorRef::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    Value = Param.DefaultString.Get(FString());
+
+    ChildSlot
+    [
+        SNew(SHorizontalBox)
+        + SHorizontalBox::Slot().FillWidth(1.0f).Padding(2)
+        [
+            SNew(SEditableTextBox)
+            .Text_Lambda([this]() { return FText::FromString(Value); })
+            .OnTextChanged_Lambda([this](const FText& T) { Value = T.ToString(); })
+        ]
+        + SHorizontalBox::Slot().AutoWidth().Padding(2)
+        [
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Pick from selection")))
+            .OnClicked(this, &SSliverParamActorRef::OnPickFromSelection)
+        ]
+    ];
+}
+
+FReply SSliverParamActorRef::OnPickFromSelection()
+{
+    if (!GEditor) return FReply::Handled();
+    TArray<AActor*> Sel;
+    GEditor->GetSelectedActors()->GetSelectedObjects<AActor>(Sel);
+    if (Sel.Num() > 0 && Sel[0]) Value = Sel[0]->GetPathName();
+    return FReply::Handled();
+}
+
+FString SSliverParamActorRef::GetValueAsJson() const
+{
+    return FString::Printf(TEXT("\"%s\""), *JsonEscapeA(Value));
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamActorRef.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamActorRef.h
@@ -1,0 +1,16 @@
+// SSliverParamActorRef.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamActorRef : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamActorRef) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    FString Value;
+    FReply OnPickFromSelection();
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamBool.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamBool.cpp
@@ -1,0 +1,21 @@
+// SSliverParamBool.cpp
+#include "Slivers/SSliverParamBool.h"
+#include "Widgets/Input/SCheckBox.h"
+
+void SSliverParamBool::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    bValue = Param.DefaultBool.Get(false);
+
+    ChildSlot
+    [
+        SNew(SCheckBox)
+        .IsChecked_Lambda([this]() { return bValue ? ECheckBoxState::Checked : ECheckBoxState::Unchecked; })
+        .OnCheckStateChanged_Lambda([this](ECheckBoxState S) { bValue = (S == ECheckBoxState::Checked); })
+    ];
+}
+
+FString SSliverParamBool::GetValueAsJson() const { return bValue ? TEXT("true") : TEXT("false"); }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamBool.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamBool.h
@@ -1,0 +1,15 @@
+// SSliverParamBool.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamBool : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamBool) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    bool bValue = false;
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamEnum.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamEnum.cpp
@@ -1,0 +1,46 @@
+// SSliverParamEnum.cpp
+#include "Slivers/SSliverParamEnum.h"
+#include "Widgets/Text/STextBlock.h"
+
+static FString JsonEscape2(const FString& In)
+{
+    FString S = In;
+    S.ReplaceInline(TEXT("\\"), TEXT("\\\\"));
+    S.ReplaceInline(TEXT("\""), TEXT("\\\""));
+    return S;
+}
+
+void SSliverParamEnum::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    for (const FHaybaSliverEnumOption& O : Param.EnumOptions)
+        Options.Add(MakeShared<FString>(O.Value));
+
+    const FString Def = Param.DefaultString.Get(Options.Num() > 0 ? *Options[0] : FString());
+    for (const TSharedPtr<FString>& Opt : Options) if (*Opt == Def) { Selected = Opt; break; }
+    if (!Selected.IsValid() && Options.Num() > 0) Selected = Options[0];
+
+    ChildSlot
+    [
+        SNew(SComboBox<TSharedPtr<FString>>)
+        .OptionsSource(&Options)
+        .OnGenerateWidget_Lambda([](TSharedPtr<FString> Item)
+        { return SNew(STextBlock).Text(FText::FromString(*Item)); })
+        .OnSelectionChanged_Lambda([this](TSharedPtr<FString> Item, ESelectInfo::Type)
+        { Selected = Item; })
+        .InitiallySelectedItem(Selected)
+        [
+            SNew(STextBlock).Text_Lambda([this]()
+            { return Selected.IsValid() ? FText::FromString(*Selected) : FText::GetEmpty(); })
+        ]
+    ];
+}
+
+FString SSliverParamEnum::GetValueAsJson() const
+{
+    if (!Selected.IsValid()) return TEXT("null");
+    return FString::Printf(TEXT("\"%s\""), *JsonEscape2(*Selected));
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamEnum.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamEnum.h
@@ -1,0 +1,17 @@
+// SSliverParamEnum.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+#include "Widgets/Input/SComboBox.h"
+
+class SSliverParamEnum : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamEnum) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    TArray<TSharedPtr<FString>> Options;
+    TSharedPtr<FString> Selected;
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamFloat.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamFloat.cpp
@@ -1,0 +1,25 @@
+// SSliverParamFloat.cpp
+#include "Slivers/SSliverParamFloat.h"
+#include "Widgets/Input/SSpinBox.h"
+
+void SSliverParamFloat::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    Value = static_cast<float>(Param.DefaultNumber.Get(0.0));
+
+    auto Spin = SNew(SSpinBox<float>)
+        .Value_Lambda([this]() { return Value; })
+        .OnValueChanged_Lambda([this](float V) { Value = V; });
+    if (Param.RangeMin.IsSet()) Spin->SetMinValue(static_cast<float>(Param.RangeMin.GetValue()));
+    if (Param.RangeMax.IsSet()) Spin->SetMaxValue(static_cast<float>(Param.RangeMax.GetValue()));
+
+    ChildSlot [ Spin ];
+}
+
+FString SSliverParamFloat::GetValueAsJson() const
+{
+    return FString::SanitizeFloat(Value);
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamFloat.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamFloat.h
@@ -1,0 +1,15 @@
+// SSliverParamFloat.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamFloat : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamFloat) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    float Value = 0.f;
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamInt.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamInt.cpp
@@ -1,0 +1,22 @@
+// SSliverParamInt.cpp
+#include "Slivers/SSliverParamInt.h"
+#include "Widgets/Input/SSpinBox.h"
+
+void SSliverParamInt::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    Value = static_cast<int32>(Param.DefaultNumber.Get(0.0));
+
+    auto Spin = SNew(SSpinBox<int32>)
+        .Value_Lambda([this]() { return Value; })
+        .OnValueChanged_Lambda([this](int32 V) { Value = V; });
+    if (Param.RangeMin.IsSet()) Spin->SetMinValue(static_cast<int32>(Param.RangeMin.GetValue()));
+    if (Param.RangeMax.IsSet()) Spin->SetMaxValue(static_cast<int32>(Param.RangeMax.GetValue()));
+
+    ChildSlot [ Spin ];
+}
+
+FString SSliverParamInt::GetValueAsJson() const { return FString::FromInt(Value); }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamInt.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamInt.h
@@ -1,0 +1,15 @@
+// SSliverParamInt.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamInt : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamInt) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    int32 Value = 0;
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamString.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamString.cpp
@@ -1,0 +1,35 @@
+// SSliverParamString.cpp
+#include "Slivers/SSliverParamString.h"
+#include "Widgets/Input/SEditableTextBox.h"
+
+static FString JsonEscape(const FString& In)
+{
+    FString S = In;
+    S.ReplaceInline(TEXT("\\"), TEXT("\\\\"));
+    S.ReplaceInline(TEXT("\""), TEXT("\\\""));
+    S.ReplaceInline(TEXT("\n"), TEXT("\\n"));
+    S.ReplaceInline(TEXT("\r"), TEXT("\\r"));
+    S.ReplaceInline(TEXT("\t"), TEXT("\\t"));
+    return S;
+}
+
+void SSliverParamString::Construct(const FArguments& InArgs)
+{
+    SSliverParamWidget::FArguments BaseArgs;
+    BaseArgs._Param = InArgs._Param;
+    SSliverParamWidget::Construct(BaseArgs);
+
+    Value = Param.DefaultString.Get(FString());
+
+    ChildSlot
+    [
+        SNew(SEditableTextBox)
+        .Text_Lambda([this]() { return FText::FromString(Value); })
+        .OnTextChanged_Lambda([this](const FText& T) { Value = T.ToString(); })
+    ];
+}
+
+FString SSliverParamString::GetValueAsJson() const
+{
+    return FString::Printf(TEXT("\"%s\""), *JsonEscape(Value));
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamString.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamString.h
@@ -1,0 +1,15 @@
+// SSliverParamString.h
+#pragma once
+#include "Slivers/SSliverParamWidget.h"
+
+class SSliverParamString : public SSliverParamWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamString) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+    virtual FString GetValueAsJson() const override;
+private:
+    FString Value;
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.cpp
@@ -1,0 +1,47 @@
+// SSliverParamWidget.cpp
+#include "Slivers/SSliverParamWidget.h"
+
+#include "Widgets/Text/STextBlock.h"
+
+namespace
+{
+    class SUnsupportedParamWidget : public SSliverParamWidget
+    {
+    public:
+        SLATE_BEGIN_ARGS(SUnsupportedParamWidget) {}
+            SLATE_ARGUMENT(FHaybaSliverParam, Param)
+        SLATE_END_ARGS()
+
+        void Construct(const FArguments& InArgs)
+        {
+            SSliverParamWidget::FArguments BaseArgs;
+            BaseArgs._Param = InArgs._Param;
+            SSliverParamWidget::Construct(BaseArgs);
+
+            ChildSlot
+            [
+                SNew(STextBlock).Text(FText::FromString(FString::Printf(
+                    TEXT("[unsupported param type: %s]"), *Param.OriginalTypeString)))
+            ];
+        }
+
+        virtual FString GetValueAsJson() const override { return TEXT("null"); }
+    };
+}
+
+FSliverParamWidgetRegistry& FSliverParamWidgetRegistry::Get()
+{
+    static FSliverParamWidgetRegistry Singleton;
+    return Singleton;
+}
+
+void FSliverParamWidgetRegistry::Register(EHaybaSliverParamType Type, FFactory Make)
+{
+    Factories.Add(Type, MoveTemp(Make));
+}
+
+TSharedRef<SSliverParamWidget> FSliverParamWidgetRegistry::Create(const FHaybaSliverParam& Param) const
+{
+    if (const FFactory* F = Factories.Find(Param.Type)) return (*F)(Param);
+    return SNew(SUnsupportedParamWidget).Param(Param);
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.cpp
@@ -45,3 +45,27 @@ TSharedRef<SSliverParamWidget> FSliverParamWidgetRegistry::Create(const FHaybaSl
     if (const FFactory* F = Factories.Find(Param.Type)) return (*F)(Param);
     return SNew(SUnsupportedParamWidget).Param(Param);
 }
+
+#include "Slivers/SSliverParamFloat.h"
+#include "Slivers/SSliverParamInt.h"
+#include "Slivers/SSliverParamBool.h"
+#include "Slivers/SSliverParamString.h"
+#include "Slivers/SSliverParamEnum.h"
+#include "Slivers/SSliverParamActorRef.h"
+
+void HaybaSliver_RegisterBuiltinParamWidgets()
+{
+    FSliverParamWidgetRegistry& R = FSliverParamWidgetRegistry::Get();
+    R.Register(EHaybaSliverParamType::Float,    [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamFloat).Param(P); });
+    R.Register(EHaybaSliverParamType::Int,      [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamInt).Param(P); });
+    R.Register(EHaybaSliverParamType::Bool,     [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamBool).Param(P); });
+    R.Register(EHaybaSliverParamType::String,   [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamString).Param(P); });
+    R.Register(EHaybaSliverParamType::Enum,     [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamEnum).Param(P); });
+    R.Register(EHaybaSliverParamType::ActorRef, [](const FHaybaSliverParam& P) -> TSharedRef<SSliverParamWidget>
+        { return SNew(SSliverParamActorRef).Param(P); });
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliverParamWidget.h
@@ -1,0 +1,47 @@
+// SSliverParamWidget.h — Abstract base for every param widget. Each
+// concrete widget knows how to (a) render a Slate row for one param
+// and (b) report its current value back to the panel when Run is
+// pressed.
+//
+// Widgets register themselves at module startup via
+// FSliverParamWidgetRegistry::Register("float", &Make).
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Slivers/HaybaSliverTypes.h"
+
+class SSliverParamWidget : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliverParamWidget) {}
+        SLATE_ARGUMENT(FHaybaSliverParam, Param)
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs) { Param = InArgs._Param; }
+
+    /** JSON fragment for this param's current value: e.g. `12.5`, `"hello"`, `true`. */
+    virtual FString GetValueAsJson() const = 0;
+
+    const FHaybaSliverParam& GetParam() const { return Param; }
+
+protected:
+    FHaybaSliverParam Param;
+};
+
+class FSliverParamWidgetRegistry
+{
+public:
+    using FFactory = TFunction<TSharedRef<SSliverParamWidget>(const FHaybaSliverParam&)>;
+
+    static FSliverParamWidgetRegistry& Get();
+    void Register(EHaybaSliverParamType Type, FFactory Make);
+    TSharedRef<SSliverParamWidget> Create(const FHaybaSliverParam& Param) const;
+
+private:
+    TMap<EHaybaSliverParamType, FFactory> Factories;
+};
+
+/** Called once on module startup to register all built-in widgets. */
+void HaybaSliver_RegisterBuiltinParamWidgets();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliversPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliversPanel.cpp
@@ -1,0 +1,71 @@
+// SSliversPanel.cpp
+#include "Slivers/SSliversPanel.h"
+
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Layout/SSplitter.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Views/STableRow.h"
+
+void SSliversPanel::Construct(const FArguments& InArgs)
+{
+    ChildSlot
+    [
+        SNew(SVerticalBox)
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().AutoWidth().Padding(2)
+            [
+                SNew(SButton)
+                .Text(FText::FromString(TEXT("Refresh")))
+                .OnClicked(this, &SSliversPanel::OnRefreshClicked)
+            ]
+            + SHorizontalBox::Slot().FillWidth(1.0f).VAlign(VAlign_Center).Padding(8, 0)
+            [
+                SNew(STextBlock).Text(FText::FromString(TEXT("Slivers (deterministic abstractions)")))
+            ]
+        ]
+        + SVerticalBox::Slot().FillHeight(1.0f)
+        [
+            SNew(SSplitter)
+            + SSplitter::Slot().Value(0.3f)
+            [
+                SAssignNew(ListView, SListView<TSharedPtr<FHaybaSliverSpec>>)
+                .ListItemsSource(&ListItems)
+                .OnGenerateRow(this, &SSliversPanel::OnGenerateRow)
+                .OnSelectionChanged(this, &SSliversPanel::OnSelectionChanged)
+                .SelectionMode(ESelectionMode::Single)
+            ]
+            + SSplitter::Slot().Value(0.7f)
+            [
+                SAssignNew(DetailPanel, SSliverDetailPanel)
+            ]
+        ]
+    ];
+
+    Refresh();
+}
+
+void SSliversPanel::Refresh()
+{
+    Loader.Refresh(FHaybaSliverLoader::DefaultUserSliversDir());
+    ListItems.Reset();
+    for (const FHaybaSliverSpec& S : Loader.List())
+        ListItems.Add(MakeShared<FHaybaSliverSpec>(S));
+    if (ListView) ListView->RequestListRefresh();
+}
+
+TSharedRef<ITableRow> SSliversPanel::OnGenerateRow(TSharedPtr<FHaybaSliverSpec> Item, const TSharedRef<STableViewBase>& Owner)
+{
+    const FString DisplayText = Item.IsValid()
+        ? FString::Printf(TEXT("%s   [%s]"), *Item->Title, *Item->Category)
+        : FString();
+    return SNew(STableRow<TSharedPtr<FHaybaSliverSpec>>, Owner)
+        [ SNew(STextBlock).Text(FText::FromString(DisplayText)) ];
+}
+
+void SSliversPanel::OnSelectionChanged(TSharedPtr<FHaybaSliverSpec> Item, ESelectInfo::Type)
+{
+    if (Item.IsValid() && DetailPanel) DetailPanel->SetSpec(*Item);
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliversPanel.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slivers/SSliversPanel.h
@@ -1,0 +1,29 @@
+// SSliversPanel.h — Top-level Slate panel: list of installed slivers
+// on the left, SSliverDetailPanel on the right.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Slivers/HaybaSliverLoader.h"
+#include "Slivers/SSliverDetailPanel.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/Views/SListView.h"
+
+class SSliversPanel : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSliversPanel) {}
+    SLATE_END_ARGS()
+    void Construct(const FArguments& InArgs);
+
+private:
+    FHaybaSliverLoader Loader;
+    TArray<TSharedPtr<FHaybaSliverSpec>> ListItems;
+    TSharedPtr<SListView<TSharedPtr<FHaybaSliverSpec>>> ListView;
+    TSharedPtr<SSliverDetailPanel> DetailPanel;
+
+    void Refresh();
+    FReply OnRefreshClicked() { Refresh(); return FReply::Handled(); }
+    TSharedRef<ITableRow> OnGenerateRow(TSharedPtr<FHaybaSliverSpec> Item, const TSharedRef<STableViewBase>& Owner);
+    void OnSelectionChanged(TSharedPtr<FHaybaSliverSpec> Item, ESelectInfo::Type);
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/Slivers/HaybaSliverSettings.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/Slivers/HaybaSliverSettings.h
@@ -1,0 +1,39 @@
+// HaybaSliverSettings.h — DeveloperSettings exposing the MCP HTTP URL
+// and the Slivers tab run mode. Lives in Project Settings → Plugins →
+// Hayba MCP → Slivers. Per-project (DefaultEditor.ini).
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "HaybaSliverSettings.generated.h"
+
+UENUM(BlueprintType)
+enum class EHaybaSliverRunMode : uint8
+{
+    Manual           UMETA(DisplayName = "Manual"),
+    // AutoDebounced — v2; placeholder enum value keeps the future widget render flat.
+    AutoDebounced250 UMETA(DisplayName = "Auto (debounced 250 ms) — v2 only"),
+};
+
+UCLASS(config = EditorPerProjectUserSettings, defaultconfig, meta = (DisplayName = "Hayba Slivers"))
+class HAYBAMCPTOOLKIT_API UHaybaSliverSettings : public UDeveloperSettings
+{
+    GENERATED_BODY()
+public:
+    UHaybaSliverSettings();
+
+    /** Base URL of the MCP server's HTTP listener. Set by hayba-mcp on startup; default matches its default port. */
+    UPROPERTY(EditAnywhere, config, Category = "Hayba Slivers")
+    FString McpHttpBaseUrl;
+
+    /** v1 ships Manual only. AutoDebounced lands in v2. */
+    UPROPERTY(EditAnywhere, config, Category = "Hayba Slivers")
+    EHaybaSliverRunMode RunMode;
+
+    /** Maximum recursion depth when slivers call each other. */
+    UPROPERTY(EditAnywhere, config, Category = "Hayba Slivers", meta = (ClampMin = "1", ClampMax = "32"))
+    int32 MaxSliverDepth;
+
+    static const UHaybaSliverSettings* GetChecked();
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "buildCommand": null,
+  "installCommand": "echo skip",
   "outputDirectory": "website",
   "rewrites": [
     { "source": "/app/:path*", "destination": "/app/index.html" },

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
-  "buildCommand": null,
-  "installCommand": "echo skip",
+  "buildCommand": "echo no build",
+  "installCommand": "echo no install",
+  "framework": null,
   "outputDirectory": "website",
   "rewrites": [
     { "source": "/app/:path*", "destination": "/app/index.html" },


### PR DESCRIPTION
## Summary
- MCP server writes \`~/.hayba/cache/retriever-tags.json\` after asset reindex (atomic write + error context).
- UE plugin loads it via \`FHaybaTagIndex\`; per-cell tag aggregation prefers UE \`Actor->Tags\`, falls back to BP class path (\`_C\` stripped) then static-mesh component asset.
- Web view: new \`tag-overrides.json\` palette (15 pinned tags) + FNV-1a deterministic hash for unknown tags.
- Cells fill by mode-tag color; chip strip below each cell shows top-5 tags; force-layout hubs re-keyed by tag (replaced dead \`semanticOf\` taxonomy).

Implements \`docs/superpowers/specs/2026-05-21-cognitive-map-tag-grouping-design.md\`.

## Test plan
- [x] vitest src/tools/asset-retriever — 33/33 (incl. tag-snapshot 3/3 + indexer 5/5)
- [ ] Manual: reindex → snapshot present at ~/.hayba/cache/retriever-tags.json
- [ ] Manual: cog-map cells show chip strips
- [ ] Manual: same tag → same color across cells
- [ ] Manual: hubs cluster by tag instead of hardcoded semantic

## Known v2 follow-ups
- BP wrapping a static-mesh with overlapping tags will double-count (one Bump per fallback path)
- Tag filter/search UI
- Click-tag-to-isolate
- In-editor overrides editor
- Stale-snapshot detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Slivers System**: Added a container-format system for deterministic abstractions with executor registry, parameter validation, and runtime execution.
* **Slivers Editor Tab**: New dedicated interface for browsing, configuring, and running slivers with dynamic parameter widgets.
* **MCP Sliver Tools**: Four new tools for managing slivers: list, get, run, and import operations.
* **HTTP Server Integration**: Background HTTP service for sliver operations alongside MCP.
* **Cognitive Map Tags**: Updated visualization to use actor-based tag grouping with tag-driven coloring and chip strips for better classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->