### PR TITLE
docs(spec): postmortem skills + memories + 5 validator v2 rules

### DIFF
--- a/.claude/skills/learn-from-working-examples.md
+++ b/.claude/skills/learn-from-working-examples.md
@@ -1,0 +1,55 @@
+---
+name: learn-from-working-examples
+description: Use before constructing PCG graphs, materials, or blueprints from first principles. Mandates exporting a working example asset first (hayba_list_pcg_assets → asset_search → hayba_export_pcg_graph) and cloning its topology rather than guessing at node/pin/parameter requirements.
+---
+
+# learn-from-working-examples
+
+UE has many "looks reasonable, runs silently wrong" patterns. PCG nodes accept inputs that don't error but produce zero output. Material parameters take values that compile but render checker. Blueprint event graphs can have valid-looking wires that never fire. The cost of guessing at these patterns is debugging a graph that runs and produces nothing. The cost of reading a working example is two MCP calls.
+
+## The rule
+
+**Before** you build a PCG graph / material / blueprint from scratch, find the closest working example in the project and clone its topology.
+
+## The 4-step flow
+
+### 1. Inventory
+- For PCG: `hayba_list_pcg_assets` — every PCG graph in `/Game`.
+- For materials: `hayba_asset_search` filtered by `Material` / `MaterialInstance`.
+- For blueprints: `hayba_asset_search` filtered by `Blueprint`.
+- For any asset class: glob through `/Game` for the matching naming pattern.
+
+### 2. Pick the closest match
+- Match by intent first ("trees on terrain"), not by name ("PCG_Trees").
+- If the project has a verified marketplace pack (UB-Landscape-Auto, Sealed Vault, etc.), prefer assets from those — they're known-good.
+
+### 3. Export
+- For PCG: `hayba_export_pcg_graph <asset_path>` returns the full topology — nodes, pins, parameters, defaults.
+- For materials / blueprints: use the asset-introspection tools in the matching domain (`material_describe`, `blueprint_describe`, etc.) or fall back to `hayba_get_node_details` for individual nodes.
+
+### 4. Clone topology, vary parameters
+- Recreate the structure (nodes + pins + connections) exactly.
+- Vary only the meshes / textures / parameters that need to change for your scene.
+- Build from scratch **only** if no working example exists.
+
+## Concrete examples
+
+### PCG forest scatter
+- Wrong: build `PCGSurfaceSamplerSettings` fed by `PCGDataFromActorSettings` pointing at a `StaticMeshActor`-tagged ground plane. Graph runs, returns `componentsExecuted: 1`, spawns zero instances.
+- Right: `hayba_export_pcg_graph /Game/UB-Landscape-Auto/.../PCG_Trees` → see that Surface is fed by `PCGGetLandscapeSettings(ActorSelection=ByClass, ActorSelectionClass=LandscapeProxy)` with `bUnbounded=True`. Clone, swap mesh references, run.
+
+### Landscape master material
+- Wrong: hand-roll a `MM_Custom` from scratch, miss the layer-info parameter set that the project's tooling expects.
+- Right: pick one of the project's existing `MM_*` masters (e.g. `MM_Temperate_Forest`), duplicate, edit base colors / roughness — the layer interface is preserved.
+
+### Foliage type config
+- Wrong: spawn `FoliageType_InstancedStaticMesh` with default density curves, get random scale chaos that fails `foliage_scale_chaos`.
+- Right: copy a `FoliageType` asset from a working pack; the density curve, scale range, and rotation jitter are already tuned.
+
+## Why this beats "construct from first principles"
+
+- **Most PCG node interactions are undocumented.** `PCGSurfaceSampler` requiring a Landscape (not just any spatial input) is one of dozens.
+- **Working examples encode constraint sets you can't see in the schema.** Pin types accept many sources at the schema level but only one shape at runtime.
+- **Marketplace packs were authored by people who shipped products.** Their parameter defaults are battle-tested; yours are guesses.
+
+If "clone working example" feels lazy, remember that the user's scene in the 2026-05-23 session was never delivered because the agent built three PCG graphs from first principles before exporting the working one. The working pattern was visible in the export. **Read it first.**

