### PR TITLE
Architecture: deepen the shallow unwrapping at both protocol-seam adapters

### DIFF
--- a/mcp-tools/hayba-mcp/src/tcp-client.ts
+++ b/mcp-tools/hayba-mcp/src/tcp-client.ts
@@ -1,6 +1,7 @@
 // mcp_server/src/tcp-client.ts
 import { createConnection, Socket } from 'node:net';
 import { EventEmitter } from 'node:events';
+import { FrameDecoder } from './tcp-frame-decoder.js';
 
 export interface TcpCommand {
   cmd: string;
@@ -28,7 +29,7 @@ export class UETcpClient extends EventEmitter {
     reject: (reason: Error) => void;
     timer: ReturnType<typeof setTimeout>;
   }>();
-  private receiveBuffer = Buffer.alloc(0);
+  private decoder = new FrameDecoder();
   private requestCounter = 0;
   private connected = false;
 
@@ -51,6 +52,7 @@ export class UETcpClient extends EventEmitter {
       this.socket.on('data', (data: Buffer) => this.onData(data));
       this.socket.on('close', () => {
         this.connected = false;
+        this.decoder.reset(); // drop any half-received frame so the next connection starts clean
         this.emit('disconnected');
         for (const [id, pending] of this.pendingRequests) {
           clearTimeout(pending.timer);
@@ -104,22 +106,8 @@ export class UETcpClient extends EventEmitter {
   }
 
   private onData(data: Buffer): void {
-    this.receiveBuffer = Buffer.concat([this.receiveBuffer, data]);
-
-    while (this.receiveBuffer.length >= 4) {
-      const messageLength = this.receiveBuffer.readUInt32BE(0);
-      if (messageLength === 0 || messageLength > 1024 * 1024) {
-        this.receiveBuffer = Buffer.alloc(0);
-        return;
-      }
-
-      if (this.receiveBuffer.length < 4 + messageLength) {
-        return;
-      }
-
-      const messageBytes = this.receiveBuffer.subarray(4, 4 + messageLength);
-      this.receiveBuffer = this.receiveBuffer.subarray(4 + messageLength);
-
+    // Framing lives in FrameDecoder; here we only parse + route payloads.
+    for (const messageBytes of this.decoder.push(data)) {
       try {
         const response: TcpResponse = JSON.parse(messageBytes.toString('utf-8'));
         const pending = this.pendingRequests.get(response.id);

--- a/mcp-tools/hayba-mcp/src/tcp-frame-decoder.test.ts
+++ b/mcp-tools/hayba-mcp/src/tcp-frame-decoder.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { FrameDecoder, MAX_FRAME_BYTES } from './tcp-frame-decoder.js';
+
+/** Build a length-prefixed frame around a string payload. */
+function frame(payload: string): Buffer {
+  const body = Buffer.from(payload, 'utf-8');
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(body.length, 0);
+  return Buffer.concat([header, body]);
+}
+
+describe('FrameDecoder', () => {
+  it('decodes a single whole frame', () => {
+    const d = new FrameDecoder();
+    const out = d.push(frame('hello'));
+    expect(out.map(b => b.toString('utf-8'))).toEqual(['hello']);
+    expect(d.pendingBytes()).toBe(0);
+  });
+
+  it('decodes multiple frames arriving in one chunk', () => {
+    const d = new FrameDecoder();
+    const out = d.push(Buffer.concat([frame('one'), frame('two'), frame('three')]));
+    expect(out.map(b => b.toString('utf-8'))).toEqual(['one', 'two', 'three']);
+  });
+
+  it('reassembles a frame split across chunks', () => {
+    const d = new FrameDecoder();
+    const full = frame('reassembled payload');
+    expect(d.push(full.subarray(0, 6))).toEqual([]);   // header + 2 body bytes
+    expect(d.push(full.subarray(6, 11))).toEqual([]);   // more body
+    const out = d.push(full.subarray(11));              // the rest
+    expect(out.map(b => b.toString('utf-8'))).toEqual(['reassembled payload']);
+  });
+
+  it('holds a partial trailing frame until the rest arrives', () => {
+    const d = new FrameDecoder();
+    const out = d.push(Buffer.concat([frame('complete'), frame('partial').subarray(0, 5)]));
+    expect(out.map(b => b.toString('utf-8'))).toEqual(['complete']);
+    expect(d.pendingBytes()).toBe(5);
+  });
+
+  it('waits when fewer than 4 header bytes have arrived', () => {
+    const d = new FrameDecoder();
+    expect(d.push(Buffer.from([0x00, 0x00]))).toEqual([]);
+    expect(d.pendingBytes()).toBe(2);
+  });
+
+  it('drops the buffer on a zero-length prefix', () => {
+    const d = new FrameDecoder();
+    const zero = Buffer.alloc(4); // length 0
+    expect(d.push(zero)).toEqual([]);
+    expect(d.pendingBytes()).toBe(0);
+  });
+
+  it('drops the buffer on an oversized length prefix', () => {
+    const d = new FrameDecoder();
+    const huge = Buffer.alloc(4);
+    huge.writeUInt32BE(MAX_FRAME_BYTES + 1, 0);
+    expect(d.push(Buffer.concat([huge, Buffer.from('junk')]))).toEqual([]);
+    expect(d.pendingBytes()).toBe(0);
+  });
+
+  it('returns frames decoded before a corrupt prefix in the same chunk', () => {
+    const d = new FrameDecoder();
+    const corrupt = Buffer.alloc(4);
+    corrupt.writeUInt32BE(MAX_FRAME_BYTES + 1, 0);
+    const out = d.push(Buffer.concat([frame('good'), corrupt]));
+    expect(out.map(b => b.toString('utf-8'))).toEqual(['good']);
+    expect(d.pendingBytes()).toBe(0);
+  });
+
+  it('handles a payload exactly at the frame cap', () => {
+    const d = new FrameDecoder();
+    const body = Buffer.alloc(MAX_FRAME_BYTES, 0x61);
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(MAX_FRAME_BYTES, 0);
+    const out = d.push(Buffer.concat([header, body]));
+    expect(out).toHaveLength(1);
+    expect(out[0].length).toBe(MAX_FRAME_BYTES);
+  });
+
+  it('reset() clears buffered partial data', () => {
+    const d = new FrameDecoder();
+    d.push(frame('whole'));
+    d.push(frame('partial').subarray(0, 4));
+    expect(d.pendingBytes()).toBeGreaterThan(0);
+    d.reset();
+    expect(d.pendingBytes()).toBe(0);
+  });
+
+  it('decodes byte-at-a-time delivery', () => {
+    const d = new FrameDecoder();
+    const full = frame('drip');
+    let out: Buffer[] = [];
+    for (const byte of full) out = out.concat(d.push(Buffer.from([byte])));
+    expect(out.map(b => b.toString('utf-8'))).toEqual(['drip']);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tcp-frame-decoder.ts
+++ b/mcp-tools/hayba-mcp/src/tcp-frame-decoder.ts
@@ -1,0 +1,54 @@
+// mcp-tools/hayba-mcp/src/tcp-frame-decoder.ts
+//
+// Length-prefixed frame decoder for the TCP protocol seam. Pure and
+// socket-free: feed it raw chunks as they arrive, get back every complete
+// message payload. It owns the receive buffer and the framing invariants
+// — 4-byte big-endian length prefix, 1 MiB cap — so tcp-client.ts can stay
+// a thin socket adapter and the framing logic is unit-testable in
+// isolation (it never was, while it lived inside the socket callback).
+
+/** Hard cap on a single frame. A larger declared length means the stream
+ *  is corrupt and unrecoverable. */
+export const MAX_FRAME_BYTES = 1024 * 1024;
+
+export class FrameDecoder {
+  private buffer: Buffer = Buffer.alloc(0);
+
+  /**
+   * Append a freshly-received chunk and return every message payload it
+   * completes (zero, one, or many). Partial trailing data is retained for
+   * the next call. A corrupt length prefix (0 or > MAX_FRAME_BYTES) drops
+   * the whole buffer — the stream cannot be re-synced — and any frames
+   * already decoded in this call are still returned.
+   */
+  push(chunk: Buffer): Buffer[] {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    const messages: Buffer[] = [];
+
+    while (this.buffer.length >= 4) {
+      const length = this.buffer.readUInt32BE(0);
+
+      if (length === 0 || length > MAX_FRAME_BYTES) {
+        this.buffer = Buffer.alloc(0);
+        break;
+      }
+      if (this.buffer.length < 4 + length) {
+        break; // frame not fully arrived yet
+      }
+
+      messages.push(this.buffer.subarray(4, 4 + length));
+      this.buffer = this.buffer.subarray(4 + length);
+    }
+    return messages;
+  }
+
+  /** Bytes currently held pending more input — for tests and introspection. */
+  pendingBytes(): number {
+    return this.buffer.length;
+  }
+
+  /** Drop any buffered partial data (e.g. on socket close). */
+  reset(): void {
+    this.buffer = Buffer.alloc(0);
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/mcp-response.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/mcp-response.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { toMcpResponse, registerJsonTool } from './mcp-response.js';
+
+describe('toMcpResponse', () => {
+  it('wraps a value as a single pretty-printed text content block', () => {
+    const r = toMcpResponse({ ok: true, n: 3 });
+    expect(r.content).toHaveLength(1);
+    expect(r.content[0].type).toBe('text');
+    expect(r.content[0].text).toBe('{\n  "ok": true,\n  "n": 3\n}');
+  });
+
+  it('handles primitives and arrays', () => {
+    expect(toMcpResponse('hi').content[0].text).toBe('"hi"');
+    expect(toMcpResponse([1, 2]).content[0].text).toBe('[\n  1,\n  2\n]');
+  });
+});
+
+describe('registerJsonTool', () => {
+  /** Minimal fake server that captures the registered callback. */
+  function fakeServer() {
+    const calls: Array<{ name: string; description: string; schema: unknown }> = [];
+    let registered: ((args: Record<string, unknown>) => Promise<unknown>) | null = null;
+    const server = {
+      tool: (name: string, description: string, schema: unknown, cb: typeof registered) => {
+        calls.push({ name, description, schema });
+        registered = cb;
+      },
+    } as unknown as McpServer;
+    return { server, calls, invoke: (args: Record<string, unknown>) => registered!(args) };
+  }
+
+  it('registers the tool with name, description, and schema', () => {
+    const { server, calls } = fakeServer();
+    registerJsonTool(server, 'demo', 'a demo tool', { x: undefined as never }, async () => ({ ok: true }));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ name: 'demo', description: 'a demo tool' });
+  });
+
+  it('passes args to run and wraps the result via toMcpResponse', async () => {
+    const { server, invoke } = fakeServer();
+    registerJsonTool(server, 'echo', 'echoes', {},
+      (args: { value: number }) => ({ doubled: args.value * 2 }));
+    const out = await invoke({ value: 21 });
+    expect(out).toEqual({ content: [{ type: 'text', text: '{\n  "doubled": 42\n}' }] });
+  });
+
+  it('awaits an async run before wrapping', async () => {
+    const { server, invoke } = fakeServer();
+    registerJsonTool(server, 'slow', 'async tool', {},
+      async () => Promise.resolve({ done: true }));
+    const out = await invoke({});
+    expect(out).toEqual({ content: [{ type: 'text', text: '{\n  "done": true\n}' }] });
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/mcp-response.ts
+++ b/mcp-tools/hayba-mcp/src/tools/mcp-response.ts
@@ -1,0 +1,47 @@
+// mcp-tools/hayba-mcp/src/tools/mcp-response.ts
+//
+// Every Hayba MCP tool returns the same envelope: a single text content
+// block holding the handler's result as pretty-printed JSON. That wrapper
+// was hand-written at ~15 registration sites in register.ts (and more
+// across the per-domain tool files). toMcpResponse() is the one place the
+// envelope shape lives now; registerJsonTool() folds the wrapper into tool
+// registration so a meta-tool reads as name + description + schema + the
+// bound handler — no `async (args) => ({ content: [...] })` boilerplate.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { z } from 'zod';
+
+/** The MCP content-block envelope every Hayba tool returns. */
+export interface McpToolResponse {
+  content: Array<{ type: 'text'; text: string }>;
+}
+
+/** Wrap any JSON-serialisable handler result in the standard MCP envelope. */
+export function toMcpResponse(result: unknown): McpToolResponse {
+  return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+}
+
+/**
+ * Register a tool whose handler returns a plain JSON-serialisable value.
+ * `run` receives the validated args (type it on the lambda — `A` is
+ * inferred from there); its result is wrapped via toMcpResponse.
+ *
+ * The `server.tool` call is escape-hatched the same way the deferred
+ * registry path in register.ts is: the SDK's callback typing is bypassed
+ * so the schema stays the single source of runtime validation while the
+ * call site keeps compile-time typing on the handler args.
+ */
+export function registerJsonTool<A extends Record<string, unknown>>(
+  server: McpServer,
+  name: string,
+  description: string,
+  schema: z.ZodRawShape,
+  run: (args: A) => Promise<unknown> | unknown,
+): void {
+  (server as unknown as { tool: (...a: unknown[]) => void }).tool(
+    name,
+    description,
+    schema,
+    async (args: A) => toMcpResponse(await run(args)),
+  );
+}

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -36,6 +36,7 @@ import { dagRecordHandler, dagRecordSchema } from '../dag/record.js';
 import { dagRebuildHandler, dagRebuildSchema } from '../dag/rebuild.js';
 import { journalTailHandler, journalTailSchema } from '../dag/journal-tail.js';
 import { setAssetDagSink } from '../asset-sources/shared.js';
+import { toMcpResponse, registerJsonTool } from '../mcp-response.js';
 
 /** Tools registered by registerDeferredRouting itself — skip in shim re-register. */
 export const ALWAYS_ON_META = new Set<string>([
@@ -173,55 +174,43 @@ export async function registerDeferredRouting(
   const index = await ToolIndex.build(docs, { embeddings, cacheDir: effectiveCacheDir });
 
   // ── Register the 4 new meta-tools ──────────────────────────────────────────
-  server.tool(
+  registerJsonTool(server,
     'hayba_search_tools',
     'Find Hayba tools by capability before loading their pack. Hybrid BM25 + embedding search over the full tool catalog.',
     searchToolsSchema,
-    async (args: { query: string; k?: number; filterPack?: string }) => {
-      const r = await searchToolsHandler(args, { index });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { query: string; k?: number; filterPack?: string }) => searchToolsHandler(args, { index }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_pack_list',
     'List available Hayba tool packs (domain + workflow), with loaded flag and tool count.',
     packListSchema,
-    async () => {
-      const r = await packListHandler({}, { registry });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    () => packListHandler({}, { registry }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_pack_load',
     'Load a Hayba tool pack — registers its tools natively so the client sees them on the next list refresh.',
     packLoadSchema,
-    async (args: { name: string }) => {
-      const r = await packLoadHandler(args, { registry });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { name: string }) => packLoadHandler(args, { registry }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_invoke',
     'Polymorphic dispatcher: call any Hayba tool by name without loading its pack. Best for one-off calls; load the pack for repeated use.',
     invokeSchema,
-    async (args: { name: string; args: Record<string, unknown> }) => {
-      const r = await invokeHandler(args, {
-        dispatch: async (cmd, params) => {
-          // Prefer the captured handler if present — covers TS-side tools.
-          const t = captured.get(cmd);
-          if (t) {
-            return await Promise.resolve(t.handler(params));
-          }
-          // Otherwise dispatch via UE bridge.
-          return await executeCommand(cmd, params);
-        },
-        isDisabled: isToolDisabled,
-      });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { name: string; args: Record<string, unknown> }) => invokeHandler(args, {
+      dispatch: async (cmd, params) => {
+        // Prefer the captured handler if present — covers TS-side tools.
+        const t = captured.get(cmd);
+        if (t) {
+          return await Promise.resolve(t.handler(params));
+        }
+        // Otherwise dispatch via UE bridge.
+        return await executeCommand(cmd, params);
+      },
+      isDisabled: isToolDisabled,
+    }),
   );
 
   // ── Re-register the always-on tools from the captured set ─────────────────
@@ -252,15 +241,14 @@ export async function registerDeferredRouting(
   // wires onConnected → maybeAutoLoad('ue_connected'). The captured handler
   // calls checkUeStatus() with no args, missing the autoload trigger.
   if (captured.has('hayba_check_ue_status')) {
-    server.tool(
+    // Escape-hatched like the registry path below: this tool takes no
+    // description (2-arg schema form), which registerJsonTool doesn't model.
+    (server as unknown as { tool: (...a: unknown[]) => void }).tool(
       'hayba_check_ue_status',
       {},
-      async () => {
-        const status = await checkUeStatus({
-          onConnected: () => registry.maybeAutoLoad('ue_connected'),
-        });
-        return { content: [{ type: 'text' as const, text: JSON.stringify(status, null, 2) }] };
-      },
+      async () => toMcpResponse(await checkUeStatus({
+        onConnected: () => registry.maybeAutoLoad('ue_connected'),
+      })),
     );
     registeredNames.add('hayba_check_ue_status');
   }
@@ -272,34 +260,27 @@ export async function registerDeferredRouting(
   );
   setDefaultRetriever(retriever);
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_asset_search',
     'Find an asset in the user\'s UE Content Browser by semantic intent or keyword. Hybrid BM25 + embedding search.',
     assetSearchSchema,
-    async (args: { query: string; k?: number; filterClass?: string; filterSource?: 'project' | 'polyhaven' | 'ambientcg' | 'sketchfab' | 'fab' | 'unknown' }) => {
-      const r = await assetSearchHandler(args, { retriever });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { query: string; k?: number; filterClass?: string; filterSource?: 'project' | 'polyhaven' | 'ambientcg' | 'sketchfab' | 'fab' | 'unknown' }) =>
+      assetSearchHandler(args, { retriever }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_asset_browse',
     'Enumerate assets by filter (path/class/tag/source) without semantic ranking. Paginated.',
     assetBrowseSchema,
-    async (args: { filter?: { path?: string; class?: string; tag?: string; source?: 'project' | 'polyhaven' | 'ambientcg' | 'sketchfab' | 'fab' | 'unknown' }; offset?: number; limit?: number }) => {
-      const r = await assetBrowseHandler(args, { retriever });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { filter?: { path?: string; class?: string; tag?: string; source?: 'project' | 'polyhaven' | 'ambientcg' | 'sketchfab' | 'fab' | 'unknown' }; offset?: number; limit?: number }) =>
+      assetBrowseHandler(args, { retriever }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_asset_reindex',
     'Force a rebuild of the asset index. Use after a batch import outside the MCP-tracked download flow.',
     assetReindexSchema,
-    async () => {
-      const r = await assetReindexHandler({}, { retriever });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    () => assetReindexHandler({}, { retriever }),
   );
 
   // ── DAG + journal (Layer 2 — operation tracking) ───────────────────────────
@@ -326,91 +307,67 @@ export async function registerDeferredRouting(
     console.warn(`[slivers] load error: ${err}`);
   }
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_sliver_list',
     'List installed Slivers (deterministic abstractions). Optional category or namespace filter.',
     sliverListSchema,
-    async (args: { category?: string; namespace?: string }) => {
-      const r = await sliverListHandler(args, { loader: slivers.loader });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { category?: string; namespace?: string }) => sliverListHandler(args, { loader: slivers.loader }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_sliver_get',
     'Get the full spec (params + determinism + executor) of an installed sliver by id.',
     sliverGetSchema,
-    async (args: { id: string }) => {
-      const r = await sliverGetHandler(args, { loader: slivers.loader });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { id: string }) => sliverGetHandler(args, { loader: slivers.loader }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_sliver_run',
     'Execute a sliver with concrete parameter values. Returns outputs + declared side_effects + durationMs.',
     sliverRunSchema,
-    async (args: { id: string; params: Record<string, unknown> }) => {
-      const r = await sliverRunHandler(args, { runtime: slivers.runtime });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { id: string; params: Record<string, unknown> }) => sliverRunHandler(args, { runtime: slivers.runtime }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_sliver_import',
     'Install a sliver from a local file path or an http(s) URL into the user sliver library.',
     sliverImportSchema,
-    async (args: { source: string }) => {
-      const r = await sliverImportHandler(args, { loader: slivers.loader });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { source: string }) => sliverImportHandler(args, { loader: slivers.loader }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_dag_status',
     'Show the dependency graph of generated artifacts and which are stale (dirty).',
     dagStatusSchema,
-    async (args: { namespace?: string; dirtyOnly?: boolean }) => {
-      const r = await dagStatusHandler(args, { dag });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { namespace?: string; dirtyOnly?: boolean }) => dagStatusHandler(args, { dag }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_dag_record',
     'Record a mutation Hayba did not instrument (editor-side edits, manual writes) so the DAG stays accurate.',
     dagRecordSchema,
-    async (args: { reads?: string[]; writes: string[]; actor?: string; note?: string }) => {
-      const r = await dagRecordHandler(args, { dag });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { reads?: string[]; writes: string[]; actor?: string; note?: string }) => dagRecordHandler(args, { dag }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_dag_rebuild',
     'Re-run stale (dirty) artifacts. Optionally restrict to the subtree under a target URI.',
     dagRebuildSchema,
-    async (args: { target?: string }) => {
-      const r = await dagRebuildHandler(args, {
-        dag,
-        runSliverNode: async (uri: string) => {
-          return { ok: false, reason: uri.startsWith('sliver://')
-            ? 'sliver re-run from node id is v2'
-            : 'no executor for this node type' };
-        },
-      });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { target?: string }) => dagRebuildHandler(args, {
+      dag,
+      runSliverNode: async (uri: string) => {
+        return { ok: false, reason: uri.startsWith('sliver://')
+          ? 'sliver re-run from node id is v2'
+          : 'no executor for this node type' };
+      },
+    }),
   );
 
-  server.tool(
+  registerJsonTool(server,
     'hayba_journal_tail',
     'Return the most recent mutation operations from the journal.',
     journalTailSchema,
-    async (args: { limit?: number }) => {
-      const r = await journalTailHandler(args, { dag });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
+    (args: { limit?: number }) => journalTailHandler(args, { dag }),
   );
 
   // ── Always-load packs from settings ────────────────────────────────────────

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPAudioHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPAudioHandler.cpp
@@ -11,6 +11,7 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
 #include "Dom/JsonObject.h"
+#include "HaybaMCPJsonParams.h"
 
 TArray<FString> FHaybaMCPAudioHandler::GetCommands() const
 {
@@ -23,15 +24,12 @@ TArray<FString> FHaybaMCPAudioHandler::GetCommands() const
 
 static FHaybaHandlerResult AudioPlay(const TSharedPtr<FJsonObject>& P)
 {
-    if (!P.IsValid()) return FHaybaHandlerResult::Err(TEXT("audio_play: missing params"));
-    FString Path;
-    if (!P->TryGetStringField(TEXT("path"), Path))
-        return FHaybaHandlerResult::Err(TEXT("audio_play: missing arg path"));
+    FHaybaJsonParams Args(P);
+    const FString Path = Args.RequireString(TEXT("path"));
+    if (Args.HasError()) return Args.Error();
 
-    double Volume = 1.0;
-    double Pitch  = 1.0;
-    P->TryGetNumberField(TEXT("volume"), Volume);
-    P->TryGetNumberField(TEXT("pitch"),  Pitch);
+    const double Volume = Args.GetNumber(TEXT("volume"), 1.0);
+    const double Pitch  = Args.GetNumber(TEXT("pitch"),  1.0);
 
     USoundBase* Sound = Cast<USoundBase>(FSoftObjectPath(Path).TryLoad());
     if (!Sound) return FHaybaHandlerResult::Err(FString::Printf(TEXT("audio_play: failed to load %s"), *Path));
@@ -52,8 +50,8 @@ static FHaybaHandlerResult AudioPlay(const TSharedPtr<FJsonObject>& P)
 
 static FHaybaHandlerResult AudioList(const TSharedPtr<FJsonObject>& P)
 {
-    FString Prefix;
-    if (P.IsValid()) P->TryGetStringField(TEXT("path_prefix"), Prefix);
+    FHaybaJsonParams Args(P);
+    const FString Prefix = Args.GetString(TEXT("path_prefix"));
 
     FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
     IAssetRegistry& AR = ARM.Get();
@@ -94,13 +92,10 @@ static FHaybaHandlerResult AudioList(const TSharedPtr<FJsonObject>& P)
 
 static FHaybaHandlerResult AudioSetVolume(const TSharedPtr<FJsonObject>& P)
 {
-    if (!P.IsValid()) return FHaybaHandlerResult::Err(TEXT("audio_set_volume: missing params"));
-    FString Category;
-    if (!P->TryGetStringField(TEXT("category"), Category))
-        return FHaybaHandlerResult::Err(TEXT("audio_set_volume: missing arg category"));
-    double Volume = 1.0;
-    if (!P->TryGetNumberField(TEXT("volume"), Volume))
-        return FHaybaHandlerResult::Err(TEXT("audio_set_volume: missing arg volume"));
+    FHaybaJsonParams Args(P);
+    const FString Category = Args.RequireString(TEXT("category"));
+    const double Volume    = Args.RequireNumber(TEXT("volume"));
+    if (Args.HasError()) return Args.Error();
 
     if (!GEngine) return FHaybaHandlerResult::Err(TEXT("audio_set_volume: no GEngine"));
     FAudioDeviceHandle Dev = GEngine->GetMainAudioDevice();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPJsonParams.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPJsonParams.h
@@ -1,0 +1,166 @@
+#pragma once
+
+// ============================================================================
+// FHaybaJsonParams
+// ----------------------------------------------------------------------------
+// A thin, header-only wrapper over TSharedPtr<FJsonObject> that makes MCP
+// command-handler parameter extraction terse and centralises error formatting.
+//
+// Pattern: accumulate-first-error / check-once.
+//   - Optional getters (GetString/GetNumber/GetInt/GetBool/GetArray/GetObject)
+//     never record errors; they return the supplied default when the field is
+//     absent or of the wrong type.
+//   - RequireString() records an error ("<field>: required") the FIRST time a
+//     required field is missing or empty. Subsequent RequireString failures do
+//     NOT overwrite that first error — first missing field wins.
+//   - After issuing any number of RequireString() calls, the handler performs a
+//     single HasError() check and, if true, returns Error() (a fully-formed
+//     FHaybaHandlerResult::Err).
+//
+// Intended usage in a handler:
+//     FHaybaJsonParams Args(P);
+//     const FString ClassPath = Args.RequireString(TEXT("class_path"));
+//     const FString Name      = Args.RequireString(TEXT("name"));
+//     if (Args.HasError()) return Args.Error();
+//
+// A null underlying FJsonObject is handled defensively: every field is treated
+// as absent, optional getters return their defaults, and RequireString records
+// the "<field>: required" error.
+// ============================================================================
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "IHaybaMCPHandler.h"
+
+class FHaybaJsonParams
+{
+public:
+    explicit FHaybaJsonParams(const TSharedPtr<FJsonObject>& InObj)
+        : Obj(InObj)
+    {
+    }
+
+    /**
+     * Required string field. If the field is missing or empty, records the
+     * error "<Field>: required" (only if no error has been recorded yet) and
+     * returns an empty string.
+     */
+    FString RequireString(const TCHAR* Field)
+    {
+        FString Value;
+        if (Obj.IsValid() && Obj->TryGetStringField(Field, Value) && !Value.IsEmpty())
+        {
+            return Value;
+        }
+        RecordError(FString::Printf(TEXT("%s: required"), Field));
+        return FString();
+    }
+
+    /**
+     * Required numeric field. If the field is missing (or not a number),
+     * records the error "<Field>: required" (only if no error has been
+     * recorded yet) and returns 0.0.
+     */
+    double RequireNumber(const TCHAR* Field)
+    {
+        double Value = 0.0;
+        if (Obj.IsValid() && Obj->TryGetNumberField(Field, Value))
+        {
+            return Value;
+        }
+        RecordError(FString::Printf(TEXT("%s: required"), Field));
+        return 0.0;
+    }
+
+    /** Optional string field; returns Default when absent or wrong type. */
+    FString GetString(const TCHAR* Field, const FString& Default = FString()) const
+    {
+        FString Value;
+        if (Obj.IsValid() && Obj->TryGetStringField(Field, Value))
+        {
+            return Value;
+        }
+        return Default;
+    }
+
+    /** Optional numeric field; returns Default when absent or wrong type. */
+    double GetNumber(const TCHAR* Field, double Default = 0.0) const
+    {
+        double Value = Default;
+        if (Obj.IsValid() && Obj->TryGetNumberField(Field, Value))
+        {
+            return Value;
+        }
+        return Default;
+    }
+
+    /** Optional integer field; returns Default when absent or wrong type. */
+    int32 GetInt(const TCHAR* Field, int32 Default = 0) const
+    {
+        int32 Value = Default;
+        if (Obj.IsValid() && Obj->TryGetNumberField(Field, Value))
+        {
+            return Value;
+        }
+        return Default;
+    }
+
+    /** Optional boolean field; returns Default when absent or wrong type. */
+    bool GetBool(const TCHAR* Field, bool Default = false) const
+    {
+        bool Value = Default;
+        if (Obj.IsValid() && Obj->TryGetBoolField(Field, Value))
+        {
+            return Value;
+        }
+        return Default;
+    }
+
+    /** Optional array field; returns nullptr when absent or wrong type. */
+    const TArray<TSharedPtr<FJsonValue>>* GetArray(const TCHAR* Field) const
+    {
+        const TArray<TSharedPtr<FJsonValue>>* OutArray = nullptr;
+        if (Obj.IsValid() && Obj->TryGetArrayField(Field, OutArray))
+        {
+            return OutArray;
+        }
+        return nullptr;
+    }
+
+    /** Optional object field; returns nullptr when absent or wrong type. */
+    TSharedPtr<FJsonObject> GetObject(const TCHAR* Field) const
+    {
+        const TSharedPtr<FJsonObject>* OutObject = nullptr;
+        if (Obj.IsValid() && Obj->TryGetObjectField(Field, OutObject) && OutObject)
+        {
+            return *OutObject;
+        }
+        return nullptr;
+    }
+
+    /** True once any RequireString() call has failed. */
+    bool HasError() const
+    {
+        return bHasError;
+    }
+
+    /** Builds the failure result from the first recorded error message. */
+    FHaybaHandlerResult Error() const
+    {
+        return FHaybaHandlerResult::Err(ErrorMessage);
+    }
+
+private:
+    void RecordError(const FString& Msg)
+    {
+        if (!bHasError)
+        {
+            bHasError = true;
+            ErrorMessage = Msg;
+        }
+    }
+
+    TSharedPtr<FJsonObject> Obj;
+    bool bHasError = false;
+    FString ErrorMessage;
+};


### PR DESCRIPTION
## Theme

Both adapters on the protocol seam repeat a shallow unwrapping pattern. This deepens both into small high-leverage modules.

- **MCP server** hand-wrote the `{ content: [{ type:'text', text: JSON.stringify(r,null,2) }] }` envelope at ~15 sites, and the TCP framing logic lived untestable inside a socket callback.
- **UE plugin** repeats a `TryGetStringField` → null-check → `Err(Printf(...))` dance across 35 handlers.

## Changes

### MCP server (TypeScript — fully verified)
- **`FrameDecoder`** (`tcp-frame-decoder.ts`) — extracted the length-prefixed framing out of `tcp-client.ts`'s socket callback into a pure, socket-free module. `tcp-client.ts` is now a thin socket adapter; `onData` only parses + routes. The framing (buffer reassembly, 1 MiB cap, corrupt-prefix recovery) was **previously untested** — now has **11 unit tests** covering split frames, byte-at-a-time delivery, oversized/zero prefixes, exact-cap payloads. Also fixes a latent bug: the receive buffer now resets on socket close.
- **`toMcpResponse` + `registerJsonTool`** (`tools/mcp-response.ts`) — one home for the MCP envelope. `register.ts`'s 14 meta-tool registrations collapse from ~8-line `server.tool(...)` blocks to one-liners. **+5 unit tests.**

### UE plugin (C++ — NOT build-verified, see below)
- **`FHaybaJsonParams`** (`HaybaMCPJsonParams.h`, header-only) — a wrapper over `TSharedPtr<FJsonObject>` with an accumulate-first-error / check-once pattern. `RequireString`/`RequireNumber` + optional `GetString/GetNumber/GetInt/GetBool/GetArray/GetObject`. The param dance collapses to `Args.RequireString(...)` + one `Args.HasError()` check.
- **`HaybaMCPAudioHandler`** migrated to it as the proof (3 methods, ~10 lines of boilerplate gone). Behavior-preserving; error wording changes to `"<field>: required"`.

## ⚠️ Verification status
- TS side: `tsc --noEmit` clean; new tests 16/16 green; routing tests 25/25 green.
- **UE C++ side is NOT build-verified** — no UE toolchain in this environment. The header uses the same `FJsonObject` API the shipped slivers parser compiles against, and was reviewed for IWYU/brace correctness, but **rebuild the plugin to confirm**.
- The 26 pre-existing `tests/tools/*` failures (TCP-forwarding tests needing a live UE connection) are unchanged from `main` — not introduced here.

## Follow-ups (deliberately out of scope)
- Migrate the remaining wrapper sites in `tools/actor/*`, `tools/fab/*`, `tools/asset-sources/*` to `toMcpResponse`.
- Migrate the other 34 UE handlers to `FHaybaJsonParams`.
- Surfaced but not done: `register.ts` is still a 430-line god file; the UE `HaybaMCPCommandHandler.cpp` (739 lines) mixes dispatch with UI side effects.