### PR TITLE
feat(mcp): unpark landscape_import + invoke ue_legacy fallthrough + python_run stdout

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/code-mode/get-tool-signature.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/code-mode/get-tool-signature.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { getToolSignatureHandler } from './get-tool-signature.js';
+
+function parseResult(res: Awaited<ReturnType<typeof getToolSignatureHandler>>): Record<string, unknown> {
+  const text = (res.content[0] as { type: string; text: string }).text;
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe('get_tool_signature legacy stubs', () => {
+  it('returns a manual stub for landscape_import instead of no_schema_available', async () => {
+    const res = await getToolSignatureHandler({ command: 'landscape_import' }, {} as never);
+    const parsed = parseResult(res);
+    expect(parsed.command).toBe('landscape_import');
+    expect(parsed.source).toBe('ue_legacy_stub');
+    expect(parsed.params).toMatchObject({
+      heightmapPath: expect.stringContaining('required'),
+    });
+  });
+
+  it('returns a manual stub for describe_assets', async () => {
+    const res = await getToolSignatureHandler({ command: 'describe_assets' }, {} as never);
+    const parsed = parseResult(res);
+    expect(parsed.command).toBe('describe_assets');
+    expect(parsed.source).toBe('ue_legacy_stub');
+  });
+
+  it('returns a manual stub for pcg_create_graph', async () => {
+    const res = await getToolSignatureHandler({ command: 'pcg_create_graph' }, {} as never);
+    const parsed = parseResult(res);
+    expect(parsed.source).toBe('ue_legacy_stub');
+  });
+
+  it('returns a manual stub for pcg_execute_graph', async () => {
+    const res = await getToolSignatureHandler({ command: 'pcg_execute_graph' }, {} as never);
+    const parsed = parseResult(res);
+    expect(parsed.source).toBe('ue_legacy_stub');
+  });
+
+  it('still returns no_schema_available for genuinely unknown commands', async () => {
+    const res = await getToolSignatureHandler({ command: 'utter_garbage_xyz' }, {} as never);
+    const parsed = parseResult(res);
+    expect(parsed.status).toBe('no_schema_available');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/code-mode/get-tool-signature.ts
+++ b/mcp-tools/hayba-mcp/src/tools/code-mode/get-tool-signature.ts
@@ -10,6 +10,69 @@ export const meta: HaybaToolMeta = {
   not_when: 'you only need a list of command names — use list_tool_categories instead',
 };
 
+/**
+ * Manual stubs for UE legacy command param shapes.
+ *
+ * These are commands handled by `FHaybaMCPLegacyHandler` (C++ side) that have
+ * no Zod-registered TS wrapper, so `deriveSignature` returns null for them.
+ * Mirrors the `Params->TryGet*Field` calls in
+ * `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp`.
+ *
+ * This is the stop-gap before the schema-sidecar approach (postmortem 5.2)
+ * lands. Keep entries narrow: just the fields the C++ handler actually reads.
+ *
+ * To invoke any of these via MCP, call
+ * `hayba_invoke({ name: '<cmd>', via: 'ue_legacy', args: {...} })`.
+ */
+type LegacySig = {
+  params: Record<string, string>;
+  returns: string;
+  cost: 'low' | 'medium' | 'high';
+  hint?: string;
+};
+const LEGACY_SIGNATURES: Record<string, LegacySig> = {
+  landscape_import: {
+    params: {
+      heightmapPath: 'string (required) — Absolute path to a PNG or R16 heightmap file',
+      worldSizeKm: 'number (optional, default 8.0) — Landscape XY size in km',
+      maxHeightM: 'number (optional, default 600.0) — Maximum height in m (0..maxHeightM mapped from uint16)',
+      actorLabel: 'string (optional, default "Hayba_Terrain") — Label for the spawned Landscape actor',
+      landscapeMaterial: 'string (optional) — UE material path; empty = no material',
+    },
+    returns: '{actorLabel, heightmapPath, worldSizeKm, maxHeightM}',
+    cost: 'high',
+    hint: 'TS wrapper exists as hayba_import_landscape; prefer that. Otherwise call via hayba_invoke({ via: "ue_legacy" }).',
+  },
+  describe_assets: {
+    params: {
+      paths: 'string[] (optional) — list of /Game asset paths to describe',
+      classPaths: 'string[] (optional) — list of /Script class paths to describe',
+    },
+    returns: '{assets:[{path,class,size,tags}]}',
+    cost: 'medium',
+    hint: 'Used by hayba_asset_browse / hayba_asset_search. May not be implemented in all plugin builds — fall back to AssetRegistryHelpers via python_run.',
+  },
+  pcg_create_graph: {
+    params: {
+      assetPath: 'string (required) — /Game path where the new PCGGraph asset is saved',
+      nodes: 'object[] (optional) — node specs ({type, id, params})',
+      edges: 'object[] (optional) — edge specs ({from:{nodeId,pin}, to:{nodeId,pin}})',
+    },
+    returns: '{assetPath, ok}',
+    cost: 'medium',
+    hint: 'Prefer hayba_create_pcg_graph (TS wrapper).',
+  },
+  pcg_execute_graph: {
+    params: {
+      assetPath: 'string (required) — /Game path of the PCGGraph asset to execute',
+      sourceActorLabel: 'string (optional) — label of the actor that hosts the PCGComponent',
+    },
+    returns: '{componentsExecuted, hism_counts}',
+    cost: 'high',
+    hint: 'Prefer hayba_execute_pcg_graph (TS wrapper). Verify hism_counts > 0; componentsExecuted alone does not prove instances spawned.',
+  },
+};
+
 function suggestClose(name: string, all: string[]): string[] {
   // Lightweight Levenshtein-like score so an LLM that guessed a wrong name
   // still gets a "did you mean" hint instead of a dead end.
@@ -49,14 +112,32 @@ export const getToolSignatureHandler: ToolHandler = async (args) => {
   }
   const sig = deriveSignature(command);
   if (!sig) {
-    const did_you_mean = suggestClose(command, listRecordedCommands());
+    // Stop-gap: manual stubs for UE legacy handlers that aren't Zod-registered.
+    const legacy = LEGACY_SIGNATURES[command];
+    if (legacy) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            command,
+            params: legacy.params,
+            returns: legacy.returns,
+            cost: legacy.cost,
+            source: 'ue_legacy_stub',
+            ...(legacy.hint ? { hint: legacy.hint } : {}),
+          }, null, 2),
+        }],
+      };
+    }
+    const allKnown = [...listRecordedCommands(), ...Object.keys(LEGACY_SIGNATURES)];
+    const did_you_mean = suggestClose(command, allKnown);
     return {
       content: [{
         type: 'text',
         text: JSON.stringify({
           status: 'no_schema_available',
           command,
-          hint: 'use list_tool_categories to discover commands, or python_run to invoke via UE Python',
+          hint: 'use list_tool_categories to discover commands, or hayba_invoke({ via: "ue_legacy" }) for UE-side handlers',
           did_you_mean,
         }, null, 2),
       }],

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -1727,6 +1727,33 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     }
   );
   // no meta registered (zone painter pure-TS handler)
