### PR TITLE
fix(plugin): thread-safe bIsRunning, render_camera inline, GAS/Sequencer null guards

### DIFF
--- a/unreal/HaybaMCPGAS/Source/HaybaMCPGAS/Private/HaybaMCPGASHandler.cpp
+++ b/unreal/HaybaMCPGAS/Source/HaybaMCPGAS/Private/HaybaMCPGASHandler.cpp
@@ -126,6 +126,7 @@ FHaybaHandlerResult FHaybaMCPGASHandler::GasGrantAbility(const TSharedPtr<FJsonO
         return FHaybaHandlerResult::Err(FString::Printf(TEXT("gas_grant_ability: ability class not found: %s"), *AbilityPath));
 
     UGameplayAbility* CDO = AbilityClass->GetDefaultObject<UGameplayAbility>();
+    if (!CDO) return FHaybaHandlerResult::Err(TEXT("gas_grant_ability: ability class has no default object (uncompiled blueprint?)"));
     FGameplayAbilitySpec Spec(CDO, Level, InputId);
     FGameplayAbilitySpecHandle Handle = ASC->GiveAbility(Spec);
 

--- a/unreal/HaybaMCPSequencer/Source/HaybaMCPSequencer/Private/HaybaMCPSequencerHandler.cpp
+++ b/unreal/HaybaMCPSequencer/Source/HaybaMCPSequencer/Private/HaybaMCPSequencerHandler.cpp
@@ -106,7 +106,11 @@ static FGuid FindOrCreateBinding(ULevelSequence* Seq, UObject* Object)
 {
     if (!Seq || !Object) return FGuid();
     UMovieScene* MS = Seq->GetMovieScene();
+    if (!MS) return FGuid();
     UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+    // BindPossessableObject dereferences World to resolve the possessable's
+    // context — a null world (no level loaded) would crash inside Sequencer.
+    if (!World) return FGuid();
 
     // search existing possessables (name-based; cheap idempotency)
     const FString ObjName = Object->GetName();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPTcpServer.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPTcpServer.h
@@ -56,7 +56,10 @@ private:
 	FRunnableThread* Thread = nullptr;
 	FSocket* ListenSocket = nullptr;
 	TSharedPtr<FHaybaMCPCommandHandler> CommandHandler;
-	bool bIsRunning = false;
+	// Read by the listener thread (Run) and connection threads, written by
+	// Shutdown/Stop on the game thread — must be thread-safe (a plain bool is a
+	// data race the compiler may hoist, never seeing shutdown).
+	FThreadSafeBool bIsRunning{ false };
 	FThreadSafeCounter ClientCount;
 
 	void HandleClientConnection(FHaybaMCPClientConnectionPtr Conn);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPRenderHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPRenderHandler.cpp
@@ -464,14 +464,22 @@ FHaybaHandlerResult FHaybaMCPRenderHandler::Handle(const FString& /*Command*/,
         return FHaybaHandlerResult::Err(TEXT("render_camera: failed to allocate FEvent"));
     }
 
-    // The lambda captures the shared ref, so S (and its FEvent) outlive this
-    // function even if the wait below times out — RunOnGameThread can never
-    // touch freed state.
-    AsyncTask(ENamedThreads::GameThread, [S]() { RunOnGameThread(S); });
-
-    // Allow the wait phase + render + headroom.
-    const uint32 BlockTimeoutMs = (uint32)((S->TimeoutSeconds + 60.0) * 1000.0);
-    const bool bSignaled = S->DoneEvent->Wait(BlockTimeoutMs);
+    // ProcessCommand already runs on the game thread, so run INLINE. The old
+    // AsyncTask(GameThread)+Wait queued a task the blocked game thread could
+    // never run -> deadlock -> always timed out (render never produced output).
+    // Only marshal when genuinely called from off the game thread; the shared
+    // ref keeps S alive across that hop even if the wait times out.
+    bool bSignaled = true;
+    if (IsInGameThread())
+    {
+        RunOnGameThread(S);
+    }
+    else
+    {
+        AsyncTask(ENamedThreads::GameThread, [S]() { RunOnGameThread(S); });
+        const uint32 BlockTimeoutMs = (uint32)((S->TimeoutSeconds + 60.0) * 1000.0);
+        bSignaled = S->DoneEvent->Wait(BlockTimeoutMs);
+    }
 
     // ── Build response ────────────────────────────────────────────────────
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();


### PR DESCRIPTION
Remaining verified crash-audit follow-ups (the 3 lower-confidence flags + the render async conversion).

- **`TcpServer::bIsRunning`** was a plain `bool` read by the listener + connection threads and written by `Shutdown`/`Stop` on the game thread — a data race the compiler may hoist (never seeing shutdown). Now `FThreadSafeBool` (matches the existing `bAlive`).
- **`render_camera`**: runs `RunOnGameThread` **inline** when already on the game thread (the common case). The old `AsyncTask(GameThread)+Wait` self-deadlocked → always timed out → never produced output. Off-thread callers keep the marshal+wait path.
- **`gas_grant_ability`**: null-check the ability CDO (uncompiled-blueprint guard).
- **Sequencer `FindOrCreateBinding`**: null-check `MovieScene` and the editor `World` before `BindPossessableObject` (which dereferences `World`).

## Verification
- Toolkit `RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**. GAS/Sequencer changes are one-line null-checks on already-included types (inspection-verified; their standalone build needs the toolkit installed).

## Still deferred (need in-editor smoke — they change command semantics)
`wait_for_idle` cooperative-poll restructure, and `build_*`/`test_run` non-blocking job envelope (these block the game thread until timeout but no longer crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)