### PR TITLE
Biome Scatter via PCG + ctx.dispatch UE seam (+ icon redesign)

### DIFF
--- a/mcp-tools/hayba-mcp/src/slivers/index.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/index.ts
@@ -8,6 +8,7 @@ import { ExecutorRegistry } from './registry.js';
 import { SliverLoader, defaultUserSliversDir } from './loader.js';
 import { SliverRuntime } from './runtime.js';
 import { COMPOSITION_FRAME_TARGET_KIND, frameTargetExecutor } from './composition/frame_target.js';
+import { SCATTER_PCG_BIOME_KIND, pcgBiomeExecutor } from './scatter/pcg_biome.js';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -22,11 +23,15 @@ export interface SetupOpts {
   bundledDir?: string;
   maxDepth?: number;
   onRun?: import('./runtime.js').SliverOnRun;
+  /** UE bridge for side-effecting executors. Production wiring adapts
+   *  `executeCommand`; tests can pass mock bridges or omit entirely. */
+  ueBridge?: import('./types.js').SliverUeBridge;
 }
 
 export async function setupSliverSystem(opts: SetupOpts = {}): Promise<SliverSystem> {
   const registry = new ExecutorRegistry();
   registry.register(COMPOSITION_FRAME_TARGET_KIND, frameTargetExecutor);
+  registry.register(SCATTER_PCG_BIOME_KIND, pcgBiomeExecutor);
 
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const loader = new SliverLoader({
@@ -40,6 +45,7 @@ export async function setupSliverSystem(opts: SetupOpts = {}): Promise<SliverSys
     getSpec: (id) => loader.get(id),
     maxDepth: opts.maxDepth ?? 8,
     onRun: opts.onRun,
+    ueBridge: opts.ueBridge,
   });
 
   return { registry, loader, runtime };

--- a/mcp-tools/hayba-mcp/src/slivers/runtime.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/runtime.ts
@@ -12,6 +12,7 @@
 import {
   SliverCycleError, SliverDepthError, SliverNotFoundError, SliverValidationError,
   type SliverParamValues, type SliverRunResult, type SliverSpec, type SliverContext,
+  type SliverUeBridge,
 } from './types.js';
 import type { ExecutorRegistry } from './registry.js';
 import { validateAndCoerceParams } from './param-validator.js';
@@ -31,6 +32,11 @@ export interface SliverRuntimeOpts {
   getSpec: (id: string) => SliverSpec | undefined;
   maxDepth?: number;
   onRun?: SliverOnRun;
+  /** Bridge that side-effecting executors use to call UE commands via
+   *  ctx.dispatch. Undefined → ctx.dispatch is undefined and only pure
+   *  executors are usable. The production wiring adapts `executeCommand`;
+   *  tests pass mock bridges. */
+  ueBridge?: SliverUeBridge;
 }
 
 /** Marker so the root catch knows these should remain unhandled at inner frames. */
@@ -45,12 +51,14 @@ export class SliverRuntime {
   private readonly getSpec: (id: string) => SliverSpec | undefined;
   private readonly maxDepth: number;
   private readonly onRun?: SliverOnRun;
+  private readonly ueBridge?: SliverUeBridge;
 
   constructor(opts: SliverRuntimeOpts) {
     this.registry = opts.registry;
     this.getSpec = opts.getSpec;
     this.maxDepth = opts.maxDepth ?? 8;
     this.onRun = opts.onRun;
+    this.ueBridge = opts.ueBridge;
   }
 
   /** Public entry point. Always resolves (never rejects). */
@@ -137,6 +145,7 @@ export class SliverRuntime {
       maxDepth: this.maxDepth,
       runSliver: (childId, childParams) =>
         this._runChildSliver(childId, childParams, newStack, effects),
+      dispatch: this.ueBridge,
     };
 
     return await executor(v.values, ctx);

--- a/mcp-tools/hayba-mcp/src/slivers/scatter/pcg_biome.test.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/scatter/pcg_biome.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { pcgBiomeExecutor, buildBiomeScatterGraph } from './pcg_biome.js';
+import type { SliverContext, SliverUeBridge } from '../types.js';
+
+const baseParams = {
+  area_actor: '/Game/Maps/Demo.BiomeVolume_0',
+  mesh: '/Game/Foliage/SM_Pine',
+  density: 0.5,
+  scale_min: 0.9,
+  scale_max: 1.2,
+  yaw_jitter: 360,
+  seed: 1337,
+  graph_name: 'BiomeScatter',
+};
+
+function ctxWith(dispatch?: SliverUeBridge): SliverContext {
+  return {
+    stack: [], maxDepth: 8,
+    runSliver: async () => ({ ok: true, outputs: {}, side_effects: [], durationMs: 0 }),
+    dispatch,
+  };
+}
+
+describe('buildBiomeScatterGraph', () => {
+  it('produces the 3-node In→Out topology (actor → sampler → spawner)', () => {
+    const g = buildBiomeScatterGraph({ ...baseParams, graph_name: 'Test_1337' });
+    expect(g.nodes.map(n => n.id).sort()).toEqual(['actor', 'sampler', 'spawner']);
+    expect(g.edges).toEqual([
+      { fromNode: 'actor',   fromPin: 'Out', toNode: 'sampler', toPin: 'In' },
+      { fromNode: 'sampler', fromPin: 'Out', toNode: 'spawner', toPin: 'In' },
+    ]);
+  });
+
+  it('threads seed + density into the surface sampler', () => {
+    const g = buildBiomeScatterGraph({ ...baseParams, density: 0.7, seed: 4242, graph_name: 'X' });
+    const sampler = g.nodes.find(n => n.id === 'sampler')!;
+    expect(sampler.class).toBe('PCGSurfaceSamplerSettings');
+    expect(sampler.properties.Seed).toBe(4242);
+    expect(sampler.properties.PointsPerSquaredMeter).toBe(0.7);
+  });
+
+  it('passes mesh + scale + yaw to the spawner', () => {
+    const g = buildBiomeScatterGraph({ ...baseParams, graph_name: 'X' });
+    const spawner = g.nodes.find(n => n.id === 'spawner')!;
+    expect(spawner.class).toBe('PCGStaticMeshSpawnerSettings');
+    expect(spawner.properties.Mesh).toBe('/Game/Foliage/SM_Pine');
+    expect(spawner.properties.ScaleMin).toBe(0.9);
+    expect(spawner.properties.ScaleMax).toBe(1.2);
+    expect(spawner.properties.YawJitter).toBe(360);
+  });
+
+  it('refers to the area actor in GetSinglePoint mode', () => {
+    const g = buildBiomeScatterGraph({ ...baseParams, graph_name: 'X' });
+    const actor = g.nodes.find(n => n.id === 'actor')!;
+    expect(actor.class).toBe('PCGDataFromActorSettings');
+    expect(actor.properties.Mode).toBe('GetSinglePoint');
+    expect(actor.properties.ActorReference).toBe('/Game/Maps/Demo.BiomeVolume_0');
+  });
+});
+
+describe('pcgBiomeExecutor', () => {
+  it('throws when no UE bridge is wired', async () => {
+    await expect(pcgBiomeExecutor(baseParams, ctxWith(undefined))).rejects.toThrow(/ueBridge/i);
+  });
+
+  it('calls create_graph then execute_graph and returns the asset path', async () => {
+    const calls: Array<{ cmd: string; params: Record<string, unknown> }> = [];
+    const dispatch: SliverUeBridge = async (cmd, params) => {
+      calls.push({ cmd, params });
+      if (cmd === 'create_graph') return { ok: true, data: { assetPath: '/Game/PCG/MyGraph.MyGraph' } };
+      if (cmd === 'execute_graph') return { ok: true, data: { instances: 42 } };
+      return { ok: false, error: `unexpected cmd ${cmd}` };
+    };
+    const out = await pcgBiomeExecutor(baseParams, ctxWith(dispatch));
+    expect(calls.map(c => c.cmd)).toEqual(['create_graph', 'execute_graph']);
+    expect(out.graph_asset).toBe('/Game/PCG/MyGraph.MyGraph');
+    expect((out.execute_result as { instances: number }).instances).toBe(42);
+
+    // The create call carries a PCGGraphJSON whose seed matches the param.
+    const createParams = calls[0].params as { graph: { nodes: Array<{ properties: Record<string, unknown> }> } };
+    const samplerSeed = createParams.graph.nodes.find(n => (n.properties as { Seed?: number }).Seed != null);
+    expect(samplerSeed?.properties.Seed).toBe(1337);
+  });
+
+  it('surfaces a create_graph failure as a thrown error', async () => {
+    const dispatch: SliverUeBridge = async (cmd) =>
+      cmd === 'create_graph' ? { ok: false, error: 'asset name taken' } : { ok: true };
+    await expect(pcgBiomeExecutor(baseParams, ctxWith(dispatch)))
+      .rejects.toThrow(/create_graph failed.*asset name taken/);
+  });
+
+  it('surfaces an execute_graph failure as a thrown error', async () => {
+    const dispatch: SliverUeBridge = async (cmd) => cmd === 'create_graph'
+      ? { ok: true, data: { assetPath: '/Game/PCG/G.G' } }
+      : { ok: false, error: 'PCG runtime missing' };
+    await expect(pcgBiomeExecutor(baseParams, ctxWith(dispatch)))
+      .rejects.toThrow(/execute_graph failed.*PCG runtime missing/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/slivers/scatter/pcg_biome.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/scatter/pcg_biome.ts
@@ -1,0 +1,132 @@
+// mcp-tools/hayba-mcp/src/slivers/scatter/pcg_biome.ts
+//
+// Side-effecting executor: builds a minimal PCG graph that scatters a
+// StaticMesh across the surface of an area actor, then asks UE to build
+// it. The graph itself is the deterministic abstraction — same params
+// produce the same PCGGraphJSON, so the LLM gets a reproducible scatter
+// without having to construct the topology by hand.
+//
+// Topology (standard PCG, not PCGEx — uses In/Out pin names per
+// graph-patterns.ts):
+//
+//     [PCGDataFromActorSettings]  -- Out --> In [PCGSurfaceSamplerSettings]
+//                                                            |
+//                                                          Out
+//                                                            v
+//                                          In [PCGStaticMeshSpawnerSettings]
+//
+// Determinism: the spec's `seed` param is written onto PCGSurfaceSampler's
+// Seed property; PCG samples deterministically from there.
+
+import type { SliverExecutor } from '../types.js';
+import type { PCGGraphJSON, PCGNode, PCGEdge } from '../../types.js';
+
+export const SCATTER_PCG_BIOME_KIND = 'scatter.pcg_biome';
+
+interface PcgBiomeParams {
+  area_actor: string;
+  mesh: string;
+  density: number;
+  scale_min: number;
+  scale_max: number;
+  yaw_jitter: number;
+  seed: number;
+  graph_name: string;
+}
+
+/** One-time-stamped graph asset name so successive runs do not collide. */
+function uniqueGraphName(base: string, seed: number): string {
+  const stamp = Date.now().toString(36);
+  return `${base}_${seed}_${stamp}`;
+}
+
+function node(
+  id: string, klass: string, label: string,
+  x: number, y: number,
+  properties: Record<string, unknown> = {},
+): PCGNode {
+  return { id, class: klass, label, position: { x, y }, properties, customData: {} };
+}
+
+function edge(fromNode: string, toNode: string, fromPin = 'Out', toPin = 'In'): PCGEdge {
+  return { fromNode, fromPin, toNode, toPin };
+}
+
+/** Build the PCGGraphJSON for one biome-scatter run. Pure — returned graph
+ *  is determined entirely by the supplied params. */
+export function buildBiomeScatterGraph(p: PcgBiomeParams): PCGGraphJSON {
+  const actorSource: PCGNode = node(
+    'actor', 'PCGDataFromActorSettings', 'Area Actor',
+    0, 0,
+    // GetSinglePoint mode per graph-patterns.ts — we want the actor's
+    // bounds as a single point seed to feed the sampler.
+    { Mode: 'GetSinglePoint', ActorReference: p.area_actor },
+  );
+  const sampler: PCGNode = node(
+    'sampler', 'PCGSurfaceSamplerSettings', 'Surface Sample',
+    260, 0,
+    {
+      PointsPerSquaredMeter: p.density,
+      Seed: p.seed,
+    },
+  );
+  const spawner: PCGNode = node(
+    'spawner', 'PCGStaticMeshSpawnerSettings', 'Spawn Mesh',
+    520, 0,
+    {
+      Mesh: p.mesh,
+      ScaleMin: p.scale_min,
+      ScaleMax: p.scale_max,
+      YawJitter: p.yaw_jitter,
+    },
+  );
+
+  return {
+    version: '2',
+    meta: {
+      sourceGraph: p.graph_name,
+      ueVersion: '5.7',
+      exportedAt: new Date().toISOString(),
+      tags: ['hayba.sliver', 'scatter.pcg_biome'],
+    },
+    nodes: [actorSource, sampler, spawner],
+    edges: [
+      edge('actor', 'sampler'),
+      edge('sampler', 'spawner'),
+    ],
+    metadata: {},
+  } as PCGGraphJSON;
+}
+
+export const pcgBiomeExecutor: SliverExecutor = async (rawParams, ctx) => {
+  const p = rawParams as unknown as PcgBiomeParams;
+
+  if (!ctx.dispatch) {
+    throw new Error(
+      'pcg_biome requires a UE bridge — setupSliverSystem({ ueBridge }) was not wired',
+    );
+  }
+
+  const graphName = uniqueGraphName(p.graph_name, p.seed);
+  const graph = buildBiomeScatterGraph({ ...p, graph_name: graphName });
+
+  const created = await ctx.dispatch('create_graph', { graph, name: graphName });
+  if (!created.ok) {
+    throw new Error(`pcg_biome: create_graph failed — ${created.error ?? 'unknown error'}`);
+  }
+  const assetPath =
+    (created.data?.assetPath as string | undefined)
+    ?? (created.data?.path as string | undefined)
+    ?? `/Game/PCG/${graphName}.${graphName}`;
+
+  const executed = await ctx.dispatch('execute_graph', { assetPath });
+  if (!executed.ok) {
+    throw new Error(`pcg_biome: execute_graph failed — ${executed.error ?? 'unknown error'}`);
+  }
+
+  return {
+    graph_asset: assetPath,
+    create_result: created.data ?? {},
+    execute_result: executed.data ?? {},
+  };
+};

--- a/mcp-tools/hayba-mcp/src/slivers/specs/com.hayba.scatter.pcg_biome.sliver.json
+++ b/mcp-tools/hayba-mcp/src/slivers/specs/com.hayba.scatter.pcg_biome.sliver.json
@@ -1,0 +1,26 @@
+{
+  "id": "com.hayba.scatter.pcg_biome",
+  "version": "1.0.0",
+  "category": "scatter",
+  "title": "Biome Scatter (PCG)",
+  "description": "Scatter a StaticMesh across the surface of a target volume actor using a procedurally-built PCG graph. The sliver constructs a PCGGraph asset from the supplied parameters (area + mesh + density + seed), then asks UE to build it — PCG handles the real terrain-aware, instanced placement. Deterministic via 'seed': identical params reproduce the same scatter. Side-effecting (creates and runs a PCG graph asset).",
+  "author": "core",
+  "params": [
+    { "id": "area_actor", "type": "actor_ref", "label": "Area / volume actor", "required": true },
+    { "id": "mesh",       "type": "asset_ref", "label": "StaticMesh to scatter", "required": true, "class_filter": "StaticMesh" },
+    { "id": "density",    "type": "float",     "label": "Density (points / m^2)", "range": [0.0001, 100], "default": 0.5 },
+    { "id": "scale_min",  "type": "float",     "label": "Scale min",              "range": [0.05, 20],   "default": 0.9 },
+    { "id": "scale_max",  "type": "float",     "label": "Scale max",              "range": [0.05, 20],   "default": 1.2 },
+    { "id": "yaw_jitter", "type": "float",     "label": "Yaw jitter (deg)",       "range": [0, 360],     "default": 360 },
+    { "id": "seed",       "type": "int",       "label": "Seed",                   "range": [0, 2147483647], "default": 1337 },
+    { "id": "graph_name", "type": "string",    "label": "Graph asset name prefix", "default": "BiomeScatter" }
+  ],
+  "executor": { "kind": "scatter.pcg_biome" },
+  "determinism": {
+    "pure": false,
+    "declared_outputs": ["graph_asset", "create_result", "execute_result"],
+    "side_effects": ["pcg.graph.create", "pcg.graph.execute"],
+    "reads": [],
+    "seed_param": "seed"
+  }
+}

--- a/mcp-tools/hayba-mcp/src/slivers/types.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/types.ts
@@ -56,6 +56,22 @@ export interface SliverRunResult {
   error?: string;
 }
 
+/** Structured return shape for an executor's dispatched UE command — always
+ *  resolved (never throws), so a side-effecting executor can branch on `ok`. */
+export interface SliverDispatchResult {
+  ok: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+}
+
+/** Bridge wired by setupSliverSystem when the host has a live UE connection
+ *  (the production wiring adapts `executeCommand`). Pure executors leave
+ *  ctx.dispatch undefined; side-effecting ones use it. */
+export type SliverUeBridge = (
+  cmd: string,
+  params: Record<string, unknown>,
+) => Promise<SliverDispatchResult>;
+
 /** Context threaded through a runSliver call. Mostly the runtime needs it; executors may read it. */
 export interface SliverContext {
   /** Reverse-DNS ids in the current call stack (oldest → newest). */
@@ -64,6 +80,10 @@ export interface SliverContext {
   maxDepth: number;
   /** Lets executors call other slivers. */
   runSliver: (id: string, params: SliverParamValues) => Promise<SliverRunResult>;
+  /** Optional UE bridge for side-effecting executors. Undefined when the
+   *  runtime was constructed without a bridge (the default — keeps pure
+   *  slivers unit-testable without UE). */
+  dispatch?: SliverUeBridge;
 }
 
 /** Executor function signature. Pure or mutating per the spec's determinism block. */

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -321,6 +321,17 @@ export async function registerDeferredRouting(
         ok: info.ok,
       });
     },
+    // Side-effecting executors reach the UE bridge through ctx.dispatch.
+    // executeCommand throws on transport/UE error; we convert to the
+    // structured SliverDispatchResult so executors can branch on `ok`.
+    ueBridge: async (cmd, params) => {
+      try {
+        const data = await executeCommand(cmd, params);
+        return { ok: true, data: data as Record<string, unknown> };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
   });
   for (const err of slivers.loader.errors()) {
     console.warn(`[slivers] load error: ${err}`);

--- a/unreal/HaybaMCPToolkit/Resources/IconSlivers.svg
+++ b/unreal/HaybaMCPToolkit/Resources/IconSlivers.svg
@@ -1,8 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
-  <rect x="10" y="13" width="44" height="9" rx="2.5" fill="#E8ECF5" stroke="#7A8AB8" stroke-width="2"/>
-  <rect x="10" y="27.5" width="44" height="9" rx="2.5" fill="#C7D8CC" stroke="#88C0A0" stroke-width="2"/>
-  <rect x="10" y="42" width="44" height="9" rx="2.5" fill="#E8ECF5" stroke="#7A8AB8" stroke-width="2"/>
-  <circle cx="18" cy="17.5" r="2" fill="#7A8AB8"/>
-  <circle cx="18" cy="32" r="2" fill="#88C0A0"/>
-  <circle cx="18" cy="46.5" r="2" fill="#7A8AB8"/>
+  <!-- the whole -->
+  <circle cx="32" cy="33" r="20" fill="#E8ECF5" stroke="#7A8AB8" stroke-width="2"/>
+  <!-- one sliver: a thin slice of it -->
+  <path d="M32 33 L32 13 A20 20 0 0 1 43.6 16.5 Z"
+        fill="#88C0A0" stroke="#5E8C72" stroke-width="2" stroke-linejoin="round"/>
+  <!-- pivot -->
+  <circle cx="32" cy="33" r="2.6" fill="#7A8AB8"/>
 </svg>


### PR DESCRIPTION
## Pivot from the original #224

The first version of this PR reinvented scatter as a TS for-loop, ignoring the fact that the plugin already has a full PCG surface (`create_graph` / `execute_graph` / `query-pcgex-docs` / `pcgex_registry.db`). After feedback that biome placement should compose PCG rather than reimplement it, force-pushed the right shape.

## What's here now

### 1. New architectural seam — `ctx.dispatch` (the first side-effecting executor needed this)
- `SliverContext` gains an optional `dispatch(cmd, params) → Promise<SliverDispatchResult>`.
- `SliverRuntime` takes an optional `ueBridge` and threads it into every executor's ctx. Pure executors are unaffected (they ignore `dispatch`).
- `register.ts` adapts the existing `executeCommand` (throws on failure) into the structured `{ok,data?,error?}` shape so executors can branch cleanly.
- Sliver type unchanged from the executor side — no fork in the executor function type. The `determinism.side_effects[]` declaration already encodes intent; the runtime tracks it via the DAG.

### 2. First side-effecting sliver — `com.hayba.scatter.pcg_biome`
- Params: `area_actor` (volume), `mesh` (StaticMesh), `density`, `scale_min/max`, `yaw_jitter`, `seed`, `graph_name`.
- Executor builds a minimal standard-PCG topology (uses `In`/`Out` pins per `graph-patterns.ts`):
  ```
  PCGDataFromActorSettings  ─Out→In─►  PCGSurfaceSamplerSettings  ─Out→In─►  PCGStaticMeshSpawnerSettings
       (Mode=GetSinglePoint,                  (PointsPerSquaredMeter=density,                (Mesh, ScaleMin/Max, YawJitter)
        ActorReference=area_actor)             Seed=seed)
  ```
- Calls `dispatch('create_graph', { graph, name })` then `dispatch('execute_graph', { assetPath })`.
- `determinism: { pure: false, side_effects: ['pcg.graph.create', 'pcg.graph.execute'], seed_param: 'seed' }` — the DAG records both writes.

The graph is the deterministic abstraction; PCG does the real terrain-aware, instanced placement (HISM, World Partition, etc).

### 3. Slivers tab icon — redesigned
Old icon read as a server rack. Replaced with a pie-slice — disc + one thin slice highlighted in the accent green. Matches the flat-geometric style of the other toolkit tab icons.

## Test plan
- [x] vitest src/slivers — 59/59 (incl. 8 new pcg_biome: topology shape, seed wiring, mesh/scale/yaw, create→execute call sequence, error surfacing, no-bridge guard)
- [x] tsc --noEmit clean
- [x] End-to-end smoke through `setupSliverSystem` with a mock bridge: 2 kinds registered, 2 specs bundled, sliver runs `create_graph → execute_graph`, returns asset path

## Notes for the live MCP test (after restart)
A real run requires UE running. The sliver calls `create_graph` (existing handler) — if a topology node name is wrong, the error surfaces cleanly via the structured dispatch result. v2 candidates: query `pcgex_registry.db` to validate node classes at build time; add multi-mesh + spline-scatter slivers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PCG (Procedural Content Generation) biome scatter executor, enabling deterministic static mesh scattering across area actors with configurable density, scale, rotation jitter, and seeding parameters.

* **Tests**
  * Added comprehensive test coverage for PCG biome scatter graph generation and execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->