--- a/.claude/skills/mcp-tool-discovery-first.md
+++ b/.claude/skills/mcp-tool-discovery-first.md
@@ -1,0 +1,41 @@
+---
+name: mcp-tool-discovery-first
+description: Use when planning ANY UE world mutation. Forces tool discovery (hayba_search_tools → list_tool_categories → hayba_pack_list) BEFORE reaching for python_run. Use whenever the task involves spawning, scattering, painting, importing, sculpting, or any other write to the UE scene.
+---
+
+# mcp-tool-discovery-first
+
+`python_run` is the **last resort**, not the first. The MCP toolkit ships ~154 commands across ~30 domains; many have typed TS wrappers, others are reachable through `hayba_invoke` or a pack that simply isn't loaded yet. Reaching for `python_run` before exhausting discovery is how sessions end with crashed editors and undelivered scenes (see `docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md`).
+
+## The ordered flow (do this at every fork)
+
+For any verb — `spawn`, `scatter`, `paint`, `import`, `sculpt`, `bake`, `set_material`, `align`, `place`, etc.:
+
+1. **`hayba_search_tools(verb)`** — search the TS-captured tools by keyword.
+2. **`list_tool_categories`** — scan all 30 domains for the verb / nearby verbs. Read the per-domain command list, not just the domain name.
+3. **`hayba_pack_list`** — check whether a relevant pack exists but isn't loaded; `hayba_pack_load <name>` brings it in.
+4. **Only after all three return nothing useful**, consider `python_run`.
+
+### Concrete examples
+
+| Task | Wrong instinct | Right discovery |
+|---|---|---|
+| "Create a landscape" | `python_run` with `unreal.Landscape` (gives a placeholder stub) | `hayba_search_tools landscape` → finds `landscape_import`; if TS wrapper parked, request it be unparked rather than smuggling around it |
+| "Scatter trees on terrain" | `python_run` looping `eas.spawn_actor_from_class` | `hayba_search_tools scatter` → find PCG-on-landscape sliver; export a working PCG asset (`hayba_list_pcg_assets` + `hayba_export_pcg_graph`) to learn the pattern |
+| "Paint a layer" | `python_run` manipulating LandscapeLayer weight maps | `list_tool_categories` → `landscape` domain → `landscape_paint_layer` (or matching sliver) |
+| "Import a heightmap" | Write the R16 to disk and hand-roll the import in python | `hayba_search_tools heightmap` / `import` → `landscape_import` MCP handler |
+
+## Anti-pattern checklist (refuse all of these)
+
+- **Never** open a TCP socket from inside UE python to a port owned by the `HaybaMCPToolkit` plugin (52342–52350). The connecting thread is the game thread; the plugin handler may need the game thread too → deadlock → editor crash. If a TS wrapper is missing, the right move is *add the wrapper, rebuild, ask the user to reconnect* — not smuggle through a side channel.
+- **Never** assume "no TS wrapper" means "tool doesn't exist." Check `list_tool_categories` for legacy UE-side handlers; consider `hayba_invoke` with the legacy command name.
+- **Never** assume `get_tool_signature` returning `no_schema_available` means "use python_run." It means "the schema sidecar didn't pick this one up" — the handler may still exist.
+- **Never** use `python_run` to mutate world state on a code path that has a typed handler. Typed handlers marshal to the game thread; raw socket calls don't.
+
+## When `python_run` is legitimate
+
+- Pure read-only diagnostics (asset registry queries, property dumps).
+- One-off explorations the user explicitly asked for.
+- Filling in a gap **after** logging that the gap exists and noting it should become a typed tool.
+
+If you ever feel the pull to `python_run` for world mutation, stop and run steps 1–3 again. The fork question is "does a typed tool exist?", and the answer is almost always yes.

