### PR TITLE
fix(website): break #heroRipples canvas/layout feedback loop (infinite scroll + broken hero)

### DIFF
--- a/website/lib/gl-quad.js
+++ b/website/lib/gl-quad.js
@@ -53,11 +53,24 @@ export function mountQuad(canvas, { fragmentShader, onFrame }) {
     return uniformCache.get(name);
   }
 
+  // The canvas must sit out of layout flow: resize() derives the buffer
+  // size from the parent rect, so an in-flow canvas feeds its own size back
+  // into the parent — unbounded growth via the ResizeObserver below.
+  if (getComputedStyle(canvas).position === 'static') {
+    console.warn('gl-quad: canvas is in layout flow; forcing absolute fill');
+    Object.assign(canvas.style, {
+      position: 'absolute', inset: '0', width: '100%', height: '100%',
+    });
+  }
+
   function resize() {
     const r = canvas.parentElement.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
-    canvas.width = Math.max(2, Math.round(r.width * dpr));
-    canvas.height = Math.max(2, Math.round(r.height * dpr));
+    const w = Math.max(2, Math.round(r.width * dpr));
+    const h = Math.max(2, Math.round(r.height * dpr));
+    if (w === canvas.width && h === canvas.height) return;
+    canvas.width = w;
+    canvas.height = h;
     gl.viewport(0, 0, canvas.width, canvas.height);
   }
   resize();

--- a/website/style.css
+++ b/website/style.css
@@ -191,6 +191,15 @@ nav.subnav {
   display: block;
 }
 
+#heroRipples {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  display: block;
+  mix-blend-mode: overlay;
+}
+
 /* ── slowly rotating aurora behind everything ── */
 .hero-aurora {
   position: absolute;

--- a/website/style.css
+++ b/website/style.css
@@ -191,11 +191,14 @@ nav.subnav {
   display: block;
 }
 
+/* Watery ripple overlay — must stay out of layout flow: gl-quad sizes the
+   canvas buffer from the hero's rect, so an in-flow canvas feeds its own
+   height back into the hero (unbounded growth). */
 #heroRipples {
   position: absolute; inset: 0;
   width: 100%; height: 100%;
   pointer-events: none;
-  z-index: 1;
+  z-index: 0;
   display: block;
   mix-blend-mode: overlay;
 }


### PR DESCRIPTION
## Problem
Production (hayba.vercel.app) develops an ever-growing page and a destroyed hero. Measured live: `scrollHeight` 348,837 -> 532,062 px in 4.5 s (~40k px/s), `#heroRipples` at 914x524,662 device px.

## Root cause
`index.html` mounts the ripple shader on `#heroRipples`, but `style.css` has **no rule for it** — the canvas sits in layout flow. `gl-quad.js` sizes the canvas buffer from the parent (`.hero`) rect on every ResizeObserver tick; an in-flow canvas's layout height *is* its buffer height, so each resize grows the hero, which re-fires the observer: unbounded growth. The hero content gets pushed ~500k px down ("breaks the hero"); the scrollbar never settles ("infinite scrolls").

An earlier commit on this branch (12a91f7) added the missing CSS but was never PR'd/merged, so production kept the bug.

## Fix
- `style.css`: absolute-fill `#heroRipples` with `mix-blend-mode: overlay` (the shader's documented intent), `z-index: 0` — not `1`, which would stack the overlay **above** the hero headline.
- `gl-quad.js`: skip no-op resizes, and force absolute-fill (with a console.warn) if any caller mounts an in-flow canvas — kills the entire bug class.

## Verification
Local serve + headless Chromium: `scrollHeight` flat at 7,864 px over 6 s (was +40k px/s), hero renders identical to the reference screenshot, zero console errors/warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed canvas positioning and rendering issues that were causing unexpected layout disruptions and performance degradation, improving overall page stability.

* **New Features**
  * Added an animated ripple effect overlay to the hero section, enhancing the visual presentation and creating a more dynamic user interface experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->