### PR TITLE
fix(material): stop auto-saving master materials per-edit (Substrate crash landmine)

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -535,7 +535,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatAddNode(const TSharedPtr<FJsonO
     // Deferred-compile + crash-resilient save: no per-edit RecompileMaterial
     // (avoids translating a half-built graph -> editor-killing assert). Persist
     // to disk now; translate via the explicit material_compile command.
-    { FString SaveErr; HaybaPersistAsset(Mat, SaveErr); }
+    Mat->MarkPackageDirty();  // in-memory only — master materials are written to disk ONLY by material_compile, so a half-built invalid-Normal graph never lands on disk for the editor to thumbnail/open-compile (Substrate check(NormalCodeChunk!=INDEX_NONE) crash)
 
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("node_id"), Expr->GetName());
@@ -625,7 +625,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatConnectNodes(const TSharedPtr<F
     // Deferred-compile + crash-resilient save: no per-edit RecompileMaterial
     // (avoids translating a half-built graph -> editor-killing assert). Persist
     // to disk now; translate via the explicit material_compile command.
-    { FString SaveErr; HaybaPersistAsset(Mat, SaveErr); }
+    Mat->MarkPackageDirty();  // in-memory only — master materials are written to disk ONLY by material_compile, so a half-built invalid-Normal graph never lands on disk for the editor to thumbnail/open-compile (Substrate check(NormalCodeChunk!=INDEX_NONE) crash)
 
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetBoolField(TEXT("connected"), true);
@@ -993,7 +993,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatSetNode(const TSharedPtr<FJsonO
     // Deferred-compile + crash-resilient save: no per-edit RecompileMaterial
     // (avoids translating a half-built graph -> editor-killing assert). Persist
     // to disk now; translate via the explicit material_compile command.
-    { FString SaveErr; HaybaPersistAsset(Mat, SaveErr); }
+    Mat->MarkPackageDirty();  // in-memory only — master materials are written to disk ONLY by material_compile, so a half-built invalid-Normal graph never lands on disk for the editor to thumbnail/open-compile (Substrate check(NormalCodeChunk!=INDEX_NONE) crash)
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("node_id"), NodeId);
     return FHaybaHandlerResult::Ok(Out);
@@ -1030,7 +1030,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatDeleteNode(const TSharedPtr<FJs
     // Deferred-compile + crash-resilient save: no per-edit RecompileMaterial
     // (avoids translating a half-built graph -> editor-killing assert). Persist
     // to disk now; translate via the explicit material_compile command.
-    { FString SaveErr; HaybaPersistAsset(Mat, SaveErr); }
+    Mat->MarkPackageDirty();  // in-memory only — master materials are written to disk ONLY by material_compile, so a half-built invalid-Normal graph never lands on disk for the editor to thumbnail/open-compile (Substrate check(NormalCodeChunk!=INDEX_NONE) crash)
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetBoolField(TEXT("deleted"), true);
     return FHaybaHandlerResult::Ok(Out);
@@ -1082,7 +1082,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatAddComment(const TSharedPtr<FJs
     Mat->GetExpressionCollection().AddComment(C);
     // Comments don't affect compilation; persist to disk (no PostEditChange,
     // which would needlessly translate the material).
-    { FString SaveErr; HaybaPersistAsset(Mat, SaveErr); }
+    Mat->MarkPackageDirty();  // in-memory only — master materials are written to disk ONLY by material_compile, so a half-built invalid-Normal graph never lands on disk for the editor to thumbnail/open-compile (Substrate check(NormalCodeChunk!=INDEX_NONE) crash)
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("comment_id"), C->GetName());
     return FHaybaHandlerResult::Ok(Out);
@@ -1140,7 +1140,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatAddRerouteDeclaration(const TSh
     // Deferred-compile + crash-resilient save: no per-edit RecompileMaterial
     // (avoids translating a half-built graph -> editor-killing assert). Persist
     // to disk now; translate via the explicit material_compile command.
-    { FString SaveErr; HaybaPersistAsset(Mat, SaveErr); }
+    Mat->MarkPackageDirty();  // in-memory only — master materials are written to disk ONLY by material_compile, so a half-built invalid-Normal graph never lands on disk for the editor to thumbnail/open-compile (Substrate check(NormalCodeChunk!=INDEX_NONE) crash)
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("node_id"), D->GetName());
     return FHaybaHandlerResult::Ok(Out);
@@ -1193,7 +1193,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatAddRerouteUsage(const TSharedPt
     // Deferred-compile + crash-resilient save: no per-edit RecompileMaterial
     // (avoids translating a half-built graph -> editor-killing assert). Persist
     // to disk now; translate via the explicit material_compile command.
-    { FString SaveErr; HaybaPersistAsset(Mat, SaveErr); }
+    Mat->MarkPackageDirty();  // in-memory only — master materials are written to disk ONLY by material_compile, so a half-built invalid-Normal graph never lands on disk for the editor to thumbnail/open-compile (Substrate check(NormalCodeChunk!=INDEX_NONE) crash)
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("node_id"), U->GetName());
     return FHaybaHandlerResult::Ok(Out);
@@ -1229,16 +1229,15 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatSetProperty(const TSharedPtr<FJ
             Applied.Add(MakeShared<FJsonValueString>(Pair.Key));
     }
 
-    // Deferred-compile: persist the changed settings to disk; the translate
-    // (which applies the new BlendMode/Domain/etc. and could assert) happens on
-    // the explicit material_compile call, not here.
-    FString SaveErr;
-    const bool bSaved = HaybaPersistAsset(Mat, SaveErr);
+    // In-memory only: master materials are written to disk solely by
+    // material_compile, so settings changes never leave a half-built material on
+    // disk for the editor to compile-on-open (Substrate Normal-chunk assert).
+    Mat->MarkPackageDirty();
 
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetArrayField(TEXT("applied"), Applied);
-    Out->SetBoolField(TEXT("saved"), bSaved);
-    if (!bSaved) Out->SetStringField(TEXT("save_error"), SaveErr);
+    Out->SetBoolField(TEXT("saved"), false);
+    Out->SetStringField(TEXT("note"), TEXT("call material_compile to apply settings and write the material to disk"));
     return FHaybaHandlerResult::Ok(Out);
 }
 
@@ -1356,7 +1355,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatDisconnect(const TSharedPtr<FJs
             return FHaybaHandlerResult::Err(FString::Printf(TEXT("material_disconnect: input index %d out of range on %s"), NamedIdx, *ToNode));
     }
 
-    { FString SaveErr; HaybaPersistAsset(Mat, SaveErr); }
+    Mat->MarkPackageDirty();  // in-memory only — master materials are written to disk ONLY by material_compile, so a half-built invalid-Normal graph never lands on disk for the editor to thumbnail/open-compile (Substrate check(NormalCodeChunk!=INDEX_NONE) crash)
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetBoolField(TEXT("disconnected"), true);
     return FHaybaHandlerResult::Ok(Out);


### PR DESCRIPTION
## Crash

\`\`\`
Assertion failed: NormalCodeChunk != INDEX_NONE [HLSLMaterialTranslator.cpp:14248]
ContentBrowser -> AssetTools -> MaterialEditor -> HLSLMaterialTranslator (NO Hayba frame)
\`\`\`

## Root cause

`r.Substrate=True` is set **project-wide**, so *every* material compiles through the Substrate translator, which registers a shared-local-basis from the material's Normal and asserts `check(NormalCodeChunk != INDEX_NONE)` whenever the Normal is wired to an expression that compiles to nothing (a half-built/invalid source).

The earlier deferred-compile work stopped *our handlers* from translating, but the per-edit **auto-save still wrote the `.uasset`**. The editor then compiles that material **on open and when the Content Browser renders its thumbnail** — entirely outside our plugin (note the crash stack has no `HaybaMCPToolkit` frame). A `check()` is uncatchable, so an auto-saved invalid-Normal material became a crash landmine triggered just by browsing to it.

## Fix (chosen approach: don't auto-save master materials)

Master-material **edit** handlers (`add_node`, `connect_nodes`, `set_node`, `delete_node`, `add_comment`, reroute decl/usage, `set_property`, `disconnect`) now `MarkPackageDirty` **in memory only**. The master material `.uasset` is written to disk **only by `material_compile`** — agent-initiated, on a finished graph. So a half-built invalid material never lands on disk for the editor to thumbnail/open-compile.

- `material_create` still saves the **empty** (valid, crash-safe) asset, preserving the create→get_info round-trip fix.
- Material **functions** and **instances** keep auto-saving (unchanged).
- `material_compile` can still assert on a genuinely-invalid graph, but that is agent-initiated and deterministic — not triggered by the user browsing the Content Browser.

## Verification
- `RunUAT BuildPlugin` against UE 5.7 → **BUILD SUCCESSFUL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)