--- a/.claude/skills/verify-by-viewport.md
+++ b/.claude/skills/verify-by-viewport.md
@@ -1,0 +1,50 @@
+---
+name: verify-by-viewport
+description: Use after any UE scene mutation (spawn, scatter, PCG execute, foliage paint, landscape edit). Mandates capture_viewport + instance-count verification BEFORE claiming success. "componentsExecuted: 1 with zero instances" is the canonical false-success pattern — never trust a tool's return value as proof of visible effect.
+---
+
+# verify-by-viewport
+
+A tool returning `ok: true` is not evidence the scene changed. PCG returning `componentsExecuted: 1` is not evidence anything spawned. A spawn returning a handle is not evidence the actor is visible at the expected location. Every mutation needs **three** independent verifications before you claim success.
+
+## The 3-step checklist (run all of them, in order)
+
+### 1. `actor_list` — count and tags match expectation
+- Filter by tag or class for the actors you just touched.
+- Assert: count matches what you intended to create.
+- Assert: scales, transforms, and tags match what you set.
+- If you mutated an existing actor, diff against the previous `actor_list` snapshot; isolated, round-number, single-axis changes likely came from the **user**, not a bug — see `[[actor-position-drift-after-user-edit]]` rule before "correcting" them.
+
+### 2. HISM instance counts (mandatory for PCG / Foliage)
+- After `hayba_execute_pcg_graph`, query the HISM components on the relevant actor(s).
+- **Zero instances == failure**, even if `componentsExecuted: 1`. The graph ran; it produced nothing.
+- Canonical cause: `PCGSurfaceSamplerSettings` fed by a non-Landscape source (see `[[pcg-surface-sampler-needs-landscape]]`).
+- For Foliage paint: read the `InstancedFoliageActor` per-type instance count.
+
+### 3. `editor_capture_viewport` — visible result
+- Capture a screenshot from a camera that frames the change.
+- Look at the image. Don't just save it.
+- For hero props: are they at the expected pixel location? Are their bases seated on the ground (watch for pivot offsets — see `[[gianttree-01-pivot-offset]]`)?
+- For PCG / Foliage: is the density what you'd expect? Are there bald patches around hero props (`foliage_no_edge_density`)?
+- For lighting / PPV: are exposure and color what you intended? Hero objects not blown out?
+
+## The canonical false-success pattern
+
+```
+hayba_execute_pcg_graph → { componentsExecuted: 1 }
+agent: "✓ PCG executed — ~140 trees, ~800 shrubs, ~4800 grass clusters"
+reality: HISM instance count == 0 across all components
+```
+
+This happened in the 2026-05-23 PCG/landscape session. The agent reported four nested wrong counts as success, the user had to point out empty viewport. **`componentsExecuted` is a "graph evaluation attempted" counter, not a spawn count.** Always read instance counts before claiming spawn success.
+
+## Other failure modes this catches
+
+- **Pivot drift:** `actor_spawn` returns success but the mesh's authoring pivot is above the visual base, so the actor floats. Caught by viewport screenshot.
+- **Wrong-tab spawn:** the mutation hit a different sublevel / WP cell that isn't loaded. Caught by `actor_list` returning 0.
+- **Silent material fallback:** texture/material path was invalid, engine substituted default. Caught by viewport — the asset looks checker / grey.
+- **User edit overwrite:** user manually moved a tree to z=-380 to seat the roots; agent reads `actor_list` diff, assumes drift, clamps back to z=0. Caught by *not* auto-correcting isolated user-style edits.
+
+## Do this even when you're confident
+
+Especially when you're confident. Confidence is the failure mode. The cost of a screenshot is seconds; the cost of "PCG executed" reported four times across an unfinished scene is the user's afternoon.

--- a/docs/superpowers/specs/2026-05-22-environmental-design-guardrails.md
+++ b/docs/superpowers/specs/2026-05-22-environmental-design-guardrails.md
@@ -90,6 +90,18 @@ Extends Part 3 of the parent spec. Rules below are added to `scene_validate v2` 
 | `non_hism_when_foliage_capable` | StaticMeshActor uses a mesh that has a FoliageType variant in the project — should be a foliage instance, not an actor | Cross-reference mesh paths |
 | `actor_in_unloaded_wp_cell` | Spawned actor in a cell that is not currently loaded in the editor view — invisible to the agent during build | Read WP streaming state |
 
+### F. Postmortem-driven rules (2026-05-23 PCG/landscape session)
+
+Added from `docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md` §6. These five rules close the loopholes exposed in the session where PCG returned `componentsExecuted: 1` with zero instances, a `LandscapePlaceholder` stub got mistaken for a real Landscape, and a TCP-socket workaround crashed the editor.
+
+| Rule | Detect | Fix |
+|---|---|---|
+| `pcg_zero_instances_after_execute` | `hayba_execute_pcg_graph` returned `componentsExecuted > 0` but no HISM instances spawned within 5s of completion | Warning: surface the affected component output, suggest checking the `Surface` input type (likely not a `LandscapeProxy`) |
+| `pcg_surface_source_not_landscape` | `PCGSurfaceSamplerSettings.Surface` is fed by `PCGDataFromActorSettings` whose actor selector targets a non-`Landscape` class | Hard error — known not to work; suggest `PCGGetLandscapeSettings(ActorSelection=ByClass, ActorSelectionClass=LandscapeProxy)` |
+| `unreal_landscape_placeholder` | World contains a `LandscapePlaceholder` actor with no `LandscapeProxy` within proximity | Hint: use `hayba_import_landscape` instead of `spawn_actor_from_class(unreal.Landscape, ...)` (which only produces a stub in UE 5.7) |
+| `tcp_socket_to_self_in_python_run` | A script passed to `python_run` calls `socket.connect(('127.0.0.1', <port>))` where port ∈ 52342..52350 | Hard reject — guaranteed crash; instruct the agent to add the missing TS wrapper instead of smuggling through a side channel |
+| `actor_position_drift_after_user_edit` | `actor_list` diff between consecutive calls shows an isolated actor with a single-axis, round-number change (matches a user-style edit profile) | Don't auto-correct; surface as "user edit detected, preserving" and require explicit agent confirmation before any re-write |
+
 All rules surface `autofix` when mechanical:
 
 | Rule | Autofix |