+
+  // ── Landscape import (TS wrapper for UE-side landscape_import handler) ────
+  server.tool(
+    'hayba_import_landscape',
+    'Import a heightmap (PNG or R16) as an UE Landscape actor. Wraps the UE-side landscape_import handler. The heightmap is sampled 0..uint16-max -> 0..maxHeightM (m). Spawns one Landscape covering worldSizeKm x worldSizeKm.',
+    {
+      heightmapPath: z.string().describe('Absolute path to a PNG or R16 heightmap file'),
+      worldSizeKm: z.number().optional().default(8.0).describe('Landscape XY size in km'),
+      maxHeightM: z.number().optional().default(600.0).describe('Maximum height in m (0..maxHeightM mapped from uint16)'),
+      actorLabel: z.string().optional().default('Hayba_Terrain').describe('Label for the spawned Landscape actor'),
+      landscapeMaterial: z.string().optional().describe('UE material path; empty = no material'),
+    },
+    async (params) => {
+      try {
+        const data = await executeCommand('landscape_import', params as Record<string, unknown>);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(data ?? { ok: true }, null, 2) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: 'text', text: `Error importing landscape: ${(e as Error).message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+  // no meta registered (thin UE bridge wrapper)
 }
 
 // Schema registry seeding. Mirrors the Zod shapes used by the eager
@@ -1940,7 +1967,13 @@ function recordEagerSchemas(
   reg('hayba_planet_stability_schema', {}, 'low', '{schema_json, example}');
 
   // ── Landscape import ──────────────────────────────────────────────────────
-  // hayba_import_landscape schema parked with the rest of the terrain stack.
+  reg('hayba_import_landscape', {
+    heightmapPath: z.string().describe('Absolute path to a PNG or R16 heightmap file'),
+    worldSizeKm: z.number().optional().default(8.0).describe('Landscape XY size in km'),
+    maxHeightM: z.number().optional().default(600.0).describe('Maximum height in m (0..maxHeightM mapped from uint16)'),
+    actorLabel: z.string().optional().default('Hayba_Terrain').describe('Label for the spawned Landscape actor'),
+    landscapeMaterial: z.string().optional().describe('UE material path; empty = no material'),
+  }, 'high', '{actorLabel, heightmapPath, worldSizeKm, maxHeightM}');
 
   // ── Zone painter domain ───────────────────────────────────────────────────
   reg('hayba_open_zone_painter', {

--- a/mcp-tools/hayba-mcp/src/tools/landscape-import.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/landscape-import.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Lightweight smoke test that the un-parked `hayba_import_landscape` wrapper
+ * actually shipped in index.ts (no longer commented out as "schema parked").
+ *
+ * We deliberately avoid booting registerTools — that would require a full
+ * MCP server + UE bridge fake — and instead source-check the registration.
+ *
+ * Companion runtime test: `routing/meta-tools/invoke.test.ts` covers the
+ * UE-legacy dispatch path that this wrapper indirectly exercises.
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexSrc = readFileSync(join(__dirname, 'index.ts'), 'utf-8');
+
+describe('hayba_import_landscape wrapper', () => {
+  it('is no longer parked — comment is gone', () => {
+    expect(indexSrc).not.toContain('hayba_import_landscape schema parked');
+  });
+
+  it('registers a server.tool entry pointing at landscape_import', () => {
+    expect(indexSrc).toContain("'hayba_import_landscape'");
+    expect(indexSrc).toMatch(/executeCommand\(['"]landscape_import['"]/);
+  });
+
+  it('declares the full param schema from the UE Cmd_ImportLandscape signature', () => {
+    // Each TryGetStringField / TryGetNumberField call in the C++ handler
+    // should have a matching schema entry.
+    expect(indexSrc).toMatch(/heightmapPath:\s*z\.string\(\)/);
+    expect(indexSrc).toMatch(/worldSizeKm:\s*z\.number\(\)/);
+    expect(indexSrc).toMatch(/maxHeightM:\s*z\.number\(\)/);
+    expect(indexSrc).toMatch(/actorLabel:\s*z\.string\(\)/);
+    expect(indexSrc).toMatch(/landscapeMaterial:\s*z\.string\(\)/);
+  });
+
+  it('registers the schema in the eager schema-registry block', () => {
+    expect(indexSrc).toMatch(/reg\(\s*['"]hayba_import_landscape['"]/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/python/python-run.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/python/python-run.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { wrapScriptForPrintRedirect } from './python-run.js';
+
+describe('wrapScriptForPrintRedirect', () => {
+  it('injects unreal.log_warning shim for builtin print', () => {
+    const wrapped = wrapScriptForPrintRedirect('print("hello")');
+    expect(wrapped).toContain('import unreal as _hayba_unreal');
+    expect(wrapped).toContain('def _hayba_print(*args, **kwargs):');
+    expect(wrapped).toContain('_hayba_unreal.log_warning(');
+    expect(wrapped).toContain('"print": _hayba_print');
+  });
+
+  it('preserves the user script verbatim inside a triple-quoted block', () => {
+    const userScript = 'x = 1 + 2\nprint(x)';
+    const wrapped = wrapScriptForPrintRedirect(userScript);
+    // Source string is passed unchanged into a """...""" literal — no
+    // indentation rewriting that could break the user's intent.
+    expect(wrapped).toContain('"""x = 1 + 2\nprint(x)"""');
+  });
+
+  it('escapes embedded triple-quotes so the wrap cannot be broken out of', () => {
+    const userScript = 'doc = """trap"""';
+    const wrapped = wrapScriptForPrintRedirect(userScript);
+    expect(wrapped).not.toContain('"""trap"""');
+    expect(wrapped).toContain('\\"\\"\\"trap\\"\\"\\"');
+  });
+
+  it('escapes backslashes so raw paths survive', () => {
+    const userScript = 'p = "C:\\Users\\me"';
+    const wrapped = wrapScriptForPrintRedirect(userScript);
+    expect(wrapped).toContain('C:\\\\Users\\\\me');
+  });
+
+  it('snapshot-style: minimal script produces the expected wrap shape', () => {
+    const wrapped = wrapScriptForPrintRedirect('print(1)');
+    expect(wrapped.split('\n')).toEqual([
+      'import unreal as _hayba_unreal',
+      'def _hayba_print(*args, **kwargs):',
+      '    sep = kwargs.get("sep", " ")',
+      '    _hayba_unreal.log_warning(sep.join(str(a) for a in args))',
+      '_hayba_user_globals = {"__name__": "__main__", "print": _hayba_print, "unreal": _hayba_unreal}',
+      '_hayba_user_src = """print(1)"""',
+      'exec(compile(_hayba_user_src, "<python_run>", "exec"), _hayba_user_globals)',
+    ]);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/python/python-run.ts
+++ b/mcp-tools/hayba-mcp/src/tools/python/python-run.ts
@@ -17,6 +17,41 @@ export const schema = z.object({
   allow_unsafe: z.boolean().optional(),
 });
 
+/**
+ * Wrap a user-supplied python script so its `print(...)` output surfaces in
+ * `editor_stream_log` via `unreal.log_warning`.
+ *
+ * Background: the UE python handler returns `stdout: "None"` because UE's
+ * embedded interpreter doesn't redirect sys.stdout back to the calling
+ * process. The cleanest TS-only fix is to override the builtin `print` so
+ * every print call routes through `unreal.log_warning`, which already shows
+ * up in the LogPython warning stream — surfaced to MCP via
+ * `editor_stream_log`.
+ *
+ * The wrapper preserves the user's script verbatim inside an `exec()` so
+ * indentation, top-level `return`, etc. behave exactly as before. Errors in
+ * the user script propagate as before (UE handler captures them into
+ * stderr/error fields).
+ */
+export function wrapScriptForPrintRedirect(userScript: string): string {
+  // We deliberately keep this string literal — no f-string interpolation of
+  // user content, no eval. The user script is passed as data via a Python
+  // triple-quoted string and `exec`'d with a fresh globals dict that has
+  // print pre-bound to log_warning.
+  const escaped = userScript
+    .replace(/\\/g, '\\\\')
+    .replace(/"""/g, '\\"\\"\\"');
+  return [
+    'import unreal as _hayba_unreal',
+    'def _hayba_print(*args, **kwargs):',
+    '    sep = kwargs.get("sep", " ")',
+    '    _hayba_unreal.log_warning(sep.join(str(a) for a in args))',
+    '_hayba_user_globals = {"__name__": "__main__", "print": _hayba_print, "unreal": _hayba_unreal}',
+    `_hayba_user_src = """${escaped}"""`,
+    'exec(compile(_hayba_user_src, "<python_run>", "exec"), _hayba_user_globals)',
+  ].join('\n');
+}
+
 export const pythonRunHandler: ToolHandler = async (args) => {
   const parsed = schema.safeParse(args);
   if (!parsed.success) {
@@ -24,7 +59,12 @@ export const pythonRunHandler: ToolHandler = async (args) => {
   }
   try {
     const client = await ensureConnected();
-    const resp = await client.send('python_run', parsed.data as Record<string, unknown>);
+    const wrapped = wrapScriptForPrintRedirect(parsed.data.script);
+    const payload: Record<string, unknown> = {
+      ...(parsed.data as Record<string, unknown>),
+      script: wrapped,
+    };
+    const resp = await client.send('python_run', payload);
     const data = (resp.data ?? {}) as Record<string, unknown>;
     if (!resp.ok) {
       if (data.tier === 3) {

--- a/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
 import { recordSchema } from '../../schema-registry.js';
-import { invokeHandler } from './invoke.js';
+import { invokeHandler, UE_LEGACY_ALLOWLIST } from './invoke.js';
 
 describe('hayba_invoke', () => {
   beforeEach(() => {
@@ -39,5 +39,70 @@ describe('hayba_invoke', () => {
     });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error.kind).toBe('unknown_tool');
+  });
+
+  describe('via: "ue_legacy" fallthrough', () => {
+    it('dispatches allowlisted commands directly via dispatchLegacy', async () => {
+      const dispatchLegacy = vi.fn(async (_cmd: string, _args: Record<string, unknown>) => ({ actorLabel: 'Hayba_Terrain' }));
+      const dispatch = vi.fn(); // should NOT be called
+      const res = await invokeHandler(
+        { name: 'landscape_import', args: { heightmapPath: 'D:/h.png' }, via: 'ue_legacy' },
+        { dispatch, dispatchLegacy, isDisabled: () => false },
+      );
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.result).toEqual({ actorLabel: 'Hayba_Terrain' });
+      expect(dispatchLegacy).toHaveBeenCalledWith('landscape_import', { heightmapPath: 'D:/h.png' });
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('falls back to dispatch when dispatchLegacy is not provided', async () => {
+      const dispatch = vi.fn(async () => ({ ok: true }));
+      const res = await invokeHandler(
+        { name: 'pcg_create_graph', args: { assetPath: '/Game/Foo' }, via: 'ue_legacy' },
+        { dispatch, isDisabled: () => false },
+      );
+      expect(res.ok).toBe(true);
+      expect(dispatch).toHaveBeenCalledWith('pcg_create_graph', { assetPath: '/Game/Foo' });
+    });
+
+    it('rejects non-allowlisted commands with legacy_not_allowlisted', async () => {
+      const dispatchLegacy = vi.fn();
+      const res = await invokeHandler(
+        { name: 'rm_rf_everything', args: {}, via: 'ue_legacy' },
+        { dispatch: vi.fn(), dispatchLegacy, isDisabled: () => false },
+      );
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.error.kind).toBe('legacy_not_allowlisted');
+        if (res.error.kind === 'legacy_not_allowlisted') {
+          expect(res.error.name).toBe('rm_rf_everything');
+        }
+      }
+      expect(dispatchLegacy).not.toHaveBeenCalled();
+    });
+
+    it('still honours isDisabled even on the legacy route', async () => {
+      const res = await invokeHandler(
+        { name: 'landscape_import', args: {}, via: 'ue_legacy' },
+        { dispatch: vi.fn(), dispatchLegacy: vi.fn(), isDisabled: () => true },
+      );
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error.kind).toBe('tool_disabled');
+    });
+
+    it('allowlist covers the postmortem-named legacy commands', () => {
+      for (const cmd of [
+        'landscape_import',
+        'describe_assets',
+        'pcg_create_graph',
+        'pcg_execute_graph',
+        'pcg_export_graph',
+        'pcg_list_assets',
+        'pcg_validate_graph',
+        'pcg_read_node_output',
+      ]) {
+        expect(UE_LEGACY_ALLOWLIST.has(cmd)).toBe(true);
+      }
+    });
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
@@ -1,28 +1,61 @@
 import { z, type ZodRawShape } from 'zod';
 import { getRawShape } from '../../schema-registry.js';
 
+/**
+ * Legacy UE commands that are safe to call via `hayba_invoke({ via: 'ue_legacy' })`.
+ *
+ * These are dispatched directly to the UE plugin via the TCP bridge, bypassing
+ * the TS captured-tools map. Add a command here only when it is known to be
+ * game-thread-safe (or marshals to the game thread internally) and has stable
+ * params. See the postmortem at
+ * `docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md` §3.3.
+ */
+export const UE_LEGACY_ALLOWLIST = new Set<string>([
+  'landscape_import',
+  'describe_assets',
+  'pcg_create_graph',
+  'pcg_execute_graph',
+  'pcg_export_graph',
+  'pcg_list_assets',
+  'pcg_validate_graph',
+  'pcg_read_node_output',
+]);
+
 export const invokeSchema = {
   name: z.string().min(1),
   args: z.record(z.unknown()).default({}),
+  via: z.enum(['ts', 'ue_legacy']).optional().default('ts')
+    .describe('Dispatch route. "ts" (default) looks the tool up in the TS captured map. "ue_legacy" calls executeCommand(name, args) directly against the UE plugin — only allowlisted commands accepted (see UE_LEGACY_ALLOWLIST).'),
 };
 
 export type InvokeResult =
   | { ok: true; result: unknown }
   | { ok: false; error: { kind: 'validation'; issues: unknown } }
   | { ok: false; error: { kind: 'tool_disabled'; name: string } }
-  | { ok: false; error: { kind: 'unknown_tool'; name: string } };
+  | { ok: false; error: { kind: 'unknown_tool'; name: string } }
+  | { ok: false; error: { kind: 'legacy_not_allowlisted'; name: string } };
 
 export interface InvokeCtx {
   dispatch: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
+  dispatchLegacy?: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
   isDisabled: (name: string) => boolean;
 }
 
 export async function invokeHandler(
-  args: { name: string; args: Record<string, unknown> },
+  args: { name: string; args: Record<string, unknown>; via?: 'ts' | 'ue_legacy' },
   ctx: InvokeCtx,
 ): Promise<InvokeResult> {
+  const via = args.via ?? 'ts';
   if (ctx.isDisabled(args.name)) {
     return { ok: false, error: { kind: 'tool_disabled', name: args.name } };
+  }
+  if (via === 'ue_legacy') {
+    if (!UE_LEGACY_ALLOWLIST.has(args.name)) {
+      return { ok: false, error: { kind: 'legacy_not_allowlisted', name: args.name } };
+    }
+    const legacy = ctx.dispatchLegacy ?? ctx.dispatch;
+    const result = await legacy(args.name, args.args ?? {});
+    return { ok: true, result };
   }
   const shape: ZodRawShape | null = getRawShape(args.name);
   if (!shape) {
@@ -39,7 +72,7 @@ export async function invokeHandler(
 export const meta = {
   cost: 'medium' as const,
   effects: ['variable'],
-  when: 'You need to call a tool that exists in an unloaded pack as a one-off.',
+  when: 'You need to call a tool that exists in an unloaded pack as a one-off, or you need to reach a UE-only legacy handler (set via:"ue_legacy").',
   not_when: 'You will call this tool repeatedly — load its pack instead.',
   pack: 'core',
 };

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -207,7 +207,7 @@ export async function registerDeferredRouting(
     'hayba_invoke',
     'Polymorphic dispatcher: call any Hayba tool by name without loading its pack. Best for one-off calls; load the pack for repeated use.',
     invokeSchema,
-    async (args: { name: string; args: Record<string, unknown> }) => {
+    async (args: { name: string; args: Record<string, unknown>; via?: 'ts' | 'ue_legacy' }) => {
       const r = await invokeHandler(args, {
         dispatch: async (cmd, params) => {
           // Prefer the captured handler if present — covers TS-side tools.
@@ -216,6 +216,12 @@ export async function registerDeferredRouting(
             return await Promise.resolve(t.handler(params));
           }
           // Otherwise dispatch via UE bridge.
+          return await executeCommand(cmd, params);
+        },
+        // ue_legacy route — always goes straight to the UE plugin TCP bridge,
+        // skipping the captured map. Used to reach C++ handlers that have no
+        // TS wrapper (e.g. landscape_import before its TS wrapper landed).
+        dispatchLegacy: async (cmd, params) => {
           return await executeCommand(cmd, params);
         },
         isDisabled: isToolDisabled,

--- a/mcp-tools/hayba-mcp/tests/tools/python-run.test.ts
+++ b/mcp-tools/hayba-mcp/tests/tools/python-run.test.ts
@@ -16,10 +16,21 @@ describe('python_run', () => {
     const r = await pythonRunHandler({ script: '' }, fakeSession);
     expect(r.isError).toBe(true);
   });
-  it('forwards correct cmd name', async () => {
+  it('forwards correct cmd name and wraps the script for print->log_warning redirect', async () => {
     mockSend.mockResolvedValue({ id: '1', ok: true, data: { stdout: 'hi' } });
     await pythonRunHandler({ script: 'print(1)' }, fakeSession);
-    expect(mockSend).toHaveBeenCalledWith('python_run', expect.objectContaining({ script: 'print(1)' }));
+    // The handler now wraps user source in a Python exec() shim that binds
+    // builtin print to unreal.log_warning, so prints surface in
+    // editor_stream_log instead of the swallowed UE stdout. See postmortem
+    // §3.4 (2026-05-23-pcg-landscape-mcp-postmortem.md).
+    expect(mockSend).toHaveBeenCalledWith(
+      'python_run',
+      expect.objectContaining({
+        script: expect.stringContaining('_hayba_user_src = """print(1)"""'),
+      }),
+    );
+    const payload = mockSend.mock.calls[0][1] as { script: string };
+    expect(payload.script).toContain('unreal.log_warning');
   });
   it('surfaces tier-3 blocked error specifically', async () => {
     mockSend.mockResolvedValue({ id: '2', ok: false, error: 'unsafe', data: { tier: 3 } });


### PR DESCRIPTION
Implements TS-side fixes from `docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md` (sections 3.1, 3.3, 3.4, 5.1 rows 5-7). Plugin C++ fixes (game-thread marshaling, empty-id rejection) deferred to a separate PR.

## What's in this PR

### 1. Un-parked `hayba_import_landscape` TS wrapper

`mcp-tools/hayba-mcp/src/tools/index.ts` — the wrapper was commented out as `// schema parked with the rest of the terrain stack`. Now registered with a Zod schema mirroring the UE-side `Cmd_ImportLandscape` handler (`heightmapPath`, `worldSizeKm`, `maxHeightM`, `actorLabel`, `landscapeMaterial`). Routes via `executeCommand('landscape_import', …)` and seeds the schema-registry so `get_tool_signature` returns the shape.

### 2. `hayba_invoke` `via: 'ue_legacy'` fallthrough

`mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts` — adds an optional `via` parameter (default `'ts'`). When set to `'ue_legacy'`, calls `executeCommand(name, args)` directly, bypassing the TS captured-tools map.

Gated on `UE_LEGACY_ALLOWLIST` (currently: `landscape_import`, `describe_assets`, `pcg_create_graph`, `pcg_execute_graph`, `pcg_export_graph`, `pcg_list_assets`, `pcg_validate_graph`, `pcg_read_node_output`). Anything else rejected with `{ kind: 'legacy_not_allowlisted', name }`.

Closes the "UE-only handler reachability gap" called out in postmortem §3.3.

### 3. `python_run` stdout via `print` -> `unreal.log_warning`

`mcp-tools/hayba-mcp/src/tools/python/python-run.ts` — the UE plugin returns `stdout: "None"` for every script. TS-only fix: wrap the user script with an `exec()` shim that binds `__builtins__.print` to `unreal.log_warning`, so prints surface in `editor_stream_log`. No UE rebuild needed.

User source is preserved verbatim inside a Python triple-quoted literal (with `"""` and backslashes escaped) so indentation, top-level statements, and string contents survive untouched.

### 4. `get_tool_signature` static map for UE legacy commands

`mcp-tools/hayba-mcp/src/tools/code-mode/get-tool-signature.ts` — instead of returning `no_schema_available` for every UE-side handler, a small manual stub map covers `landscape_import`, `describe_assets`, `pcg_create_graph`, `pcg_execute_graph`. The LLM can now construct calls without rebuilding the plugin.

This is the stop-gap before the schema-sidecar approach lands (postmortem §5.2).

## Tests

All run via Vitest in `mcp-tools/hayba-mcp`:

- `src/tools/routing/meta-tools/invoke.test.ts` — 5 new tests for the `ue_legacy` route (allowlisted dispatch, dispatch fallback, non-allowlisted rejection, `isDisabled` still honoured, allowlist content).
- `src/tools/python/python-run.test.ts` (new) — wrap-string structure + escape + snapshot tests.
- `src/tools/code-mode/get-tool-signature.test.ts` (new) — confirms each legacy stub returns `source: 'ue_legacy_stub'` and that genuinely-unknown commands still return `no_schema_available`.
- `src/tools/landscape-import.test.ts` (new) — smoke-checks that the un-parked wrapper actually shipped (no longer commented out).
- `tests/tools/python-run.test.ts` — updated to assert the wrapped payload shape.

## Local verification

```
cd mcp-tools/hayba-mcp
npx tsc --noEmit       # exit 0 (8 pre-existing errors; was 9 before — net -1)
npx vitest run …       # 23/23 new tests pass
npm test               # full suite: 420/446 (26 pre-existing failures unrelated)
```

The 26 remaining failures are pre-existing infrastructure issues (no `Sender` configured in the actor / scene / editor test files) — verified by stashing this branch and running on origin/main (same 27 failures, minus the one this PR fixed in `tests/tools/python-run.test.ts`).

Postmortem reference: `docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)