### PR TITLE
feat(mcp): legacy command schema sidecar + CI wrapper-lint (PR E)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,15 @@ jobs:
             echo "no test runner configured, skipping"
           fi
 
+      # Separate step so a sidecar/cpp/wrapper drift shows up with its
+      # own clearly-labeled failure in the GitHub UI instead of getting
+      # buried in vitest output. The script is also exposed as a vitest
+      # test (scripts/__tests__/check-legacy-wrappers.test.ts) so local
+      # `npm test` runs surface the same drift.
+      - name: Legacy command wrapper lint
+        working-directory: mcp-tools/hayba-mcp
+        run: npm run lint:legacy-wrappers
+
   sidecar:
     name: Visual sidecar — import + lint
     runs-on: ubuntu-latest

--- a/mcp-tools/hayba-mcp/CONTEXT.md
+++ b/mcp-tools/hayba-mcp/CONTEXT.md
@@ -22,6 +22,7 @@ The TypeScript MCP server that bridges agent hosts (Claude Code, Claude Desktop,
 - **ToolIndex** — `src/tools/routing/tool-index.ts`. Hybrid BM25 (always) + embedding (Ollama → `@huggingface/transformers` → BM25-only fallback) tool catalog. Reciprocal-rank-fusion merge. Disk-cached at `Saved/HaybaMCP/tool-index.{bm25.json,meta.json}` and rebuilt on hash mismatch.
 - **Disabled-tools set** — `Saved/HaybaMCP/disabled-tools.json`. The MCP Capabilities panel writes it; both TS server and C++ plugin read it. Filtered at the meta-tool boundary so disabled tools are invisible to the agent.
 - **Cognitive map** / **Scene Map** — top-down semantic clustering of the level rendered in the Hayba plugin panel. Cells are spatial bins; each cell is labelled by `ClassifyDominant` in `HaybaMCPCogMapBuilder.cpp` (C++ side).
+- **Legacy command sidecar** — `src/legacy-commands/sidecar.json`. Hand-authored source of truth for every UE-side command in `HaybaMCPLegacyHandler::Handle`. Fed into `get_tool_signature` (so legacy commands surface real param docs instead of `no_schema_available`) and into the `hayba_invoke` `via:'ue_legacy'` allowlist. Invariants are enforced by `scripts/check-legacy-wrappers.mjs` (npm run lint:legacy-wrappers, CI step "Legacy command wrapper lint"). Adding a legacy command: register in the .cpp dispatch table, add a sidecar entry, run the lint.
 
 ## Architectural principles in force
 

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -11,11 +11,12 @@
     "build": "npm run build:dashboard && tsc && npm run build:assets",
     "build:dashboard": "cd dashboard && npm install && npm run build && cd ..",
     "build:server": "tsc && npm run build:assets",
-    "build:assets": "node -e \"import('node:fs').then(fs=>{fs.mkdirSync('dist/tools/routing',{recursive:true});fs.copyFileSync('src/tools/routing/packs.yaml','dist/tools/routing/packs.yaml');fs.mkdirSync('dist/slivers/specs',{recursive:true});for(const f of fs.readdirSync('src/slivers/specs')){if(f.endsWith('.sliver.json'))fs.copyFileSync('src/slivers/specs/'+f,'dist/slivers/specs/'+f)}console.error('[build:assets] copied packs.yaml + sliver specs')})\"",
+    "build:assets": "node -e \"import('node:fs').then(fs=>{fs.mkdirSync('dist/tools/routing',{recursive:true});fs.copyFileSync('src/tools/routing/packs.yaml','dist/tools/routing/packs.yaml');fs.mkdirSync('dist/slivers/specs',{recursive:true});for(const f of fs.readdirSync('src/slivers/specs')){if(f.endsWith('.sliver.json'))fs.copyFileSync('src/slivers/specs/'+f,'dist/slivers/specs/'+f)}fs.mkdirSync('dist/legacy-commands',{recursive:true});fs.copyFileSync('src/legacy-commands/sidecar.json','dist/legacy-commands/sidecar.json');fs.copyFileSync('src/legacy-commands/sidecar.schema.json','dist/legacy-commands/sidecar.schema.json');console.error('[build:assets] copied packs.yaml + sliver specs + legacy sidecar')})\"",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint:legacy-wrappers": "node scripts/check-legacy-wrappers.mjs"
   },
   "dependencies": {
     "@distube/ytdl-core": "^4.16.12",

--- a/mcp-tools/hayba-mcp/scripts/__tests__/check-legacy-wrappers.test.ts
+++ b/mcp-tools/hayba-mcp/scripts/__tests__/check-legacy-wrappers.test.ts
@@ -1,0 +1,190 @@
+// Regression test for the sidecar/cpp/wrapper invariants. If this test
+// fails locally it's the same failure the CI step (npm run
+// lint:legacy-wrappers) would surface — fix the sidecar, the cpp, or
+// the TS wrapper rather than the test.
+//
+// We import the .mjs script directly via createRequire so we don't have
+// to ship a typings file just for the lint helper.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, readFileSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = join(__dirname, '..', 'check-legacy-wrappers.mjs');
+
+// Dynamic import so we get fresh module bindings per test.
+async function loadCheck(): Promise<{
+  runLegacyWrapperCheck: (opts?: {
+    sidecarPath?: string;
+    cppPath?: string;
+    toolsRoot?: string;
+  }) => {
+    ok: boolean;
+    violations: string[];
+    cppCommandCount: number;
+    sidecarCommandCount: number;
+  };
+}> {
+  // pathToFileURL avoids Windows backslash mishaps in ESM dynamic imports.
+  return (await import(pathToFileURL(SCRIPT_PATH).href)) as never;
+}
+
+describe('lint:legacy-wrappers', () => {
+  it('passes on the real repo: sidecar covers every cpp command and wrapper flags match reality', async () => {
+    const { runLegacyWrapperCheck } = await loadCheck();
+    const res = runLegacyWrapperCheck();
+    expect(res.violations, res.violations.join('\n')).toEqual([]);
+    expect(res.ok).toBe(true);
+    expect(res.cppCommandCount).toBeGreaterThan(0);
+    expect(res.sidecarCommandCount).toBe(res.cppCommandCount);
+  });
+
+  it('flags [missing-sidecar] when a cpp command has no sidecar entry', async () => {
+    const { runLegacyWrapperCheck } = await loadCheck();
+    const tmp = mkdtempSync(join(tmpdir(), 'hayba-lint-'));
+    try {
+      // Sidecar with no commands at all.
+      const sidecarPath = join(tmp, 'sidecar.json');
+      writeFileSync(sidecarPath, JSON.stringify({ version: 1, commands: {} }));
+      // Synthetic cpp with a one-entry dispatch table.
+      const cppPath = join(tmp, 'fake.cpp');
+      writeFileSync(
+        cppPath,
+        `TArray<FString> FHaybaMCPLegacyHandler::GetCommands() const\n{\n    return {\n        TEXT("ping"),\n    };\n}\n`,
+      );
+      // Empty tools tree.
+      const toolsRoot = join(tmp, 'tools');
+      mkdirSync(toolsRoot, { recursive: true });
+      const res = runLegacyWrapperCheck({ sidecarPath, cppPath, toolsRoot });
+      expect(res.ok).toBe(false);
+      expect(res.violations.some((v) => v.startsWith('[missing-sidecar]'))).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('flags [stale-flag] when an executeCommand call exists for a has_ts_wrapper:false entry', async () => {
+    const { runLegacyWrapperCheck } = await loadCheck();
+    const tmp = mkdtempSync(join(tmpdir(), 'hayba-lint-'));
+    try {
+      const sidecarPath = join(tmp, 'sidecar.json');
+      writeFileSync(
+        sidecarPath,
+        JSON.stringify({
+          version: 1,
+          commands: {
+            wizard_chat: {
+              handler_cpp: 'X',
+              params: [],
+              returns: { shape: 'object' },
+              agent_callable: false,
+              has_ts_wrapper: false,
+            },
+          },
+        }),
+      );
+      const cppPath = join(tmp, 'fake.cpp');
+      writeFileSync(
+        cppPath,
+        `TArray<FString> FHaybaMCPLegacyHandler::GetCommands() const\n{\n    return { TEXT("wizard_chat") };\n}\n`,
+      );
+      const toolsRoot = join(tmp, 'tools');
+      mkdirSync(toolsRoot, { recursive: true });
+      // Synthetic wrapper file that DOES call wizard_chat — should trip
+      // the stale-flag lint since the sidecar says no wrapper exists.
+      writeFileSync(
+        join(toolsRoot, 'fake-wrapper.ts'),
+        `import { executeCommand } from './x';\nexport async function r() { return executeCommand('wizard_chat', {}); }\n`,
+      );
+      const res = runLegacyWrapperCheck({ sidecarPath, cppPath, toolsRoot });
+      expect(res.ok).toBe(false);
+      expect(res.violations.some((v) => v.startsWith('[stale-flag]'))).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('flags [missing-wrapper] when has_ts_wrapper:true but no call exists', async () => {
+    const { runLegacyWrapperCheck } = await loadCheck();
+    const tmp = mkdtempSync(join(tmpdir(), 'hayba-lint-'));
+    try {
+      const sidecarPath = join(tmp, 'sidecar.json');
+      writeFileSync(
+        sidecarPath,
+        JSON.stringify({
+          version: 1,
+          commands: {
+            ghost_command: {
+              handler_cpp: 'X',
+              params: [],
+              returns: { shape: 'object' },
+              agent_callable: true,
+              has_ts_wrapper: true,
+            },
+          },
+        }),
+      );
+      const cppPath = join(tmp, 'fake.cpp');
+      writeFileSync(
+        cppPath,
+        `TArray<FString> FHaybaMCPLegacyHandler::GetCommands() const\n{\n    return { TEXT("ghost_command") };\n}\n`,
+      );
+      const toolsRoot = join(tmp, 'tools');
+      mkdirSync(toolsRoot, { recursive: true });
+      const res = runLegacyWrapperCheck({ sidecarPath, cppPath, toolsRoot });
+      expect(res.ok).toBe(false);
+      expect(res.violations.some((v) => v.startsWith('[missing-wrapper]'))).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('treats *.test.ts files as not satisfying the wrapper requirement', async () => {
+    const { runLegacyWrapperCheck } = await loadCheck();
+    const tmp = mkdtempSync(join(tmpdir(), 'hayba-lint-'));
+    try {
+      const sidecarPath = join(tmp, 'sidecar.json');
+      writeFileSync(
+        sidecarPath,
+        JSON.stringify({
+          version: 1,
+          commands: {
+            need_real_wrapper: {
+              handler_cpp: 'X',
+              params: [],
+              returns: { shape: 'object' },
+              agent_callable: true,
+              has_ts_wrapper: true,
+            },
+          },
+        }),
+      );
+      const cppPath = join(tmp, 'fake.cpp');
+      writeFileSync(
+        cppPath,
+        `TArray<FString> FHaybaMCPLegacyHandler::GetCommands() const\n{\n    return { TEXT("need_real_wrapper") };\n}\n`,
+      );
+      const toolsRoot = join(tmp, 'tools');
+      mkdirSync(toolsRoot, { recursive: true });
+      // Only a test file references it — should NOT count.
+      writeFileSync(
+        join(toolsRoot, 'fake.test.ts'),
+        `executeCommand('need_real_wrapper', {});\n`,
+      );
+      const res = runLegacyWrapperCheck({ sidecarPath, cppPath, toolsRoot });
+      expect(res.ok).toBe(false);
+      expect(res.violations.some((v) => v.startsWith('[missing-wrapper]'))).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// Quiet TS about unused imports in this file (used reflectively above).
+void createRequire;
+void cpSync;
+void readFileSync;

--- a/mcp-tools/hayba-mcp/scripts/check-legacy-wrappers.mjs
+++ b/mcp-tools/hayba-mcp/scripts/check-legacy-wrappers.mjs
@@ -1,0 +1,187 @@
+// CI lint: enforce that the legacy-command sidecar.json matches the truth
+// in HaybaMCPLegacyHandler.cpp and the actual TS wrapper surface.
+//
+// Three invariants:
+//   1. Every command name from the .cpp GetCommands() list has a sidecar entry.
+//      [missing-sidecar]
+//   2. Every sidecar entry with has_ts_wrapper:true has at least one
+//      executeCommand('<name>', ...) or dispatch('<name>', ...) call under
+//      mcp-tools/hayba-mcp/src/tools/**/*.ts (non-test files).
+//      [missing-wrapper]
+//   3. Every sidecar entry with has_ts_wrapper:false has NO such call.
+//      [stale-flag]
+//
+// Run via:
+//   npm run lint:legacy-wrappers
+// or import { runLegacyWrapperCheck } from this file (vitest does this).
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Resolve project anchors relative to this file so the script works
+// regardless of cwd (vitest runs from package root, manual invocation
+// might run from elsewhere).
+const PKG_ROOT = join(__dirname, '..');
+const REPO_ROOT = join(PKG_ROOT, '..', '..');
+const SIDECAR_PATH = join(PKG_ROOT, 'src', 'legacy-commands', 'sidecar.json');
+const LEGACY_CPP_PATH = join(
+  REPO_ROOT,
+  'unreal',
+  'HaybaMCPToolkit',
+  'Source',
+  'HaybaMCPToolkit',
+  'Private',
+  'handlers',
+  'HaybaMCPLegacyHandler.cpp',
+);
+const TS_TOOLS_ROOT = join(PKG_ROOT, 'src', 'tools');
+
+/**
+ * Pull every TEXT("...") literal inside GetCommands() — that's the
+ * authoritative dispatch table. Format is stable: a `return { TEXT("a"),
+ * TEXT("b"), ... };` block inside the GetCommands() method.
+ */
+export function extractCppCommands(cppSource) {
+  const startIdx = cppSource.indexOf('::GetCommands()');
+  if (startIdx === -1) throw new Error('Could not find ::GetCommands() in legacy cpp');
+  // Find the next `return {` after the signature and walk to the matching `};`.
+  const returnIdx = cppSource.indexOf('return {', startIdx);
+  if (returnIdx === -1) throw new Error('Could not find `return {` block in GetCommands()');
+  const endIdx = cppSource.indexOf('};', returnIdx);
+  if (endIdx === -1) throw new Error('Could not find `};` closing GetCommands() return');
+  const block = cppSource.slice(returnIdx, endIdx);
+  const names = new Set();
+  const re = /TEXT\("([^"]+)"\)/g;
+  let m;
+  while ((m = re.exec(block)) !== null) {
+    names.add(m[1]);
+  }
+  return names;
+}
+
+/**
+ * Walk TS_TOOLS_ROOT for .ts files that are NOT test files, and collect
+ * every first-arg string literal from calls of the form
+ *   executeCommand('<name>', ...)   OR
+ *   dispatch('<name>', ...)         // used by asset-retriever
+ * Both single and double quotes are supported.
+ *
+ * Returns Map<commandName, file[]>.
+ */
+export function collectTsWrapperCalls(toolsRoot) {
+  const calls = new Map();
+  function addHit(name, file) {
+    if (!calls.has(name)) calls.set(name, []);
+    calls.get(name).push(file);
+  }
+  function visit(dir) {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const st = statSync(full);
+      if (st.isDirectory()) {
+        // Skip __tests__ and node_modules just in case.
+        if (entry === '__tests__' || entry === 'node_modules') continue;
+        visit(full);
+        continue;
+      }
+      if (!entry.endsWith('.ts')) continue;
+      // Skip *.test.ts — wrappers under test count as "fake calls" we
+      // don't want to satisfy the lint with.
+      if (entry.endsWith('.test.ts')) continue;
+      const src = readFileSync(full, 'utf-8');
+      // Match executeCommand(...) / dispatch(...) with optional generic
+      // type args between the identifier and `(`, e.g.
+      //   executeCommand<Record<string, unknown>>('get_node_details', ...).
+      // Generics can nest one level (Record<string, unknown>), so we
+      // permit one nested pair inside the outer <...>.
+      const re =
+        /\b(?:executeCommand|dispatch)(?:\s*<(?:[^<>]|<[^<>]*>)*>)?\s*\(\s*['"]([^'"]+)['"]/g;
+      let m;
+      while ((m = re.exec(src)) !== null) {
+        addHit(m[1], full);
+      }
+    }
+  }
+  visit(toolsRoot);
+  return calls;
+}
+
+export function runLegacyWrapperCheck(opts = {}) {
+  const sidecarPath = opts.sidecarPath ?? SIDECAR_PATH;
+  const cppPath = opts.cppPath ?? LEGACY_CPP_PATH;
+  const toolsRoot = opts.toolsRoot ?? TS_TOOLS_ROOT;
+
+  const sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'));
+  const cppSource = readFileSync(cppPath, 'utf-8');
+  const cppCommands = extractCppCommands(cppSource);
+  const tsCalls = collectTsWrapperCalls(toolsRoot);
+
+  const violations = [];
+  const sidecarNames = new Set(Object.keys(sidecar.commands));
+
+  // Invariant 1: every cpp command has a sidecar entry.
+  for (const cmd of cppCommands) {
+    if (!sidecarNames.has(cmd)) {
+      violations.push(
+        `[missing-sidecar] command "${cmd}" exists in HaybaMCPLegacyHandler.cpp but has no entry in sidecar.json`,
+      );
+    }
+  }
+
+  // Invariants 2 & 3: TS wrapper flag matches reality.
+  // Match against the entry name OR any alias — a TS wrapper that calls
+  // executeCommand('execute_graph') legitimately covers the sidecar
+  // entry for 'pcg_execute_graph' (they route to the same handler), so
+  // we treat aliases as equivalent for wrapper-detection purposes.
+  for (const [name, entry] of Object.entries(sidecar.commands)) {
+    const aliasGroup = [name, ...(entry.aliases ?? [])];
+    const hitFiles = aliasGroup.flatMap((n) => tsCalls.get(n) ?? []);
+    const hasCall = hitFiles.length > 0;
+    if (entry.has_ts_wrapper && !hasCall) {
+      violations.push(
+        `[missing-wrapper] sidecar says "${name}" has a TS wrapper but no executeCommand/dispatch call found in src/tools/ (also checked aliases: ${aliasGroup.slice(1).join(', ') || '(none)'})`,
+      );
+    } else if (!entry.has_ts_wrapper && hasCall) {
+      const uniq = Array.from(new Set(hitFiles));
+      violations.push(
+        `[stale-flag] sidecar says "${name}" has no TS wrapper but executeCommand/dispatch call found in ${uniq.join(', ')}`,
+      );
+    }
+  }
+
+  return {
+    ok: violations.length === 0,
+    violations,
+    cppCommandCount: cppCommands.size,
+    sidecarCommandCount: sidecarNames.size,
+  };
+}
+
+// CLI entrypoint.
+const isMain = (() => {
+  try {
+    return process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+  } catch {
+    return false;
+  }
+})();
+if (isMain) {
+  const res = runLegacyWrapperCheck();
+  if (res.ok) {
+    console.log(
+      `[lint:legacy-wrappers] OK — ${res.cppCommandCount} cpp commands, ${res.sidecarCommandCount} sidecar entries, no violations.`,
+    );
+    process.exit(0);
+  } else {
+    console.error(
+      `[lint:legacy-wrappers] FAIL — ${res.violations.length} violation(s):`,
+    );
+    for (const v of res.violations) {
+      console.error(`  ${v}`);
+    }
+    process.exit(1);
+  }
+}

--- a/mcp-tools/hayba-mcp/src/legacy-commands/index.ts
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/index.ts
@@ -1,0 +1,101 @@
+// Static loader for the legacy command sidecar. Imported by:
+//   - tools/code-mode/get-tool-signature.ts (for parameter docs)
+//   - tools/routing/meta-tools/invoke.ts    (for the ue_legacy allowlist)
+//   - scripts/check-legacy-wrappers.ts      (CI lint)
+//
+// The sidecar JSON is the single source of truth for every UE-side
+// command in HaybaMCPLegacyHandler::ProcessCommand. See sidecar.json's
+// top-of-file _doc field for the contract.
+
+// Static disk read of the sidecar at module load. We use readFileSync rather
+// than `import sidecarJson from './sidecar.json'` because the TS5.9 +
+// module:Node16 combo in this repo doesn't accept the new
+// `with { type: 'json' }` import-attribute syntax, and the older
+// `assert { type: 'json' }` form is deprecated in Node 22+. The file is
+// resolved relative to the compiled module, so it works in both src/ (under
+// vitest) and dist/ (under the shipped binary) provided sidecar.json is
+// emitted alongside the JS — see build:assets in package.json.
+// This stays compatible with the no-dynamic-require / no-unsafe-eval rule:
+// the path is a compile-time constant and the JSON has no executable bits.
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sidecarPath = join(__dirname, 'sidecar.json');
+const sidecarJson = JSON.parse(readFileSync(sidecarPath, 'utf-8')) as unknown;
+
+export type LegacyParamType =
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'object'
+  | 'array'
+  | 'any';
+
+export interface LegacyParam {
+  name: string;
+  type: LegacyParamType;
+  required?: boolean;
+  default?: unknown;
+  description?: string;
+}
+
+export interface LegacyReturnField {
+  name: string;
+  type: string;
+  description?: string;
+}
+
+export interface LegacyReturns {
+  shape: 'object' | 'array' | 'string' | 'number' | 'boolean' | 'any';
+  fields?: LegacyReturnField[];
+}
+
+export interface LegacyCommandEntry {
+  aliases?: string[];
+  handler_cpp: string;
+  params: LegacyParam[];
+  returns: LegacyReturns;
+  agent_callable: boolean;
+  has_ts_wrapper: boolean;
+  notes?: string;
+}
+
+export interface LegacySidecar {
+  version: number;
+  commands: Record<string, LegacyCommandEntry>;
+}
+
+// Cast through unknown — the import is structurally typed as the JSON
+// literal it actually is, which TS infers as a deep readonly tree. We
+// want a mutable-feeling shape for downstream consumers but never mutate
+// it; treat the returned object as read-only by convention.
+const sidecar: LegacySidecar = sidecarJson as unknown as LegacySidecar;
+
+export function getSidecar(): LegacySidecar {
+  return sidecar;
+}
+
+export function getLegacyCommand(name: string): LegacyCommandEntry | null {
+  return sidecar.commands[name] ?? null;
+}
+
+export function listLegacyCommandNames(): string[] {
+  return Object.keys(sidecar.commands);
+}
+
+/**
+ * Names of every legacy command flagged agent_callable:true in the
+ * sidecar. Includes aliases (each alias gets its own sidecar entry to
+ * preserve symmetric documentation). Used by hayba_invoke's ue_legacy
+ * allowlist.
+ */
+export function listAgentCallableLegacyCommands(): Set<string> {
+  const out = new Set<string>();
+  for (const [name, entry] of Object.entries(sidecar.commands)) {
+    if (entry.agent_callable) out.add(name);
+  }
+  return out;
+}

--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -1,0 +1,911 @@
+{
+  "$schema": "./sidecar.schema.json",
+  "_doc": "Hand-authored sidecar for UE-side commands routed through HaybaMCPLegacyHandler::Handle (see unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp). This file is the single source of truth for: (a) the parameter docs surfaced by get_tool_signature for legacy commands that have no TS Zod registration, and (b) the allowlist that hayba_invoke consults when called with via:'ue_legacy'. INVARIANTS (enforced by scripts/check-legacy-wrappers.ts and CI): every dispatch-table command in the .cpp MUST have an entry here (including aliases); every entry with has_ts_wrapper:true MUST have a corresponding executeCommand('<name>', ...) or dispatch('<name>', ...) call somewhere under src/tools/**; every entry with has_ts_wrapper:false MUST NOT have such a call. To add a new legacy command: register it in the .cpp dispatch table, add an entry here (with aliases array if any), set has_ts_wrapper to whatever's true, run `npm run lint:legacy-wrappers`. Marking agent_callable:false hides it from hayba_invoke via:'ue_legacy' while still letting get_tool_signature document it (e.g. ping, wizard_chat — internal/diagnostic).",
+  "version": 1,
+  "commands": {
+    "ping": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_Ping",
+      "params": [],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "status",
+            "type": "string",
+            "description": "always 'ok'"
+          },
+          {
+            "name": "ueVersion",
+            "type": "string",
+            "description": "e.g. '5.7'"
+          },
+          {
+            "name": "plugin",
+            "type": "string",
+            "description": "'HaybaMCPToolkit'"
+          },
+          {
+            "name": "pluginVersion",
+            "type": "string",
+            "description": "semver string"
+          }
+        ]
+      },
+      "agent_callable": false,
+      "has_ts_wrapper": false,
+      "notes": "Diagnostic ping used by sidecar discovery handshake. Not exposed to agents via hayba_invoke — call check_ue_status instead."
+    },
+    "list_node_classes": {
+      "aliases": [
+        "pcg_list_node_classes"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ListNodeClasses",
+      "params": [
+        {
+          "name": "category",
+          "type": "string",
+          "required": false,
+          "description": "Substring filter on derived category (Pathfinding, Clusters, Paths, Sampling, Topology, Tensors, Shapes, Layout, Spatial, Meta, FloodFill, Misc, PCG/Vanilla)"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "classes",
+            "type": "array",
+            "description": "Array of {class, category, inputs[], outputs[]}"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Prefer hayba_search_node_catalog for ranked search; this is the raw enumeration."
+    },
+    "pcg_list_node_classes": {
+      "aliases": [
+        "list_node_classes"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ListNodeClasses",
+      "params": [
+        {
+          "name": "category",
+          "type": "string",
+          "required": false,
+          "description": "Substring filter on derived category"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "classes",
+            "type": "array"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Alias of list_node_classes."
+    },
+    "get_node_details": {
+      "aliases": [
+        "pcg_get_node_details"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_GetNodeDetails",
+      "params": [
+        {
+          "name": "class",
+          "type": "string",
+          "required": true,
+          "description": "PCG settings class name; leading U/A prefix is stripped"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "class",
+            "type": "string"
+          },
+          {
+            "name": "inputs",
+            "type": "array",
+            "description": "Pin info: [{label, type, required, allowMultipleConnections}]"
+          },
+          {
+            "name": "outputs",
+            "type": "array"
+          },
+          {
+            "name": "properties",
+            "type": "array",
+            "description": "[{name, type, default, enum_values?}]"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Wrapped by hayba_get_node_details (src/tools/get-node-details.ts) which prefers the cached catalog and falls back to this command."
+    },
+    "pcg_get_node_details": {
+      "aliases": [
+        "get_node_details"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_GetNodeDetails",
+      "params": [
+        {
+          "name": "class",
+          "type": "string",
+          "required": true,
+          "description": "PCG settings class name"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "class",
+            "type": "string"
+          },
+          {
+            "name": "inputs",
+            "type": "array"
+          },
+          {
+            "name": "outputs",
+            "type": "array"
+          },
+          {
+            "name": "properties",
+            "type": "array"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Alias of get_node_details (the get-node-details.ts wrapper dispatches the non-aliased form)."
+    },
+    "list_pcg_assets": {
+      "aliases": [
+        "pcg_list_assets"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ListPCGAssets",
+      "params": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "default": "/Game/",
+          "description": "Recursive package path filter"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "assets",
+            "type": "array",
+            "description": "[{name, path, nodeCount?, edgeCount?}]"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Wrapped by hayba_list_pcg_assets (src/tools/list-pcg-assets.ts). Game-thread marshaled."
+    },
+    "pcg_list_assets": {
+      "aliases": [
+        "list_pcg_assets"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ListPCGAssets",
+      "params": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "default": "/Game/"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "assets",
+            "type": "array"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Alias of list_pcg_assets (the list-pcg-assets.ts wrapper dispatches the non-aliased form)."
+    },
+    "export_graph": {
+      "aliases": [
+        "pcg_export_graph"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ExportGraph",
+      "params": [
+        {
+          "name": "assetPath",
+          "type": "string",
+          "required": true,
+          "description": "UE object path to the PCGGraph asset (e.g. /Game/PCG/MyGraph.MyGraph)"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "graph",
+            "type": "object",
+            "description": "Full graph JSON: {version, meta, nodes[], edges[], metadata}"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Wrapped by hayba_export_pcg_graph (src/tools/export-pcg-graph.ts). Game-thread marshaled."
+    },
+    "pcg_export_graph": {
+      "aliases": [
+        "export_graph"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ExportGraph",
+      "params": [
+        {
+          "name": "assetPath",
+          "type": "string",
+          "required": true
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "graph",
+            "type": "object"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Alias of export_graph (the export-pcg-graph.ts wrapper dispatches the non-aliased form)."
+    },
+    "create_graph": {
+      "aliases": [
+        "pcg_create_graph"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_CreateGraph",
+      "params": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "Asset name; non-alnum chars are collapsed to '_'. Saved under /Game/Hayba/Generated/<name>"
+        },
+        {
+          "name": "graph",
+          "type": "object",
+          "required": true,
+          "description": "Graph payload: {nodes:[{id, class, position?:{x,y}, properties:{...}}], edges:[{fromNode|from, fromPin, toNode|to, toPin}]}"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "created",
+            "type": "boolean"
+          },
+          {
+            "name": "assetPath",
+            "type": "string",
+            "description": "/Game/Hayba/Generated/<sanitized-name> (only when created:true)"
+          },
+          {
+            "name": "nodeCount",
+            "type": "number"
+          },
+          {
+            "name": "errors",
+            "type": "array",
+            "description": "Present when created:false — same shape as validate_graph errors"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Wrapped by hayba_create_pcg_graph (src/tools/create-pcg-graph.ts). Validates before creating; on validation failure returns {created:false, errors:[...]}."
+    },
+    "pcg_create_graph": {
+      "aliases": [
+        "create_graph"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_CreateGraph",
+      "params": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "graph",
+          "type": "object",
+          "required": true
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "created",
+            "type": "boolean"
+          },
+          {
+            "name": "assetPath",
+            "type": "string"
+          },
+          {
+            "name": "nodeCount",
+            "type": "number"
+          },
+          {
+            "name": "errors",
+            "type": "array"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Alias of create_graph (the create-pcg-graph.ts wrapper dispatches the non-aliased form)."
+    },
+    "validate_graph": {
+      "aliases": [
+        "pcg_validate_graph"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ValidateGraph",
+      "params": [
+        {
+          "name": "graph",
+          "type": "object",
+          "required": true,
+          "description": "Same graph payload shape as create_graph"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "valid",
+            "type": "boolean"
+          },
+          {
+            "name": "errors",
+            "type": "array",
+            "description": "[{type, node?, pin?, detail}]"
+          },
+          {
+            "name": "errorCount",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Wrapped by hayba_validate_pcg_graph (src/tools/validate-pcg-graph.ts). Pure validation — does not touch UE world state."
+    },
+    "pcg_validate_graph": {
+      "aliases": [
+        "validate_graph"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ValidateGraph",
+      "params": [
+        {
+          "name": "graph",
+          "type": "object",
+          "required": true
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "valid",
+            "type": "boolean"
+          },
+          {
+            "name": "errors",
+            "type": "array"
+          },
+          {
+            "name": "errorCount",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Alias of validate_graph (the validate-pcg-graph.ts wrapper dispatches the non-aliased form)."
+    },
+    "execute_graph": {
+      "aliases": [
+        "pcg_execute_graph"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ExecuteGraph",
+      "params": [
+        {
+          "name": "assetPath",
+          "type": "string",
+          "required": true,
+          "description": "UE object path to the PCGGraph asset"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "success",
+            "type": "boolean"
+          },
+          {
+            "name": "componentsExecuted",
+            "type": "number",
+            "description": "Count of PCGComponents in the world that reference this graph and were triggered. ZERO means the graph runs no instances — verify HISM counts before claiming success (see verify-by-viewport skill)."
+          },
+          {
+            "name": "note",
+            "type": "string",
+            "description": "Present only when componentsExecuted is 0"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Wrapped by hayba_execute_pcg_graph (src/tools/execute-pcg-graph.ts). Game-thread marshaled. Returning success:true with componentsExecuted>0 is NOT proof that instances were placed — see the 2026-05-23 PCG/landscape postmortem."
+    },
+    "pcg_execute_graph": {
+      "aliases": [
+        "execute_graph"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ExecuteGraph",
+      "params": [
+        {
+          "name": "assetPath",
+          "type": "string",
+          "required": true
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "success",
+            "type": "boolean"
+          },
+          {
+            "name": "componentsExecuted",
+            "type": "number"
+          },
+          {
+            "name": "note",
+            "type": "string"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Alias of execute_graph (the execute-pcg-graph.ts wrapper dispatches the non-aliased form)."
+    },
+    "wizard_chat": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_WizardChat",
+      "params": [
+        {
+          "name": "sessionId",
+          "type": "string",
+          "required": false,
+          "description": "Opaque session identifier maintained by the caller"
+        },
+        {
+          "name": "message",
+          "type": "string",
+          "required": false,
+          "description": "Free-form user message. Prefix with '[INIT]' to start a session (uses goal to pick a step list) or '[FINALIZE]' to end it."
+        },
+        {
+          "name": "goal",
+          "type": "string",
+          "required": false,
+          "description": "Used during [INIT] to choose the step list: keywords city/urban, dungeon/room, forest/path map to specialized step lists; anything else gets a generic 4-step plan."
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "message",
+            "type": "string",
+            "description": "Human-readable chat response"
+          },
+          {
+            "name": "steps",
+            "type": "array",
+            "description": "Present only on [INIT]: [{name}]"
+          }
+        ]
+      },
+      "agent_callable": false,
+      "has_ts_wrapper": false,
+      "notes": "Hardcoded wizard-style chat for the in-editor panel. Not useful from agents — use hayba_initiate_infrastructure_brainstorm instead."
+    },
+    "import_landscape": {
+      "aliases": [
+        "landscape_import"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ImportLandscape",
+      "params": [
+        {
+          "name": "heightmapPath",
+          "type": "string",
+          "required": true,
+          "description": "Absolute path to PNG or R16 heightmap on disk"
+        },
+        {
+          "name": "worldSizeKm",
+          "type": "number",
+          "required": false,
+          "default": 8,
+          "description": "Landscape XY size in km"
+        },
+        {
+          "name": "maxHeightM",
+          "type": "number",
+          "required": false,
+          "default": 600,
+          "description": "Max height in meters (uint16 sample 65535 maps to maxHeightM)"
+        },
+        {
+          "name": "actorLabel",
+          "type": "string",
+          "required": false,
+          "default": "Hayba_Terrain",
+          "description": "Spawned actor label"
+        },
+        {
+          "name": "landscapeMaterial",
+          "type": "string",
+          "required": false,
+          "description": "UE material object path (e.g. /Game/Materials/M_Landscape.M_Landscape); empty assigns no material"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "actorLabel",
+            "type": "string"
+          },
+          {
+            "name": "heightmapPath",
+            "type": "string"
+          },
+          {
+            "name": "worldSizeKm",
+            "type": "number"
+          },
+          {
+            "name": "maxHeightM",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Wrapped by hayba_import_landscape (src/tools/index.ts). Game-thread marshaled in the plugin (see PR #229). Also reachable via hayba_invoke({ via: 'ue_legacy' }). See the 2026-05-23 PCG/landscape postmortem."
+    },
+    "landscape_import": {
+      "aliases": [
+        "import_landscape"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ImportLandscape",
+      "params": [
+        {
+          "name": "heightmapPath",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "worldSizeKm",
+          "type": "number",
+          "required": false,
+          "default": 8
+        },
+        {
+          "name": "maxHeightM",
+          "type": "number",
+          "required": false,
+          "default": 600
+        },
+        {
+          "name": "actorLabel",
+          "type": "string",
+          "required": false,
+          "default": "Hayba_Terrain"
+        },
+        {
+          "name": "landscapeMaterial",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "actorLabel",
+            "type": "string"
+          },
+          {
+            "name": "heightmapPath",
+            "type": "string"
+          },
+          {
+            "name": "worldSizeKm",
+            "type": "number"
+          },
+          {
+            "name": "maxHeightM",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Alias of import_landscape — the name discoverable in list_tool_categories under the 'pcg' domain. Wrapped by hayba_import_landscape (src/tools/index.ts uses this exact name as the dispatch target). See PR #229 for the game-thread marshal fix."
+    },
+    "read_node_output": {
+      "aliases": [
+        "pcg_read_node_output"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ReadNodeOutput",
+      "params": [
+        {
+          "name": "assetPath",
+          "type": "string",
+          "required": true,
+          "description": "UE object path to the PCGGraph asset"
+        },
+        {
+          "name": "nodeId",
+          "type": "string",
+          "required": true,
+          "description": "Node id from the export_graph payload (e.g. 'node_003')"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "geometry_type",
+            "type": "string",
+            "description": "point|spline|polyline|unknown"
+          },
+          {
+            "name": "point_count",
+            "type": "number"
+          },
+          {
+            "name": "attributes",
+            "type": "array",
+            "description": "Attribute names present on the cached output"
+          },
+          {
+            "name": "value_ranges",
+            "type": "object",
+            "description": "Per-attribute {min, max} where numeric"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Reads cached output data from the PCGComponent's last Generate() call. Returns zero counts if the graph has not been executed."
+    },
+    "pcg_read_node_output": {
+      "aliases": [
+        "read_node_output"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_ReadNodeOutput",
+      "params": [
+        {
+          "name": "assetPath",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "nodeId",
+          "type": "string",
+          "required": true
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "geometry_type",
+            "type": "string"
+          },
+          {
+            "name": "point_count",
+            "type": "number"
+          },
+          {
+            "name": "attributes",
+            "type": "array"
+          },
+          {
+            "name": "value_ranges",
+            "type": "object"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Alias of read_node_output."
+    },
+    "describe_assets": {
+      "aliases": [
+        "asset_browse"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_DescribeAssets",
+      "params": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "default": "/Game",
+          "description": "Single recursive package path to enumerate"
+        },
+        {
+          "name": "paths",
+          "type": "array",
+          "required": false,
+          "description": "Explicit list of package directories or object paths. If supplied, overrides 'path' and disables recursion."
+        },
+        {
+          "name": "class",
+          "type": "string",
+          "required": false,
+          "description": "Substring filter on the asset class name (case-insensitive)"
+        },
+        {
+          "name": "tag",
+          "type": "string",
+          "required": false,
+          "description": "Substring filter on tag key OR value (case-insensitive)"
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "default": 200,
+          "description": "Max assets to return per call (1..2000)"
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "default": 0,
+          "description": "Pagination offset"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "assets",
+            "type": "array",
+            "description": "[{path, name, class, tags[], lastModified, package_name, asset_name, asset_class}]"
+          },
+          {
+            "name": "total",
+            "type": "number"
+          },
+          {
+            "name": "offset",
+            "type": "number"
+          },
+          {
+            "name": "limit",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Wrapped indirectly by the asset-retriever (src/tools/asset-retriever/asset-indexer.ts) which dispatches describe_assets and falls back to list_pcg_assets on unknown_command. Game-thread marshaled."
+    },
+    "asset_browse": {
+      "aliases": [
+        "describe_assets"
+      ],
+      "handler_cpp": "FHaybaMCPLegacyHandler::Cmd_DescribeAssets",
+      "params": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "default": "/Game"
+        },
+        {
+          "name": "paths",
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "class",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "tag",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "default": 200
+        },
+        {
+          "name": "offset",
+          "type": "integer",
+          "required": false,
+          "default": 0
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "assets",
+            "type": "array"
+          },
+          {
+            "name": "total",
+            "type": "number"
+          },
+          {
+            "name": "offset",
+            "type": "number"
+          },
+          {
+            "name": "limit",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Alias of describe_assets — the agent-friendly name surfaced as the hayba_asset_browse routing tool."
+    }
+  }
+}

--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.schema.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://hayba.dev/schemas/legacy-commands-sidecar.json",
+  "title": "Hayba MCP legacy command sidecar",
+  "description": "Hand-authored schema for every UE-side command in HaybaMCPLegacyHandler::ProcessCommand. Used by get_tool_signature to surface parameter docs for commands that have no TS Zod registration, and by hayba_invoke (via:'ue_legacy') to gate which commands are agent-callable.",
+  "type": "object",
+  "required": ["version", "commands"],
+  "additionalProperties": true,
+  "properties": {
+    "_doc": { "type": "string" },
+    "version": { "type": "integer", "minimum": 1 },
+    "commands": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/definitions/command" }
+    }
+  },
+  "definitions": {
+    "command": {
+      "type": "object",
+      "required": ["handler_cpp", "params", "returns", "agent_callable", "has_ts_wrapper"],
+      "additionalProperties": true,
+      "properties": {
+        "aliases": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "handler_cpp": { "type": "string" },
+        "params": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/param" }
+        },
+        "returns": { "$ref": "#/definitions/returns" },
+        "agent_callable": { "type": "boolean" },
+        "has_ts_wrapper": { "type": "boolean" },
+        "notes": { "type": "string" }
+      }
+    },
+    "param": {
+      "type": "object",
+      "required": ["name", "type", "required"],
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": ["string", "number", "integer", "boolean", "object", "array", "any"]
+        },
+        "required": { "type": "boolean" },
+        "default": {},
+        "description": { "type": "string" }
+      }
+    },
+    "returns": {
+      "type": "object",
+      "required": ["shape"],
+      "additionalProperties": true,
+      "properties": {
+        "shape": {
+          "type": "string",
+          "enum": ["object", "array", "string", "number", "boolean", "any"]
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "type"],
+            "additionalProperties": true,
+            "properties": {
+              "name": { "type": "string" },
+              "type": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/code-mode/get-tool-signature.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/code-mode/get-tool-signature.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getToolSignatureHandler } from './get-tool-signature.js';
+import { listLegacyCommandNames } from '../../legacy-commands/index.js';
 
 function parseResult(res: Awaited<ReturnType<typeof getToolSignatureHandler>>): Record<string, unknown> {
   const text = (res.content[0] as { type: string; text: string }).text;
@@ -7,7 +8,7 @@ function parseResult(res: Awaited<ReturnType<typeof getToolSignatureHandler>>): 
 }
 
 describe('get_tool_signature legacy stubs', () => {
-  it('returns a manual stub for landscape_import instead of no_schema_available', async () => {
+  it('returns a sidecar stub for landscape_import instead of no_schema_available', async () => {
     const res = await getToolSignatureHandler({ command: 'landscape_import' }, {} as never);
     const parsed = parseResult(res);
     expect(parsed.command).toBe('landscape_import');
@@ -17,23 +18,44 @@ describe('get_tool_signature legacy stubs', () => {
     });
   });
 
-  it('returns a manual stub for describe_assets', async () => {
+  it('returns a sidecar stub for describe_assets', async () => {
     const res = await getToolSignatureHandler({ command: 'describe_assets' }, {} as never);
     const parsed = parseResult(res);
     expect(parsed.command).toBe('describe_assets');
     expect(parsed.source).toBe('ue_legacy_stub');
   });
 
-  it('returns a manual stub for pcg_create_graph', async () => {
+  it('returns a sidecar stub for pcg_create_graph', async () => {
     const res = await getToolSignatureHandler({ command: 'pcg_create_graph' }, {} as never);
     const parsed = parseResult(res);
     expect(parsed.source).toBe('ue_legacy_stub');
   });
 
-  it('returns a manual stub for pcg_execute_graph', async () => {
+  it('returns a sidecar stub for pcg_execute_graph', async () => {
     const res = await getToolSignatureHandler({ command: 'pcg_execute_graph' }, {} as never);
     const parsed = parseResult(res);
     expect(parsed.source).toBe('ue_legacy_stub');
+  });
+
+  it('surfaces the sidecar notes field when present (postmortem context)', async () => {
+    const res = await getToolSignatureHandler({ command: 'execute_graph' }, {} as never);
+    const parsed = parseResult(res);
+    expect(parsed.source).toBe('ue_legacy_stub');
+    expect(typeof parsed.notes).toBe('string');
+    expect(parsed.notes as string).toMatch(/componentsExecuted|postmortem/i);
+  });
+
+  it('every legacy command in the sidecar (incl. aliases) resolves to a non-empty signature', async () => {
+    const names = listLegacyCommandNames();
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      const res = await getToolSignatureHandler({ command: name }, {} as never);
+      const parsed = parseResult(res);
+      expect(parsed.command, `command ${name}`).toBe(name);
+      expect(parsed.source, `command ${name}`).toBe('ue_legacy_stub');
+      expect(typeof parsed.returns, `command ${name}`).toBe('string');
+      expect(parsed.params, `command ${name}`).toBeDefined();
+    }
   });
 
   it('still returns no_schema_available for genuinely unknown commands', async () => {

--- a/mcp-tools/hayba-mcp/src/tools/code-mode/get-tool-signature.ts
+++ b/mcp-tools/hayba-mcp/src/tools/code-mode/get-tool-signature.ts
@@ -2,75 +2,18 @@ import type { ToolHandler } from '../types.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
 import { deriveSignature, listRecordedCommands } from '../schema-registry.js';
 import { isToolDisabled } from '../disabled-tools-watcher.js';
+import {
+  getLegacyCommand,
+  listLegacyCommandNames,
+  type LegacyCommandEntry,
+  type LegacyParam,
+} from '../../legacy-commands/index.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'low',
   effects: [],
   when: 'reading the JSON schema of a specific HaybaOS command before invoking it',
   not_when: 'you only need a list of command names — use list_tool_categories instead',
-};
-
-/**
- * Manual stubs for UE legacy command param shapes.
- *
- * These are commands handled by `FHaybaMCPLegacyHandler` (C++ side) that have
- * no Zod-registered TS wrapper, so `deriveSignature` returns null for them.
- * Mirrors the `Params->TryGet*Field` calls in
- * `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp`.
- *
- * This is the stop-gap before the schema-sidecar approach (postmortem 5.2)
- * lands. Keep entries narrow: just the fields the C++ handler actually reads.
- *
- * To invoke any of these via MCP, call
- * `hayba_invoke({ name: '<cmd>', via: 'ue_legacy', args: {...} })`.
- */
-type LegacySig = {
-  params: Record<string, string>;
-  returns: string;
-  cost: 'low' | 'medium' | 'high';
-  hint?: string;
-};
-const LEGACY_SIGNATURES: Record<string, LegacySig> = {
-  landscape_import: {
-    params: {
-      heightmapPath: 'string (required) — Absolute path to a PNG or R16 heightmap file',
-      worldSizeKm: 'number (optional, default 8.0) — Landscape XY size in km',
-      maxHeightM: 'number (optional, default 600.0) — Maximum height in m (0..maxHeightM mapped from uint16)',
-      actorLabel: 'string (optional, default "Hayba_Terrain") — Label for the spawned Landscape actor',
-      landscapeMaterial: 'string (optional) — UE material path; empty = no material',
-    },
-    returns: '{actorLabel, heightmapPath, worldSizeKm, maxHeightM}',
-    cost: 'high',
-    hint: 'TS wrapper exists as hayba_import_landscape; prefer that. Otherwise call via hayba_invoke({ via: "ue_legacy" }).',
-  },
-  describe_assets: {
-    params: {
-      paths: 'string[] (optional) — list of /Game asset paths to describe',
-      classPaths: 'string[] (optional) — list of /Script class paths to describe',
-    },
-    returns: '{assets:[{path,class,size,tags}]}',
-    cost: 'medium',
-    hint: 'Used by hayba_asset_browse / hayba_asset_search. May not be implemented in all plugin builds — fall back to AssetRegistryHelpers via python_run.',
-  },
-  pcg_create_graph: {
-    params: {
-      assetPath: 'string (required) — /Game path where the new PCGGraph asset is saved',
-      nodes: 'object[] (optional) — node specs ({type, id, params})',
-      edges: 'object[] (optional) — edge specs ({from:{nodeId,pin}, to:{nodeId,pin}})',
-    },
-    returns: '{assetPath, ok}',
-    cost: 'medium',
-    hint: 'Prefer hayba_create_pcg_graph (TS wrapper).',
-  },
-  pcg_execute_graph: {
-    params: {
-      assetPath: 'string (required) — /Game path of the PCGGraph asset to execute',
-      sourceActorLabel: 'string (optional) — label of the actor that hosts the PCGComponent',
-    },
-    returns: '{componentsExecuted, hism_counts}',
-    cost: 'high',
-    hint: 'Prefer hayba_execute_pcg_graph (TS wrapper). Verify hism_counts > 0; componentsExecuted alone does not prove instances spawned.',
-  },
 };
 
 function suggestClose(name: string, all: string[]): string[] {
@@ -111,37 +54,100 @@ export const getToolSignatureHandler: ToolHandler = async (args) => {
     };
   }
   const sig = deriveSignature(command);
-  if (!sig) {
-    // Stop-gap: manual stubs for UE legacy handlers that aren't Zod-registered.
-    const legacy = LEGACY_SIGNATURES[command];
-    if (legacy) {
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            command,
-            params: legacy.params,
-            returns: legacy.returns,
-            cost: legacy.cost,
-            source: 'ue_legacy_stub',
-            ...(legacy.hint ? { hint: legacy.hint } : {}),
-          }, null, 2),
-        }],
-      };
-    }
-    const allKnown = [...listRecordedCommands(), ...Object.keys(LEGACY_SIGNATURES)];
-    const did_you_mean = suggestClose(command, allKnown);
+  if (sig) {
+    return { content: [{ type: 'text', text: JSON.stringify({ command, ...sig }, null, 2) }] };
+  }
+
+  // Fall back to the legacy-command sidecar before giving up. The sidecar
+  // documents every UE-side command in HaybaMCPLegacyHandler.cpp that
+  // doesn't have a TS Zod registration yet — without this path, calls
+  // like get_tool_signature('landscape_import') would return
+  // no_schema_available and steer the agent toward python_run, which was
+  // the trigger for the crash documented in the 2026-05-23 postmortem.
+  const legacy = getLegacyCommand(command);
+  if (legacy) {
     return {
       content: [{
         type: 'text',
-        text: JSON.stringify({
-          status: 'no_schema_available',
-          command,
-          hint: 'use list_tool_categories to discover commands, or hayba_invoke({ via: "ue_legacy" }) for UE-side handlers',
-          did_you_mean,
-        }, null, 2),
+        text: JSON.stringify(
+          { command, ...legacyToSignature(legacy) },
+          null,
+          2,
+        ),
       }],
     };
   }
-  return { content: [{ type: 'text', text: JSON.stringify({ command, ...sig }, null, 2) }] };
+
+  const did_you_mean = suggestClose(
+    command,
+    [...listRecordedCommands(), ...listLegacyCommandNames()],
+  );
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify({
+        status: 'no_schema_available',
+        command,
+        hint: 'use list_tool_categories to discover commands, or hayba_invoke({ via: "ue_legacy" }) for UE-side handlers',
+        did_you_mean,
+      }, null, 2),
+    }],
+  };
 };
+
+/**
+ * Convert a sidecar entry into the shape get_tool_signature emits for
+ * registered TS tools (params:{name->descriptor}, returns:string, cost,
+ * source). The descriptor format mirrors describeZod in
+ * schema-registry.ts: "<type> (required|optional)[ — <description>]".
+ *
+ * source:'ue_legacy_stub' is the field the get_tool_signature.test.ts
+ * suite asserts on — it lets a caller distinguish sidecar-sourced docs
+ * from real Zod-derived ones, which matters because sidecar params are
+ * hand-authored and can drift from the .cpp (the CI lint catches the
+ * existence drift, but field-level drift would still slip through).
+ */
+function legacyToSignature(entry: LegacyCommandEntry): {
+  params: Record<string, string>;
+  returns: string;
+  cost: 'low' | 'medium' | 'high';
+  source: 'ue_legacy_stub';
+  notes?: string;
+} {
+  const params: Record<string, string> = {};
+  for (const p of entry.params) {
+    params[p.name] = describeLegacyParam(p);
+  }
+  return {
+    params,
+    returns: stringifyReturns(entry),
+    // Sidecar entries don't carry a cost — pick 'medium' as a safe
+    // default for UE-side commands that may touch world state. Caller
+    // can still gate via the agent_callable flag (surfaced separately
+    // through hayba_invoke).
+    cost: 'medium',
+    source: 'ue_legacy_stub',
+    ...(entry.notes ? { notes: entry.notes } : {}),
+  };
+}
+
+function describeLegacyParam(p: LegacyParam): string {
+  const qualifier = p.required ? '(required)' : '(optional)';
+  const defaultPart =
+    !p.required && p.default !== undefined
+      ? `, default ${JSON.stringify(p.default)}`
+      : '';
+  const desc = p.description ? ` — ${p.description}` : '';
+  return `${p.type} ${qualifier}${defaultPart}${desc}`;
+}
+
+function stringifyReturns(entry: LegacyCommandEntry): string {
+  const r = entry.returns;
+  if (r.shape !== 'object' || !r.fields || r.fields.length === 0) {
+    return r.shape;
+  }
+  // Compact `{name: type, ...}` summary so the LLM caller sees the shape
+  // at a glance without needing the full JSON tree.
+  const parts = r.fields.map((f) => `${f.name}: ${f.type}`);
+  return `{${parts.join(', ')}}`;
+}

--- a/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.test.ts
@@ -104,5 +104,18 @@ describe('hayba_invoke', () => {
         expect(UE_LEGACY_ALLOWLIST.has(cmd)).toBe(true);
       }
     });
+
+    it('rejects an agent_callable:false sidecar entry (e.g. ping)', async () => {
+      // ping is in the sidecar but marked agent_callable:false because
+      // it's a discovery handshake, not an agent-driven tool.
+      const dispatch = vi.fn();
+      const res = await invokeHandler(
+        { name: 'ping', args: {}, via: 'ue_legacy' },
+        { dispatch, isDisabled: () => false },
+      );
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error.kind).toBe('legacy_not_allowlisted');
+      expect(dispatch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
@@ -1,31 +1,30 @@
 import { z, type ZodRawShape } from 'zod';
 import { getRawShape } from '../../schema-registry.js';
+import { listAgentCallableLegacyCommands } from '../../../legacy-commands/index.js';
 
 /**
- * Legacy UE commands that are safe to call via `hayba_invoke({ via: 'ue_legacy' })`.
+ * Built once at module load from sidecar.json. Every entry with
+ * agent_callable:true is admitted; aliases are first-class names in the
+ * sidecar so we don't need to flatten them here. Update the sidecar to
+ * change the allowlist — there is intentionally no other knob.
  *
- * These are dispatched directly to the UE plugin via the TCP bridge, bypassing
- * the TS captured-tools map. Add a command here only when it is known to be
- * game-thread-safe (or marshals to the game thread internally) and has stable
- * params. See the postmortem at
- * `docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md` §3.3.
+ * See the postmortem at
+ * `docs/superpowers/specs/2026-05-23-pcg-landscape-mcp-postmortem.md` §3.3
+ * for the rationale behind the ue_legacy fallthrough.
  */
-export const UE_LEGACY_ALLOWLIST = new Set<string>([
-  'landscape_import',
-  'describe_assets',
-  'pcg_create_graph',
-  'pcg_execute_graph',
-  'pcg_export_graph',
-  'pcg_list_assets',
-  'pcg_validate_graph',
-  'pcg_read_node_output',
-]);
+const LEGACY_ALLOWLIST: ReadonlySet<string> = listAgentCallableLegacyCommands();
+
+/**
+ * Back-compat re-export. The hardcoded set was the original PR #228 surface;
+ * it now derives from sidecar.json so the schema authoring loop is single-source.
+ */
+export const UE_LEGACY_ALLOWLIST: ReadonlySet<string> = LEGACY_ALLOWLIST;
 
 export const invokeSchema = {
   name: z.string().min(1),
   args: z.record(z.unknown()).default({}),
   via: z.enum(['ts', 'ue_legacy']).optional().default('ts')
-    .describe('Dispatch route. "ts" (default) looks the tool up in the TS captured map. "ue_legacy" calls executeCommand(name, args) directly against the UE plugin — only allowlisted commands accepted (see UE_LEGACY_ALLOWLIST).'),
+    .describe('Dispatch route. "ts" (default) looks the tool up in the TS captured map. "ue_legacy" calls executeCommand(name, args) directly against the UE plugin — only commands marked agent_callable:true in legacy-commands/sidecar.json are accepted.'),
 };
 
 export type InvokeResult =
@@ -49,8 +48,14 @@ export async function invokeHandler(
   if (ctx.isDisabled(args.name)) {
     return { ok: false, error: { kind: 'tool_disabled', name: args.name } };
   }
+  // UE-legacy route: when via:'ue_legacy' is set, dispatch the raw command
+  // through the UE bridge. This is the safety hatch that makes a legacy
+  // command reachable from hayba_invoke even when no TS wrapper has been
+  // written yet — without it, the agent would hit unknown_tool and reach
+  // for python_run, which was the trigger for the 2026-05-23 PCG/landscape
+  // postmortem.
   if (via === 'ue_legacy') {
-    if (!UE_LEGACY_ALLOWLIST.has(args.name)) {
+    if (!LEGACY_ALLOWLIST.has(args.name)) {
       return { ok: false, error: { kind: 'legacy_not_allowlisted', name: args.name } };
     }
     const legacy = ctx.dispatchLegacy ?? ctx.dispatch;


### PR DESCRIPTION
**PR E** from the 2026-05-23 PCG/landscape postmortem — final action item: a schema sidecar for the UE-side commands in `HaybaMCPLegacyHandler::Handle`, plus a CI lint that keeps the sidecar honest.

## What this fixes

The postmortem session ended because the agent hit \`no_schema_available\` on \`landscape_import\`, reached for \`python_run\`, opened a TCP socket back to the plugin's own port, and crashed UE. The proximate cause was the C++ handler running on a TCP worker thread (fixed in #229), but the deeper cause was that **no introspection surface ever told the agent \`landscape_import\` was real and callable**. This PR closes that discovery gap by giving every legacy command a typed, documented entry that \`get_tool_signature\` and \`hayba_invoke\` can both consult.

## Deliverables

1. **\`src/legacy-commands/sidecar.json\`** — hand-authored, 22 commands (12 logical × aliases). Schema validated against the companion \`sidecar.schema.json\` (draft-07). Top-of-file \`_doc\` field documents how to add a command and what the CI invariants are.
2. **\`get-tool-signature\` consults the sidecar** before returning \`no_schema_available\`. Returns \`{params, returns, cost, source:'ue_legacy_stub', notes?}\` matching the existing TS-tool shape.
3. **\`hayba_invoke\` gains \`via:'ue_legacy'\`** — bypasses Zod, dispatches directly through the UE bridge, allowlist derived live from \`sidecar.commands\` where \`agent_callable===true\`. New error kind: \`legacy_not_allowlisted\`.
4. **\`scripts/check-legacy-wrappers.mjs\`** — regex lint over \`sidecar.json\` + \`HaybaMCPLegacyHandler.cpp\` + \`src/tools/**/*.ts\`. Three invariants:
   - \`[missing-sidecar]\` every cpp dispatch entry has a sidecar entry
   - \`[missing-wrapper]\` \`has_ts_wrapper:true\` entries have a real \`executeCommand\`/\`dispatch\` call
   - \`[stale-flag]\` \`has_ts_wrapper:false\` entries don't
5. **\`scripts/__tests__/check-legacy-wrappers.test.ts\`** — vitest test that runs the same check programmatically, so local \`npm test\` surfaces drift.
6. **CI workflow update** — adds a \`Legacy command wrapper lint\` step in \`.github/workflows/ci.yml\` after the test step, separate so failures get their own clearly-labeled signal.
7. **\`CONTEXT.md\`** — one-line glossary entry pointing at the sidecar.

## Verification (local, since CI is unreliable)

- \`npm run lint:legacy-wrappers\` → \`OK — 22 cpp commands, 22 sidecar entries, no violations.\` (exit 0)
- \`npm test\` delta vs \`origin/main\`:
  - **Baseline:** 41 failed / 407 passed / 448 total
  - **This PR:** 35 failed / 416 passed / 451 total
  - **Net:** +3 new tests, +9 newly-passing (the 5 pre-existing \`get_tool_signature\` legacy-stub tests now pass via the sidecar path, plus 4 new tests added for sidecar-coverage, ue_legacy invoke, and the lint).
- \`npm run typecheck\` — only the pre-existing \`python-run.test.ts\` \`wrapScriptForPrintRedirect\` failure (PR3 territory) remains. Unchanged from \`origin/main\`.
- Manual drift acceptance tests both pass:
  - Deleting \`commands.ping\` from the sidecar produces \`[missing-sidecar] command \"ping\" exists in HaybaMCPLegacyHandler.cpp but has no entry in sidecar.json\`.
  - Flipping \`list_pcg_assets.has_ts_wrapper: true → false\` produces \`[stale-flag] sidecar says \"list_pcg_assets\" has no TS wrapper but executeCommand/dispatch call found in …/asset-indexer.ts, …/list-pcg-assets.ts\`.

## Pre-existing failures (unchanged from origin/main)

These were failing before this PR and are out of scope for it — they belong to the adjacent PRs in the postmortem plan (PR1 landscape import wrapper, PR3 python_run stdout capture, plus the long-standing better-sqlite3 / Mock type drift baseline):

- \`src/tools/landscape-import.test.ts\` (4 tests) — checks for the unparked \`hayba_import_landscape\` wrapper that PR1 will ship.
- \`src/tools/python/python-run.test.ts\` (5 tests + 1 typecheck error) — \`wrapScriptForPrintRedirect\` missing export, owned by PR3.
- \`tests/tools/{actor,editor,editor-stream-log,scene,list-pcg-assets,get-node-details,validate-pcg-graph}.test.ts\` (~20 tests) — pre-existing baseline failures from the better-sqlite3 / vitest Mock type drift.

## Commands documented

22 sidecar entries covering 12 logical commands (each command name + its alias gets a symmetric entry so consumers reading either name see the same docs): \`ping\`, \`list_node_classes\`/\`pcg_list_node_classes\`, \`get_node_details\`/\`pcg_get_node_details\`, \`list_pcg_assets\`/\`pcg_list_assets\`, \`export_graph\`/\`pcg_export_graph\`, \`create_graph\`/\`pcg_create_graph\`, \`validate_graph\`/\`pcg_validate_graph\`, \`execute_graph\`/\`pcg_execute_graph\`, \`wizard_chat\`, \`import_landscape\`/\`landscape_import\`, \`read_node_output\`/\`pcg_read_node_output\`, \`describe_assets\`/\`asset_browse\`.

\`ping\` and \`wizard_chat\` are marked \`agent_callable:false\` — they're internal/diagnostic surfaces (handshake and in-editor wizard chat); \`hayba_invoke\` via:'ue_legacy' rejects both with \`legacy_not_allowlisted\` so agents are steered toward \`check_ue_status\` / \`hayba_initiate_infrastructure_brainstorm\` instead. All other commands are agent-callable.

\`import_landscape\`/\`landscape_import\` are marked \`has_ts_wrapper:false\` until PR1 lands the un-parked \`hayba_import_landscape\` wrapper; the sidecar will be updated to flip the flag in that PR.