--- a/docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md
+++ b/docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md
@@ -1,0 +1,204 @@
+# 2026-05-23 — Postmortem: PCG foliage + Landscape import session
+
+**Status:** post-incident, no PR yet. Action items for follow-up specs.
+**Crash:** UE editor crashed mid-session inside `Cmd_ImportLandscape` (legacy handler).
+**Outcome shipped to user:** zero — close-up forest scene was never delivered.
+
+## 1. TL;DR
+
+I spent a long session trying to build a "forest + brazier close-up" scene through the MCP tools and failed three times in a row: (1) PCG executed but spawned zero instances because the surface source was a `StaticMeshActor` instead of a `LandscapeProxy`; (2) my "fake elevation" workaround (6 oversized rocks) was the wrong direction and the user called it out; (3) when I finally tried the right path (real Landscape via the plugin's `landscape_import`), the UE editor crashed because the C++ handler does game-thread-only work from the TCP worker thread, with no marshal.
+
+The MCP toolkit has a real, working `landscape_import` handler — its TS wrapper is **commented out** in `mcp-tools/hayba-mcp/src/tools/index.ts:1943` ("schema parked"). I never discovered this through MCP introspection because `get_tool_signature` returns `no_schema_available` for legacy commands and `hayba_invoke` rejects anything not in the TS captured-tools map. I reached for a TCP-socket-from-python workaround which deadlocked the editor.
+
+My biggest mistake was **reaching for `python_run` instead of exhausting MCP tool discovery** at every fork. The user called this out explicitly — twice. The second time was the trigger for the report.
+
+## 2. Session timeline (the failures)
+
+| Step | What I did | What broke | Why |
+|---|---|---|---|
+| 1 | Spawned hero brazier + 8 trees + 2 rocks via `python_run` | OK for heroes, but I let the same pattern leak into "scatter trees" later | No typed `spawn_with_mesh` handler; I treated python as the path of least resistance |
+| 2 | Captured viewport, declared success | Tree_0 was floating because SM_GiantTree_01's pivot is ~380 above base | I trusted spawn return without verifying the visible result |
+| 3 | "Fixed" Tree_0 by clamping to z=0 | Undid the user's manual positioning (they had moved it to z=-380 to seat the roots) | I read `actor_list` diff as bug, not edit |
+| 4 | Built PCG graph using `PCGDataFromActorSettings` pointing at the ground plane via tag | PCG returned `componentsExecuted: 1` but `hism_counts: {}` (zero instances) | `PCGSurfaceSampler` only accepts a real Landscape; I treated `componentsExecuted: 1` as success without verifying instance count |
+| 5 | Scaled ground to 200, then 1000 | User had to manually re-scale because I missed that the visible plane is the same scale value but the camera was far | Verified the wrong dimension |
+| 6 | Added 6 oversized "hills" rocks as fake elevation | User rejected ("we need actual forest in background", "still 0 PCG instances") | Didn't ask, applied a workaround instead of finding the right pattern |
+| 7 | Exported the working `UB-Landscape-Auto/PCG_Trees` graph | Confirmed the pattern: source must be `PCGGetLandscapeSettings` (`ActorSelection=ByClass, ActorSelectionClass=LandscapeProxy`) | Should have done this **before** the first PCG attempt |
+| 8 | Tried to spawn a Landscape via `unreal.Landscape` | Returned `LandscapePlaceholder` (empty stub, not a real Landscape) | UE 5.7 doesn't expose `ALandscape::Import` to Python |
+| 9 | Searched MCP for landscape tool — found `landscape_import` in `list_tool_categories` | `hayba_invoke` rejected it; `get_tool_signature` returned `no_schema_available` | TS wrapper is parked (commented out at `index.ts:1943`); `hayba_invoke` only dispatches TS-captured tools |
+| 10 | Tried direct TCP socket to plugin port 52342 from inside UE python | UE crashed | Recursive dispatch + game-thread-only work on TCP worker thread |
+
+## 3. MCP tool issues (every one I tripped on)
+
+### 3.1 Parked TS wrappers
+`hayba_import_landscape` is referenced as a TODO at `mcp-tools/hayba-mcp/src/tools/index.ts:1943` ("schema parked with the rest of the terrain stack"). The UE handler exists and works (modulo the threading bug below). With no TS wrapper, the tool is invisible to MCP introspection and unreachable through `hayba_invoke`. **Same situation likely exists for other domains** — `list_tool_categories` lists 154 commands across 30 domains, but only ~70 have TS wrappers loaded. The gap should be auditable.
+
+**Fix:** add a one-line registration audit: for every command in `list_tool_categories`, assert that at least one TS tool routes to it via `executeCommand(cmd, ...)`. CI failure if not.
+
+### 3.2 `get_tool_signature` blind to legacy commands
+`get_tool_signature` only knows about Zod-registered TS schemas. For UE-side handlers (anything in `HaybaMCPLegacyHandler.cpp`'s switch), it returns `no_schema_available` with a "use python_run" hint — actively guiding me toward the workaround that crashed UE.
+
+**Fix:** the C++ handlers already declare their required params (`Params->TryGetStringField(TEXT("heightmapPath"), …)`). Generate a JSON schema sidecar at plugin-build time by parsing those calls, ship it next to the binary, and have `get_tool_signature` consult it before returning `no_schema_available`.
+
+### 3.3 `hayba_invoke` doesn't fall through to UE
+`hayba_invoke` looks up the tool name in the TS captured map and returns `unknown_tool` if not found. It should optionally fall through to `executeCommand(name, params)` for UE-side handlers, gated on an allowlist of legacy commands.
+
+**Fix:** add a `via: 'ue_legacy'` parameter to `hayba_invoke`; route through `executeCommand` when set. Document which legacy commands are safe to invoke this way (game-thread-marshaled).
+
+### 3.4 `python_run` stdout is swallowed
+Every `print(...)` in `python_run` returned `stdout: "None"`. I had to write to disk and `Read` the file back for every diagnostic — a 2-call pattern instead of 1. The `LogPython: Error:` lines DO surface in `editor_stream_log` but ordinary `print` doesn't make it back through the response.
+
+**Fix:** wrap the executed string with a stdout redirector (`io.StringIO` + `redirect_stdout` context manager) inside the C++ python_run handler, attach the captured text to the response.
+
+### 3.5 `asset_browse` / `asset_search` rely on a missing UE command
+Both tools error with `Unknown command: describe_assets`. The TS wrappers were written assuming a UE-side `describe_assets` handler that doesn't ship in this build. The fallback was python's `AssetRegistryHelpers`, which I had to use instead.
+
+**Fix:** add the `describe_assets` UE handler (one switch case in the legacy handler around `IAssetRegistry::GetAssetsByPath`). Until then, mark the TS wrappers as `disabled: true` in the pack manifest so they don't surface in `hayba_search_tools`.
+
+### 3.6 `landscape_import` runs on TCP worker thread → undefined behavior
+`HaybaMCPLandscapeImporter.cpp:100` calls `World->SpawnActor<ALandscape>()` from whichever thread invoked `FHaybaMCPLegacyHandler::Handle()`. Looking at the call site, that's the TCP server's worker. UE's `SpawnActor`, `LoadObject`, and any world mutation must happen on the game thread.
+
+**This is the bug that crashed UE.** Other handlers in the legacy switch (`Cmd_CreateGraph`, `Cmd_ExecuteGraph`, ...) may have the same issue — they were luckier (graph creation has fewer thread invariants) or just haven't crashed yet.
+
+**Fix:** in `HaybaMCPLegacyHandler::Handle`, identify the subset of commands that mutate world state and dispatch them through `AsyncTask(ENamedThreads::GameThread, ...)` with a future for the response. Same pattern the `python_run` handler already uses (it marshals to game thread internally — that's why python works at all).
+
+### 3.7 `landscape_import` accepts requests with missing `id`
+The crash log showed `LogJson: Warning: Field id was not found` followed by `Processing command: landscape_import (id: )`. The handler processed the request anyway. Even if my response framing was correct, an empty `id` means the TS client can never match the response to the request. This is a silent bug — explains some of the unreliability I saw earlier in the session.
+
+**Fix:** reject any incoming command with empty `id` early in the TCP dispatch, return a framed error frame so the client knows.
+
+### 3.8 PCG `SurfaceSampler` requires a `LandscapeProxy` — undocumented
+The validator's pin-shape check (`Surface` input required, type `Spatial`) doesn't catch the runtime requirement that `Surface` data must come from a Landscape, not from a `StaticMeshActor`-derived `PCGDataFromActorSettings`. PCG returns zero points silently.
+
+**Fix:** add a validator rule: if a `PCGSurfaceSamplerSettings`'s `Surface` input is fed by a `PCGDataFromActorSettings` whose actor selector targets a non-Landscape class, emit warning `surface_source_not_landscape`. Better still: pre-flight that the world contains at least one `LandscapeProxy` before executing any graph using `PCGSurfaceSampler`.
+
+### 3.9 `hayba_search_node_catalog` returns empty without warning that DB isn't seeded
+Returned `[]` for every query I tried. The DB is built by `hayba_scrape_node_registry`; it had never been run for this project. The empty result looked like "no such node" when it should have been "registry not seeded — run scrape".
+
+**Fix:** when the catalog is empty, return a structured error: `{ catalog_empty: true, fix: 'run hayba_scrape_node_registry once' }`.
+
+### 3.10 `hayba_pack_load core` re-adds tools that were already loaded
+Cosmetic but confusing — every call returns the same `addedTools` list whether they were new or re-loaded. Should report what was actually newly registered.
+
+### 3.11 Tier-3 gating of `python_run` for ordinary file writes
+Writing a 1 MB R16 heightmap to `D:\Hackathons\hayba\.scratch\` triggers `"Tier 3 (filesystem/subprocess) blocked. Set AllowUnsafePython=true"`. The plugin's own scratch directory and `.scratch/` paths under the repo should be allowlisted at tier 2, so simple diagnostics don't need the unsafe flag.
+
+## 4. My own mistakes (no rationalization)
+
+### 4.1 Reached for `python_run` before exhausting MCP discovery
+Cardinal sin. The user said this twice — once mid-session ("dont use PYTHON scripts, try using the actual PCG and PCGEx... like srsly") and once near the end ("BRO I HAVE LANDSCAPES inside the MCP tool stop relying on PYTHON"). Both times, the right MCP tool existed and I missed it because I hadn't checked `hayba_search_tools` / `list_tool_categories` / `hayba_pack_list` first.
+
+The pattern I should have followed at every fork:
+1. `hayba_search_tools` for the verb (`landscape`, `scatter`, `import`, `paint`)
+2. `list_tool_categories` to scan the full domain map
+3. `hayba_pack_list` to see if the relevant pack is loaded but unsurfaced
+4. Only after all three return nothing useful, consider `python_run`
+
+### 4.2 Treated "tool returned success" as proof of effect
+Multiple times:
+- `pc.generate_local(True)` → assumed instances spawned, didn't check.
+- `hayba_execute_pcg_graph` returned `componentsExecuted: 1` → I reported "PCG executed (~140 trees, ~800 shrubs, ~4800 grass clusters)" before counting actual instances. They were zero.
+- Hero spawn returned `ok: true` → I claimed the scene was built before screenshotting.
+
+**The rule from the previous spec already exists**: "verify by viewport / instance count, not by tool success." I knew it; I didn't apply it.
+
+### 4.3 Auto-corrected the user's manual fix
+`Tree_0` came back from `actor_list` at z=-380 and I assumed it was the pivot-snap bug from earlier. I clamped it to z=0. The user had **manually** moved it to z=-380 to seat the roots properly. Lost their fix.
+
+**Rule:** when state diverges from "what I last wrote," default assumption is **the user edited it**, not that the tool drifted. Especially during an interactive session.
+
+### 4.4 Built workarounds instead of asking
+The "6 oversized hills as fake elevation" was a bad substitute for the real ask ("we need actual forest in the background"). I should have surfaced "real Landscape vs fake decoration?" as a fork question instead of just shipping the workaround. The cost of a 1-line question is much lower than the cost of a wrong visual.
+
+### 4.5 Opened a TCP socket from inside UE Python to the plugin's own port
+This crashed UE. Even setting aside the game-thread issue, this is structurally wrong: a process making blocking RPC calls to itself can deadlock trivially. It was a desperate workaround for #3.1/#3.3 and should never have been attempted. If the TS wrapper is missing, the right move is "add the wrapper, rebuild, restart MCP" — not "smuggle the call through a side channel."
+
+### 4.6 Didn't read the working PCG graph until I'd already failed three times
+`hayba_export_pcg_graph` against `/Game/UB-Landscape-Auto/.../PCG_Trees` showed me **immediately** that the pattern is `PCGGetLandscapeSettings(ByClass=LandscapeProxy)` with `bUnbounded=True`. I should have done this BEFORE writing my first graph. "Look at a working example" beats "construct from first principles" every time.
+
+## 5. Proposed fixes
+
+### 5.1 Plugin code (high priority)
+
+| File | Change | Why |
+|---|---|---|
+| `HaybaMCPLegacyHandler.cpp` | Marshal `landscape_import` and any other world-mutating command through `AsyncTask(ENamedThreads::GameThread)`; pattern from `python_run` handler | Prevents the crash that ended this session |
+| `HaybaMCPLegacyHandler.cpp` | Reject commands with empty `id` early, return framed error | Stops silent unreliability |
+| `HaybaMCPLandscapeImporter.cpp` | Validate heightmap dimensions early; reject if landscape grid layout can't be derived; warn instead of crash if `LandscapeMaterial` path is invalid | Defense in depth |
+| `mcp-tools/hayba-mcp/src/tools/index.ts:1943` | Un-park `hayba_import_landscape` wrapper; ship with the Zod schema {`heightmapPath`, `worldSizeKm`, `maxHeightM`, `actorLabel?`, `landscapeMaterial?`} | The tool the user expected to find |
+| `mcp-tools/hayba-mcp/src/tools/hayba-invoke.ts` (or wherever invoke lives) | Add `via: 'ue_legacy'` option that calls `executeCommand` directly | Closes the "UE-only handler" reachability gap |
+| `python_run` handler | Wrap script in `contextlib.redirect_stdout(io.StringIO())` and attach captured text to response | Removes the file-roundtrip diagnostic pattern |
+| New: `describe_assets` UE handler | Implement properly; until then mark `asset_browse`/`asset_search` as `disabled` in pack manifest | Makes the existing TS wrappers actually work |
+
+### 5.2 Schema / discovery (medium priority)
+
+- Generate a JSON schema sidecar for legacy commands at plugin build time (parse `Params->TryGet*` calls). Ship as `LegacyCommandSchemas.json`. `get_tool_signature` reads it before falling back to `no_schema_available`.
+- CI lint: for every domain command in `list_tool_categories`, require at least one TS tool that calls `executeCommand(cmd, ...)` OR mark explicitly as `manual_only: true`.
+
+### 5.3 New skill: `mcp-tool-discovery-first`
+
+A short skill that runs at the start of any task involving UE world mutation:
+
+```
+For any verb (spawn, scatter, paint, import, sculpt, ...):
+  1. hayba_search_tools(verb)
+  2. list_tool_categories (scan domains for verb)
+  3. hayba_pack_list (check for unloaded packs)
+  4. Only if all return empty, consider python_run.
+  5. Never open a socket to a port the plugin owns from within UE.
+```
+
+This is what I should have done at every step.
+
+### 5.4 New skill: `verify-by-viewport`
+
+Already exists implicitly in the previous spec. Promote to explicit checklist:
+
+```
+After every world mutation:
+  - actor_list (count + tags + scales match expected)
+  - For PCG: query HISM instance counts; ZERO == failure regardless of "executed" status
+  - editor_capture_viewport (or send_user_file with the saved PNG)
+  - Only then claim the step succeeded
+```
+
+### 5.5 New skill: `learn-from-working-examples`
+
+Before constructing PCG graphs / materials / blueprints from first principles:
+
+```
+1. hayba_list_pcg_assets / asset_search / glob for similar assets in /Game
+2. hayba_export_pcg_graph on the closest match
+3. Clone the topology; vary the meshes/parameters
+4. Build from scratch ONLY if no working example exists
+```
+
+### 5.6 Memories to write
+
+- **PCG SurfaceSampler input MUST be a `LandscapeProxy`** — `PCGDataFromActorSettings` on a `StaticMeshActor` produces Spatial data that the sampler silently ignores. Confirmed by exporting `/Game/UB-Landscape-Auto/.../PCG_Trees` (uses `PCGGetLandscapeSettings(ByClass=LandscapeProxy)` + `bUnbounded=true`).
+- **GiantTree_01 mesh pivot is +380 above base** — spawning at z=0 puts roots floating. User's preferred fix: place actor at z=-380. Same logic likely applies to other large hero trees; a per-mesh offset table is the right home (env-design guardrails spec already calls for this).
+- **Don't open TCP sockets from UE Python to plugin-owned ports** — deadlocks game thread, can crash editor.
+- **UE 5.7 `unreal.Landscape` spawn gives `LandscapePlaceholder` stub**, not a real Landscape. Real Landscapes require `ALandscape::Import` (C++ only) or the `landscape_import` MCP handler (once unparked and game-thread-fixed).
+
+## 6. Validator v2 — additional rules from this session
+
+Carrying these into the existing validator-v2 spec:
+
+| Rule | Detect | Fix |
+|---|---|---|
+| `pcg_zero_instances_after_execute` | `hayba_execute_pcg_graph` returned `componentsExecuted > 0` but no HISM instances spawned | Surface as warning, suggest checking Surface input type |
+| `pcg_surface_source_not_landscape` | `PCGSurfaceSamplerSettings.Surface` fed by `PCGDataFromActorSettings` whose actor isn't a Landscape | Hard error — known not to work |
+| `unreal_landscape_placeholder` | World contains `LandscapePlaceholder` actor with no real Landscape | Hint to use `landscape_import` instead of `spawn_actor_from_class` |
+| `tcp_socket_to_self` | Python script in `python_run` calls `socket.connect(('127.0.0.1', 52342..52350))` | Hard reject — crashes UE |
+| `actor_position_drift_after_user_edit` | `actor_list` diff between calls shows user-style edit (round numbers, single axis, single actor) | Don't auto-correct; surface as "user edit detected, preserving" |
+
+## 7. Action items
+
+1. **Fix the crash** (plugin C++): marshal `Cmd_ImportLandscape` to game thread. Same audit for `Cmd_CreateGraph`, `Cmd_ExecuteGraph`, etc.
+2. **Un-park `hayba_import_landscape`** TS wrapper + Zod schema. Add the wrapper for `landscape_paint_layer` while we're in there.
+3. **Wire `python_run` stdout capture**.
+4. **Add `describe_assets` UE handler** so `asset_browse`/`asset_search` work.
+5. **Write the 3 new skills**: `mcp-tool-discovery-first`, `verify-by-viewport`, `learn-from-working-examples`.
+6. **Write the 4 memories** under `.claude/projects/D--Hackathons-hayba/memory/`.
+7. **Extend validator-v2 spec** with the 5 new rules.
+
+None of these were attempted in this session — leaving them to the follow-up PR. The user's scene was never delivered; that's the cost of these tooling gaps, and the gaps are real, not just my misuse.


### PR DESCRIPTION
@
Implements the documentation / discipline fixes from `docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md` (sections 5.3, 5.4, 5.5, 5.6, and 6).

## What ships

### 3 new skills (`.claude/skills/`)
- **`mcp-tool-discovery-first.md`** — forces `hayba_search_tools` → `list_tool_categories` → `hayba_pack_list` before reaching for `python_run`. Includes the anti-pattern checklist (never open a TCP socket from UE python to a port the plugin owns). Implements postmortem §5.3.
- **`verify-by-viewport.md`** — explicit 3-step checklist (`actor_list` count + tags, HISM instance counts for PCG, `editor_capture_viewport`) after every mutation. Calls out the canonical false-success pattern: `componentsExecuted: 1` with zero instances. Implements postmortem §5.4.
- **`learn-from-working-examples.md`** — `hayba_list_pcg_assets` → `hayba_export_pcg_graph` → clone topology before building from first principles. Implements postmortem §5.5.

### 5 validator v2 rules (Section F appended to `docs/superpowers/specs/2026-05-22-environmental-design-guardrails.md` Part 1)
- `pcg_zero_instances_after_execute` — warn when `componentsExecuted > 0` but HISM count is 0.
- `pcg_surface_source_not_landscape` — hard error on `PCGSurfaceSamplerSettings.Surface` fed by a non-Landscape actor selector.
- `unreal_landscape_placeholder` — hint to use `hayba_import_landscape` instead of `spawn_actor_from_class(unreal.Landscape, ...)`.
- `tcp_socket_to_self_in_python_run` — hard reject scripts that connect to 127.0.0.1:52342..52350 from inside `python_run`.
- `actor_position_drift_after_user_edit` — never auto-correct isolated single-axis round-number diffs; surface as "user edit detected, preserving".

### 4 memories (outside repo — per-user)
Live at `C:\Users\Admin\.claude\projects\D--Hackathons-hayba\memory\` and are intentionally NOT committed (per-user memory store):
- `pcg_surface_sampler_needs_landscape.md`
- `gianttree_01_pivot_offset.md`
- `no_tcp_from_ue_python_to_plugin.md`
- `unreal_landscape_spawn_is_placeholder.md`

The project `MEMORY.md` index was updated locally with one-line pointers for each, alphabetically reasonable place.

## Notes

- `docs/superpowers/` is gitignored — both spec files were staged with `git add -f`.
- The postmortem spec itself was vendored into this branch (originally lived only on the main checkout) so the validator-rule cross-reference resolves.
- No code changes. Plugin fixes (un-park `hayba_import_landscape` TS wrapper, game-thread marshalling in `HaybaMCPLegacyHandler.cpp`, `python_run` stdout capture, `describe_assets` UE handler) are scoped to follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added workflow guidelines for asset creation and cloning best practices.
  * Added tool discovery methodology for scene mutations.
  * Added verification checklist for scene changes with visual confirmation steps.

* **New Features**
  * Added five new safety guardrails to detect and prevent common configuration errors and crashes during environmental design operations.
  * Added postmortem documentation with lessons learned and follow-up recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->