### PR TITLE
feat(asset): expose asset_delete / asset_move / asset_rename as MCP tools

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/asset/asset-delete.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset/asset-delete.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['deletes_asset', 'modifies_project'],
+  when: 'permanently deleting a content asset by object path',
+  not_when: 'moving (asset_move) or renaming (asset_rename) an asset',
+};
+
+export const schema = z.object({
+  path: z.string().min(1).describe('Object path of the asset to delete, e.g. /Game/Foo/MF_X.MF_X'),
+});
+
+export const assetDeleteHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_delete', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/asset/asset-move.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset/asset-move.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['moves_asset', 'modifies_project'],
+  when: 'relocating a content asset to a different folder, keeping its name (references/redirectors handled)',
+  not_when: 'renaming in place (asset_rename) or deleting (asset_delete) an asset',
+};
+
+export const schema = z.object({
+  path: z.string().min(1).describe('Object path of the asset to move, e.g. /Game/Foo/MF_X.MF_X'),
+  target_dir: z.string().min(1).describe('Destination folder path (no asset name), e.g. /Game/MaterialLibrary/functions/primitives'),
+});
+
+export const assetMoveHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_move', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/asset/asset-rename.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset/asset-rename.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['renames_asset', 'modifies_project'],
+  when: 'renaming a content asset in place (same folder, new name)',
+  not_when: 'moving to another folder (asset_move) or deleting (asset_delete) an asset',
+};
+
+export const schema = z.object({
+  path: z.string().min(1).describe('Object path of the asset to rename, e.g. /Game/Foo/MF_X.MF_X'),
+  new_name: z.string().min(1).describe('New asset name only (not a path), e.g. MF_Y'),
+});
+
+export const assetRenameHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_rename', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/asset/asset-tools.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset/asset-tools.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Smoke test for the asset-domain wrapper tools:
+ * - asset_delete
+ * - asset_move
+ * - asset_rename
+ *
+ * Tests that each wrapper is:
+ * 1. Registered in index.ts with server.tool()
+ * 2. Wired to executeCommand() with the correct command name (in handler files)
+ * 3. Registered in the eager schema-registry block via reg()
+ * 4. Has the correct schema fields
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexSrc = readFileSync(join(__dirname, '..', 'index.ts'), 'utf-8');
+
+const assetDeleteSrc = readFileSync(join(__dirname, 'asset-delete.ts'), 'utf-8');
+const assetMoveSrc = readFileSync(join(__dirname, 'asset-move.ts'), 'utf-8');
+const assetRenameSrc = readFileSync(join(__dirname, 'asset-rename.ts'), 'utf-8');
+
+describe('asset-domain wrappers', () => {
+  describe('asset_delete', () => {
+    it('has a server.tool registration', () => {
+      expect(indexSrc).toMatch(/server\.tool\(\s*['"]asset_delete['"]/);
+    });
+    it('calls executeCommand with the correct command name in handler', () => {
+      expect(assetDeleteSrc).toMatch(/executeCommand\(\s*['"]asset_delete['"]/);
+    });
+    it('registers the schema in the eager schema-registry block', () => {
+      expect(indexSrc).toMatch(/reg\(\s*['"]asset_delete['"]/);
+    });
+    it('has a path schema field', () => {
+      expect(assetDeleteSrc).toMatch(/path:\s*z\.string\(\)\.min\(1\)/);
+    });
+  });
+
+  describe('asset_move', () => {
+    it('has a server.tool registration', () => {
+      expect(indexSrc).toMatch(/server\.tool\(\s*['"]asset_move['"]/);
+    });
+    it('calls executeCommand with the correct command name in handler', () => {
+      expect(assetMoveSrc).toMatch(/executeCommand\(\s*['"]asset_move['"]/);
+    });
+    it('registers the schema in the eager schema-registry block', () => {
+      expect(indexSrc).toMatch(/reg\(\s*['"]asset_move['"]/);
+    });
+    it('has path and target_dir schema fields', () => {
+      expect(assetMoveSrc).toMatch(/path:\s*z\.string\(\)\.min\(1\)/);
+      expect(assetMoveSrc).toMatch(/target_dir:\s*z\.string\(\)\.min\(1\)/);
+    });
+  });
+
+  describe('asset_rename', () => {
+    it('has a server.tool registration', () => {
+      expect(indexSrc).toMatch(/server\.tool\(\s*['"]asset_rename['"]/);
+    });
+    it('calls executeCommand with the correct command name in handler', () => {
+      expect(assetRenameSrc).toMatch(/executeCommand\(\s*['"]asset_rename['"]/);
+    });
+    it('registers the schema in the eager schema-registry block', () => {
+      expect(indexSrc).toMatch(/reg\(\s*['"]asset_rename['"]/);
+    });
+    it('has path and new_name schema fields', () => {
+      expect(assetRenameSrc).toMatch(/path:\s*z\.string\(\)\.min\(1\)/);
+      expect(assetRenameSrc).toMatch(/new_name:\s*z\.string\(\)\.min\(1\)/);
+    });
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -46,6 +46,10 @@ import { materialAddNodeHandler, meta as materialAddNodeMeta } from './material/
 import { materialConnectNodesHandler, meta as materialConnectNodesMeta } from './material/material-connect-nodes.js';
 import { materialFunctionCreateHandler, meta as materialFunctionCreateMeta } from './material/material-function-create.js';
 
+import { assetDeleteHandler, meta as assetDeleteMeta } from './asset/asset-delete.js';
+import { assetMoveHandler, meta as assetMoveMeta } from './asset/asset-move.js';
+import { assetRenameHandler, meta as assetRenameMeta } from './asset/asset-rename.js';
+
 // ── Asset-source connectors (pure Node — no UE bridge except python_run) ──────
 import { handlePolyhavenSearch, meta as polyhavenSearchMeta } from './asset-sources/polyhaven-search.js';
 import { handlePolyhavenDownload, meta as polyhavenDownloadMeta } from './asset-sources/polyhaven-download.js';
@@ -607,6 +611,48 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     }
   );
   remember('material_function_create', materialFunctionCreateMeta);
+
+  // ── Asset domain ────────────────────────────────────────────────────────────
+  server.tool(
+    'asset_delete',
+    appendMeta('Permanently delete a content asset by object path.', assetDeleteMeta),
+    {
+      path: z.string().min(1).describe('Object path of the asset to delete, e.g. /Game/Foo/MF_X.MF_X'),
+    },
+    async (params) => {
+      const r = await assetDeleteHandler(params as Record<string, unknown>, session);
+      return { content: r.content, isError: r.isError };
+    }
+  );
+  remember('asset_delete', assetDeleteMeta);
+
+  server.tool(
+    'asset_move',
+    appendMeta('Move a content asset to a different folder, keeping its name (references/redirectors handled).', assetMoveMeta),
+    {
+      path: z.string().min(1).describe('Object path of the asset to move, e.g. /Game/Foo/MF_X.MF_X'),
+      target_dir: z.string().min(1).describe('Destination folder path (no asset name), e.g. /Game/MaterialLibrary/functions/primitives'),
+    },
+    async (params) => {
+      const r = await assetMoveHandler(params as Record<string, unknown>, session);
+      return { content: r.content, isError: r.isError };
+    }
+  );
+  remember('asset_move', assetMoveMeta);
+
+  server.tool(
+    'asset_rename',
+    appendMeta('Rename a content asset in place (same folder, new name).', assetRenameMeta),
+    {
+      path: z.string().min(1).describe('Object path of the asset to rename, e.g. /Game/Foo/MF_X.MF_X'),
+      new_name: z.string().min(1).describe('New asset name only (not a path), e.g. MF_Y'),
+    },
+    async (params) => {
+      const r = await assetRenameHandler(params as Record<string, unknown>, session);
+      return { content: r.content, isError: r.isError };
+    }
+  );
+  remember('asset_rename', assetRenameMeta);
 
   // ── Scene domain ────────────────────────────────────────────────────────────
 
@@ -2214,6 +2260,19 @@ function recordEagerSchemas(
     package_path: z.string().min(1).describe('UE content path for the new material function'),
     name: z.string().min(1).describe('Name of the material function asset'),
   }, 'low', '{path, name}');
+
+  // ── Asset domain ────────────────────────────────────────────────────────────
+  reg('asset_delete', {
+    path: z.string().min(1).describe('Object path of the asset to delete, e.g. /Game/Foo/MF_X.MF_X'),
+  }, 'low', '{deleted:true}');
+  reg('asset_move', {
+    path: z.string().min(1).describe('Object path of the asset to move, e.g. /Game/Foo/MF_X.MF_X'),
+    target_dir: z.string().min(1).describe('Destination folder path (no asset name)'),
+  }, 'low', '{ok, old_path, new_path}');
+  reg('asset_rename', {
+    path: z.string().min(1).describe('Object path of the asset to rename, e.g. /Game/Foo/MF_X.MF_X'),
+    new_name: z.string().min(1).describe('New asset name only (not a path)'),
+  }, 'low', '{old_path, new_path}');
 
   // ── Scene domain ──────────────────────────────────────────────────────────
   reg('scene_export', {


### PR DESCRIPTION
The asset domain (delete/move/rename and more) is **already implemented in the UE C++** `HaybaMCPAssetHandler` but was unreachable to the agent — hayba only exposes a UE command once it has a TS wrapper registered in `index.ts` (the `ue_legacy` route rejects anything not allow-listed in `sidecar.json`). This adds the missing wrapper layer for the three mutating asset ops, mirroring the `material_*` tools landed in #243.

## Tools added
- `asset_delete` `{path}` → `{deleted:true}`
- `asset_move` `{path, target_dir}` → `{ok, old_path, new_path}` (keeps the asset name; references/redirectors handled by the C++ via `FAssetRenameData`)
- `asset_rename` `{path, new_name}` → `{old_path, new_path}`

## Changes
- New wrappers `src/tools/asset/asset-{delete,move,rename}.ts` (copy the `material-get-info.ts` shape; param names verified against the C++ `TryGetStringField` calls).
- Registered in `src/tools/index.ts`: `server.tool(...)` + `remember(...)` + eager `reg(...)` for each.
- Source-check test `src/tools/asset/asset-tools.test.ts` (12 assertions, green).

## Verification
- `vitest run src/tools/asset/asset-tools.test.ts` → 12/12 pass.
- `tsc --noEmit` clean (after building the `@hayba/*` workspace deps).
- Full suite: 557 pass / 27 fail — the 27 are the documented pre-existing UE-bridge mock failures, unrelated to this change.

No C++, plugin, or editor changes — the commands already ship in the plugin; this only makes them agent-callable after an MCP server reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)