### PR TITLE
feat(validator): runtime rule system + plugin history panel

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/asset-retriever/meta-tools/browse.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-retriever/meta-tools/browse.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
+import { join } from 'node:path';
 import type { AssetRetriever } from '../asset-retriever.js';
 import type { Page } from '../asset-catalog.js';
+import { runAfterTool } from '../../../validator/runner.js';
+import { attachFindingsToValue } from '../../../validator/response.js';
+import type { ValidatorFinding } from '../../../validator/rules.js';
 
 export const assetBrowseSchema = {
   filter: z.object({
@@ -15,11 +19,38 @@ export const assetBrowseSchema = {
 
 export interface AssetBrowseCtx { retriever: AssetRetriever; }
 
+export type AssetBrowseResult = Page & { validator?: { findings: ValidatorFinding[] } };
+
 export async function assetBrowseHandler(
   args: { filter?: { path?: string; class?: string; tag?: string; source?: 'project' | 'polyhaven' | 'ambientcg' | 'sketchfab' | 'fab' | 'unknown' }; offset?: number; limit?: number },
   ctx: AssetBrowseCtx,
-): Promise<Page> {
-  return ctx.retriever.browse(args.filter ?? {}, args.offset ?? 0, args.limit ?? 50);
+): Promise<AssetBrowseResult> {
+  let result: Page;
+  try {
+    result = await ctx.retriever.browse(args.filter ?? {}, args.offset ?? 0, args.limit ?? 50);
+  } catch (e) {
+    // Surface as the result so the asset_browse_describe_assets_missing rule
+    // (which regex-matches "Unknown command: describe_assets") can fire.
+    result = { total: 0, offset: args.offset ?? 0, limit: args.limit ?? 50, docs: [] };
+    const errored = { error: e instanceof Error ? e.message : String(e) } as Record<string, unknown>;
+    const findings = await runAfterTool({
+      toolName: 'hayba_asset_browse',
+      toolArgs: args as Record<string, unknown>,
+      toolResult: errored,
+      ue: null,
+      scratchDir: join(process.cwd(), '.scratch'),
+    });
+    return attachFindingsToValue(result as unknown as Record<string, unknown>, findings) as unknown as AssetBrowseResult;
+  }
+
+  const findings = await runAfterTool({
+    toolName: 'hayba_asset_browse',
+    toolArgs: args as Record<string, unknown>,
+    toolResult: result,
+    ue: null,
+    scratchDir: join(process.cwd(), '.scratch'),
+  });
+  return attachFindingsToValue(result as unknown as Record<string, unknown>, findings) as unknown as AssetBrowseResult;
 }
 
 export const meta = {

--- a/mcp-tools/hayba-mcp/src/tools/execute-pcg-graph.ts
+++ b/mcp-tools/hayba-mcp/src/tools/execute-pcg-graph.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
+import { join } from 'node:path';
 import { executeCommand } from './tool-executor.js';
+import { runAfterTool } from '../validator/runner.js';
+import { attachFindingsToValue } from '../validator/response.js';
+import type { ValidatorFinding } from '../validator/rules.js';
 
 const schema = z.object({
   assetPath: z.string().min(1).describe('Full UE asset path to the PCGGraph to execute')
@@ -7,7 +11,36 @@ const schema = z.object({
 
 export type ExecutePcgGraphParams = z.infer<typeof schema>;
 
-export async function executePcgGraph(params: ExecutePcgGraphParams) {
+export interface ExecutePcgGraphResult extends Record<string, unknown> {
+  validator?: { findings: ValidatorFinding[] };
+}
+
+export async function executePcgGraph(params: ExecutePcgGraphParams): Promise<ExecutePcgGraphResult> {
   const { assetPath } = schema.parse(params);
-  return executeCommand('execute_graph', { assetPath });
+  let result: Record<string, unknown>;
+  try {
+    result = await executeCommand('execute_graph', { assetPath });
+  } catch (e) {
+    // Still emit findings for the error-text-based rules.
+    result = { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+
+  // Lazy-import the TCP client to avoid pulling network deps into pure-TS test
+  // setups that import this module without an active UE.
+  let ue = null;
+  try {
+    const tcpMod = await import('../tcp-client.js');
+    ue = await tcpMod.ensureConnected().catch(() => null);
+  } catch {
+    ue = null;
+  }
+
+  const findings = await runAfterTool({
+    toolName: 'hayba_execute_pcg_graph',
+    toolArgs: { assetPath },
+    toolResult: result,
+    ue,
+    scratchDir: join(process.cwd(), '.scratch'),
+  });
+  return attachFindingsToValue(result, findings);
 }

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -119,6 +119,19 @@ import { setPainterHeightmapHandler } from './hayba-set-painter-heightmap.js';
 import { setupConventionsHandler } from './hayba-setup-conventions.js';
 import { analyzeConventionsHandler } from './hayba-analyze-conventions.js';
 
+// ── Validator (runtime rule system + history panel feed) ────────────────────
+import { installToolHooks } from '../validator/index.js';
+import {
+  validatorRunSchema, validatorRunHandler,
+  validatorHistorySchema, validatorHistoryHandler,
+  validatorResolveSchema, validatorResolveHandler,
+  validatorClearSchema, validatorClearHandler,
+  validatorRulesSchema, validatorRulesHandler,
+  validatorSetRuleEnabledSchema, validatorSetRuleEnabledHandler,
+  defaultScratchDir as validatorScratchDir,
+} from './validator/tools.js';
+import { ensureConnected as ensureUeForValidator } from '../tcp-client.js';
+
 // SessionManager (Gaea session) parked while terrain features are off — kept
 // as a typed shim so registerTools' signature doesn't churn for callers.
 type SessionManagerStub = Record<string, unknown>;
@@ -1727,6 +1740,88 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     }
   );
   // no meta registered (zone painter pure-TS handler)
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // ── Validator (runtime rule system + history) ───────────────────────────
+  //
+  // Five MCP tools that expose the validator surface to agents and to the
+  // UE plugin's Validator panel:
+  //   - validator_run      : manual evaluation pass
+  //   - validator_history  : read persisted findings
+  //   - validator_resolve  : mark a finding resolved / unresolved
+  //   - validator_clear    : wipe history
+  //   - validator_rules    : list the rule catalog (+ disabled state)
+  //
+  // Rule definitions live in src/validator/rules.ts; evaluators in
+  // src/validator/tool-hooks.ts (auto-installed below).
+  // ──────────────────────────────────────────────────────────────────────────
+  // Install evaluator hooks once — wires actual logic onto rules catalog.
+  installToolHooks();
+
+  const getUe = async () => {
+    try { return await ensureUeForValidator().catch(() => null); } catch { return null; }
+  };
+
+  server.tool(
+    'validator_run',
+    'Manually evaluate validator rules. Pass scope=\'all\' or { rule_ids: [...] }. Persists findings to history.',
+    validatorRunSchema,
+    async (args: { scope?: 'all' | { rule_ids?: string[] }; persist?: boolean }) => {
+      const ue = await getUe();
+      const r = await validatorRunHandler(args, { ue, scratchDir: validatorScratchDir() });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'validator_history',
+    'Read persisted validator findings. Filter by limit / since_iso / include_resolved / rule_ids.',
+    validatorHistorySchema,
+    async (args: { limit?: number; since_iso?: string; include_resolved?: boolean; rule_ids?: string[] }) => {
+      const r = await validatorHistoryHandler(args);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'validator_resolve',
+    'Mark a validator finding as resolved (or restore it). Identifies the finding by its ISO timestamp.',
+    validatorResolveSchema,
+    async (args: { timestamp: string; resolved: boolean }) => {
+      const r = await validatorResolveHandler(args);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'validator_clear',
+    'Clear the validator history. Requires { confirm: true } to actually wipe.',
+    validatorClearSchema,
+    async (args: { confirm: boolean }) => {
+      const r = await validatorClearHandler(args);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'validator_rules',
+    'Return the validator rule catalog. Include each rule\'s message, hint, refs, and disabled state.',
+    validatorRulesSchema,
+    async (args: { include_disabled_state?: boolean }) => {
+      const r = await validatorRulesHandler(args);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'validator_set_rule_enabled',
+    'Enable or disable a validator rule by id. Persists to .scratch/validator-config.json.',
+    validatorSetRuleEnabledSchema,
+    async (args: { rule_id: string; enabled: boolean }) => {
+      const r = await validatorSetRuleEnabledHandler(args);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
 }
 
 // Schema registry seeding. Mirrors the Zod shapes used by the eager

--- a/mcp-tools/hayba-mcp/src/tools/python-run-validator-wrap.ts
+++ b/mcp-tools/hayba-mcp/src/tools/python-run-validator-wrap.ts
@@ -1,0 +1,77 @@
+// Pre-flight validator wrapper for python_run.
+//
+// We DO NOT edit `python/python-run.ts` directly — sibling PR2 owns that file.
+// Instead this module exposes a wrapped handler that:
+//   1. Pre-checks the script for the self-socket pattern.
+//   2. On match: REJECTS the call (returns an error result with a validator
+//      finding embedded) — this is the only safe behaviour because the script
+//      would otherwise deadlock UE on the game thread.
+//   3. Otherwise delegates to the original pythonRunHandler.
+//
+// TODO(validator-wire-up): once PR2 is merged this logic should live inline
+// in python-run.ts and the wrapper file can be removed.
+
+import { z } from 'zod';
+import type { ToolHandler } from './types.js';
+import { pythonRunHandler, schema as pythonRunSchema } from './python/python-run.js';
+import { emitDirectFinding, isSelfSocketScript } from '../validator/index.js';
+import { attachFindingsToResponse } from '../validator/response.js';
+import { runAfterTool } from '../validator/runner.js';
+import { join } from 'node:path';
+
+export const wrappedPythonRunSchema = pythonRunSchema;
+
+interface WrapOpts {
+  scratchDir?: string;
+}
+
+export function makeValidatedPythonRunHandler(opts: WrapOpts = {}): ToolHandler {
+  const scratchDir = opts.scratchDir ?? join(process.cwd(), '.scratch');
+
+  return async (rawArgs, _session) => {
+    const parsed = z.object(pythonRunSchema.shape).safeParse(rawArgs);
+    if (!parsed.success) {
+      return {
+        content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }],
+        isError: true,
+      };
+    }
+    const args = parsed.data;
+
+    // ── Pre-flight: self-socket → hard reject ───────────────────────────
+    if (isSelfSocketScript(args.script)) {
+      const finding = await emitDirectFinding({
+        ruleId: 'tcp_socket_to_self_in_python_run',
+        severity: 'error',
+        message: 'python_run script opens a TCP socket to the UE plugin port (would deadlock)',
+        hint: 'Use the Python plugin API (`unreal.*`) directly instead of round-tripping through the TCP server (52342–52350).',
+        refs: ['[[python-run-no-self-connect]]'],
+        context: { script_preview: args.script.slice(0, 200) },
+        toolName: 'python_run',
+      });
+      return attachFindingsToResponse(
+        {
+          content: [{
+            type: 'text',
+            text: 'python_run rejected by validator: script would open a TCP socket back to the UE plugin port, which deadlocks the game thread.',
+          }],
+          isError: true,
+        },
+        [finding],
+      );
+    }
+
+    // ── Delegate to the real handler ─────────────────────────────────────
+    const result = await pythonRunHandler(args as unknown as Record<string, unknown>, _session ?? {});
+
+    // ── Post-condition: any other rules that target python_run ──────────
+    const findings = await runAfterTool({
+      toolName: 'python_run',
+      toolArgs: args as unknown as Record<string, unknown>,
+      toolResult: result,
+      ue: null, // no follow-up UE queries needed for self-socket post-cond
+      scratchDir,
+    });
+    return attachFindingsToResponse(result as { content: Array<{ type: 'text'; text: string }>; isError?: boolean }, findings);
+  };
+}

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -57,6 +57,12 @@ export const ALWAYS_ON_META = new Set<string>([
   'hayba_dag_record',
   'hayba_dag_rebuild',
   'hayba_journal_tail',
+  'validator_run',
+  'validator_history',
+  'validator_resolve',
+  'validator_clear',
+  'validator_rules',
+  'validator_set_rule_enabled',
 ]);
 
 export interface CapturedTool {
@@ -247,6 +253,14 @@ export async function registerDeferredRouting(
   };
   passthrough('list_tool_categories');
   passthrough('get_tool_signature');
+  // Validator tools — always-on so the UE plugin's Validator panel and any
+  // agent can read/manage history without loading a pack.
+  passthrough('validator_run');
+  passthrough('validator_history');
+  passthrough('validator_resolve');
+  passthrough('validator_clear');
+  passthrough('validator_rules');
+  passthrough('validator_set_rule_enabled');
 
   // For hayba_check_ue_status: REPLACE the captured handler with one that
   // wires onConnected → maybeAutoLoad('ue_connected'). The captured handler

--- a/mcp-tools/hayba-mcp/src/tools/validator/tools.ts
+++ b/mcp-tools/hayba-mcp/src/tools/validator/tools.ts
@@ -1,0 +1,168 @@
+// MCP tool handlers for the validator surface.
+//
+// Five tools:
+//   validator_run      → manual evaluation pass
+//   validator_history  → read persisted findings (UI primary source of truth)
+//   validator_resolve  → mark a finding resolved / unresolved
+//   validator_clear    → wipe history
+//   validator_rules    → catalog of all known rules + their disabled state
+
+import { z } from 'zod';
+import { join } from 'node:path';
+import {
+  RULES,
+  runManual,
+  listFindings,
+  markResolved,
+  clearHistory,
+  isRuleDisabled,
+  setRuleDisabled,
+  type ValidatorContext,
+  type ValidatorRule,
+} from '../../validator/index.js';
+import type { UETcpClient } from '../../tcp-client.js';
+
+export const validatorRunSchema = {
+  scope: z.union([
+    z.literal('all'),
+    z.object({ rule_ids: z.array(z.string()).optional() }),
+  ]).optional(),
+  persist: z.boolean().optional(),
+};
+
+export interface ValidatorRunCtx {
+  ue: UETcpClient | null;
+  scratchDir: string;
+}
+
+export async function validatorRunHandler(
+  args: { scope?: 'all' | { rule_ids?: string[] }; persist?: boolean },
+  ctx: ValidatorRunCtx,
+): Promise<{ findings: ReturnType<typeof toApiFinding>[]; total: number }> {
+  const scope: 'all' | { ids?: string[] } =
+    args.scope === undefined || args.scope === 'all'
+      ? 'all'
+      : { ids: args.scope.rule_ids };
+
+  const ctxFactory = (rule: ValidatorRule): ValidatorContext => ({
+    toolName: 'validator_run',
+    toolArgs: { ruleId: rule.id },
+    toolResult: null,
+    ue: ctx.ue,
+    scratchDir: ctx.scratchDir,
+  });
+
+  const findings = await runManual(scope, ctxFactory);
+  return { findings: findings.map(toApiFinding), total: findings.length };
+}
+
+export const validatorHistorySchema = {
+  limit: z.number().int().min(1).max(10_000).optional(),
+  since_iso: z.string().optional(),
+  include_resolved: z.boolean().optional(),
+  rule_ids: z.array(z.string()).optional(),
+};
+
+export async function validatorHistoryHandler(args: {
+  limit?: number;
+  since_iso?: string;
+  include_resolved?: boolean;
+  rule_ids?: string[];
+}): Promise<{ findings: ReturnType<typeof toApiFinding>[] }> {
+  const findings = await listFindings({
+    limit: args.limit,
+    sinceIso: args.since_iso,
+    includeResolved: args.include_resolved,
+    ruleIds: args.rule_ids,
+  });
+  return { findings: findings.map(toApiFinding) };
+}
+
+export const validatorResolveSchema = {
+  timestamp: z.string(),
+  resolved: z.boolean(),
+};
+
+export async function validatorResolveHandler(args: {
+  timestamp: string;
+  resolved: boolean;
+}): Promise<{ ok: boolean; changed: boolean }> {
+  const changed = await markResolved(args.timestamp, args.resolved);
+  return { ok: true, changed };
+}
+
+export const validatorClearSchema = {
+  confirm: z.boolean(),
+};
+
+export async function validatorClearHandler(args: { confirm: boolean }): Promise<
+  { ok: boolean; removed: number } | { ok: false; error: string }
+> {
+  if (!args.confirm) {
+    return { ok: false, error: 'pass confirm:true to actually clear history' };
+  }
+  const { removed } = await clearHistory();
+  return { ok: true, removed };
+}
+
+export const validatorRulesSchema = {
+  include_disabled_state: z.boolean().optional(),
+};
+
+export interface RuleCatalogEntry {
+  id: string;
+  severity: ValidatorRule['severity'];
+  message: string;
+  hint: string;
+  refs?: string[];
+  trigger: ValidatorRule['trigger'];
+  has_evaluator: boolean;
+  disabled?: boolean;
+}
+
+export async function validatorRulesHandler(args: { include_disabled_state?: boolean }): Promise<{
+  rules: RuleCatalogEntry[];
+}> {
+  const includeState = args.include_disabled_state !== false;
+  return {
+    rules: RULES.map(r => ({
+      id: r.id,
+      severity: r.severity,
+      message: r.message,
+      hint: r.hint,
+      refs: r.refs,
+      trigger: r.trigger,
+      has_evaluator: typeof r.evaluate === 'function',
+      ...(includeState ? { disabled: isRuleDisabled(r.id) } : {}),
+    })),
+  };
+}
+
+export const validatorSetRuleEnabledSchema = {
+  rule_id: z.string(),
+  enabled: z.boolean(),
+};
+
+export async function validatorSetRuleEnabledHandler(args: { rule_id: string; enabled: boolean }): Promise<{ ok: boolean }> {
+  setRuleDisabled(args.rule_id, !args.enabled);
+  return { ok: true };
+}
+
+function toApiFinding(f: import('../../validator/index.js').ValidatorFinding) {
+  return {
+    rule_id: f.ruleId,
+    severity: f.severity,
+    message: f.message,
+    hint: f.hint,
+    refs: f.refs,
+    context: f.context,
+    timestamp: f.timestamp,
+    tool_name: f.toolName,
+    resolved: f.resolved ?? false,
+    resolved_at: f.resolvedAt,
+  };
+}
+
+export function defaultScratchDir(projectDir?: string): string {
+  return join(projectDir ?? process.cwd(), '.scratch');
+}

--- a/mcp-tools/hayba-mcp/src/validator/__tests__/history.test.ts
+++ b/mcp-tools/hayba-mcp/src/validator/__tests__/history.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  appendFinding,
+  listFindings,
+  markResolved,
+  clearHistory,
+  setHistoryPath,
+  getHistoryPath,
+} from '../history.js';
+import type { ValidatorFinding } from '../rules.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'validator-hist-'));
+  setHistoryPath(join(tmpDir, 'history.jsonl'));
+});
+
+afterEach(() => {
+  setHistoryPath(null);
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function mkFinding(overrides: Partial<ValidatorFinding> = {}): ValidatorFinding {
+  return {
+    ruleId: 'pcg_zero_instances_after_execute',
+    severity: 'warning',
+    message: 'test',
+    hint: 'test',
+    timestamp: new Date().toISOString(),
+    toolName: 'pcg_execute_graph',
+    ...overrides,
+  };
+}
+
+describe('history', () => {
+  it('append then list round-trips a finding', async () => {
+    const f = mkFinding();
+    await appendFinding(f);
+    const all = await listFindings();
+    expect(all).toHaveLength(1);
+    expect(all[0].ruleId).toBe(f.ruleId);
+  });
+
+  it('respects limit option', async () => {
+    for (let i = 0; i < 5; i++) {
+      await appendFinding(mkFinding({ timestamp: `2026-05-23T00:00:0${i}Z` }));
+    }
+    const all = await listFindings({ limit: 3 });
+    expect(all).toHaveLength(3);
+  });
+
+  it('hides resolved findings by default and surfaces them with includeResolved', async () => {
+    const ts = '2026-05-23T00:00:00.000Z';
+    await appendFinding(mkFinding({ timestamp: ts }));
+    await markResolved(ts, true);
+
+    const def = await listFindings();
+    expect(def).toHaveLength(0);
+
+    const withResolved = await listFindings({ includeResolved: true });
+    expect(withResolved).toHaveLength(1);
+    expect(withResolved[0].resolved).toBe(true);
+    expect(withResolved[0].resolvedAt).toBeDefined();
+  });
+
+  it('markResolved(false) restores a finding', async () => {
+    const ts = '2026-05-23T00:00:00.001Z';
+    await appendFinding(mkFinding({ timestamp: ts }));
+    await markResolved(ts, true);
+    await markResolved(ts, false);
+    const all = await listFindings();
+    expect(all).toHaveLength(1);
+    expect(all[0].resolved).toBe(false);
+  });
+
+  it('clearHistory returns count and empties file', async () => {
+    await appendFinding(mkFinding({ timestamp: '2026-05-23T00:00:00.002Z' }));
+    await appendFinding(mkFinding({ timestamp: '2026-05-23T00:00:00.003Z' }));
+    const { removed } = await clearHistory();
+    expect(removed).toBe(2);
+    const all = await listFindings({ includeResolved: true });
+    expect(all).toHaveLength(0);
+  });
+
+  it('filters by ruleIds and severities', async () => {
+    await appendFinding(mkFinding({ timestamp: 'a', ruleId: 'pcg_asset_not_found', severity: 'error' }));
+    await appendFinding(mkFinding({ timestamp: 'b', ruleId: 'pcg_zero_instances_after_execute', severity: 'warning' }));
+    await appendFinding(mkFinding({ timestamp: 'c', ruleId: 'pcg_zero_instances_after_execute', severity: 'warning' }));
+
+    const errs = await listFindings({ severities: ['error'] });
+    expect(errs.map(f => f.timestamp)).toEqual(['a']);
+
+    const justZero = await listFindings({ ruleIds: ['pcg_zero_instances_after_execute'] });
+    expect(justZero).toHaveLength(2);
+  });
+
+  it('getHistoryPath honours the override', () => {
+    expect(getHistoryPath()).toBe(join(tmpDir, 'history.jsonl'));
+  });
+});

--- a/mcp-tools/hayba-mcp/src/validator/__tests__/rules.test.ts
+++ b/mcp-tools/hayba-mcp/src/validator/__tests__/rules.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { RULES, rulesById, rulesForTool, type ValidatorRule } from '../rules.js';
+
+describe('rules catalog', () => {
+  it('seeds at least 10 rules', () => {
+    expect(RULES.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('each rule has every required field', () => {
+    for (const r of RULES) {
+      expect(r.id).toBeTruthy();
+      expect(['error', 'warning', 'info']).toContain(r.severity);
+      expect(typeof r.message).toBe('string');
+      expect(r.message.length).toBeGreaterThan(0);
+      expect(typeof r.hint).toBe('string');
+      expect(r.hint.length).toBeGreaterThan(0);
+      // trigger is either 'manual' or { after_tool: ... }
+      if (r.trigger !== 'manual') {
+        expect(r.trigger).toHaveProperty('after_tool');
+      }
+    }
+  });
+
+  it('rule ids are unique', () => {
+    const ids = RULES.map(r => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('contains the five canonical Section F rule ids', () => {
+    const ids = new Set(RULES.map(r => r.id));
+    for (const required of [
+      'pcg_zero_instances_after_execute',
+      'pcg_surface_source_not_landscape',
+      'unreal_landscape_placeholder',
+      'tcp_socket_to_self_in_python_run',
+      'actor_position_drift_after_user_edit',
+    ]) {
+      expect(ids.has(required)).toBe(true);
+    }
+  });
+
+  it('contains the five other AI-floppy postmortem rules', () => {
+    const ids = new Set(RULES.map(r => r.id));
+    for (const required of [
+      'pcg_execute_no_component_in_world',
+      'pcg_asset_not_found',
+      'landscape_import_no_landscape_in_world',
+      'actor_spawn_class_not_found',
+      'asset_browse_describe_assets_missing',
+    ]) {
+      expect(ids.has(required)).toBe(true);
+    }
+  });
+
+  it('rulesForTool returns all rules whose after_tool matches', () => {
+    const matches = rulesForTool('hayba_execute_pcg_graph');
+    const ids = matches.map(r => r.id);
+    expect(ids).toContain('pcg_zero_instances_after_execute');
+    expect(ids).toContain('pcg_execute_no_component_in_world');
+    expect(ids).toContain('pcg_asset_not_found');
+  });
+
+  it('rulesById builds a lookup map of the catalog', () => {
+    const map = rulesById();
+    for (const r of RULES) {
+      expect(map.get(r.id)?.id).toBe(r.id);
+    }
+  });
+
+  it('manual rules are not returned by rulesForTool', () => {
+    const manualRule = RULES.find(r => r.trigger === 'manual') as ValidatorRule;
+    expect(manualRule).toBeDefined();
+    for (const r of rulesForTool(manualRule.id)) {
+      // manual rules should never show up regardless of tool name
+      expect(r.id).not.toBe(manualRule.id);
+    }
+  });
+});

--- a/mcp-tools/hayba-mcp/src/validator/__tests__/runner.test.ts
+++ b/mcp-tools/hayba-mcp/src/validator/__tests__/runner.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runAfterTool } from '../runner.js';
+import { setHistoryPath, listFindings } from '../history.js';
+import { setConfigPath, setRuleDisabled } from '../config.js';
+import { installToolHooks, _resetToolHooksForTests } from '../tool-hooks.js';
+import type { UETcpClient } from '../../tcp-client.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'validator-runner-'));
+  setHistoryPath(join(tmpDir, 'history.jsonl'));
+  setConfigPath(join(tmpDir, 'config.json'));
+  _resetToolHooksForTests();
+  installToolHooks();
+});
+
+afterEach(() => {
+  setHistoryPath(null);
+  setConfigPath(null);
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Build a minimal stub UE client that replies to python_run with ok and writes
+ *  a zero-instance count to the validator scratch file. */
+function stubUe(opts: { writeCount: number; scratchDir: string }): UETcpClient {
+  return {
+    async send(_cmd: string, _params: Record<string, unknown>) {
+      // Simulate the script writing its output file.
+      mkdirSync(opts.scratchDir, { recursive: true });
+      writeFileSync(
+        join(opts.scratchDir, 'validator_pcg_instance_count.json'),
+        JSON.stringify({ total: opts.writeCount, actors: 1 }),
+      );
+      return { id: 'x', ok: true, data: { stdout: JSON.stringify({ total: opts.writeCount }) } };
+    },
+  } as unknown as UETcpClient;
+}
+
+describe('runAfterTool', () => {
+  it('emits pcg_zero_instances finding when count is 0', async () => {
+    const ue = stubUe({ writeCount: 0, scratchDir: tmpDir });
+    const findings = await runAfterTool({
+      toolName: 'hayba_execute_pcg_graph',
+      toolArgs: { assetPath: '/Game/Foo' },
+      toolResult: { componentsExecuted: 1 },
+      ue,
+      scratchDir: tmpDir,
+    });
+    const ids = findings.map(f => f.ruleId);
+    expect(ids).toContain('pcg_zero_instances_after_execute');
+
+    // history should now contain the finding
+    const hist = await listFindings();
+    expect(hist.find(f => f.ruleId === 'pcg_zero_instances_after_execute')).toBeDefined();
+  });
+
+  it('does NOT emit pcg_zero_instances when count > 0', async () => {
+    const ue = stubUe({ writeCount: 42, scratchDir: tmpDir });
+    const findings = await runAfterTool({
+      toolName: 'hayba_execute_pcg_graph',
+      toolArgs: { assetPath: '/Game/Foo' },
+      toolResult: { componentsExecuted: 1 },
+      ue,
+      scratchDir: tmpDir,
+    });
+    expect(findings.find(f => f.ruleId === 'pcg_zero_instances_after_execute')).toBeUndefined();
+  });
+
+  it('emits pcg_execute_no_component_in_world from error text', async () => {
+    const findings = await runAfterTool({
+      toolName: 'pcg_execute_graph',
+      toolArgs: { assetPath: '/Game/Foo' },
+      toolResult: 'No PCGComponents found using this graph',
+      ue: null,
+      scratchDir: tmpDir,
+    });
+    expect(findings.map(f => f.ruleId)).toContain('pcg_execute_no_component_in_world');
+  });
+
+  it('emits pcg_asset_not_found from error text', async () => {
+    const findings = await runAfterTool({
+      toolName: 'hayba_export_pcg_graph',
+      toolArgs: { assetPath: '/Game/MissingGraph' },
+      toolResult: { ok: false, error: 'could not load asset /Game/MissingGraph' },
+      ue: null,
+      scratchDir: tmpDir,
+    });
+    const f = findings.find(x => x.ruleId === 'pcg_asset_not_found');
+    expect(f).toBeDefined();
+    expect(f?.context?.assetPath).toBe('/Game/MissingGraph');
+  });
+
+  it('emits asset_browse_describe_assets_missing from error text', async () => {
+    const findings = await runAfterTool({
+      toolName: 'hayba_asset_browse',
+      toolArgs: {},
+      toolResult: { error: 'Unknown command: describe_assets' },
+      ue: null,
+      scratchDir: tmpDir,
+    });
+    expect(findings.map(f => f.ruleId)).toContain('asset_browse_describe_assets_missing');
+  });
+
+  it('skips disabled rules', async () => {
+    setRuleDisabled('pcg_execute_no_component_in_world', true);
+    const findings = await runAfterTool({
+      toolName: 'pcg_execute_graph',
+      toolArgs: { assetPath: '/Game/Foo' },
+      toolResult: 'No PCGComponents found using this graph',
+      ue: null,
+      scratchDir: tmpDir,
+    });
+    expect(findings.map(f => f.ruleId)).not.toContain('pcg_execute_no_component_in_world');
+  });
+
+  it('persists findings to history', async () => {
+    await runAfterTool({
+      toolName: 'pcg_execute_graph',
+      toolArgs: { assetPath: '/Game/Foo' },
+      toolResult: 'No PCGComponents found using this graph',
+      ue: null,
+      scratchDir: tmpDir,
+    });
+    expect(existsSync(join(tmpDir, 'history.jsonl'))).toBe(true);
+    const hist = await listFindings();
+    expect(hist.length).toBeGreaterThan(0);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/validator/__tests__/tool-hooks.test.ts
+++ b/mcp-tools/hayba-mcp/src/validator/__tests__/tool-hooks.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { isSelfSocketScript, installToolHooks, _resetToolHooksForTests } from '../tool-hooks.js';
+import { setHistoryPath, listFindings } from '../history.js';
+import { setConfigPath } from '../config.js';
+import { rulesById } from '../rules.js';
+import { makeValidatedPythonRunHandler } from '../../tools/python-run-validator-wrap.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'validator-hooks-'));
+  setHistoryPath(join(tmpDir, 'history.jsonl'));
+  setConfigPath(join(tmpDir, 'config.json'));
+  _resetToolHooksForTests();
+  installToolHooks();
+});
+
+afterEach(() => {
+  setHistoryPath(null);
+  setConfigPath(null);
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('isSelfSocketScript', () => {
+  it('flags scripts that connect to 52342–52350', () => {
+    expect(isSelfSocketScript('import socket\ns = socket.socket()\ns.connect(("127.0.0.1", 52342))')).toBe(true);
+    expect(isSelfSocketScript('s.connect(("localhost", 52345))')).toBe(true);
+    expect(isSelfSocketScript('s.connect(("127.0.0.1", 52350))')).toBe(true);
+  });
+
+  it('ignores ports outside the UE plugin range', () => {
+    expect(isSelfSocketScript('s.connect(("127.0.0.1", 8080))')).toBe(false);
+    expect(isSelfSocketScript('s.connect(("127.0.0.1", 52341))')).toBe(false);
+    expect(isSelfSocketScript('s.connect(("127.0.0.1", 52351))')).toBe(false);
+  });
+
+  it('ignores remote hosts', () => {
+    expect(isSelfSocketScript('s.connect(("10.0.0.5", 52342))')).toBe(false);
+  });
+
+  it('returns false for scripts without socket calls', () => {
+    expect(isSelfSocketScript('unreal.EditorAssetLibrary.list_assets("/Game/")')).toBe(false);
+  });
+});
+
+describe('attachEvaluator wired evaluators', () => {
+  it('every implemented rule has an evaluator after installToolHooks()', () => {
+    const map = rulesById();
+    expect(map.get('pcg_zero_instances_after_execute')?.evaluate).toBeTypeOf('function');
+    expect(map.get('pcg_execute_no_component_in_world')?.evaluate).toBeTypeOf('function');
+    expect(map.get('pcg_asset_not_found')?.evaluate).toBeTypeOf('function');
+    expect(map.get('landscape_import_no_landscape_in_world')?.evaluate).toBeTypeOf('function');
+    expect(map.get('asset_browse_describe_assets_missing')?.evaluate).toBeTypeOf('function');
+    expect(map.get('tcp_socket_to_self_in_python_run')?.evaluate).toBeTypeOf('function');
+  });
+});
+
+describe('python_run pre-flight wrapper', () => {
+  it('rejects a self-socket script and emits a finding', async () => {
+    const handler = makeValidatedPythonRunHandler({ scratchDir: tmpDir });
+    const result = await handler({
+      script: 'import socket\ns = socket.socket()\ns.connect(("127.0.0.1", 52342))',
+      allow_unsafe: true,
+    }, {});
+    expect(result.isError).toBe(true);
+    const text = result.content.map(c => c.text).join('\n');
+    expect(text).toMatch(/tcp_socket_to_self_in_python_run/);
+    expect(text).toMatch(/rejected by validator/);
+
+    const hist = await listFindings();
+    expect(hist.find(f => f.ruleId === 'tcp_socket_to_self_in_python_run')).toBeDefined();
+  });
+
+  it('does not call into UE for self-socket scripts', async () => {
+    // Spy through the dynamic import path used by python-run.ts.
+    // The cleanest signal: the handler returns isError synchronously without
+    // having reached UE — covered above by isError===true on a fresh tmpDir.
+    const handler = makeValidatedPythonRunHandler({ scratchDir: tmpDir });
+    const result = await handler({
+      script: 's.connect(("localhost", 52344))',
+    }, {});
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects safely with an actionable hint', async () => {
+    const handler = makeValidatedPythonRunHandler({ scratchDir: tmpDir });
+    const result = await handler({
+      script: 's.connect(("127.0.0.1", 52342))',
+    }, {});
+    const text = result.content.map(c => c.text).join('\n');
+    expect(text).toMatch(/unreal\.\*/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/validator/config.ts
+++ b/mcp-tools/hayba-mcp/src/validator/config.ts
@@ -1,0 +1,62 @@
+// Per-rule enable/disable configuration.
+//
+// Persisted to JSON so the UE plugin's Configure panel can toggle rules
+// without round-tripping through MCP. Schema is tiny: `{ disabled: string[] }`.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+let CONFIG_PATH_OVERRIDE: string | null = null;
+
+function defaultConfigPath(): string {
+  const env = process.env.HAYBA_VALIDATOR_CONFIG;
+  if (env) return env;
+  return join(process.cwd(), '.scratch', 'validator-config.json');
+}
+
+export function setConfigPath(p: string | null): void {
+  CONFIG_PATH_OVERRIDE = p;
+}
+
+function getConfigPath(): string {
+  return CONFIG_PATH_OVERRIDE ?? defaultConfigPath();
+}
+
+interface ValidatorConfig {
+  disabled: string[];
+}
+
+function loadConfig(): ValidatorConfig {
+  const path = getConfigPath();
+  if (!existsSync(path)) return { disabled: [] };
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<ValidatorConfig>;
+    return { disabled: Array.isArray(parsed.disabled) ? parsed.disabled : [] };
+  } catch {
+    return { disabled: [] };
+  }
+}
+
+function saveConfig(c: ValidatorConfig): void {
+  const path = getConfigPath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(c, null, 2), 'utf-8');
+}
+
+export function isRuleDisabled(id: string): boolean {
+  return loadConfig().disabled.includes(id);
+}
+
+export function setRuleDisabled(id: string, disabled: boolean): void {
+  const c = loadConfig();
+  const has = c.disabled.includes(id);
+  if (disabled && !has) c.disabled.push(id);
+  if (!disabled && has) c.disabled = c.disabled.filter(x => x !== id);
+  saveConfig(c);
+}
+
+export function listDisabledRules(): string[] {
+  return loadConfig().disabled.slice();
+}

--- a/mcp-tools/hayba-mcp/src/validator/history.ts
+++ b/mcp-tools/hayba-mcp/src/validator/history.ts
@@ -1,0 +1,120 @@
+// Persistent validator finding history.
+//
+// JSONL file (one finding per line) so the UE plugin can watch + tail the same
+// stream without a transport bridge to the MCP server. Cheap in-memory cache
+// keeps appends fast; reads re-parse from disk (correct for typical history
+// sizes < 10k findings — promote to SQLite if that ever becomes painful).
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { ValidatorFinding } from './rules.js';
+
+let HISTORY_PATH_OVERRIDE: string | null = null;
+
+function defaultHistoryPath(): string {
+  const env = process.env.HAYBA_VALIDATOR_HISTORY;
+  if (env) return env;
+  // Repo-root .scratch/ — same convention as the rest of the scratch artefacts.
+  const cwd = process.cwd();
+  return join(cwd, '.scratch', 'validator-history.jsonl');
+}
+
+/** Override the on-disk path. Used by tests to write to a tmp file. */
+export function setHistoryPath(p: string | null): void {
+  HISTORY_PATH_OVERRIDE = p;
+}
+
+export function getHistoryPath(): string {
+  return HISTORY_PATH_OVERRIDE ?? defaultHistoryPath();
+}
+
+function ensureDir(path: string): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+export interface AppendOptions {
+  /** Skip writing duplicates with the same timestamp+ruleId. */
+  dedupe?: boolean;
+}
+
+export async function appendFinding(f: ValidatorFinding, opts: AppendOptions = {}): Promise<void> {
+  const path = getHistoryPath();
+  ensureDir(path);
+
+  if (opts.dedupe && existsSync(path)) {
+    const findings = await listFindings({ includeResolved: true });
+    const dup = findings.some(x => x.timestamp === f.timestamp && x.ruleId === f.ruleId);
+    if (dup) return;
+  }
+
+  appendFileSync(path, JSON.stringify(f) + '\n', 'utf-8');
+}
+
+export interface ListOptions {
+  limit?: number;
+  sinceIso?: string;
+  includeResolved?: boolean;
+  ruleIds?: string[];
+  severities?: Array<ValidatorFinding['severity']>;
+}
+
+export async function listFindings(opts: ListOptions = {}): Promise<ValidatorFinding[]> {
+  const path = getHistoryPath();
+  if (!existsSync(path)) return [];
+  const stat = statSync(path);
+  if (stat.size === 0) return [];
+
+  const lines = readFileSync(path, 'utf-8').split('\n').filter(l => l.trim().length > 0);
+  const findings: ValidatorFinding[] = [];
+  for (const line of lines) {
+    try {
+      findings.push(JSON.parse(line) as ValidatorFinding);
+    } catch {
+      // skip malformed lines (partial write, manual edit) — keep tailing.
+    }
+  }
+
+  let out = findings;
+  if (!opts.includeResolved) out = out.filter(f => !f.resolved);
+  if (opts.sinceIso) out = out.filter(f => f.timestamp >= opts.sinceIso!);
+  if (opts.ruleIds && opts.ruleIds.length) {
+    const set = new Set(opts.ruleIds);
+    out = out.filter(f => set.has(f.ruleId));
+  }
+  if (opts.severities && opts.severities.length) {
+    const set = new Set(opts.severities);
+    out = out.filter(f => set.has(f.severity));
+  }
+  if (opts.limit && opts.limit > 0) out = out.slice(-opts.limit);
+
+  return out;
+}
+
+export async function markResolved(timestamp: string, resolved: boolean): Promise<boolean> {
+  const path = getHistoryPath();
+  if (!existsSync(path)) return false;
+  const all = await listFindings({ includeResolved: true });
+  let changed = false;
+  const updated = all.map(f => {
+    if (f.timestamp === timestamp) {
+      changed = true;
+      return resolved
+        ? { ...f, resolved: true, resolvedAt: new Date().toISOString() }
+        : { ...f, resolved: false, resolvedAt: undefined };
+    }
+    return f;
+  });
+  if (changed) {
+    writeFileSync(path, updated.map(f => JSON.stringify(f)).join('\n') + '\n', 'utf-8');
+  }
+  return changed;
+}
+
+export async function clearHistory(): Promise<{ removed: number }> {
+  const path = getHistoryPath();
+  if (!existsSync(path)) return { removed: 0 };
+  const all = await listFindings({ includeResolved: true });
+  writeFileSync(path, '', 'utf-8');
+  return { removed: all.length };
+}

--- a/mcp-tools/hayba-mcp/src/validator/index.ts
+++ b/mcp-tools/hayba-mcp/src/validator/index.ts
@@ -1,0 +1,9 @@
+// Validator public surface.
+
+export { RULES, rulesById, rulesForTool, attachEvaluator } from './rules.js';
+export type { ValidatorRule, ValidatorFinding, ValidatorContext, ValidatorSeverity, ValidatorTrigger } from './rules.js';
+export { runAfterTool, runManual, emitDirectFinding } from './runner.js';
+export { appendFinding, listFindings, markResolved, clearHistory, getHistoryPath, setHistoryPath } from './history.js';
+export { isRuleDisabled, setRuleDisabled, listDisabledRules, setConfigPath } from './config.js';
+export { installToolHooks, isSelfSocketScript } from './tool-hooks.js';
+export { attachFindingsToResponse, attachFindingsToValue } from './response.js';

--- a/mcp-tools/hayba-mcp/src/validator/response.ts
+++ b/mcp-tools/hayba-mcp/src/validator/response.ts
@@ -1,0 +1,71 @@
+// Wire validator findings into MCP responses.
+//
+// Two helpers:
+//   - attachFindingsToResponse  → wraps an MCP {content,isError} payload
+//   - attachFindingsToValue     → wraps a raw JSON value (handler that returns
+//                                 plain JSON, then is JSON.stringified for MCP)
+
+import type { ValidatorFinding } from './rules.js';
+
+interface McpResponse {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+function findingToLine(f: ValidatorFinding): string {
+  const tag = f.severity === 'error' ? '[validator:error]'
+            : f.severity === 'warning' ? '[validator:warning]'
+            : '[validator:info]';
+  const refs = f.refs && f.refs.length ? ` (${f.refs.join(' ')})` : '';
+  return `${tag} ${f.ruleId}: ${f.message}${refs} — ${f.hint}`;
+}
+
+export function attachFindingsToResponse(
+  resp: McpResponse,
+  findings: ValidatorFinding[],
+): McpResponse {
+  if (!findings.length) return resp;
+  const isError = resp.isError === true || findings.some(f => f.severity === 'error');
+  const extra = findings.map(findingToLine).join('\n');
+  const validatorBlock = {
+    findings: findings.map(f => ({
+      ruleId: f.ruleId,
+      severity: f.severity,
+      message: f.message,
+      hint: f.hint,
+      refs: f.refs,
+      context: f.context,
+      timestamp: f.timestamp,
+    })),
+  };
+  return {
+    ...resp,
+    isError,
+    content: [
+      ...resp.content,
+      { type: 'text', text: `\n${extra}` },
+      { type: 'text', text: JSON.stringify({ validator: validatorBlock }, null, 2) },
+    ],
+  };
+}
+
+export function attachFindingsToValue<T extends Record<string, unknown>>(
+  value: T,
+  findings: ValidatorFinding[],
+): T & { validator?: { findings: ValidatorFinding[] } } {
+  if (!findings.length) return value;
+  return {
+    ...value,
+    validator: {
+      findings: findings.map(f => ({
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+        hint: f.hint,
+        refs: f.refs,
+        context: f.context,
+        timestamp: f.timestamp,
+      })) as unknown as ValidatorFinding[],
+    },
+  };
+}

--- a/mcp-tools/hayba-mcp/src/validator/rules.ts
+++ b/mcp-tools/hayba-mcp/src/validator/rules.ts
@@ -1,0 +1,183 @@
+// Validator rule registry.
+//
+// Each rule has a canonical id (matches Section F of
+// `docs/superpowers/specs/2026-05-22-environmental-design-guardrails.md` and
+// the AI-floppy patterns identified in the 2026-05-23 PCG/landscape MCP
+// postmortem). Rules can be evaluated automatically (post-condition of a tool
+// call) or be catalog-only — listed in the UI so the user knows the system
+// would warn them, even before an evaluator is wired.
+//
+// The catalog is the source of truth for the UI; runtime evaluators live in
+// `tool-hooks.ts` and are attached to entries below by reference, not by
+// duplicating the metadata.
+
+import type { UETcpClient } from '../tcp-client.js';
+
+export type ValidatorSeverity = 'error' | 'warning' | 'info';
+
+export interface ValidatorContext {
+  /** Name of the tool whose post-condition is being evaluated. */
+  toolName: string;
+  /** The validated args the tool was called with. */
+  toolArgs: Record<string, unknown>;
+  /** The raw response value the tool returned (TS-side, before MCP wrapping). */
+  toolResult: unknown;
+  /** Live TCP client to UE for follow-up queries (may be null for unit tests). */
+  ue: UETcpClient | null;
+  /** Where to scratch intermediate JSON files (default = repo `.scratch/`). */
+  scratchDir: string;
+}
+
+export interface ValidatorFinding {
+  ruleId: string;
+  severity: ValidatorSeverity;
+  message: string;
+  hint: string;
+  refs?: string[];
+  context?: Record<string, unknown>;
+  /** ISO8601 timestamp; doubles as the stable record id for resolve/clear. */
+  timestamp: string;
+  toolName: string;
+  resolved?: boolean;
+  resolvedAt?: string;
+}
+
+export type ValidatorTrigger =
+  | 'manual'
+  | { after_tool: string | string[] };
+
+export interface ValidatorRule {
+  id: string;
+  severity: ValidatorSeverity;
+  message: string;
+  hint: string;
+  refs?: string[];
+  trigger: ValidatorTrigger;
+  /** When omitted, the rule is descriptive only — present in the catalog so
+   *  users see it in the Configure panel, but never auto-evaluated. */
+  evaluate?: (ctx: ValidatorContext) => Promise<ValidatorFinding | null>;
+}
+
+// ── Catalog ─────────────────────────────────────────────────────────────────
+//
+// Evaluators are assigned in `tool-hooks.ts` via `attachEvaluator()`. Keeping
+// the catalog data-only here means tests can import this module without
+// pulling in the TCP / python_run plumbing.
+
+export const RULES: ValidatorRule[] = [
+  // ── Section F: 5 rules from PR #227 ─────────────────────────────────────
+  {
+    id: 'pcg_zero_instances_after_execute',
+    severity: 'warning',
+    message: 'PCG graph executed but produced 0 instances in the world',
+    hint: 'The graph ran (componentsExecuted > 0) but no Hierarchical/Instanced Static Mesh instances exist on any PCGVolume using it. Common causes: Surface Sampler bound to a non-landscape source, all points culled by a Density filter, or output pin not wired to a Static Mesh Spawner. Inspect the graph in the editor and re-run with hayba_execute_pcg_graph.',
+    refs: ['[[pcg-surface-sampler-needs-landscape]]', '[[pcg-zero-instances-postmortem]]'],
+    trigger: { after_tool: ['pcg_execute_graph', 'hayba_execute_pcg_graph'] },
+  },
+  {
+    id: 'pcg_surface_source_not_landscape',
+    severity: 'warning',
+    message: 'Surface Sampler source is not an ALandscape — likely no points generated',
+    hint: 'PCG Surface Sampler defaults to sampling the actor type set in its Settings. When the source is a generic StaticMeshActor or volume, the sampler usually produces 0 points. Set the source to `Landscape` (or a tagged landscape proxy) and re-execute.',
+    refs: ['[[pcg-surface-sampler-needs-landscape]]'],
+    trigger: 'manual',
+  },
+  {
+    id: 'unreal_landscape_placeholder',
+    severity: 'info',
+    message: 'World contains placeholder landscape (default flat 0,0,0)',
+    hint: 'A LandscapeProxy exists but appears to be the editor default (no heightmap imported, zero-elevation). Most PCG workflows need a sculpted or imported landscape — use `landscape_import` to bring in heightmap+masks.',
+    refs: ['[[landscape-placeholder-detection]]'],
+    trigger: 'manual',
+  },
+  {
+    id: 'tcp_socket_to_self_in_python_run',
+    severity: 'error',
+    message: 'python_run script opens a TCP socket to the UE plugin port (would deadlock)',
+    hint: 'Calling back into the MCP TCP listener (52342–52350) from inside a python_run script reenters the game thread and crashes UE. Use the Python plugin API (`unreal.*`) directly instead of round-tripping through the TCP server.',
+    refs: ['[[python-run-no-self-connect]]'],
+    trigger: { after_tool: 'python_run' },
+  },
+  {
+    id: 'actor_position_drift_after_user_edit',
+    severity: 'warning',
+    message: 'Actor position differs from the last recorded value (user may have moved it)',
+    hint: 'The actor at this label has been moved in the editor between MCP-driven updates. If you continue, your transform will overwrite the user\'s edit. Re-fetch with actor_list before applying transforms, or coordinate with the user.',
+    refs: ['[[actor-position-drift]]'],
+    trigger: 'manual',
+  },
+
+  // ── Other 5 AI-floppy hints from the postmortem ─────────────────────────
+  {
+    id: 'pcg_execute_no_component_in_world',
+    severity: 'warning',
+    message: 'No PCGComponent in the level is bound to the executed graph',
+    hint: 'pcg_execute_graph found 0 PCGComponents referencing this graph. Either drop a PCGVolume into the level and assign the graph, or use actor_spawn to spawn one programmatically before re-executing.',
+    refs: ['[[pcg-execute-needs-component]]'],
+    trigger: { after_tool: ['pcg_execute_graph', 'hayba_execute_pcg_graph'] },
+  },
+  {
+    id: 'pcg_asset_not_found',
+    severity: 'error',
+    message: 'PCG asset path could not be resolved',
+    hint: 'The provided assetPath did not resolve to a PCGGraph. Double-check the path (must start with /Game/) and that the asset exists — list candidates with hayba_list_pcg_assets.',
+    refs: ['[[pcg-asset-path-resolution]]'],
+    trigger: { after_tool: ['pcg_execute_graph', 'hayba_execute_pcg_graph', 'hayba_export_pcg_graph'] },
+  },
+  {
+    id: 'landscape_import_no_landscape_in_world',
+    severity: 'error',
+    message: 'landscape_import returned success but no LandscapeProxy exists in the world',
+    hint: 'The import handler reported ok=true but no `unreal.LandscapeProxy` actor is present in the editor world. Check the editor output log filtered by `LogHaybaMCPImporter` for the underlying error.',
+    refs: ['[[landscape-import-silent-failure]]'],
+    trigger: { after_tool: 'landscape_import' },
+  },
+  {
+    id: 'actor_spawn_class_not_found',
+    severity: 'error',
+    message: 'actor_spawn could not resolve the requested class path',
+    hint: 'The class name or asset path passed to actor_spawn did not match a known UClass. Use the fully qualified path (e.g. `/Game/MyContent/BP_Foo.BP_Foo_C`) or a registered short name. Browse with hayba_asset_browse.',
+    refs: ['[[actor-spawn-class-resolution]]'],
+    trigger: 'manual',
+  },
+  {
+    id: 'asset_browse_describe_assets_missing',
+    severity: 'warning',
+    message: 'UE responded "Unknown command: describe_assets" — the plugin is out of date',
+    hint: 'The hayba_asset_browse handler relies on the `describe_assets` UE command which is missing in this plugin build. Rebuild the HaybaMCPToolkit plugin from source, or use `python_run` with `unreal.EditorAssetLibrary.list_assets()` as a fallback.',
+    refs: ['[[asset-browse-plugin-out-of-date]]'],
+    trigger: { after_tool: ['hayba_asset_browse', 'hayba_asset_search'] },
+  },
+];
+
+/** Build an id → rule lookup (rebuilt on each call so tests can mutate). */
+export function rulesById(): Map<string, ValidatorRule> {
+  const m = new Map<string, ValidatorRule>();
+  for (const r of RULES) m.set(r.id, r);
+  return m;
+}
+
+/** All rules whose trigger matches the given tool name. */
+export function rulesForTool(toolName: string): ValidatorRule[] {
+  const matches: ValidatorRule[] = [];
+  for (const r of RULES) {
+    if (r.trigger === 'manual') continue;
+    const t = r.trigger.after_tool;
+    if (Array.isArray(t) ? t.includes(toolName) : t === toolName) matches.push(r);
+  }
+  return matches;
+}
+
+/** Attach (or override) the evaluator for a rule by id. Used by tool-hooks
+ *  to keep the catalog data-only while still wiring real logic. */
+export function attachEvaluator(
+  id: string,
+  fn: NonNullable<ValidatorRule['evaluate']>,
+): void {
+  const r = rulesById().get(id);
+  // rulesById() returned a copy of the map; we mutate the original RULES entry.
+  const target = RULES.find(x => x.id === id);
+  if (!target) throw new Error(`attachEvaluator: rule "${id}" not found`);
+  target.evaluate = fn;
+  void r;
+}

--- a/mcp-tools/hayba-mcp/src/validator/runner.ts
+++ b/mcp-tools/hayba-mcp/src/validator/runner.ts
@@ -1,0 +1,117 @@
+// Validator runtime — evaluates rules and persists findings to history.
+//
+// Two entry points:
+//   - runAfterTool: post-condition pass triggered by tool wrappers.
+//   - runManual:    user-driven pass triggered by validator_run MCP tool.
+
+import { RULES, rulesForTool, rulesById, type ValidatorContext, type ValidatorFinding, type ValidatorRule } from './rules.js';
+import { appendFinding } from './history.js';
+import { isRuleDisabled } from './config.js';
+
+export type { ValidatorContext, ValidatorFinding } from './rules.js';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/** Evaluate every rule registered to trigger after `ctx.toolName`. Persists
+ *  each non-null finding to history before returning. */
+export async function runAfterTool(ctx: ValidatorContext): Promise<ValidatorFinding[]> {
+  const rules = rulesForTool(ctx.toolName);
+  const findings: ValidatorFinding[] = [];
+  for (const rule of rules) {
+    if (isRuleDisabled(rule.id)) continue;
+    if (!rule.evaluate) continue;
+    let f: ValidatorFinding | null = null;
+    try {
+      f = await rule.evaluate(ctx);
+    } catch (e) {
+      // Rule evaluator threw — record as info so the user can see something
+      // went wrong, but don't fail the parent tool call.
+      f = {
+        ruleId: rule.id,
+        severity: 'info',
+        message: `validator: rule "${rule.id}" evaluator threw`,
+        hint: e instanceof Error ? e.message : String(e),
+        timestamp: nowIso(),
+        toolName: ctx.toolName,
+      };
+    }
+    if (f) {
+      // Normalise fields the evaluator might omit.
+      const normalised: ValidatorFinding = {
+        ...f,
+        timestamp: f.timestamp || nowIso(),
+        toolName: f.toolName || ctx.toolName,
+      };
+      findings.push(normalised);
+      await appendFinding(normalised);
+    }
+  }
+  return findings;
+}
+
+export interface ManualRunScope {
+  ids?: string[];
+}
+
+/** Run a subset of rules in "manual" mode. Most catalog-only rules have no
+ *  evaluator, so calling them returns nothing — manual mode is for the user
+ *  to ask "re-check rule X" from the Validator panel. */
+export async function runManual(
+  scope: ManualRunScope | 'all',
+  ctxFactory: (rule: ValidatorRule) => ValidatorContext,
+): Promise<ValidatorFinding[]> {
+  const byId = rulesById();
+  const wanted: ValidatorRule[] = [];
+  if (scope === 'all') {
+    for (const r of RULES) wanted.push(r);
+  } else {
+    for (const id of scope.ids ?? []) {
+      const r = byId.get(id);
+      if (r) wanted.push(r);
+    }
+  }
+
+  const findings: ValidatorFinding[] = [];
+  for (const rule of wanted) {
+    if (isRuleDisabled(rule.id)) continue;
+    if (!rule.evaluate) continue;
+    const ctx = ctxFactory(rule);
+    try {
+      const f = await rule.evaluate(ctx);
+      if (f) {
+        const normalised: ValidatorFinding = {
+          ...f,
+          timestamp: f.timestamp || nowIso(),
+          toolName: f.toolName || ctx.toolName,
+        };
+        findings.push(normalised);
+        await appendFinding(normalised);
+      }
+    } catch (e) {
+      const f: ValidatorFinding = {
+        ruleId: rule.id,
+        severity: 'info',
+        message: `validator: rule "${rule.id}" evaluator threw`,
+        hint: e instanceof Error ? e.message : String(e),
+        timestamp: nowIso(),
+        toolName: 'validator_run',
+      };
+      findings.push(f);
+      await appendFinding(f);
+    }
+  }
+  return findings;
+}
+
+/** Build a one-shot finding outside the evaluator flow (used by tool wrappers
+ *  that need to emit a pre-flight rejection). The finding is persisted to
+ *  history just like an after-tool finding. */
+export async function emitDirectFinding(
+  partial: Omit<ValidatorFinding, 'timestamp'> & { timestamp?: string },
+): Promise<ValidatorFinding> {
+  const f: ValidatorFinding = { ...partial, timestamp: partial.timestamp ?? nowIso() };
+  await appendFinding(f);
+  return f;
+}

--- a/mcp-tools/hayba-mcp/src/validator/tool-hooks.ts
+++ b/mcp-tools/hayba-mcp/src/validator/tool-hooks.ts
@@ -1,0 +1,268 @@
+// Tool-hook evaluators — wire concrete logic onto the catalog entries declared
+// in `rules.ts`. Calling `installToolHooks()` once at server startup attaches
+// every evaluator below.
+
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { attachEvaluator, type ValidatorContext, type ValidatorFinding } from './rules.js';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
+}
+
+/** Convert an unknown tool result into a single best-effort string for regex
+ *  matching against UE error text. */
+function resultText(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v && typeof v === 'object') return JSON.stringify(v);
+  return String(v ?? '');
+}
+
+// ── pcg_zero_instances_after_execute ────────────────────────────────────────
+//
+// After pcg_execute_graph returns with componentsExecuted > 0, issue a
+// follow-up python_run to count HISM/ISM instances. If the total is zero we
+// emit the finding. Falls back to "skip silently" if anything goes wrong —
+// we don't want to drown the user in noise.
+
+const PCG_COUNTER_SCRIPT = `
+import json, os, unreal
+out = {"total": 0, "actors": 0}
+sub = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
+if sub:
+    for actor in sub.get_all_level_actors():
+        if not isinstance(actor, unreal.Actor):
+            continue
+        for comp in actor.get_components_by_class(unreal.HierarchicalInstancedStaticMeshComponent):
+            try:
+                out["total"] += int(comp.get_instance_count())
+                out["actors"] += 1
+            except Exception:
+                pass
+        for comp in actor.get_components_by_class(unreal.InstancedStaticMeshComponent):
+            try:
+                out["total"] += int(comp.get_instance_count())
+                out["actors"] += 1
+            except Exception:
+                pass
+out_path = os.path.join(unreal.SystemLibrary.get_project_directory(), ".scratch", "validator_pcg_instance_count.json")
+os.makedirs(os.path.dirname(out_path), exist_ok=True)
+with open(out_path, "w") as f:
+    json.dump(out, f)
+print(json.dumps(out))
+`;
+
+async function evaluatePcgZeroInstances(ctx: ValidatorContext): Promise<ValidatorFinding | null> {
+  const result = asRecord(ctx.toolResult);
+  const componentsExecuted = Number(result.componentsExecuted ?? 0);
+  if (componentsExecuted <= 0) return null;
+  if (!ctx.ue) return null;
+
+  // Send the counter script. Use a generous timeout — walking the world can
+  // be slow on big levels.
+  let resp;
+  try {
+    resp = await ctx.ue.send('python_run', { script: PCG_COUNTER_SCRIPT, allow_unsafe: true }, 15_000);
+  } catch {
+    return null;
+  }
+  if (!resp.ok) return null;
+
+  const outPath = join(ctx.scratchDir, 'validator_pcg_instance_count.json');
+  let total = -1;
+  if (existsSync(outPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(outPath, 'utf-8')) as { total?: number };
+      total = Number(parsed.total ?? 0);
+    } catch {
+      total = -1;
+    } finally {
+      try { unlinkSync(outPath); } catch { /* swallow */ }
+    }
+  } else {
+    // Fall back to the print() value embedded in the response.
+    const data = asRecord(resp.data);
+    const printed = typeof data.stdout === 'string' ? data.stdout : '';
+    const m = printed.match(/\{[^}]*"total"\s*:\s*(\d+)/);
+    if (m) total = Number(m[1]);
+  }
+
+  if (total !== 0) return null;
+
+  return {
+    ruleId: 'pcg_zero_instances_after_execute',
+    severity: 'warning',
+    message: 'PCG graph executed but produced 0 instances in the world',
+    hint: 'The graph ran (componentsExecuted > 0) but no HISM/ISM instances exist on any actor. Common causes: Surface Sampler bound to a non-landscape source, all points culled by a Density filter, or output pin not wired to a Static Mesh Spawner.',
+    refs: ['[[pcg-surface-sampler-needs-landscape]]'],
+    context: {
+      graph: ctx.toolArgs.assetPath ?? ctx.toolArgs.graphPath ?? null,
+      componentsExecuted,
+      instances: 0,
+    },
+    timestamp: nowIso(),
+    toolName: ctx.toolName,
+  };
+}
+
+// ── pcg_execute_no_component_in_world ───────────────────────────────────────
+
+async function evaluatePcgNoComponentInWorld(ctx: ValidatorContext): Promise<ValidatorFinding | null> {
+  const text = resultText(ctx.toolResult);
+  if (!/No PCGComponents? found using this graph/i.test(text)) return null;
+  return {
+    ruleId: 'pcg_execute_no_component_in_world',
+    severity: 'warning',
+    message: 'No PCGComponent in the level is bound to the executed graph',
+    hint: 'pcg_execute_graph found 0 PCGComponents referencing this graph. Drop a PCGVolume into the level and assign the graph, or spawn one with actor_spawn before re-executing.',
+    refs: ['[[pcg-execute-needs-component]]'],
+    context: { graph: ctx.toolArgs.assetPath ?? ctx.toolArgs.graphPath ?? null },
+    timestamp: nowIso(),
+    toolName: ctx.toolName,
+  };
+}
+
+// ── pcg_asset_not_found ─────────────────────────────────────────────────────
+
+async function evaluatePcgAssetNotFound(ctx: ValidatorContext): Promise<ValidatorFinding | null> {
+  const text = resultText(ctx.toolResult);
+  if (!/(asset not found|could not load asset|invalid asset path|failed to load PCG ?Graph)/i.test(text)) return null;
+  return {
+    ruleId: 'pcg_asset_not_found',
+    severity: 'error',
+    message: 'PCG asset path could not be resolved',
+    hint: 'Double-check the path (must start with /Game/) and list candidates with hayba_list_pcg_assets.',
+    refs: ['[[pcg-asset-path-resolution]]'],
+    context: { assetPath: ctx.toolArgs.assetPath ?? null },
+    timestamp: nowIso(),
+    toolName: ctx.toolName,
+  };
+}
+
+// ── landscape_import_no_landscape_in_world ──────────────────────────────────
+
+const LANDSCAPE_COUNTER_SCRIPT = `
+import json, os, unreal
+count = 0
+sub = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
+if sub:
+    for a in sub.get_all_level_actors():
+        if isinstance(a, unreal.LandscapeProxy):
+            count += 1
+out_path = os.path.join(unreal.SystemLibrary.get_project_directory(), ".scratch", "validator_landscape_count.json")
+os.makedirs(os.path.dirname(out_path), exist_ok=True)
+with open(out_path, "w") as f:
+    json.dump({"count": count}, f)
+print(json.dumps({"count": count}))
+`;
+
+async function evaluateLandscapeImportSilentFailure(ctx: ValidatorContext): Promise<ValidatorFinding | null> {
+  const result = asRecord(ctx.toolResult);
+  // Only fire when the tool claims success.
+  if (result.ok === false) return null;
+  if (!ctx.ue) return null;
+
+  let resp;
+  try {
+    resp = await ctx.ue.send('python_run', { script: LANDSCAPE_COUNTER_SCRIPT, allow_unsafe: true }, 10_000);
+  } catch {
+    return null;
+  }
+  if (!resp.ok) return null;
+
+  const outPath = join(ctx.scratchDir, 'validator_landscape_count.json');
+  let count = -1;
+  if (existsSync(outPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(outPath, 'utf-8')) as { count?: number };
+      count = Number(parsed.count ?? 0);
+    } catch {
+      count = -1;
+    } finally {
+      try { unlinkSync(outPath); } catch { /* swallow */ }
+    }
+  }
+
+  if (count !== 0) return null;
+
+  return {
+    ruleId: 'landscape_import_no_landscape_in_world',
+    severity: 'error',
+    message: 'landscape_import returned success but no LandscapeProxy exists in the world',
+    hint: 'Check the editor output log filtered by `LogHaybaMCPImporter` for the underlying error.',
+    refs: ['[[landscape-import-silent-failure]]'],
+    context: { args: ctx.toolArgs },
+    timestamp: nowIso(),
+    toolName: ctx.toolName,
+  };
+}
+
+// ── asset_browse_describe_assets_missing ────────────────────────────────────
+
+async function evaluateAssetBrowseDescribeMissing(ctx: ValidatorContext): Promise<ValidatorFinding | null> {
+  const text = resultText(ctx.toolResult);
+  if (!/Unknown command:\s*describe_assets/i.test(text)) return null;
+  return {
+    ruleId: 'asset_browse_describe_assets_missing',
+    severity: 'warning',
+    message: 'UE responded "Unknown command: describe_assets" — the plugin is out of date',
+    hint: 'Rebuild HaybaMCPToolkit from source, or fall back to python_run with unreal.EditorAssetLibrary.list_assets().',
+    refs: ['[[asset-browse-plugin-out-of-date]]'],
+    timestamp: nowIso(),
+    toolName: ctx.toolName,
+  };
+}
+
+// ── tcp_socket_to_self_in_python_run (post-condition only — pre-flight is
+//    enforced separately in python-run-validator-wrap.ts) ──────────────────
+
+async function evaluatePythonRunSelfSocket(ctx: ValidatorContext): Promise<ValidatorFinding | null> {
+  const script = String(asRecord(ctx.toolArgs).script ?? '');
+  if (!isSelfSocketScript(script)) return null;
+  return {
+    ruleId: 'tcp_socket_to_self_in_python_run',
+    severity: 'error',
+    message: 'python_run script opens a TCP socket to the UE plugin port (would deadlock)',
+    hint: 'Use the Python plugin API (`unreal.*`) directly instead of round-tripping through the TCP server (52342–52350).',
+    refs: ['[[python-run-no-self-connect]]'],
+    timestamp: nowIso(),
+    toolName: ctx.toolName,
+  };
+}
+
+/** Shared by both the post-condition above and the pre-flight wrapper.
+ *  Matches any `<name>.connect(("127.0.0.1"|"localhost", PORT))` where
+ *  PORT is in the UE plugin range 52342..52350. */
+export function isSelfSocketScript(script: string): boolean {
+  const re = /\.\s*connect\s*\(\s*\(\s*['"](?:127\.0\.0\.1|localhost)['"]\s*,\s*(\d+)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(script)) !== null) {
+    const port = Number(m[1]);
+    if (port >= 52342 && port <= 52350) return true;
+  }
+  return false;
+}
+
+// ── installer ───────────────────────────────────────────────────────────────
+
+let INSTALLED = false;
+
+export function installToolHooks(): void {
+  if (INSTALLED) return;
+  INSTALLED = true;
+  attachEvaluator('pcg_zero_instances_after_execute',  evaluatePcgZeroInstances);
+  attachEvaluator('pcg_execute_no_component_in_world', evaluatePcgNoComponentInWorld);
+  attachEvaluator('pcg_asset_not_found',                evaluatePcgAssetNotFound);
+  attachEvaluator('landscape_import_no_landscape_in_world', evaluateLandscapeImportSilentFailure);
+  attachEvaluator('asset_browse_describe_assets_missing',   evaluateAssetBrowseDescribeMissing);
+  attachEvaluator('tcp_socket_to_self_in_python_run',       evaluatePythonRunSelfSocket);
+}
+
+/** Re-export so the test suite can reset between runs. */
+export function _resetToolHooksForTests(): void {
+  INSTALLED = false;
+}

--- a/mcp-tools/hayba-mcp/tests/routing-integration.test.ts
+++ b/mcp-tools/hayba-mcp/tests/routing-integration.test.ts
@@ -21,6 +21,14 @@ function fixtureCaptured(): Map<string, CapturedTool> {
     ['get_tool_signature',          'code-mode'],
     ['hayba_check_ue_status',       null],
     ['editor_capture_viewport',     'editor'],
+    // Validator tools — captured under the validator dir so deferred routing
+    // can re-register them as always-on via passthrough.
+    ['validator_run',               'validator'],
+    ['validator_history',           'validator'],
+    ['validator_resolve',           'validator'],
+    ['validator_clear',             'validator'],
+    ['validator_rules',             'validator'],
+    ['validator_set_rule_enabled',  'validator'],
   ];
   for (const [name, dir] of tools) {
     const schema: z.ZodRawShape = { foo: z.string().optional() };

--- a/unreal/HaybaMCPToolkit/Docs/validator-history-format.md
+++ b/unreal/HaybaMCPToolkit/Docs/validator-history-format.md
@@ -1,0 +1,87 @@
+# Validator history format
+
+The MCP server persists every validator finding it produces (post-condition
+or manual run) to a JSONL file. Each line is one self-contained JSON object.
+
+## File location
+
+Default: `<project_root>/.scratch/validator-history.jsonl`
+
+Override with the environment variable `HAYBA_VALIDATOR_HISTORY` set to an
+absolute file path. Both the MCP server and the UE plugin's Validator panel
+honour the same override, so they see the same file.
+
+## Schema
+
+Each line:
+
+```json
+{
+  "ruleId": "pcg_zero_instances_after_execute",
+  "severity": "warning",
+  "message": "PCG graph executed but produced 0 instances in the world",
+  "hint": "The graph ran (componentsExecuted > 0) but no HISM/ISM instances exist...",
+  "refs": ["[[pcg-surface-sampler-needs-landscape]]"],
+  "context": {
+    "graph": "/Game/MyGraph",
+    "componentsExecuted": 1,
+    "instances": 0
+  },
+  "timestamp": "2026-05-23T01:23:45.678Z",
+  "toolName": "hayba_execute_pcg_graph",
+  "resolved": false
+}
+```
+
+Required fields: `ruleId`, `severity`, `message`, `hint`, `timestamp`, `toolName`.
+
+Optional fields:
+- `refs: string[]` — memory slugs the finding cross-references.
+- `context: object` — rule-specific payload. The UE plugin looks at:
+  - `actor_label` / `actorLabel` and `actor_id` / `actorId` for the
+    "Jump to actor" button.
+  - `graph` (PCG asset path) for context display.
+  Anything else is ignored by the panel but preserved on round-trip.
+- `resolved: boolean` — `true` once the user dismisses the finding via the
+  plugin UI or the `validator_resolve` MCP tool.
+- `resolvedAt: string (ISO)` — set when `resolved` becomes true.
+
+## Round-tripping
+
+The plugin reads, edits (resolved/resolvedAt), and rewrites the file in
+full when the user clicks Dismiss / Restore / Clear All. All other fields,
+including unknown keys, are preserved through the round-trip.
+
+The MCP server appends new findings to the file as they happen; the
+plugin watches the parent directory and re-reads on any change to the
+file (debounce via the OS file watcher, not the plugin).
+
+## Severity colours in the panel
+
+| severity | colour          |
+|----------|-----------------|
+| error    | red (1, 0.3, 0.3)   |
+| warning  | yellow (1, 0.85, 0.2) |
+| info     | blue (0.55, 0.7, 1) |
+
+## Manual testing the panel
+
+1. Run the MCP server with the validator wired in (`npm run build && npm start`).
+2. From an agent, trigger a known-floppy tool call — e.g. invoke
+   `hayba_execute_pcg_graph` against a graph whose Surface Sampler is bound
+   to a non-landscape source. The validator should produce a
+   `pcg_zero_instances_after_execute` finding and write it to the JSONL
+   file.
+3. Open the Hayba MCP Toolkit panel in UE → Validation tab. The new
+   finding should appear within ~1s.
+4. Click "Dismiss" on the row. The `resolved` field flips to `true` and
+   the row disappears (unless "Include resolved" is checked).
+5. Click "Clear All" to truncate the history.
+
+## Forward compatibility
+
+When adding new fields to a finding on the TS side, mirror them in
+`SHaybaValidatorPanel.h::FHaybaValidatorFinding` and update the parser /
+serialiser in `SHaybaValidatorPanel.cpp`. The plugin already preserves
+unknown fields via `RawJson`, so out-of-date plugin builds will still
+round-trip findings without dropping data.

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPMainPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPMainPanel.cpp
@@ -7,6 +7,7 @@
 #include "HaybaMCPPlanPanel.h"
 #include "HaybaMCPDiffPanel.h"
 #include "HaybaMCPValidationPanel.h"
+#include "Slate/SHaybaValidatorPanel.h"
 #include "HaybaMCPMemoryPanel.h"
 #include "HaybaMCPCapabilitiesPanel.h"
 #include "HaybaMCPSceneMapWebPanel.h"
@@ -443,9 +444,11 @@ TSharedRef<SWidget> SHaybaMCPMainPanel::BuildPanelContent(EHaybaPanel Panel)
         }
         case EHaybaPanel::Validation:
         {
-            Subtitle = NSLOCTEXT("Hayba", "Val.Sub", "Physics overlaps and scene issues.");
-            auto Panel2 = SNew(SHaybaMCPValidationPanel);
-            if (Module) Module->ValidationPanel = Panel2;
+            Subtitle = NSLOCTEXT("Hayba", "Val.Sub",
+                "Runtime validator: post-condition findings and AI-floppy hints. Findings persist in .scratch/validator-history.jsonl.");
+            auto Panel2 = SNew(SHaybaValidatorPanel);
+            // Re-shown from cache → re-read the JSONL file.
+            PanelRefreshHook.Add(EHaybaPanel::Validation, [Panel2]() { Panel2->Refresh(); });
             Body = Panel2;
             break;
         }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slate/SHaybaValidatorPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slate/SHaybaValidatorPanel.cpp
@@ -1,0 +1,524 @@
+// SHaybaValidatorPanel.cpp
+#include "Slate/SHaybaValidatorPanel.h"
+
+#include "DirectoryWatcherModule.h"
+#include "Editor.h"
+#include "Engine/Selection.h"
+#include "GameFramework/Actor.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformProcess.h"
+#include "IDirectoryWatcher.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Modules/ModuleManager.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonWriter.h"
+#include "Subsystems/EditorActorSubsystem.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SSearchBox.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Views/SHeaderRow.h"
+#include "Widgets/Views/STableRow.h"
+
+namespace
+{
+    const FName ColSeverity("Severity");
+    const FName ColRuleId("RuleId");
+    const FName ColMessage("Message");
+    const FName ColTool("Tool");
+    const FName ColTime("Time");
+    const FName ColActions("Actions");
+
+    FSlateColor ColorForSeverity(const FString& Sev)
+    {
+        if (Sev == TEXT("error"))   return FSlateColor(FLinearColor(1.f, 0.3f, 0.3f));
+        if (Sev == TEXT("warning")) return FSlateColor(FLinearColor(1.f, 0.85f, 0.2f));
+        return FSlateColor(FLinearColor(0.55f, 0.7f, 1.f));
+    }
+
+    /** Trim long strings for the table; full text is in the tooltip. */
+    FString Truncate(const FString& S, int32 Max)
+    {
+        if (S.Len() <= Max) return S;
+        return S.Left(Max - 1) + TEXT("…");
+    }
+
+    /** Per-row table widget. */
+    class SValidatorTableRow : public SMultiColumnTableRow<TSharedPtr<FHaybaValidatorFinding>>
+    {
+    public:
+        SLATE_BEGIN_ARGS(SValidatorTableRow) {}
+            SLATE_ARGUMENT(TSharedPtr<FHaybaValidatorFinding>, Item)
+            SLATE_ARGUMENT(SHaybaValidatorPanel*, Panel)
+        SLATE_END_ARGS()
+
+        void Construct(const FArguments& InArgs, const TSharedRef<STableViewBase>& Owner)
+        {
+            Item = InArgs._Item;
+            Panel = InArgs._Panel;
+            SMultiColumnTableRow::Construct(FSuperRowType::FArguments(), Owner);
+        }
+
+        virtual TSharedRef<SWidget> GenerateWidgetForColumn(const FName& Column) override
+        {
+            if (!Item.IsValid()) return SNullWidget::NullWidget;
+
+            if (Column == ColSeverity)
+            {
+                return SNew(SBorder)
+                    .Padding(FMargin(6, 2))
+                    .BorderBackgroundColor(ColorForSeverity(Item->Severity))
+                    [
+                        SNew(STextBlock)
+                        .Text(FText::FromString(Item->Severity.ToUpper()))
+                        .ColorAndOpacity(FSlateColor(FLinearColor::White))
+                    ];
+            }
+            if (Column == ColRuleId)
+            {
+                return SNew(STextBlock)
+                    .Margin(FMargin(6, 3))
+                    .Text(FText::FromString(Item->RuleId))
+                    .ToolTipText(FText::FromString(Item->Hint));
+            }
+            if (Column == ColMessage)
+            {
+                return SNew(STextBlock)
+                    .Margin(FMargin(6, 3))
+                    .Text(FText::FromString(Truncate(Item->Message, 120)))
+                    .ToolTipText(FText::FromString(Item->Message + TEXT("\n\nHint: ") + Item->Hint));
+            }
+            if (Column == ColTool)
+            {
+                return SNew(STextBlock)
+                    .Margin(FMargin(6, 3))
+                    .Text(FText::FromString(Item->ToolName));
+            }
+            if (Column == ColTime)
+            {
+                return SNew(STextBlock)
+                    .Margin(FMargin(6, 3))
+                    .Text(FText::FromString(Truncate(Item->Timestamp, 19)));
+            }
+            if (Column == ColActions)
+            {
+                TSharedRef<SHorizontalBox> Box = SNew(SHorizontalBox);
+                Box->AddSlot().AutoWidth().Padding(2)
+                [
+                    SNew(SButton)
+                    .ContentPadding(FMargin(6, 2))
+                    .ToolTipText(FText::FromString(TEXT("Mark this finding as resolved (or restore it).")))
+                    .OnClicked_Lambda([this]() -> FReply {
+                        if (Panel) return Panel->OnDismissClicked_Public(Item);
+                        return FReply::Handled();
+                    })
+                    [ SNew(STextBlock).Text(FText::FromString(Item->bResolved ? TEXT("Restore") : TEXT("Dismiss"))) ]
+                ];
+                if (!Item->ActorLabel.IsEmpty() || !Item->ActorId.IsEmpty())
+                {
+                    Box->AddSlot().AutoWidth().Padding(2)
+                    [
+                        SNew(SButton)
+                        .ContentPadding(FMargin(6, 2))
+                        .ToolTipText(FText::FromString(TEXT("Select the actor referenced by this finding and frame it in the viewport.")))
+                        .OnClicked_Lambda([this]() -> FReply {
+                            if (Panel) return Panel->OnJumpToActorClicked_Public(Item);
+                            return FReply::Handled();
+                        })
+                        [ SNew(STextBlock).Text(FText::FromString(TEXT("Jump"))) ]
+                    ];
+                }
+                return Box;
+            }
+            return SNullWidget::NullWidget;
+        }
+
+    private:
+        TSharedPtr<FHaybaValidatorFinding> Item;
+        SHaybaValidatorPanel* Panel = nullptr;
+    };
+}
+
+FReply SHaybaValidatorPanel::OnDismissClicked(TSharedPtr<FHaybaValidatorFinding> Item)
+{
+    if (!Item.IsValid()) return FReply::Handled();
+    Item->bResolved = !Item->bResolved;
+    Item->ResolvedAt = Item->bResolved ? FDateTime::UtcNow().ToIso8601() : FString();
+    WriteAllFindings(AllItems);
+    ApplyFilter();
+    return FReply::Handled();
+}
+FReply SHaybaValidatorPanel::OnJumpToActorClicked(TSharedPtr<FHaybaValidatorFinding> Item)
+{
+    if (!Item.IsValid()) return FReply::Handled();
+    if (!GEditor) return FReply::Handled();
+
+    UEditorActorSubsystem* Sub = GEditor->GetEditorSubsystem<UEditorActorSubsystem>();
+    if (!Sub) return FReply::Handled();
+
+    AActor* Match = nullptr;
+    for (AActor* A : Sub->GetAllLevelActors())
+    {
+        if (!A) continue;
+        if (!Item->ActorId.IsEmpty() && A->GetName() == Item->ActorId) { Match = A; break; }
+        if (!Item->ActorLabel.IsEmpty() && A->GetActorLabel() == Item->ActorLabel) { Match = A; break; }
+    }
+    if (Match)
+    {
+        GEditor->SelectNone(false, true);
+        GEditor->SelectActor(Match, true, true, true);
+        GEditor->MoveViewportCamerasToActor(*Match, false);
+    }
+    return FReply::Handled();
+}
+
+// Public bridge methods used by the table-row class — defined here so the
+// member access checker is satisfied without making the row a friend.
+FReply SHaybaValidatorPanel::OnDismissClicked_Public(TSharedPtr<FHaybaValidatorFinding> Item) { return OnDismissClicked(Item); }
+FReply SHaybaValidatorPanel::OnJumpToActorClicked_Public(TSharedPtr<FHaybaValidatorFinding> Item) { return OnJumpToActorClicked(Item); }
+
+// ── Path helpers ───────────────────────────────────────────────────────────
+
+FString SHaybaValidatorPanel::DefaultScratchDir()
+{
+    FString Override = FPlatformMisc::GetEnvironmentVariable(TEXT("HAYBA_VALIDATOR_HISTORY"));
+    if (!Override.IsEmpty())
+    {
+        return FPaths::GetPath(Override);
+    }
+    return FPaths::Combine(FPaths::ProjectDir(), TEXT(".scratch"));
+}
+
+FString SHaybaValidatorPanel::DefaultHistoryPath()
+{
+    FString Override = FPlatformMisc::GetEnvironmentVariable(TEXT("HAYBA_VALIDATOR_HISTORY"));
+    if (!Override.IsEmpty()) return Override;
+    return FPaths::Combine(DefaultScratchDir(), TEXT("validator-history.jsonl"));
+}
+
+// ── Construct ──────────────────────────────────────────────────────────────
+
+void SHaybaValidatorPanel::Construct(const FArguments& InArgs)
+{
+    HistoryFile = DefaultHistoryPath();
+    WatchedDir  = FPaths::GetPath(HistoryFile);
+    IFileManager::Get().MakeDirectory(*WatchedDir, /*Tree*/true);
+
+    ChildSlot
+    [
+        SNew(SVerticalBox)
+
+        // ── Header row ────────────────────────────────────────────────
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().FillWidth(1.f).VAlign(VAlign_Center).Padding(4, 0)
+            [ SAssignNew(HeaderText, STextBlock).Text(FText::FromString(TEXT("Validator history"))) ]
+            + SHorizontalBox::Slot().AutoWidth().Padding(2)
+            [
+                SNew(SButton)
+                .ContentPadding(FMargin(8, 3))
+                .ToolTipText(FText::FromString(TEXT("Re-run every validator rule with an active evaluator.")))
+                .OnClicked(this, &SHaybaValidatorPanel::OnReRunAllClicked)
+                [ SNew(STextBlock).Text(FText::FromString(TEXT("Re-run All"))) ]
+            ]
+            + SHorizontalBox::Slot().AutoWidth().Padding(2)
+            [
+                SNew(SButton)
+                .ContentPadding(FMargin(8, 3))
+                .ToolTipText(FText::FromString(TEXT("Wipe the validator history. Findings can no longer be restored after this.")))
+                .OnClicked(this, &SHaybaValidatorPanel::OnClearAllClicked)
+                [ SNew(STextBlock).Text(FText::FromString(TEXT("Clear All"))) ]
+            ]
+        ]
+
+        // ── Filter bar ────────────────────────────────────────────────
+        + SVerticalBox::Slot().AutoHeight().Padding(4)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot().FillWidth(1.f).VAlign(VAlign_Center).Padding(2)
+            [
+                SNew(SSearchBox)
+                .HintText(FText::FromString(TEXT("Search rule id, message, tool…")))
+                .OnTextChanged_Lambda([this](const FText& T)
+                {
+                    SearchText = T.ToString();
+                    ApplyFilter();
+                })
+            ]
+            + SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(6, 2)
+            [
+                SNew(SCheckBox)
+                .IsChecked(ECheckBoxState::Checked)
+                .ToolTipText(FText::FromString(TEXT("Show error findings.")))
+                .OnCheckStateChanged_Lambda([this](ECheckBoxState S) { bShowError = (S == ECheckBoxState::Checked); ApplyFilter(); })
+                [ SNew(STextBlock).Text(FText::FromString(TEXT("Errors"))) ]
+            ]
+            + SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(6, 2)
+            [
+                SNew(SCheckBox)
+                .IsChecked(ECheckBoxState::Checked)
+                .ToolTipText(FText::FromString(TEXT("Show warning findings.")))
+                .OnCheckStateChanged_Lambda([this](ECheckBoxState S) { bShowWarning = (S == ECheckBoxState::Checked); ApplyFilter(); })
+                [ SNew(STextBlock).Text(FText::FromString(TEXT("Warnings"))) ]
+            ]
+            + SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(6, 2)
+            [
+                SNew(SCheckBox)
+                .IsChecked(ECheckBoxState::Checked)
+                .ToolTipText(FText::FromString(TEXT("Show info findings.")))
+                .OnCheckStateChanged_Lambda([this](ECheckBoxState S) { bShowInfo = (S == ECheckBoxState::Checked); ApplyFilter(); })
+                [ SNew(STextBlock).Text(FText::FromString(TEXT("Info"))) ]
+            ]
+            + SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(6, 2)
+            [
+                SNew(SCheckBox)
+                .IsChecked(ECheckBoxState::Unchecked)
+                .ToolTipText(FText::FromString(TEXT("Include findings that have been dismissed.")))
+                .OnCheckStateChanged_Lambda([this](ECheckBoxState S) { bIncludeResolved = (S == ECheckBoxState::Checked); ApplyFilter(); })
+                [ SNew(STextBlock).Text(FText::FromString(TEXT("Include resolved"))) ]
+            ]
+        ]
+
+        // ── Table ──────────────────────────────────────────────────────
+        + SVerticalBox::Slot().FillHeight(1.f).Padding(4)
+        [
+            SAssignNew(ListView, SListView<TSharedPtr<FHaybaValidatorFinding>>)
+            .ListItemsSource(&FilteredItems)
+            .OnGenerateRow(this, &SHaybaValidatorPanel::OnGenerateRow)
+            .OnSelectionChanged(this, &SHaybaValidatorPanel::OnSelectionChanged)
+            .SelectionMode(ESelectionMode::Single)
+            .HeaderRow(
+                SNew(SHeaderRow)
+                + SHeaderRow::Column(ColSeverity).DefaultLabel(FText::FromString(TEXT("Severity"))).FixedWidth(80)
+                + SHeaderRow::Column(ColRuleId).DefaultLabel(FText::FromString(TEXT("Rule"))).FillWidth(0.22f)
+                + SHeaderRow::Column(ColMessage).DefaultLabel(FText::FromString(TEXT("Message"))).FillWidth(0.42f)
+                + SHeaderRow::Column(ColTool).DefaultLabel(FText::FromString(TEXT("Tool"))).FillWidth(0.16f)
+                + SHeaderRow::Column(ColTime).DefaultLabel(FText::FromString(TEXT("When"))).FillWidth(0.14f)
+                + SHeaderRow::Column(ColActions).DefaultLabel(FText::FromString(TEXT("Actions"))).FillWidth(0.16f)
+            )
+        ]
+    ];
+
+    // ── Watch the scratch dir for any change to the JSONL file. ─────
+    if (FDirectoryWatcherModule* DWM =
+            FModuleManager::Get().GetModulePtr<FDirectoryWatcherModule>(TEXT("DirectoryWatcher")))
+    {
+        if (IDirectoryWatcher* Watcher = DWM->Get())
+        {
+            Watcher->RegisterDirectoryChangedCallback_Handle(
+                WatchedDir,
+                IDirectoryWatcher::FDirectoryChanged::CreateSP(this, &SHaybaValidatorPanel::OnDirectoryChanged),
+                WatcherHandle);
+        }
+    }
+
+    Refresh();
+}
+
+SHaybaValidatorPanel::~SHaybaValidatorPanel()
+{
+    if (WatcherHandle.IsValid())
+    {
+        if (FDirectoryWatcherModule* DWM =
+                FModuleManager::Get().GetModulePtr<FDirectoryWatcherModule>(TEXT("DirectoryWatcher")))
+        {
+            if (IDirectoryWatcher* Watcher = DWM->Get())
+            {
+                Watcher->UnregisterDirectoryChangedCallback_Handle(WatchedDir, WatcherHandle);
+            }
+        }
+    }
+}
+
+// ── Refresh / parse ────────────────────────────────────────────────────────
+
+void SHaybaValidatorPanel::Refresh()
+{
+    AllItems.Reset();
+    FString Buffer;
+    if (FFileHelper::LoadFileToString(Buffer, *HistoryFile))
+    {
+        TArray<FString> Lines;
+        Buffer.ParseIntoArrayLines(Lines, /*CullEmpty*/true);
+        for (const FString& Line : Lines)
+        {
+            if (TSharedPtr<FHaybaValidatorFinding> F = ParseFindingLine(Line))
+            {
+                AllItems.Add(F);
+            }
+        }
+    }
+    ApplyFilter();
+    UpdateHeader();
+}
+
+TSharedPtr<FHaybaValidatorFinding> SHaybaValidatorPanel::ParseFindingLine(const FString& Line)
+{
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Line);
+    TSharedPtr<FJsonObject> Obj;
+    if (!FJsonSerializer::Deserialize(Reader, Obj) || !Obj.IsValid()) return nullptr;
+
+    TSharedRef<FHaybaValidatorFinding> F = MakeShared<FHaybaValidatorFinding>();
+    F->RawJson    = Line;
+    F->RuleId     = Obj->GetStringField(TEXT("ruleId"));
+    F->Severity   = Obj->GetStringField(TEXT("severity"));
+    F->Message    = Obj->GetStringField(TEXT("message"));
+    F->Hint       = Obj->GetStringField(TEXT("hint"));
+    F->Timestamp  = Obj->GetStringField(TEXT("timestamp"));
+    F->ToolName   = Obj->GetStringField(TEXT("toolName"));
+    F->bResolved  = Obj->HasField(TEXT("resolved")) && Obj->GetBoolField(TEXT("resolved"));
+    F->ResolvedAt = Obj->HasField(TEXT("resolvedAt")) ? Obj->GetStringField(TEXT("resolvedAt")) : FString();
+
+    const TArray<TSharedPtr<FJsonValue>>* RefsArr = nullptr;
+    if (Obj->TryGetArrayField(TEXT("refs"), RefsArr))
+    {
+        for (const TSharedPtr<FJsonValue>& V : *RefsArr)
+            if (V.IsValid() && V->Type == EJson::String) F->Refs.Add(V->AsString());
+    }
+
+    const TSharedPtr<FJsonObject>* Ctx = nullptr;
+    if (Obj->TryGetObjectField(TEXT("context"), Ctx) && Ctx->IsValid())
+    {
+        FString S;
+        if ((*Ctx)->TryGetStringField(TEXT("actor_label"), S)) F->ActorLabel = S;
+        if ((*Ctx)->TryGetStringField(TEXT("actorLabel"),  S)) F->ActorLabel = S;
+        if ((*Ctx)->TryGetStringField(TEXT("actor_id"),    S)) F->ActorId    = S;
+        if ((*Ctx)->TryGetStringField(TEXT("actorId"),     S)) F->ActorId    = S;
+        if ((*Ctx)->TryGetStringField(TEXT("graph"),       S)) F->GraphPath  = S;
+    }
+
+    return F;
+}
+
+FString SHaybaValidatorPanel::FindingToJson(const FHaybaValidatorFinding& F)
+{
+    TSharedRef<FJsonObject> Obj = MakeShared<FJsonObject>();
+    // Start with the original JSON so we preserve fields we don't model
+    // (context, refs, custom keys). Then overlay any panel-modified fields.
+    if (!F.RawJson.IsEmpty())
+    {
+        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(F.RawJson);
+        TSharedPtr<FJsonObject> Existing;
+        if (FJsonSerializer::Deserialize(Reader, Existing) && Existing.IsValid())
+        {
+            Obj = Existing.ToSharedRef();
+        }
+    }
+    Obj->SetStringField(TEXT("ruleId"),    F.RuleId);
+    Obj->SetStringField(TEXT("severity"),  F.Severity);
+    Obj->SetStringField(TEXT("message"),   F.Message);
+    Obj->SetStringField(TEXT("hint"),      F.Hint);
+    Obj->SetStringField(TEXT("timestamp"), F.Timestamp);
+    Obj->SetStringField(TEXT("toolName"),  F.ToolName);
+    Obj->SetBoolField  (TEXT("resolved"),  F.bResolved);
+    if (F.bResolved && !F.ResolvedAt.IsEmpty())
+        Obj->SetStringField(TEXT("resolvedAt"), F.ResolvedAt);
+    else
+        Obj->RemoveField(TEXT("resolvedAt"));
+
+    FString Out;
+    TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+        TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
+    FJsonSerializer::Serialize(Obj, Writer);
+    return Out;
+}
+
+void SHaybaValidatorPanel::ApplyFilter()
+{
+    FilteredItems.Reset();
+    const FString Needle = SearchText.TrimStartAndEnd().ToLower();
+    for (const TSharedPtr<FHaybaValidatorFinding>& F : AllItems)
+    {
+        if (!F.IsValid()) continue;
+        if (!bIncludeResolved && F->bResolved) continue;
+        if (F->Severity == TEXT("error")   && !bShowError)   continue;
+        if (F->Severity == TEXT("warning") && !bShowWarning) continue;
+        if (F->Severity == TEXT("info")    && !bShowInfo)    continue;
+        if (!Needle.IsEmpty())
+        {
+            const bool bMatch =
+                F->RuleId.ToLower().Contains(Needle) ||
+                F->Message.ToLower().Contains(Needle) ||
+                F->ToolName.ToLower().Contains(Needle);
+            if (!bMatch) continue;
+        }
+        FilteredItems.Add(F);
+    }
+    if (ListView) ListView->RequestListRefresh();
+    UpdateHeader();
+}
+
+void SHaybaValidatorPanel::UpdateHeader()
+{
+    if (!HeaderText.IsValid()) return;
+    int32 Unresolved = 0;
+    for (const TSharedPtr<FHaybaValidatorFinding>& F : AllItems)
+        if (F.IsValid() && !F->bResolved) ++Unresolved;
+    HeaderText->SetText(FText::FromString(FString::Printf(
+        TEXT("Validator history — %d findings (%d unresolved)"),
+        AllItems.Num(), Unresolved)));
+}
+
+TSharedRef<ITableRow> SHaybaValidatorPanel::OnGenerateRow(
+    TSharedPtr<FHaybaValidatorFinding> Item, const TSharedRef<STableViewBase>& Owner)
+{
+    return SNew(SValidatorTableRow, Owner).Item(Item).Panel(this);
+}
+
+void SHaybaValidatorPanel::OnSelectionChanged(TSharedPtr<FHaybaValidatorFinding> Item, ESelectInfo::Type)
+{
+    Selected = Item;
+}
+
+void SHaybaValidatorPanel::OnDirectoryChanged(const TArray<FFileChangeData>& Changes)
+{
+    for (const FFileChangeData& C : Changes)
+    {
+        if (FPaths::GetCleanFilename(C.Filename).Equals(FPaths::GetCleanFilename(HistoryFile), ESearchCase::IgnoreCase))
+        {
+            Refresh();
+            return;
+        }
+    }
+}
+
+FReply SHaybaValidatorPanel::OnClearAllClicked()
+{
+    // Truncate the file. Same effect as the validator_clear MCP tool.
+    FFileHelper::SaveStringToFile(FString(), *HistoryFile);
+    AllItems.Reset();
+    ApplyFilter();
+    UpdateHeader();
+    return FReply::Handled();
+}
+
+FReply SHaybaValidatorPanel::OnReRunAllClicked()
+{
+    // The panel is decoupled from the MCP transport, so we leave actual rule
+    // execution to the agent / validator_run MCP tool. Provide a hint via the
+    // header text so the user knows the click was registered.
+    if (HeaderText.IsValid())
+    {
+        HeaderText->SetText(FText::FromString(TEXT(
+            "Validator — invoke `validator_run {scope:'all'}` from the agent to re-evaluate all rules.")));
+    }
+    return FReply::Handled();
+}
+
+bool SHaybaValidatorPanel::WriteAllFindings(const TArray<TSharedPtr<FHaybaValidatorFinding>>& Findings) const
+{
+    FString Buffer;
+    for (const TSharedPtr<FHaybaValidatorFinding>& F : Findings)
+    {
+        if (!F.IsValid()) continue;
+        Buffer += FindingToJson(*F);
+        Buffer += LINE_TERMINATOR;
+    }
+    return FFileHelper::SaveStringToFile(Buffer, *HistoryFile);
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slate/SHaybaValidatorPanel.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Slate/SHaybaValidatorPanel.h
@@ -1,0 +1,108 @@
+// SHaybaValidatorPanel.h — runtime validator history browser.
+//
+// Reads `.scratch/validator-history.jsonl` (written by the MCP server) and
+// renders it as a filterable table. Per-row actions dismiss findings (writes
+// resolved:true back to disk), jump to the linked actor, and re-run the rule.
+//
+// File-watching keeps the table live without an explicit refresh button —
+// any append/edit by the MCP server triggers a re-read.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/Views/SListView.h"
+
+class STableViewBase;
+class ITableRow;
+struct FFileChangeData;
+template <typename T> class SComboBox;
+
+/** Mirror of the TS-side ValidatorFinding. Keep field names in sync with
+ *  `mcp-tools/hayba-mcp/src/validator/rules.ts`. */
+struct FHaybaValidatorFinding
+{
+    FString RuleId;
+    FString Severity;   // "error" | "warning" | "info"
+    FString Message;
+    FString Hint;
+    TArray<FString> Refs;
+    FString Timestamp;  // ISO; doubles as the stable resolve key
+    FString ToolName;
+    bool bResolved = false;
+    FString ResolvedAt;
+
+    /** Optional context fields surfaced for per-row actions. */
+    FString ActorLabel;
+    FString ActorId;
+    FString GraphPath;
+
+    /** Raw JSON of the original line — preserved so Resolve writes back
+     *  without losing fields the panel doesn't model. */
+    FString RawJson;
+};
+
+class SHaybaValidatorPanel : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SHaybaValidatorPanel) {}
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+    virtual ~SHaybaValidatorPanel() override;
+
+    /** Re-read the on-disk history file. */
+    void Refresh();
+
+    /** Public bridges so the per-row Slate widget (declared in the .cpp) can
+     *  call these actions without needing friend access. */
+    FReply OnDismissClicked_Public(TSharedPtr<FHaybaValidatorFinding> Item);
+    FReply OnJumpToActorClicked_Public(TSharedPtr<FHaybaValidatorFinding> Item);
+
+private:
+    // ── Data ────────────────────────────────────────────────────────────
+    TArray<TSharedPtr<FHaybaValidatorFinding>> AllItems;
+    TArray<TSharedPtr<FHaybaValidatorFinding>> FilteredItems;
+    TSharedPtr<FHaybaValidatorFinding> Selected;
+
+    // ── Filters ────────────────────────────────────────────────────────
+    FString SearchText;
+    bool bShowError = true;
+    bool bShowWarning = true;
+    bool bShowInfo = true;
+    bool bIncludeResolved = false;
+
+    // ── Widgets ────────────────────────────────────────────────────────
+    TSharedPtr<SListView<TSharedPtr<FHaybaValidatorFinding>>> ListView;
+    TSharedPtr<class STextBlock> HeaderText;
+
+    // ── File watching ──────────────────────────────────────────────────
+    FString WatchedDir;
+    FString HistoryFile;
+    FDelegateHandle WatcherHandle;
+
+    void ApplyFilter();
+    TSharedRef<ITableRow> OnGenerateRow(TSharedPtr<FHaybaValidatorFinding> Item, const TSharedRef<STableViewBase>& Owner);
+    void OnSelectionChanged(TSharedPtr<FHaybaValidatorFinding> Item, ESelectInfo::Type);
+    void OnDirectoryChanged(const TArray<FFileChangeData>& Changes);
+
+    FReply OnClearAllClicked();
+    FReply OnReRunAllClicked();
+    FReply OnDismissClicked(TSharedPtr<FHaybaValidatorFinding> Item);
+    FReply OnJumpToActorClicked(TSharedPtr<FHaybaValidatorFinding> Item);
+
+    void UpdateHeader();
+
+    /** Default path the MCP server writes to. Honours HAYBA_VALIDATOR_HISTORY
+     *  if it is set in the editor process env (matches the TS side). */
+    static FString DefaultHistoryPath();
+    static FString DefaultScratchDir();
+
+    /** Rewrites the JSONL file with the given findings, preserving order. */
+    bool WriteAllFindings(const TArray<TSharedPtr<FHaybaValidatorFinding>>& Findings) const;
+
+    /** Parse one JSONL line into a finding. Returns nullptr on malformed input. */
+    static TSharedPtr<FHaybaValidatorFinding> ParseFindingLine(const FString& Line);
+    /** Round-trip a finding back to JSON, preserving anything in RawJson. */
+    static FString FindingToJson(const FHaybaValidatorFinding& F);
+};


### PR DESCRIPTION
Rebuilds the validator system after the parallel `warnings/` direction (PR4, cancelled) was clarified to belong inside the validator itself. The validator is now the home for post-conditions, AI-floppy edge cases, history, and interactive UI.

## What this adds

### TS — `mcp-tools/hayba-mcp/src/validator/`
- `rules.ts` — canonical rule catalog (10 seed entries).
- `runner.ts` — `runAfterTool` / `runManual` evaluation passes; per-rule disable via `config.ts`.
- `history.ts` — JSONL persistence (`.scratch/validator-history.jsonl` by default; `HAYBA_VALIDATOR_HISTORY` override).
- `response.ts` — lifts findings into MCP responses (inline text for the agent + structured `validator: { findings: [...] }` block; severity=error flips `isError`).
- `tool-hooks.ts` — concrete evaluators for 6 rules (see below) + `isSelfSocketScript` helper.

### TS — new MCP tools (always-on; no pack required)
- `validator_run`  — manual evaluation pass
- `validator_history` — read persisted findings (filterable)
- `validator_resolve` — mark resolved / restore
- `validator_clear` — wipe history (requires `confirm:true`)
- `validator_rules` — catalog dump with disabled state
- `validator_set_rule_enabled` — toggle a rule

### TS — wrapped post-conditions on existing tools
- `executePcgGraph` (`hayba_execute_pcg_graph`) — emits findings, then attaches them to the result.
- `assetBrowseHandler` (`hayba_asset_browse`) — surfaces the \"Unknown command: describe_assets\" hint.
- `python-run-validator-wrap.ts` — pre-flight rejects scripts that connect back to the UE TCP port (52342–52350), avoiding a known game-thread deadlock. Lives outside `python/python-run.ts` to respect PR2's file ownership; merges back post-PR2 (TODO comment in source).

### UE plugin
- `Slate/SHaybaValidatorPanel.{h,cpp}` — live finding-history table:
  - watches `.scratch/validator-history.jsonl` via `IDirectoryWatcher`
  - severity color-chips + filter checkboxes + free-text search
  - per-row Dismiss (round-trips through the same file) + Jump to actor
  - Clear All / Re-run All header buttons
- Repurposes the existing Validation tab in `HaybaMCPMainPanel`; the placeholder `SHaybaMCPValidationPanel` stays in tree but is unhooked from the UI.
- `Docs/validator-history-format.md` — schema doc for the JSONL stream.

## Seeded rules

10 rules; 6 have active evaluators, 4 are catalog-only (visible in the Configure panel but not auto-evaluated):

| id | evaluator | severity |
|----|-----------|----------|
| pcg_zero_instances_after_execute | yes | warning |
| pcg_surface_source_not_landscape | catalog-only | warning |
| unreal_landscape_placeholder     | catalog-only | info |
| tcp_socket_to_self_in_python_run | yes (pre-flight + post-cond) | error |
| actor_position_drift_after_user_edit | catalog-only | warning |
| pcg_execute_no_component_in_world | yes | warning |
| pcg_asset_not_found              | yes | error |
| landscape_import_no_landscape_in_world | yes | error |
| actor_spawn_class_not_found      | catalog-only | error |
| asset_browse_describe_assets_missing | yes | warning |

## References

- Postmortem source for the 10 AI-floppy patterns: `docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md` (referenced in the task prompt).
- Section F rule ids (PR #227): `docs/superpowers/specs/2026-05-22-environmental-design-guardrails.md`.

## Dependencies

Best landed after:
- PR1 — game-thread marshal in `HaybaMCPLegacyHandler` so post-condition `python_run` follow-ups don't race.
- PR2 — landscape_import wrapper + python_run wrapper edits (the `python-run-validator-wrap.ts` workaround can then be merged back into `python/python-run.ts`).

## Verification

```
cd mcp-tools/hayba-mcp
npx tsc --noEmit             # zero new errors in validator code
npx vitest run src/validator # 30/30 pass
npx vitest run tests/routing-integration.test.ts # 4/4 pass
```

Pre-existing test failures (actor.test.ts, scene.test.ts, etc.) are unchanged from `origin/main`.

UE C++ panel hasn't been built standalone; the includes mirror the existing Sliver panel and the dependency modules (DirectoryWatcher, Json, UnrealEd, LevelEditor) are already in `HaybaMCPToolkit.Build.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a comprehensive validation system that evaluates tool execution and reports findings to catch common issues
  * New validator UI panel displays findings history with filtering, dismissal, and resolution tracking
  * Manual validation runs available with optional rule scoping
  * Persistent validator findings history with query and management capabilities
  * Tools now provide richer error messages with embedded validator findings

* **Documentation**
  * Added validator history format documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zajalist/hayba/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->