### PR TITLE
fix: persist newly created material/blueprint assets to disk immediately

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPBlueprintHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPBlueprintHandler.cpp
@@ -17,6 +17,7 @@
 #include "K2Node_CallFunction.h"
 #include "UObject/UObjectGlobals.h"
 #include "UObject/Package.h"
+#include "UObject/SavePackage.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Misc/PackageName.h"
 
@@ -190,9 +191,22 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::Create(const TSharedPtr<FJsonObje
     FAssetRegistryModule::AssetCreated(BP);
     Package->MarkPackageDirty();
 
+    // Persist immediately: CreateBlueprint only builds the asset in memory, so a
+    // crash before the next edit would lose it. Save the .uasset to disk now.
+    bool bSaved = false;
+    {
+        const FString FileName = FPackageName::LongPackageNameToFilename(
+            Package->GetName(), FPackageName::GetAssetPackageExtension());
+        FSavePackageArgs SaveArgs;
+        SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+        SaveArgs.SaveFlags = SAVE_NoError;
+        bSaved = UPackage::SavePackage(Package, BP, *FileName, SaveArgs);
+    }
+
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("path"), BP->GetPathName());
     Out->SetStringField(TEXT("name"), Name);
+    Out->SetBoolField(TEXT("saved"), bSaved);
     return FHaybaHandlerResult::Ok(Out);
 }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -427,9 +427,17 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCreate(const TSharedPtr<FJsonOb
     UObject* Created = Tools.CreateAsset(Name, Dir, UMaterial::StaticClass(), Factory);
     if (!Created) return FHaybaHandlerResult::Err(TEXT("material_create: CreateAsset failed"));
 
+    // Persist immediately: CreateAsset only makes the asset in memory, so a
+    // crash (or session end) before the first edit would lose it and later
+    // material_get_info would report "no UMaterial at path".
+    FString SaveErr;
+    const bool bSaved = HaybaPersistAsset(Created, SaveErr);
+
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("path"), Created->GetPathName());
     Out->SetStringField(TEXT("name"), Name);
+    Out->SetBoolField(TEXT("saved"), bSaved);
+    if (!bSaved) Out->SetStringField(TEXT("save_error"), SaveErr);
     return FHaybaHandlerResult::Ok(Out);
 }
 
@@ -447,9 +455,16 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatFunctionCreate(const TSharedPtr
     UObject* Created = Tools.CreateAsset(Name, Dir, UMaterialFunction::StaticClass(), Factory);
     if (!Created) return FHaybaHandlerResult::Err(TEXT("material_function_create: CreateAsset failed"));
 
+    // Persist immediately (see material_create) so the function survives a crash
+    // before its first edit.
+    FString SaveErr;
+    const bool bSaved = HaybaPersistAsset(Created, SaveErr);
+
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("path"), Created->GetPathName());
     Out->SetStringField(TEXT("name"), Name);
+    Out->SetBoolField(TEXT("saved"), bSaved);
+    if (!bSaved) Out->SetStringField(TEXT("save_error"), SaveErr);
     return FHaybaHandlerResult::Ok(Out);
 }
 
@@ -635,8 +650,15 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCreateInstance(const TSharedPtr
     UObject* Created = Tools.CreateAsset(Name, Dir, UMaterialInstanceConstant::StaticClass(), Factory);
     if (!Created) return FHaybaHandlerResult::Err(TEXT("material_create_instance: CreateAsset failed"));
 
+    // Persist immediately (see material_create) so the instance survives a crash
+    // before its first parameter is set.
+    FString SaveErr;
+    const bool bSaved = HaybaPersistAsset(Created, SaveErr);
+
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("path"), Created->GetPathName());
+    Out->SetBoolField(TEXT("saved"), bSaved);
+    if (!bSaved) Out->SetStringField(TEXT("save_error"), SaveErr);
     return FHaybaHandlerResult::Ok(Out);
 }
 


### PR DESCRIPTION
## Problem

`material_get_info` was failing with `no UMaterial or UMaterialFunction at path` for an asset that had been created earlier (e.g. `MF_Cond_Biofilm`).

**Root cause:** the create handlers only made the asset *in memory*. `material_create`, `material_function_create`, `material_create_instance` (and `blueprint_create`) call `CreateAsset`/`CreateBlueprint` + `MarkPackageDirty` but never write the `.uasset` to disk. The crash-resilient auto-save added in #250 covered the *edit/compile* handlers but **missed the create handlers** — so an asset created and then lost to a crash/session-end before its first edit was never persisted, and a later `LoadObject` (in `material_get_info`) found nothing.

## Fix

Each create handler now persists the new asset to disk immediately (`HaybaPersistAsset`; `SavePackage` for blueprint) and returns `saved`. This closes the create→crash window in the deferred-compile / auto-save model — newly created assets are durable right away. Safe: factory-fresh assets have valid default graphs, so the save doesn't trigger an assert-prone translate.

## Verification

- C++ compiles against UE 5.7 via standalone `RunUAT BuildPlugin` → **BUILD SUCCESSFUL** (only pre-existing PCG-deprecation warnings remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)