### PR TITLE
UE 5.7 API drift fixes (handlers)

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCaptureActor.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCaptureActor.cpp
@@ -14,7 +14,6 @@ AHaybaMCPCaptureActor::AHaybaMCPCaptureActor()
     // the screenshot pipeline, not user-facing content. Without this the
     // actor shows up as a visible "blue spray bottle" in hero shots taken
     // from other angles (see mcp-architectural-issues #13).
-    bHidden = true;
     SetHidden(true);
     SetActorHiddenInGame(true);
     // Strip from cooked builds — we only need this in the editor.

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPAnimationHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPAnimationHandler.cpp
@@ -217,7 +217,10 @@ FHaybaHandlerResult FHaybaMCPAnimationHandler::AddState(const TSharedPtr<FJsonOb
     UAnimStateNode* StateNode = Creator.CreateNode(/*bSelectNewNode*/false);
     if (!StateNode)
         return FHaybaHandlerResult::Err(TEXT("anim_blueprint_add_state: CreateNode failed"));
-    StateNode->StateType = EAnimStateType::AST_State;
+    // UE 5.7: EAnimStateType::AST_State was removed; the enum now has only
+    // AST_SingleAnimation and AST_BlendGraph. We always allocate a bound
+    // sub-graph below, so AST_BlendGraph is the correct replacement.
+    StateNode->StateType = EAnimStateType::AST_BlendGraph;
     Creator.Finalize();
 
     StateNode->NodePosX = 0;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPGASHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPGASHandler.cpp
@@ -130,7 +130,7 @@ FHaybaHandlerResult FHaybaMCPGASHandler::GasGrantAbility(const TSharedPtr<FJsonO
     FGameplayAbilitySpecHandle Handle = ASC->GiveAbility(Spec);
 
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetNumberField(TEXT("handle"), Handle.Handle);
+    Out->SetStringField(TEXT("handle"), Handle.ToString());
     Out->SetStringField(TEXT("ability"), AbilityClass->GetPathName());
     return FHaybaHandlerResult::Ok(Out);
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.cpp
@@ -6,7 +6,6 @@
 #if WITH_EDITOR
 #include "Editor.h"
 #include "Editor/EditorEngine.h"
-#include "EditorDelegates.h"
 #include "Engine/World.h"
 #include "Engine/GameViewportClient.h"
 #include "UnrealClient.h"

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.h
@@ -40,5 +40,8 @@ private:
     // Set when EndPIE/CancelPIE fires while a wait loop is running — checked
     // each iteration to abort cleanly.
     bool bCancelPending = false;
+
+    friend FHaybaHandlerResult FHaybaMCPPIEHandler_WaitLoop(
+        FHaybaMCPPIEHandler& Self, const TSharedPtr<class FJsonObject>& P, const FString& Comparator);
 #endif
 };

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPerfHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPerfHandler.cpp
@@ -4,6 +4,8 @@
 #include "HAL/PlatformMemory.h"
 #include "RHI.h"
 #include "RHIGlobals.h"
+#include "RHIStats.h"
+#include "DynamicRHI.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
 #include "Engine/Texture.h"
@@ -44,12 +46,10 @@ FHaybaHandlerResult FHaybaMCPPerfHandler::GetPerfStats(const TSharedPtr<FJsonObj
     Out->SetNumberField(TEXT("avg_frame_ms"), GAverageMS);
     Out->SetNumberField(TEXT("last_delta_ms"), DeltaMs);
 
-    // RHI counters: NumDrawCallsRHI / NumPrimitivesDrawnRHI are tracked per frame
-    // via the GRHIGlobals struct in UE 5.7. Field names verified against UE 5.7
-    // public RHI headers; if these names changed, build will fail with a clear
-    // unresolved-symbol error here.
-    Out->SetNumberField(TEXT("draw_calls"), (double)GRHIGlobals.NumDrawCallsRHI);
-    Out->SetNumberField(TEXT("primitives_drawn"), (double)GRHIGlobals.NumPrimitivesDrawnRHI);
+    // RHI counters: in UE 5.7 GNumDrawCallsRHI / GNumPrimitivesDrawnRHI are
+    // per-GPU global int32 arrays declared in RHIStats.h. Index 0 == primary GPU.
+    Out->SetNumberField(TEXT("draw_calls"), (double)GNumDrawCallsRHI[0]);
+    Out->SetNumberField(TEXT("primitives_drawn"), (double)GNumPrimitivesDrawnRHI[0]);
 
     // Memory
     const FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
@@ -58,11 +58,18 @@ FHaybaHandlerResult FHaybaMCPPerfHandler::GetPerfStats(const TSharedPtr<FJsonObj
     Out->SetNumberField(TEXT("cpu_peak_physical_mb"), (double)(MemStats.PeakUsedPhysical / (1024.0 * 1024.0)));
     Out->SetNumberField(TEXT("cpu_avail_physical_mb"),(double)(MemStats.AvailablePhysical / (1024.0 * 1024.0)));
 
-    // GPU memory (best-effort; not all RHIs report it)
+    // GPU memory (best-effort; not all RHIs report it).
+    // In UE 5.7 DedicatedVideoMemory lives on FTextureMemoryStats, queried via
+    // RHIGetTextureMemoryStats. Value is -1 when the RHI can't report it.
     uint64 GpuDedicatedMB = 0;
-    if (GRHIGlobals.DedicatedVideoMemory > 0)
+    if (GDynamicRHI)
     {
-        GpuDedicatedMB = GRHIGlobals.DedicatedVideoMemory / (1024 * 1024);
+        FTextureMemoryStats TexMemStats;
+        RHIGetTextureMemoryStats(TexMemStats);
+        if (TexMemStats.DedicatedVideoMemory > 0)
+        {
+            GpuDedicatedMB = (uint64)TexMemStats.DedicatedVideoMemory / (1024 * 1024);
+        }
     }
     Out->SetNumberField(TEXT("gpu_dedicated_mb"), (double)GpuDedicatedMB);
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPTestHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPTestHandler.cpp
@@ -207,7 +207,9 @@ namespace
             FAutomationTestExecutionInfo ExecInfo;
             const int32 RoleIndex = 0;
 
-            const bool bStarted = Framework.StartTestByName(Name, RoleIndex);
+            // UE 5.7: StartTestByName returns void. Detect failure via GetCurrentTest().
+            Framework.StartTestByName(Name, RoleIndex);
+            const bool bStarted = Framework.GetCurrentTest() != nullptr;
             if (!bStarted)
             {
                 SkippedArr.Add(MakeStr(Name));

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPTextureHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPTextureHandler.cpp
@@ -6,7 +6,7 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
 #include "Dom/JsonObject.h"
-#include "UObject/Enum.h"
+#include "UObject/Class.h"
 
 TArray<FString> FHaybaMCPTextureHandler::GetCommands() const
 {


### PR DESCRIPTION
## Summary
Compile fixes for pre-existing UE 5.7 API drift in seven handlers — surfaced when trying to build the plugin against the live geoforge project. Independent of any feature work; merge first to unblock #217/#218/#219 testing.

| File | Fix |
|---|---|
| HaybaMCPAnimationHandler.cpp | EAnimStateType::AST_State → AST_BlendGraph (enum reduced in UE 5.7) |
| HaybaMCPCaptureActor.cpp | Dropped redundant \`bHidden = true\` (made private); SetHidden() call already present |
| HaybaMCPGASHandler.cpp | Spec handle: SetNumberField(\`.Handle\`) → SetStringField(\`.ToString()\`) |
| HaybaMCPPIEHandler.cpp | Dropped \`#include "EditorDelegates.h"\` — \`Editor.h\` re-exports FEditorDelegates |
| HaybaMCPPerfHandler.cpp | GRHIGlobals.NumDrawCallsRHI → GNumDrawCallsRHI[0] (per-GPU array); DedicatedVideoMemory via RHIGetTextureMemoryStats |
| HaybaMCPTestHandler.cpp | StartTestByName now void; success = (GetCurrentTest() != nullptr) |
| HaybaMCPTextureHandler.cpp | UObject/Enum.h → UObject/Class.h |

## Test plan
- [ ] Editor rebuilds modules cleanly on first launch in geoforge project
- [ ] Plugin loads with no startup errors

## Notes
The first compile pass failed before reaching all files — there may be additional drift errors revealed by a successful pass through the seven fixed handlers. Will iterate.