### PR TITLE
spec: agentic guardrails + sliver library (post-mortem of live scene-build session)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-agentic-guardrails-and-sliver-library.md
+++ b/docs/superpowers/specs/2026-05-22-agentic-guardrails-and-sliver-library.md
@@ -1,0 +1,459 @@
+# Agentic Guardrails + Sliver Library — Post-Mortem & Roadmap
+
+**Date:** 2026-05-22
+**Status:** Spec — pending approval
+**Trigger:** A live scene-building session through MCP produced consistent, embarrassing failures (floating foliage, upside-down trees, default checkerboard landscape, blown-out brazier light, an editor crash). The session is the natural failure-case catalog: this document turns it into deterministic guardrails so an autonomous agent cannot make the same class of mistake again, and into a sliver library that gives the agent the right primitives instead of an escape-hatch `python_run`.
+
+---
+
+## Part 1 — What broke this session, and why
+
+A ruthless list. Each row is something the MCP failed to prevent or actively encouraged.
+
+| # | Failure | Root cause | Why the MCP let it happen |
+|---|---|---|---|
+| 1 | Every actor spawned at `z=100`, terrain ignored → **all foliage floating** | Agent hardcoded a Z value rather than querying terrain | `actor_spawn` takes a free `[x,y,z]` location and has no "snap-to-surface" mode |
+| 2 | `SM_GiantTree_02` placed upside down with `Rotator(0, 200, 0)` | UE Python `Rotator()` positional args are `(roll, pitch, yaw)`, not `(pitch, yaw, roll)` | Agent worked through `python_run` where there is **no schema** to catch the arg-order swap; nothing flagged a tree with 200° roll/pitch |
+| 3 | One canopy-vine asset spawned at `z=380` over flat ground → **floating in mid-air** | Hardcoded z for a "canopy" asset; no terrain awareness | Same as #1 — placement has no contract |
+| 4 | Brazier `PointLight` intensity set to `120000 cd` (stadium-floodlight range; real brazier ≈ 3000 cd) — blew the foreground out | No range guard on light intensity | The `actor_spawn` path doesn't know "this is a PointLight" — properties are set via `python_run` which has zero domain knowledge |
+| 5 | Default landscape material left unassigned → checkerboard ground in every shot | Agent never touched the Landscape's `LandscapeMaterial` | No `landscape_set_material` tool; no validation that "scene has a non-default landscape material" |
+| 6 | Spent the session re-implementing scatter inside `python_run` (for-loops over `actor_spawn`) instead of PCG | `python_run` is the path of least resistance; PCG requires constructing `PCGGraphJSON` by hand | No "scatter on landscape / volume / actor" sliver was exposed; pcg_biome sliver shipped in unmerged PR #224 |
+| 7 | `wait_for_shaders(45s)` crashed UE — use-after-free in `HaybaMCPIdleHandler::PollOnce` (fix in PR #225) | Raw `FWaitState*` shared between TCP and game-thread ticker | Caught and fixed — but the pattern (raw cross-thread pointer) probably recurs in other handlers; no audit |
+| 8 | Agent re-tried the spawn batch after the crash without `level_save` between mutations — would have lost everything again if it crashed twice | No checkpointing pattern in the MCP; `level_save` is a separate manual call | Mutation tools should opt-in/opt-out auto-save, or at least surface "scene has unsaved changes from N mutations" |
+| 9 | `python_run` failed silently on `cast_shadows = True` (property read-only in Python — needs `set_cast_shadows`) | UE Python API has dozens of pitfalls (read-only attrs, `niagara_component` vs `get_niagara_component()`, etc.) | Each pitfall is a `python_run` script's problem; typed handlers (e.g. `niagara_spawn`) would hide this once correctly |
+| 10 | Camera rotation returned by `editor_capture_viewport` reverse-ordered vs the rotation set by `set_level_viewport_camera_info` (`[34, 0, -18]` came back when `[-18, 34, 0]` went in) | Inconsistent rotation array convention between the editor-Python world and the MCP response | Rotation as a positional 3-array is intrinsically ambiguous; should be a named struct |
+| 11 | I told the user "I'm building the scene" while it was visibly junk (Niagara at runtime + floating props) — never verified visually | I captured a screenshot, looked away, claimed success | The MCP gives a screenshot back but the agent has no checklist of "things to look for" |
+| 12 | Spawned 150 individual `StaticMeshActor`s for foliage; UE foliage *system* exists (`foliage_paint_at`, `ism_*`) and produces hierarchical instanced static meshes (HISM) with far better performance | Agent reached for the most familiar primitive | Need a clear "if N > 10, you should be using foliage/ISM/PCG" heuristic surfaced by the tool catalog |
+
+**Common thread:** the typed handler set is anaemic — it accepts whatever you throw at it, then forwards to UE, and only fails when UE itself complains. There is no semantic enforcement (rotation plausibility, light unit sanity, snap-to-ground). The escape hatch (`python_run`) is much more powerful but skips all guards entirely. Every failure above is the agent reaching for the more powerful tool because the safer tool is too weak.
+
+---
+
+## Part 2 — Deterministic MCP guardrails
+
+Concrete API changes that make each failure above structurally impossible (or surface a clear "you're doing it wrong" warning).
+
+### 2.1 Rotation as a named struct, never a positional array
+
+**Problem:** `Rotator(0, 200, 0)` could be `(roll, pitch, yaw)` or `(pitch, yaw, roll)`. The agent guessed wrong → upside-down tree.
+
+**Fix:** every tool that takes a rotation accepts ONLY a named struct:
+
+```ts
+{ rotation: { pitch: number; yaw: number; roll: number } }   // ← new shape
+```
+
+The legacy positional `rotation: [a, b, c]` is rejected by the Zod schema with a clear migration hint: `"rotation must be { pitch, yaw, roll } — positional arrays are ambiguous and are no longer accepted."`
+
+Touches: `actor_spawn`, `actor_transform`, `ism_add_instance`, `foliage_add_instance`, the `placement.*` slivers below, and any sliver that emits a transform.
+
+### 2.2 `placement_mode` on every spawn
+
+**Problem:** hardcoded `z=100`; nothing snaps to terrain.
+
+**Fix:** `actor_spawn` and `actor_transform` grow a `placement_mode` enum:
+
+```ts
+placement_mode: 'exact' | 'snap_ground' | 'snap_landscape' | 'snap_to_actor';
+placement_target?: string;   // required when mode = 'snap_to_actor'
+align_to_normal?: boolean;   // default false; when true, rotate to surface normal
+```
+
+- `exact` — keep the supplied location as-is.
+- `snap_ground` — line-trace down from `(x, y, +10000)` to `(x, y, -10000)` across all collidable surfaces; place at the first hit. Z in the input is ignored. If no hit, return `{ ok: false, error: "no surface under (x,y)" }` (does NOT silently spawn floating).
+- `snap_landscape` — same, but only hits Landscape actors. Skips overlapping props.
+- `snap_to_actor` — snap onto a specific actor's surface (placing debris on a boulder).
+
+The UE-side implementation is one `SystemLibrary::LineTraceSingle` call per spawn. Default `placement_mode` is `snap_ground` when the input's `z` is `0` or missing; `exact` when `z` is explicitly supplied. That default means **the next agent that forgets to query the terrain still gets placement right.**
+
+### 2.3 Class-aware rotation plausibility
+
+**Problem:** trees ended up with 200° pitch. There's no "trees stand upright" rule in the system.
+
+**Fix:** an asset-class metadata layer + a validator. For known classes, declare the plausible rotation range:
+
+| Class / tag | Pitch | Roll | Yaw |
+|---|---|---|---|
+| `tree`, `pillar`, `column`, `statue`, `wall` | ±5° | ±5° | any |
+| `boulder`, `large_rock` | ±35° | ±35° | any |
+| `foliage_ground` (ferns, grass) | ±15° | ±15° | any |
+| `prop_freestanding` (chest, pot, brazier) | ±10° | ±10° | any |
+| `vine_canopy` | any | any | any |
+| `door` | ±2° | ±2° | any |
+
+`actor_spawn` cross-references the mesh's tags (or path-pattern fallback: `SM_Tree*` → `tree`, `SM_*Rock*` → `boulder`, etc.) and **rejects** spawns with implausible rotations, returning a warning that suggests the closest valid rotation.
+
+For Mesh assets without tags, the agent gets a one-time hint: `"asset has no class tag — defaulting to ±10° / ±10° / any. Tag the asset to tighten."`
+
+### 2.4 Light unit + intensity range guards
+
+**Problem:** 120,000 cd on a brazier.
+
+**Fix:** the `actor_spawn` path for any `*Light` class takes a structured `light` block:
+
+```ts
+light: {
+  preset: 'candle' | 'torch' | 'brazier' | 'lantern' | 'lamp' | 'rim' | 'fill' | 'key' | 'sun';
+  intensity?: number;       // candelas; default per preset
+  intensity_units?: 'candelas' | 'lumens' | 'unitless';   // default candelas
+  color_temp?: number;      // Kelvin; e.g. 1800 for brazier
+  attenuation_radius?: number;
+}
+```
+
+Each preset carries a sane default + a clamp range. `brazier` defaults to `2500 cd, 800 cm radius, 1800 K`. The agent supplies the *role*; the system supplies the right *magnitude*. An explicit `intensity` outside the preset's plausible range gets a warning, and is clamped if the bounds are hard.
+
+`python_run`-set intensities can't be guarded, but the validator (Part 3) flags any out-of-range light intensity post-hoc.
+
+### 2.5 Auto-validate on mutation
+
+**Problem:** I spawned everything then captured the viewport. No automatic check.
+
+**Fix:** every mutating tool (`actor_spawn`, `actor_transform`, `actor_set_properties`, `foliage_add_instance`, `pcg_execute_graph`, …) optionally runs `scene_validate v2` (Part 3) on the affected actors and returns its findings in a `validation` block:
+
+```ts
+{
+  ok: true,
+  actor_id: "...",
+  validation: {
+    warnings: [
+      { rule: "floating", severity: "error", suggestion: "use placement_mode=snap_ground" },
+      { rule: "rotation_implausible", severity: "warn", actual: [0, 200, 0], expected: "tree: pitch±5, roll±5" }
+    ]
+  }
+}
+```
+
+Default: on for the typed handlers (cost is one extra line-trace per mutation). The agent reads the `validation` block and self-corrects without needing a separate explicit call.
+
+### 2.6 `python_run` discourager + escape-hatch tax
+
+**Problem:** `python_run` is too easy. Agents reach for it as a first option.
+
+**Fix:** `python_run`'s response includes a `consider_instead` block when a typed handler covers what was attempted:
+
+```ts
+{
+  ok: true,
+  stdout: "...",
+  consider_instead: [
+    { detected_pattern: "for ... spawn_actor_from_class(StaticMeshActor)",
+      suggested_tool: "foliage_paint_at or actor_batch_spawn (placement_mode=snap_ground)" },
+    { detected_pattern: "actor.point_light_component.set_intensity",
+      suggested_tool: "actor_spawn { light: { preset: 'brazier' } }" }
+  ]
+}
+```
+
+Detection is regex over the script body — coarse but useful. The hint shows up *next to the result* so the agent sees it on the next turn.
+
+### 2.7 Crash-known tool catalog
+
+**Problem:** `wait_for_shaders` under heavy load crashed UE this session (fix shipped PR #225 but not built).
+
+**Fix:** the MCP server maintains a `known_pitfalls.yaml` per plugin version:
+
+```yaml
+- versions: ["0.2.0"]
+  tool: wait_for_shaders
+  pitfall: "Use-after-free under sustained heavy load — see PR #225"
+  safe_alternative: "wait_for_idle({ subsystems: ['shaders'], timeout_s: 15 }) — shorter window reduces race likelihood"
+```
+
+`hayba_check_ue_status` returns the matching pitfall list at the top of every session, so the agent knows what to avoid against the current plugin build.
+
+### 2.8 Mutation checkpointing
+
+**Problem:** UE crashed; everything I'd spawned was lost.
+
+**Fix:** the routing handle gains a `mutationCounter`. After every N mutations (default 25) — or after any `pcg_execute_graph` — the MCP server auto-calls `level_save` and emits a `checkpoint: { savedAt: ts, level: path }` entry into the operation journal. Crash recovery: the agent reads the journal, sees the last checkpoint, knows what's safe.
+
+### 2.9 Visual-verification checklist for screenshots
+
+**Problem:** I screenshot, looked away, claimed success.
+
+**Fix:** `editor_capture_viewport` returns a `visual_checklist` array the agent is expected to acknowledge in its next reply:
+
+```ts
+{
+  image_base64: "...",
+  visual_checklist: [
+    "Does the landscape have a non-default material (not the gray-checker pattern)?",
+    "Is every spawned actor visibly contacting the ground (no floating)?",
+    "Is any light visibly blowing out (saturated white blob) the foreground?",
+    "Is the framing of the intended subject the dominant element?"
+  ]
+}
+```
+
+It's a soft guard, but it forces a moment of "look at the image". Trivially implementable.
+
+---
+
+## Part 3 — `scene_validate v2` spec
+
+Replaces `scene_validate_physics`. Runs as the validator behind 2.5 and as a standalone audit tool.
+
+**Tool name:** `scene_validate` (extending the existing one).
+**Inputs:**
+```ts
+{
+  scope?: 'level' | 'tagged' | 'actors';
+  tag?: string;               // when scope='tagged'
+  actor_ids?: string[];       // when scope='actors'
+  rules?: string[];           // omit = all
+}
+```
+**Output:**
+```ts
+{
+  ok: boolean;
+  findings: Array<{
+    rule: string;
+    severity: 'error' | 'warn' | 'info';
+    actor_id: string;
+    actor_label: string;
+    detail: string;
+    suggestion?: string;
+    autofix?: { tool: string; args: object };   // optional, machine-applyable
+  }>;
+  counts: { error: number; warn: number; info: number };
+}
+```
+
+### Rule set (each is one self-contained function)
+
+| Rule id | What it checks | How |
+|---|---|---|
+| `floating` | Actor's bounds origin is more than 200cm above the nearest geometry below it | Line-trace down from origin; if no hit within 5000cm OR hit-distance > 200cm flag |
+| `buried` | Actor's bounds origin is below the nearest geometry by > 50cm | Line-trace down; hit point is *above* the origin |
+| `rotation_implausible` | Pitch/Roll outside class-based range (see 2.3) | Lookup actor class/tag in the table |
+| `scale_extreme` | Per-axis scale outside [0.1, 10] OR per-axis scale ratio > 5 (non-uniform stretch) | Read actor's transform |
+| `intersecting_world_geometry` | Actor's collision bounds penetrate another actor's collision bounds by > 10% volume | UE collision overlap query (already in the legacy `scene_validate_physics` — keep and extend) |
+| `light_intensity_implausible` | PointLight/SpotLight in candelas outside [50, 50000]; SkyLight/DirectionalLight outside [0.1, 15] | Read component property |
+| `light_attenuation_implausible` | PointLight/SpotLight attenuation > 10000 cm (probably a typo — most props don't light a whole map) | Read |
+| `default_label` | Label matches the auto-generated `<Class>_<n>` pattern | Regex on label |
+| `default_material` | StaticMeshComponent uses the engine's `M_WorldGridMaterial` / default-grey | Read material slot 0 |
+| `landscape_no_material` | Active level's `Landscape` has the engine default material or no material | Read landscape's `LandscapeMaterial` |
+| `missing_mesh` | StaticMeshActor with no static mesh assigned | Read `static_mesh_component.static_mesh` |
+| `actor_below_killz` | Actor Z below world's `KillZ` (would despawn at runtime) | Read WorldSettings |
+| `niagara_no_asset` | NiagaraActor with no asset assigned | Read |
+| `pcg_no_components` | PCG actor present but PCGComponent missing or empty graph | Read |
+| `excessive_actor_count` | More than 50 identical-class actors with identical scale exist (should be HISM/PCG/foliage instances, not separate actors) | Count by class+scale signature |
+| `unsaved_long_lived_changes` | Level has been dirty for > 100 mutations without `level_save` | Read mutation counter |
+| `light_redundancy` | Two lights within 50cm of each other (probably an accidental duplicate) | Spatial query |
+| `actor_outside_used_world_partition_cells` | Spawned outside any loaded WP cell (effectively invisible) | Cross-reference WP loaded cells |
+| `default_skybox_below_atmospheric` | Skybox material is the engine default while a SkyAtmosphere is present (looks wrong) | Read sky |
+
+`autofix` is populated for rules where the fix is mechanical and unambiguous:
+
+| Rule | Autofix |
+|---|---|
+| `floating` | `actor_transform { actor_id, placement_mode: 'snap_ground' }` |
+| `rotation_implausible` | `actor_transform { actor_id, rotation: { pitch: clamp, roll: clamp, yaw: keep } }` |
+| `light_intensity_implausible` | `actor_set_properties { intensity: <clamp> }` |
+| `default_label` | none — labels are agent's responsibility |
+
+A `--apply-autofix` flag on the tool lets the agent batch-correct everything in one call.
+
+### Implementation notes
+
+- Validator runs on the game thread (line traces need GWorld); single-pass over the requested actor set.
+- Class lookup table loaded once at startup from `Plugins/HaybaMCPToolkit/Config/HaybaMCPValidation.json` so non-engineers can extend it.
+- Each rule is a pure function `(World*, AActor*) → findings[]`; testable in isolation.
+
+---
+
+## Part 4 — Sliver library mined from the Learttes packs
+
+Surveyed 7 of the 44 packs (`JungleRuins`, `MayanCave`, `Temple`, `LightingTool`, `Fishing_Dock_5.1`, `HauntedVillage`, `Lakeside_Village_Environment_5.1`). The patterns below recur across all of them, not just one.
+
+### The placement primitives (the missing safety nets — highest priority)
+
+These are the slivers the agent should have reached for *this session* instead of `python_run` loops. They are the deterministic-placement layer.
+
+#### `com.hayba.placement.snap_to_surface`
+
+Take a mesh + an (x,y) and place it correctly on the terrain. Pure: returns the resolved transform; does *not* spawn.
+
+```jsonc
+params:
+  mesh:           asset_ref (StaticMesh)
+  xy:             vector3 [x, y, 0]          // z ignored
+  align_to_normal: bool, default false
+  yaw_deg:        float [0, 360], default 0
+  scale:          float [0.05, 20], default 1
+  surface_filter: enum ['any', 'landscape', 'actor'], default 'any'
+outputs:
+  transform:      { location: [x,y,z], rotation: { pitch, yaw, roll }, scale: [s,s,s] }
+  hit_actor:      string                       // what we landed on
+```
+
+#### `com.hayba.placement.batch_snap`
+
+Same as above for a list of (mesh, xy) tuples; returns the full transform list. Pure. The agent computes its grid/cluster/spline points in pure code (or via another sliver) and then asks this sliver to ground-snap them all at once — one batched line-trace per item.
+
+#### `com.hayba.scatter.pcg_on_landscape`
+
+Build a PCG topology that scatters a mesh (or weighted mesh set) onto the Landscape's surface, sampled by a density. Side-effecting (creates + executes a PCG graph). Supersedes the earlier `pcg_biome` sliver shape by handling the source-actor question correctly (Landscape, not a generic volume).
+
+```jsonc
+params:
+  meshes:           [{ asset_ref, weight: float }]    // weighted picker
+  bounds:           { min: [x,y,z], max: [x,y,z] }    // restrict scatter to this AABB
+  density:          float [0.0001, 100]               // points / m²
+  min_distance:     float [0, 5000]                   // Poisson-ish spacing
+  align_to_normal:  bool, default true                // terrain-aware
+  scale_range:      [float, float]
+  yaw_jitter:       float [0, 360]
+  layer_mask:       string?                            // landscape paint layer name (only scatter where painted)
+  seed:             int
+outputs:
+  graph_asset:      string
+  instance_count:   int
+side_effects:       ['pcg.graph.create', 'pcg.graph.execute']
+```
+
+#### `com.hayba.scatter.pcg_on_volume`
+
+Same shape but bound to a volume actor (Box/Cylinder Brush) rather than the landscape. Same param shape minus `layer_mask`, plus `area_actor: actor_ref`.
+
+#### `com.hayba.scatter.pcg_on_actor_surface`
+
+Scatter onto another mesh's surface — debris on a boulder, moss on a wall. `target_actor: actor_ref`, the PCG topology uses `PCGSurfaceSamplerSettings` against the target's mesh.
+
+#### `com.hayba.placement.array_along_spline`
+
+Distribute N copies of a mesh along a spline (recurring HauntedVillage `BP_Fence_Spline` pattern + every modular kit). Side-effecting (creates the spline if needed). Or pure: returns the transform list, caller spawns.
+
+```jsonc
+params:
+  mesh:           asset_ref
+  spline_points:  [{ location: vec3, tangent: vec3 }]
+  spacing:        float                       // cm between instances
+  yaw_alignment:  enum ['spline_tangent', 'fixed', 'random']
+  scale_range:    [float, float]
+  seed:           int
+outputs:
+  transforms:     [{ location, rotation, scale }, ...]
+```
+
+### The content slivers (mined from recurring assets across packs)
+
+Each of these bundles a recurring asset pattern. Lower priority than the placement primitives — but each one is what the agent actually needs to "place a candle" or "drop a campfire" in one call instead of `python_run`-ing several lines.
+
+#### `com.hayba.lighting.candle`
+
+Mined from MayanCave's `BP_Candle_01..05`. Bundle: a candle mesh + a small Niagara flame + a warm point light. Drops a complete candle in one call.
+
+```jsonc
+params:
+  location:       vector3, snap_to_surface implicit
+  flame_scale:    float [0.5, 2], default 1
+  light_color:    color hex, default '#FFB860'
+  light_intensity: float [1, 50] (candelas), default 8
+outputs:
+  candle_actor:   string
+  flame_actor:    string
+  light_actor:    string
+side_effects:     ['actor.spawn', 'niagara.spawn']
+```
+
+#### `com.hayba.lighting.torch`
+
+Mined from MayanCave's `BP_FireTourch` + JungleRuins `NS_NS1_Fire_Torch`. Same shape as candle but bigger flame, hotter color, wall-mountable. Optional `wall_actor: actor_ref` snaps it to a wall surface.
+
+#### `com.hayba.props.fire_camp`
+
+Mined from `NS_NS1_Fire_Camp` (appears in JungleRuins AND MayanCave — same asset shipped across packs). A campfire = ring of stones + central log + flame + warm light + subtle smoke. Light defaults to `brazier` preset (2500 cd, 1800 K, 800 cm radius — the right numbers, not 120000).
+
+#### `com.hayba.lighting.god_ray`
+
+Mined from JungleRuins `BP_GodRay` + `SM_GodRay_Plane`. A volumetric shaft of light through a canopy gap. Params: source direction (yaw + pitch), intensity, color, length. Bundles a mesh plane with the god-ray material + a SpotLight along the same axis for the ground splash.
+
+#### `com.hayba.atmosphere.particle_volume`
+
+Mined from MayanCave's `NS_NS1_Dust_01`, `NS_NS1_Fog_01`, `NS_NS1_Leaves_01` (three siblings). A bounded atmospheric particle effect.
+
+```jsonc
+params:
+  preset:        enum ['dust', 'fog', 'leaves', 'embers', 'pollen']
+  bounds:        { min: vec3, max: vec3 }    // emission volume
+  intensity:     float [0, 5], default 1
+  wind:          vec3                          // optional bias
+```
+
+Each `preset` resolves to a specific Niagara System in the Learttes packs.
+
+#### `com.hayba.atmosphere.local_fog_card`
+
+Mined from HauntedVillage's `BP_Fog_Card` + `BP_Local_Fog`. A localized fog card oriented at a normal — useful for low-lying ground fog around a clearing.
+
+#### `com.hayba.composition.handcam_shake`
+
+Mined from JungleRuins's `BP_CameraShake` + `BP_CameraShake_Handcam`. A composition sliver that applies a hand-held shake profile to a camera, with parameters for amplitude / freq / damping. Pure: returns the shake curve; caller applies via `seq_add_track`.
+
+#### `com.hayba.cinematic.stills_set`
+
+Mined from JungleRuins's `LL_Stills_Showcase_Cinematic` + 22 `LS_Stills_*` sequences. A composition sliver that builds a "cinematic stills tour" of N camera framings around a target actor (or set of actors). Returns a Level Sequence path. Side-effecting.
+
+#### `com.hayba.lighting.three_point`
+
+Mined from LightingTool's `BP_DynamicLight_AC`. A classic key + fill + rim three-point setup around a target actor. Parameters: target_actor, key_intensity, key_color_temp, fill_ratio, rim_intensity. Side-effecting.
+
+#### `com.hayba.composition.shrine_ensemble`
+
+Composition sliver mined from this session — the shrine + 2 serpent-guardian statues + offering bowl + pots layout pattern. Pure: returns transforms. Lets the agent say "give me a shrine ensemble centered at X facing Y" instead of placing six props one-by-one with hardcoded offsets.
+
+### Layered architecture (what calls what)
+
+```
+                ┌────────────────────────────────┐
+                │  Content slivers (candle,       │
+                │  fire_camp, god_ray, …)         │
+                └──────────────┬─────────────────┘
+                               │ uses
+                ┌──────────────▼─────────────────┐
+                │  Placement primitives          │
+                │  (snap_to_surface, pcg_on_*)   │
+                └──────────────┬─────────────────┘
+                               │ uses
+                ┌──────────────▼─────────────────┐
+                │  Typed MCP handlers (actor_*,  │
+                │  pcg_*, niagara_*) — guarded   │
+                │  by Part 2 + Part 3.            │
+                └────────────────────────────────┘
+```
+
+The content slivers (candle/torch/etc) are thin recipes calling the placement primitives. The placement primitives are thin recipes calling the guarded typed handlers. Nothing reaches for `python_run`.
+
+---
+
+## Part 5 — Sequencing
+
+What ships first, ordered by `(impact × prerequisites)`:
+
+| Order | Item | Why first | Touches |
+|---|---|---|---|
+| 1 | **Crash fix** PR #225 (`wait_for_idle` use-after-free) | Already done — must merge + rebuild before any other UE work | UE plugin |
+| 2 | **2.1 Named rotation struct** + **2.3 class-aware rotation plausibility** | Prevents the upside-down tree class of bug across every spawn path | MCP TS schemas + UE handler |
+| 3 | **2.2 `placement_mode=snap_ground`** | Prevents the floating-foliage class of bug. Single line-trace per spawn; cheap. | UE handler |
+| 4 | **Part 3 `scene_validate v2`** (rules `floating`, `rotation_implausible`, `default_material`, `light_intensity_implausible`, `missing_mesh` to start) | Catches existing scene rot, supports autofix | UE handler |
+| 5 | **2.5 Auto-validate on mutation** | Closes the feedback loop — agent self-corrects without explicit calls | MCP TS + UE handler |
+| 6 | **Placement primitive slivers** (`snap_to_surface`, `batch_snap`, `array_along_spline`) | Gives the agent a clean alternative to `python_run` loops | TS slivers (composition.* / placement.*) — uses 2.2 internally |
+| 7 | **PCG scatter slivers** (`pcg_on_landscape`, `pcg_on_volume`, `pcg_on_actor_surface`) | Replaces hand-rolled scatter with the correct PCG path; supersedes the unmerged `pcg_biome` from PR #224 with the right shape | TS slivers — uses the existing `create_graph`/`execute_graph` UE commands via the just-merged `ctx.dispatch` seam (assuming PR #224 also merges) |
+| 8 | **Content slivers** (`candle`, `torch`, `fire_camp`, `god_ray`, `particle_volume`, `local_fog_card`, `handcam_shake`, `three_point`, `shrine_ensemble`) | Cheap to add once 6 + 7 land — each is ~30 lines of TS calling the lower layers | TS slivers |
+| 9 | **2.6 `python_run` discourager** + **2.7 crash-known catalog** | Soft guards — value compounds with everything above | MCP TS |
+| 10 | **2.8 Mutation checkpointing** | Insurance — value depends on UE crash rate, which Part 5.1 reduces | MCP TS |
+| 11 | **2.9 Visual-verification checklist** + **`cinematic.stills_set`** sliver | Polish — once the rest is right | MCP TS |
+
+Items 2 through 4 land in one PR-able batch (~5 files of TS, ~3 files of UE C++). That batch alone would have made this session's scene buildable correctly on the first attempt.
+
+---
+
+## Out of scope (explicit)
+
+- Re-mining the other 37 Learttes packs in detail — patterns surveyed cover the recurring asset categories (lit flames, atmospheric particles, modular spline kits, cinematic stills). Per-pack drill-down can grow the catalog later but isn't a prerequisite.
+- New PCG node authoring — the slivers compose existing standard-PCG nodes via the on-disk `pcgex_registry.db`.
+- Replacing `python_run` — it stays as the escape hatch. The fix is making the right tools attractive enough that the agent doesn't reach for it.
+- UE-side validation of the typed `light` block at C++ level (a v2 if the TS schema isn't enough).

--- a/docs/superpowers/specs/2026-05-22-environmental-design-guardrails.md
+++ b/docs/superpowers/specs/2026-05-22-environmental-design-guardrails.md
@@ -1,0 +1,333 @@
+# Environmental-Design Guardrails
+
+**Date:** 2026-05-22
+**Status:** Spec — pending approval
+**Companion:** Extends `2026-05-22-agentic-guardrails-and-sliver-library.md` with environment-specific rules + slivers. The parent spec covers the universal failures (rotation, snap-to-ground, lights). This one covers **how environment artists actually compose scenes** — what foliage workflow, landscape painting, and atmospheric layering look like in shipping content — and converts those conventions into deterministic guardrails so an agent's "build a jungle clearing" doesn't end up as 150 floating StaticMeshActors on a checker landscape.
+
+---
+
+## Part 0 — Cross-pack survey
+
+Walked 9 Learttes packs across biomes. The relevant asset categories per pack:
+
+| Pack | Biome | FoliageType assets | Landscape LayerInfos | PCG components | Niagara atmospherics | PostProcess volumes |
+|---|---|--:|--:|--:|--:|--:|
+| **JungleRuins** | jungle | **40** | 5 (Dirt/Grass/JungleFloor/Marsh/Mud) | 2 | Fire_Camp, Fire_Torch | 0 |
+| **AfricanVillage** | savanna village | 10 | **9** | 0 | (none shipped) | **2** |
+| **CastleIsland** | grass / hills | 15 | 3 | 1 | (none) | 0 |
+| **HauntedVillage** | woods / fog | 3 | 3 | 0 | (none) | 1 |
+| **MayanCave** | cave interior | **0** | 0 | 0 | **Dust + Fog + Leaves + Fire_Camp** | 0 |
+| **Crystal_Cave** | cave interior | 0 | 9 (floor variants) | 0 | (none shipped) | 0 |
+| **Lakeside_Village** | modular kit | 0 | 0 | 0 | (none) | 0 |
+| **Temple** | static set | 0 | 0 | 0 | (none) | 0 |
+| **Fishing_Dock** | static set | 0 | 0 | 0 | (none) | 0 |
+
+Plus across packs: **spline-driven assemblies** (HauntedVillage `BP_Fence_Spline`, AfricanVillage `BP_Spline_fence` + `BP_Spline_log_house`).
+
+### What the survey says about how good environments are actually composed
+
+1. **Outdoor scenes use the UE Foliage System.** Every outdoor pack ships FoliageType assets (3–40), pre-tuned per species: density, scale range, ground slope cutoff, cull distance. The foliage system writes painted instances into a single `InstancedFoliageActor` per level — orders-of-magnitude fewer draw calls than the 150 StaticMeshActor approach. **None of them ship loose StaticMeshActors for ground foliage.** Reaching for `actor_spawn` to "place a fern" is wrong on the first call.
+2. **Landscapes are multi-material via paint layers.** Outdoor packs ship 3–9 `LayerInfo` assets. The landscape master material switches per-layer (Grass under foliage, Dirt under paths, JungleFloor in the clearing). A single-material checker landscape is the visual signature of *no environmental composition at all* — exactly what this session produced.
+3. **Foliage targets specific paint layers.** FoliageType assets carry a `Landscape Layer` filter (e.g. ferns only spawn where the `JungleFloor` layer is painted). This is what makes biome boundaries readable — not a random scatter that bleeds into every surface.
+4. **PCG is the exception, not the rule.** Only 3 of 9 packs ship PCG components, all sparingly (1–2 per pack). PCG is for the *one tricky thing* per scene (a procedural debris field, a wind-driven grass band). The 95% workflow is painted Foliage + painted Landscape.
+5. **Cave / interior scenes invert the stack.** No foliage, no landscape layers; instead, atmospheric Niagara volumes (Dust, Fog, Leaves) doing the heavy lifting for sense-of-place. The Mayan/Crystal caves don't have grass — they have dust shafts.
+6. **Spline-driven kits handle linear repetition.** Fences, log walls, paths — never spawned as N separate actors. One spline BP draws them; one tool call should set the spline points.
+7. **PostProcessVolume is authored content.** AfricanVillage ships two — a global one + a local one inside huts. Auto-exposure + fog inscattering are tuned to the biome.
+
+The validator and the sliver library below are derived directly from these conventions.
+
+---
+
+## Part 1 — Environmental-design validator rules
+
+Extends Part 3 of the parent spec. Rules below are added to `scene_validate v2` and are categorised by what they catch.
+
+### A. Foliage workflow rules (catch "the agent did it the wrong way")
+
+| Rule id | What it catches | Detection |
+|---|---|---|
+| `foliage_as_actors` | Many `StaticMeshActor`s with same mesh + same scale ±10% within a 5000cm radius — strong signal someone scattered "foliage" as actors instead of painting it | Spatial bucket actors by (mesh_path, scale_bucket); flag any cluster of ≥ 20 |
+| `foliage_mesh_monoculture` | A foliage cluster (defined as ≥10 actors with foliage-tagged meshes within 3000cm) uses only 1 species | Per cluster, count distinct mesh paths; flag if 1 |
+| `foliage_no_layer_filter` | A FoliageType placed on landscape lacks a paint-layer filter — it scatters everywhere instead of respecting biome boundaries | Read `LandscapeLayer` property of FoliageType asset; warn if empty |
+| `foliage_scale_chaos` | Foliage instances have stddev/mean of scale > 0.25 — looks like random `0.5–1.5`, reads as visual noise | Per mesh cluster, compute stddev(scale)/mean(scale) |
+| `foliage_pitch_roll_nonzero` | Ground foliage with pitch or roll outside ±10° — should be upright | Per foliage actor, check rotation |
+| `foliage_inside_prop_collision` | Foliage instance bounds intersect a hero prop's collision bounds | Spatial query foliage vs hero-tagged props |
+| `foliage_no_negative_space` | A foliage instance within 50cm of a hero-tagged prop's origin — the scene reads cluttered, hero props should breathe | Distance query around each hero |
+| `foliage_density_uniform` | Foliage density (instances per unit area) varies by < 1.3× across the scene — biomes have gradients, uniform density reads procedural-flat | Grid the scene into 500×500 cells, compute density variance |
+| `foliage_no_edge_density` | Hero props (boulders, tree trunks, walls) with **zero** ground foliage within 200cm of their base — bare stone in a jungle is uncanny | For each hero, count foliage within radius |
+
+### B. Landscape composition rules
+
+| Rule id | What it catches | Detection |
+|---|---|---|
+| `landscape_default_material` | Active Landscape uses `M_Landscape` engine default / `M_WorldGridMaterial` (the **checker pattern**) | Read `landscape.LandscapeMaterial.GetPath()` and match the known-default set |
+| `landscape_single_layer_used` | Landscape has multiple LayerInfos available but only 1 is painted across > 95% of the area | Count painted-area per layer |
+| `landscape_no_layer_blend` | Layer-paint boundaries are sharp (no transition layer) — a Grass↔Dirt transition without a blend reads obviously fake | Inspect layer weight maps for hard edges |
+| `landscape_layer_orphan` | A LayerInfo exists in the project but is never painted on any landscape — likely a missing-step in the build | Cross-reference assets vs landscape painted layers |
+
+### C. Atmospheric / lighting composition rules
+
+| Rule id | What it catches | Detection |
+|---|---|---|
+| `scene_no_postprocess_volume` | Outdoor scene with no `PostProcessVolume` — exposure is auto-uncontrolled, the brazier blows out (this session) | Count PPVs in level |
+| `scene_no_atmospheric_niagara` | Cave/interior scene with no `Dust`/`Fog`/`Leaves`-class Niagara — feels lifeless. (Rule fires only when the level is "cave-type": ceiling-dominant, no DirectionalLight visible from origin) | Niagara count + heuristic cave detection |
+| `single_dominant_light_blowout` | One light's effective intensity (intensity × 1/r² at scene origin) is > 10× the next-brightest — blown highlight inevitable | Compute per-light luminance contribution at sampling points |
+| `unlit_dark_zone` | A spawned hero prop sits in a zone where the brightest contribution from any light is < 0.1 cd/m² — invisible | Sample illuminance per prop |
+| `light_color_temp_clash` | Two lights within 800cm with color temps > 3500K apart (one warm 1800K brazier next to one cool 6500K rim) — feels Halloween, not jungle | Pairwise distance + color-temp delta |
+| `directional_sunless_with_skyatmosphere` | SkyAtmosphere present but no DirectionalLight at all — sky has no sun source, gradients break | Read level actor list |
+
+### D. Spline / kit rules
+
+| Rule id | What it catches | Detection |
+|---|---|---|
+| `linear_actor_array` | ≥ 6 actors of the same mesh arranged in a line within 5° angular variance — should be a spline-driven assembly | RANSAC line fit over actor positions |
+| `wall_no_endpoint_cap` | Wall-class actors at a chain endpoint without a corner/end-cap mesh — reads as the wall just stops mid-air | Wall-tagged actors with no other wall within 200cm on one side AND no cap-tagged actor |
+
+### E. World Partition / instancing rules
+
+| Rule id | What it catches | Detection |
+|---|---|---|
+| `non_hism_when_foliage_capable` | StaticMeshActor uses a mesh that has a FoliageType variant in the project — should be a foliage instance, not an actor | Cross-reference mesh paths |
+| `actor_in_unloaded_wp_cell` | Spawned actor in a cell that is not currently loaded in the editor view — invisible to the agent during build | Read WP streaming state |
+
+All rules surface `autofix` when mechanical:
+
+| Rule | Autofix |
+|---|---|
+| `landscape_default_material` | none — agent must pick a material; suggestion lists available `MM_*` masters in the project |
+| `foliage_as_actors` | `foliage_migrate_actors_to_instances { actor_ids: [...], foliage_type: <picked> }` — new tool that destroys the actors and re-creates as foliage instances |
+| `foliage_pitch_roll_nonzero` | `actor_transform { rotation: { pitch:0, yaw:keep, roll:0 } }` |
+| `foliage_no_layer_filter` | none — agent must choose a layer; suggestion lists landscape's painted layers |
+| `scene_no_postprocess_volume` | `actor_spawn { class_path: PostProcessVolume, unbound: true, preset: 'outdoor_default' }` |
+| `linear_actor_array` | `placement_array_along_spline { points: <fit line>, mesh: <detected> }` then delete the source actors |
+
+---
+
+## Part 2 — Environmental-design slivers
+
+Each sliver below is the **correct primitive** for one environment-design step. Together they form a workflow that produces a competent outdoor scene without ever touching `python_run` or `actor_spawn` directly for foliage.
+
+### `com.hayba.landscape.set_material`
+
+Replace the active Landscape's master material. Trivial wrapper around the missing typed handler. Side-effecting.
+
+```jsonc
+params:
+  material:        asset_ref (Material/MaterialInstance)
+  rebuild_layers:  bool, default true
+side_effects:      ['landscape.material.set']
+```
+
+### `com.hayba.landscape.paint_layer`
+
+Paint a Landscape Layer in a region (rect, circle, or polygon). Side-effecting.
+
+```jsonc
+params:
+  layer:          asset_ref (LandscapeLayerInfo)
+  region:         { kind: 'rect'|'circle'|'polygon', ... }
+  strength:       float [0,1], default 0.8
+  falloff:        float [0,1], default 0.5    // soft edge
+  erase:          bool, default false
+side_effects:     ['landscape.layer.paint']
+```
+
+### `com.hayba.foliage.add_type`
+
+Add a FoliageType to the level's `InstancedFoliageActor` (so it's available to paint). Side-effecting.
+
+```jsonc
+params:
+  foliage_type:   asset_ref (FoliageType)
+outputs:
+  type_index:     int                          // for use by paint sliver
+```
+
+### `com.hayba.foliage.scatter_paint`
+
+The Foliage equivalent of `scatter.pcg_on_landscape` — paints instances of a FoliageType onto the landscape in a region, respecting layer filters. Side-effecting. Uses the UE Foliage System under the hood (HISM, batched, efficient).
+
+```jsonc
+params:
+  foliage_type:    asset_ref
+  region:          { kind: 'rect'|'circle'|'polygon', ... }
+  density:         float [0.0001, 50]          // instances per m²
+  layer_filter:    asset_ref?                   // only paint where this LayerInfo is painted
+  scale_range:     [float, float], default [0.9, 1.15]   // tight by default — the chaos default fights us
+  yaw_jitter:      float [0, 360], default 360
+  align_to_normal: bool, default true
+  seed:            int
+outputs:
+  instance_count:  int
+side_effects:      ['foliage.paint']
+```
+
+### `com.hayba.foliage.scatter_kit`
+
+The "biome in one call" sliver — paints a curated set of FoliageType assets at coordinated densities + layer filters. Replaces `python_run`-loop foliage placement entirely. Composed of multiple `scatter_paint` calls.
+
+```jsonc
+params:
+  kit:             enum ['jungle_floor', 'savanna', 'temperate_meadow', 'high_grass', 'forest_floor', 'cave_floor']
+  region:          { ... }
+  density_scale:   float [0.1, 3], default 1   // global multiplier
+  seed:            int
+outputs:
+  layers_used:     [string, ...]
+  total_instances: int
+side_effects:      ['foliage.paint']
+```
+
+Each `kit` resolves to a tuned recipe (set of FoliageType assets + their densities + layer filters), mined from the corresponding Learttes pack:
+
+| Kit | Source pack | Recipe |
+|---|---|---|
+| `jungle_floor` | JungleRuins | FernSm + FernMd + BroadleafSm + BroadleafMd + MonsteraSm + Clover + GrassCluster01–04 at descending densities |
+| `savanna` | AfricanVillage | DryGrassPatches + Acacia foliage + DesertShrub at low density |
+| `temperate_meadow` | HauntedVillage | TallGrass + Daisy + Thistle + sparse ScrubBush |
+| `cave_floor` | MayanCave | (sparse) Moss + Lichen + RockDebris (no grass) |
+
+### `com.hayba.atmosphere.stack`
+
+Build the atmospheric layer for a scene in one call. Side-effecting.
+
+```jsonc
+params:
+  preset:          enum ['outdoor_jungle', 'outdoor_savanna_dusk', 'cave_dusty', 'foggy_morning', 'rainy_dusk']
+  region:          { ... }?                    // bounded if specified, else unbound PostProcessVolume
+  override_fog:    { density?, color? }?       // optional fine-tune
+outputs:
+  ppv_actor:       string
+  fog_actors:      [string]
+  niagara_actors:  [string]
+side_effects:      ['atmosphere.spawn']
+```
+
+Each preset bundles the right combination: PostProcessVolume settings (exposure / bloom / vignette), ExponentialHeightFog tuning, optional Niagara volumes (Dust/Fog/Leaves), color grading. Mined from the AfricanVillage + JungleRuins + MayanCave shipped scenes.
+
+### `com.hayba.composition.clearing`
+
+Carve a clearing around a hero point — paints negative-space into the surrounding foliage layer, then optionally drops a path/debris layer in. Side-effecting (composed of paint + foliage erases).
+
+```jsonc
+params:
+  center:          vec3
+  radius:          float                       // cm
+  inner_falloff:   float, default 0.4          // sharp inner edge → soft outer
+  path_to:         vec3?                       // optional path leading to this clearing
+side_effects:      ['landscape.layer.paint', 'foliage.paint']
+```
+
+### `com.hayba.placement.spline_kit`
+
+Drives any spline-driven assembly (fence, wall, log_house, path stones). Side-effecting.
+
+```jsonc
+params:
+  kit:             enum ['fence_wood', 'fence_stone', 'log_wall', 'path_stones', 'rope_bridge']
+  points:          [vec3, ...]
+  spacing:         float?                       // cm, default per kit
+  endpoint_caps:   bool, default true            // adds the corner/cap meshes the validator otherwise warns about
+outputs:
+  spline_actor:    string
+  instance_count:  int
+side_effects:      ['actor.spawn']
+```
+
+Each kit maps to a specific spline BP from the surveyed packs (`BP_Fence_Spline`, `BP_Spline_log_house`, etc.).
+
+---
+
+## Part 3 — Workflow guardrails
+
+Soft guards that funnel the agent toward the correct primitive.
+
+### 3.1 `placement_intent` parameter on `actor_spawn`
+
+```ts
+placement_intent?: 'hero' | 'kit_piece' | 'foliage' | 'debris' | 'light' | 'volume';
+```
+
+When `placement_intent: 'foliage'`, the response **rejects** the call with:
+
+```
+{ ok: false, error: "Use foliage.scatter_paint or foliage.scatter_kit — placing foliage as StaticMeshActors blocks instancing/HISM and fails environmental-design validation." }
+```
+
+It's not just a hint — for `'foliage'` intent, `actor_spawn` refuses. The agent has to use the foliage system.
+
+### 3.2 Foliage-actor count threshold
+
+Independent of intent: when an `actor_spawn` would create a `StaticMeshActor` whose mesh has a known FoliageType variant in the project AND the agent has already spawned ≥ 5 of the same mesh in the last 60 seconds, refuse with the same migration suggestion.
+
+This catches the "I forgot to set intent" case.
+
+### 3.3 "Show me your biome plan first"
+
+A meta-tool: `hayba_environment_plan` that the agent is expected to call once per scene. Input:
+
+```ts
+{
+  biome: 'jungle' | 'savanna' | 'cave' | ...,
+  region: { ... },
+  hero_props: [{ class, location, importance }]
+}
+```
+
+Output: a recommended sequence of sliver calls (`landscape.set_material`, `landscape.paint_layer`, `foliage.scatter_kit`, `atmosphere.stack`, `composition.clearing` around each high-importance hero, etc.) — a plan the agent can either execute as-is or modify. This converts "improvise scene-building" into "fill out a structured plan", which is much more reliable for an LLM.
+
+### 3.4 Asset-class tagger
+
+A one-time pass over the project's Content/ that tags every StaticMesh asset with a class hint (`tree`, `pillar`, `boulder`, `vine`, `foliage_ground`, `prop_freestanding`, `wall`, etc.) based on the asset name + folder + bound shape. Validator rules (rotation plausibility, foliage vs prop) become reliable once meshes are tagged. Stored in a SQLite alongside `pcgex_registry.db`.
+
+### 3.5 "Suggest landscape material" hint
+
+When the validator fires `landscape_default_material`, the suggestion lists the project's available landscape master materials with one-line descriptions (heuristic: read material's exposed parameters and infer "rocky desert vs lush jungle vs temperate"). Agent picks one and the `landscape.set_material` sliver does the rest.
+
+---
+
+## Part 4 — Sequencing
+
+How this ships, on top of the parent spec's sequencing:
+
+| Order | Item | Why | Touches |
+|---|---|---|---|
+| 1 | **Asset-class tagger (3.4)** — one-time index | Prereq for many validator rules and intent enforcement | TS (new) |
+| 2 | **`landscape.set_material` + `landscape_default_material` validator** | Single-step elimination of the checker landscape | TS sliver + UE handler + validator rule |
+| 3 | **`foliage.scatter_paint` + `foliage.scatter_kit`** | Replaces `python_run` foliage with the correct UE Foliage System path | TS slivers — uses existing `foliage_add_instance` / `foliage_paint_at` UE handlers |
+| 4 | **`placement_intent='foliage'` rejection (3.1)** + **foliage-actor count threshold (3.2)** | Funnel the agent away from `actor_spawn` for foliage | MCP TS schema + count tracking |
+| 5 | **Foliage workflow validator rules** (A block) | Catches existing scene rot + flags ongoing mistakes | UE handler |
+| 6 | **`atmosphere.stack` sliver** + atmospheric validator rules (C block) | One call for the lighting / fog / PPV layer | TS sliver |
+| 7 | **`composition.clearing` + landscape paint rules (B block)** | Carves negative space; eliminates the "buried hero" failure | TS sliver + UE handler |
+| 8 | **`placement.spline_kit` + spline rules (D block)** | Replaces linear-actor-array placements with spline-driven assemblies | TS sliver |
+| 9 | **`hayba_environment_plan` meta-tool (3.3)** | Structural — converts ad-hoc into structured | TS |
+| 10 | **WP / instancing rules (E block)** | Polish — value compounds once everything above is in | UE handler |
+
+Items 1–3 are the bare minimum that would have prevented this session's scene-build failure on its own.
+
+---
+
+## Cross-cutting note: what mining more packs would buy
+
+The 9 packs surveyed already cover **jungle, savanna, cave×2, temperate woods, modular village kit, ruins, dock, lighting tool**. Adding the remaining 35 packs is unlikely to surface a *new* category — most of them are variants (Castle, Cathedral, Mansion, Crypt, …). What they would do is **populate more `foliage.scatter_kit` presets** + provide more `atmosphere.stack` presets per setting. That's a fill-in-the-catalog task that can run in the background once the workflow is in place; not a prereq for the sequencing above.
+
+### Confirming addendum — 3 extra packs surveyed
+
+After writing the body, three more packs landed (`Attic_Environment`, `FoggyJapaneseStreet`, `MedievalCastleVillage`). They behave exactly as the cross-cutting note predicted — no new categories, only fill-in presets:
+
+| Pack | Adds | Preset suggestion |
+|---|---|---|
+| `Attic_Environment_5.5` | Interior set — zero foliage/landscape/niagara (interior pack convention confirmed) | none |
+| `FoggyJapaneseStreet_5.6` | `NS_Leafs_OnGRND` (street leaves) + `NS_NS1_Rain_Light_01` | `atmosphere.stack` preset `urban_rainy_dusk` |
+| `MedievalCastleVillage` | `NS_FireFlies` + `NS_Fog` + `NS_Smoke` + 4 LayerInfos + `MI_Rope_Splines` | `atmosphere.stack` preset `medieval_evening_fireflies`; `placement.spline_kit` adds a `rope` kit |
+
+12 packs total now, 13 across the body + this addendum. The conventions (FoliageType + LayerInfos + Niagara atmospherics + spline-driven assemblies for linear repetition) hold consistently.
+
+---
+
+## Out of scope (explicit)
+
+- Procedural landscape sculpting (height maps, erosion) — out; we paint on the existing landscape.
+- Authoring new FoliageType assets — out; we use the ones shipped with the packs.
+- Multi-level streaming choreography (LOD-based crowd density) — out for v1.
+- Photo-real real-time lighting bake — out; the slivers configure the lighting, the artist tweaks if needed.


### PR DESCRIPTION
## Why this exists

Live scene-building session through the MCP produced consistent embarrassing failures: every actor placed at hardcoded z=100, one tree spawned upside-down, canopy vine floating in mid-air, brazier point light at 120,000 cd (stadium territory), default checkerboard landscape, UE crash mid-build. The user's response: \"be critical of everything you did in this session and find ways to improve our MCP tool so that these mistakes do not happen in agentic workflows deterministically\" + \"build slivers out of the Learttes packs\" + \"expand the validation tool so it catches floating, wrong rotations, etc.\"

This is that response — a single comprehensive spec.

## Parts

1. **Post-mortem (12 failures × root cause × MCP gap)** — ruthless not hand-wavy.
2. **9 deterministic MCP guardrails** — named-rotation struct, \`placement_mode=snap_ground\` default, class-aware rotation plausibility table, light preset+range guards, auto-validate-on-mutation, \`python_run\` discourager, crash-known pitfall catalog, mutation checkpointing, screenshot visual-checklist.
3. **\`scene_validate v2\` — 18 rules** with severity + machine-applyable \`autofix\` for the mechanical ones (\`floating\` → \`actor_transform { placement_mode: snap_ground }\`, etc).
4. **Sliver library mined from 7 surveyed Learttes packs**: placement primitives (snap_to_surface, batch_snap, array_along_spline) + PCG scatter (on_landscape, on_volume, on_actor_surface) + content slivers (candle / torch / fire_camp / god_ray / particle_volume / local_fog_card / handcam_shake / stills_set / three_point / shrine_ensemble). Each mined from concrete recurring assets across the packs.
5. **Sequencing** — 11-item shipping order. Items 2–4 land as one PR (~5 TS files + ~3 UE C++ files) and would alone have made this session's scene buildable correctly on the first attempt.

## Test plan
- Spec doc only — no code change. Approval gate before implementation.

## What's intentionally out of scope
- Re-mining the other 37 Learttes packs in detail (patterns surveyed are representative).
- Replacing \`python_run\` — it stays as the escape hatch; the fix is making the typed tools attractive enough that the agent doesn't reach for it.