### PR TITLE
fix(ue): use-after-free in wait_for_idle/wait_for_shaders — crashed UE under heavy load

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp
@@ -89,6 +89,19 @@ namespace HaybaIdle
         // Filled on the game thread, read on the TCP thread after DoneEvent fires.
         bool                     bAllSettled      = false;
         double                   FinalDurationMs  = 0.0;
+
+        // The FEvent is pool-allocated and must be returned exactly once
+        // when the last shared owner releases. Doing it here ties the
+        // pool return to the state's lifetime so neither thread can
+        // double-free or leak it.
+        ~FWaitState()
+        {
+            if (DoneEvent)
+            {
+                FPlatformProcess::ReturnSynchEventToPool(DoneEvent);
+                DoneEvent = nullptr;
+            }
+        }
     };
 
     static bool IsBusy(const FString& Sub, const FWaitState& S)
@@ -223,53 +236,66 @@ FHaybaHandlerResult FHaybaMCPIdleHandler::Handle(const FString& Command,
     if (!State.DoneEvent) return FHaybaHandlerResult::Err(TEXT("Failed to allocate FEvent"));
 
     // ── Schedule polling on the game thread ───────────────────────────────
-    // Capture pointer to a heap-allocated copy so the lambda can mutate it
-    // across ticks. The TCP thread frees it after DoneEvent fires.
-    FWaitState* HeapState = new FWaitState(MoveTemp(State));
+    // Shared ownership: the TCP thread (this scope) holds one ref, the
+    // game-thread ticker lambda holds another. Whichever releases last
+    // destructs FWaitState, which returns DoneEvent to the pool. This
+    // fixes a use-after-free where the TCP thread's FEvent wait could
+    // expire while the ticker was still polling, freeing the state out
+    // from under the next tick (crash: PollOnce reading freed Subsystems).
+    TSharedRef<FWaitState, ESPMode::ThreadSafe> SharedState =
+        MakeShared<FWaitState, ESPMode::ThreadSafe>(MoveTemp(State));
 
-    AsyncTask(ENamedThreads::GameThread, [HeapState]()
+    AsyncTask(ENamedThreads::GameThread, [SharedState]()
     {
         // GC nudge — only when gc requested. Queue once, before the first poll,
         // so IsGCBusyImpl observes the pending pass briefly then sees it settle.
-        if (HeapState->Subsystems.Contains(TEXT("gc")) && GEngine)
+        if (SharedState->Subsystems.Contains(TEXT("gc")) && GEngine)
         {
             GEngine->ForceGarbageCollection(/*bFullPurge=*/ false);
         }
         // Capture busyOnEntry on the game thread (predicates are not thread-safe).
-        for (const FString& Sub : HeapState->Subsystems)
+        for (const FString& Sub : SharedState->Subsystems)
         {
-            HeapState->BusyOnEntry.Add(Sub, IsBusy(Sub, *HeapState));
+            SharedState->BusyOnEntry.Add(Sub, IsBusy(Sub, *SharedState));
         }
-        HeapState->TickHandle = FTSTicker::GetCoreTicker().AddTicker(
-            FTickerDelegate::CreateLambda([HeapState](float Dt) { return PollOnce(Dt, HeapState); }),
+        SharedState->TickHandle = FTSTicker::GetCoreTicker().AddTicker(
+            FTickerDelegate::CreateLambda([SharedState](float Dt) { return PollOnce(Dt, &SharedState.Get()); }),
             POLL_INTERVAL_SECONDS);
     });
 
     // ── Block this thread until polling completes or timeout fires ─────────
     // FEvent wait timeout is in milliseconds. Allow timeout_s + 1s slack so
-    // the game-thread poller always fires Done first.
-    const uint32 WaitTimeoutMs = (uint32)(HeapState->TimeoutSeconds * 1000.0) + 1000;
-    const bool bSignaled = HeapState->DoneEvent->Wait(WaitTimeoutMs);
+    // the game-thread poller normally fires Done first.
+    const uint32 WaitTimeoutMs = (uint32)(SharedState->TimeoutSeconds * 1000.0) + 1000;
+    const bool bSignaled = SharedState->DoneEvent->Wait(WaitTimeoutMs);
 
     // Build response (read game-thread-filled state — safe because the event
     // signal serializes the write).
     TSharedPtr<FJsonObject> Resp;
     if (bSignaled)
     {
-        Resp = BuildResponse(*HeapState);
+        Resp = BuildResponse(*SharedState);
     }
     else
     {
-        // FEvent timed out before the game-thread poller — shouldn't happen
-        // given the +1s slack, but degrade gracefully.
-        HeapState->FinalDurationMs = (FPlatformTime::Seconds() - HeapState->T0Seconds) * 1000.0;
-        HeapState->bAllSettled = false;
-        Resp = BuildResponse(*HeapState);
+        // FEvent timed out before the game-thread poller. Stop the ticker
+        // first so it cannot keep mutating SharedState while we read it;
+        // RemoveTicker is safe from any thread but does not wait on an
+        // in-flight tick — the shared ownership above is what makes that
+        // safe (no use-after-free regardless of in-flight ticks).
+        if (SharedState->TickHandle.IsValid())
+        {
+            FTSTicker::GetCoreTicker().RemoveTicker(SharedState->TickHandle);
+            SharedState->TickHandle.Reset();
+        }
+        SharedState->FinalDurationMs = (FPlatformTime::Seconds() - SharedState->T0Seconds) * 1000.0;
+        SharedState->bAllSettled = false;
+        Resp = BuildResponse(*SharedState);
     }
 
-    FPlatformProcess::ReturnSynchEventToPool(HeapState->DoneEvent);
-    HeapState->DoneEvent = nullptr;
-    delete HeapState;
+    // No manual cleanup: when this scope's SharedState ref drops and the
+    // game-thread ticker drops its lambda ref (whichever happens last),
+    // FWaitState's destructor returns DoneEvent to the pool.
 
     return FHaybaHandlerResult::Ok(Resp);
 }


### PR DESCRIPTION
## Bug

UE 5.7 hard crash in the MCP plugin's idle/shader-wait path. Reproduced **today** in the geoforge editor — spawned 19 StaticMeshActors via \`python_run\` then called \`wait_for_shaders(max_seconds=45)\`. ~46 seconds in, UE died with:

\`\`\`
EXCEPTION_ACCESS_VIOLATION reading address 0xffffffffffffffff
UnrealEditor_HaybaMCPToolkit!HaybaIdle::PollOnce()
  Private\handlers\HaybaMCPIdleHandler.cpp:142
\`\`\`

Crash dump: \`Saved/Crashes/UECC-Windows-0C25CC9F4F3081A4E11BEF9853BA7AA9_0000\`.

## Root cause

Classic use-after-free between the TCP request thread and the game-thread ticker:

1. \`Handle()\` (TCP thread) heap-allocates an \`FWaitState\`, schedules a polling delegate on the core ticker (game thread), blocks on an \`FEvent\` for \`timeout_s + 1s\` slack.
2. Under heavy game-thread load (spawning many actors + shader compilation), the FTSTicker fell behind. The TCP-side FEvent wait **expired before** the game-thread PollOnce detected the timeout and triggered DoneEvent.
3. TCP thread builds the degraded response, returns the event to the pool, \`delete HeapState\` — and returns.
4. Game-thread ticker is still registered. Its next tick reads \`S->Subsystems\` on the freed state → access violation reading 0xffffffffffffffff.

The +1s slack comment in the file noted this "shouldn't happen" — but it can, under exactly the load this plugin is designed to trigger (mass spawn + shader recompile).

## Fix

Shared ownership via \`TSharedRef<FWaitState, ESPMode::ThreadSafe>\` so the TCP thread and the ticker lambda each hold a ref; the last to release destructs the state. \`FWaitState\` gets a destructor that returns \`DoneEvent\` to the pool exactly once at the right time.

Defense in depth: the \`bSignaled=false\` (TCP-side timeout) branch now also \`RemoveTicker\`s the ticker before reading shared state, so no further \`PollOnce\` runs concurrently with the response build.

## Verification

- ⚠️ **Not build-verified** — no UE toolchain in this environment. The change is a small, well-bounded raw-ptr→\`TSharedRef\` swap in one file (47 insertions / 21 deletions, no API surface change). Rebuild the plugin to confirm.
- Repro on \`main\` is reliable: 19 \`actor_spawn\`s via \`python_run\` then \`wait_for_shaders\`. Repro should be gone after merge + rebuild.

## Notes

This is the same family of issue as the \`OnRunClicked\` lambda \`[this]\` capture we flagged in the Slivers Plan B review (#218) — TWeakPtr / shared ownership patterns belong on every cross-thread state in this plugin. Worth a follow-up sweep of the other handlers for similar raw-pointer-across-thread patterns (PIE wait-loop, Anim handler, etc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced cross-thread synchronization in the idle-wait handler to improve resource management and thread-safety during polling operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->