### PR TITLE
feat(material): shader optimization feedback after material_compile

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -368,11 +368,11 @@ const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
     },
     {
       name: 'material_compile',
-      description: 'Explicitly compile a material (apply staged settings + surface translator errors). Graph edits auto-save and defer compilation; call this once the graph is complete.',
+      description: 'Explicitly compile a material (apply staged settings + surface translator errors) and return shader optimization stats. Graph edits auto-save and defer compilation; call this once the graph is complete. The result includes a stats block (per-shader instruction counts, texture samples, samplers, interpolators) plus an OPTIMIZATION FEEDBACK summary with hints.',
       meta: materialCompileMeta,
       handler: materialCompileHandler,
       cost: 'medium',
-      returns: '{errors:[string], has_errors, saved}',
+      returns: '{errors:[string], has_errors, saved, stats:{shaders:[{name,instructions}], texture_samples, texture_lookups, virtual_texture_lookups, samplers, max_samplers, interpolators_used, interpolators_max}}',
       niche: M,
       schema: {
         material_path: z.string().min(1).describe('Path to the master material asset to compile'),

--- a/mcp-tools/hayba-mcp/src/tools/material/material-compile.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/material/material-compile.test.ts
@@ -1,24 +1,56 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const executeCommandMock = vi.fn(async () => ({ errors: [], has_errors: false, saved: true }) as unknown);
+
 vi.mock('../tool-executor.js', () => ({
-  executeCommand: vi.fn(async () => ({ errors: [], has_errors: false, saved: true })),
+  executeCommand: (...args: unknown[]) => executeCommandMock(...(args as [])),
 }));
 
-import { executeCommand } from '../tool-executor.js';
 import { materialCompileHandler } from './material-compile.js';
 
 describe('material_compile', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    executeCommandMock.mockReset();
+    executeCommandMock.mockResolvedValue({ errors: [], has_errors: false, saved: true });
+  });
 
   it('forwards material_compile with the material path', async () => {
     const r = await materialCompileHandler({ material_path: '/Game/M_Test' });
-    expect(executeCommand).toHaveBeenCalledWith('material_compile', expect.objectContaining({ material_path: '/Game/M_Test' }));
+    expect(executeCommandMock).toHaveBeenCalledWith('material_compile', expect.objectContaining({ material_path: '/Game/M_Test' }));
     expect(r.isError).toBeFalsy();
   });
 
   it('rejects missing material_path', async () => {
     const r = await materialCompileHandler({});
     expect(r.isError).toBe(true);
-    expect(executeCommand).not.toHaveBeenCalled();
+    expect(executeCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('returns only the JSON block when UE omits stats (old plugin builds)', async () => {
+    const r = await materialCompileHandler({ material_path: '/Game/M_Test' });
+    expect(r.content).toHaveLength(1);
+    expect(r.content[0].text).toContain('"saved": true');
+  });
+
+  it('appends an optimization-feedback block when UE returns stats', async () => {
+    executeCommandMock.mockResolvedValue({
+      errors: [],
+      has_errors: false,
+      saved: true,
+      stats: {
+        shaders: [{ name: 'Base pass shader', instructions: 142 }],
+        texture_samples: 4,
+        samplers: 3,
+        max_samplers: 16,
+        interpolators_used: 8,
+        interpolators_max: 16,
+      },
+    });
+    const r = await materialCompileHandler({ material_path: '/Game/M_Test' });
+    expect(r.content).toHaveLength(2);
+    // First block is the raw JSON, second is the feedback.
+    expect(r.content[0].text).toContain('"stats"');
+    expect(r.content[1].text).toContain('OPTIMIZATION FEEDBACK');
+    expect(r.content[1].text).toContain('Base pass shader: 142');
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/material/material-compile.ts
+++ b/mcp-tools/hayba-mcp/src/tools/material/material-compile.ts
@@ -2,11 +2,12 @@ import { z } from 'zod';
 import type { ToolResult, SessionManager } from '../types.js';
 import { executeCommand } from '../tool-executor.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { formatOptimizationFeedback, type MaterialStats } from './material-stats.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'medium',
   effects: ['modifies_asset'],
-  when: 'explicitly compiling a material after building/editing its graph, to apply staged settings and surface translator errors',
+  when: 'explicitly compiling a material after building/editing its graph, to apply staged settings, surface translator errors, and read back shader optimization stats (instruction counts, texture samples)',
   not_when: 'mid-edit — graph edits (add_node/connect/set_node/...) already auto-save to disk and intentionally DEFER compilation; only compile once the graph is complete',
 };
 
@@ -20,5 +21,18 @@ export async function materialCompileHandler(args: Record<string, unknown>, _ses
     return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
   }
   const data = await executeCommand('material_compile', parsed.data as Record<string, unknown>);
-  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+
+  const content: ToolResult['content'] = [
+    { type: 'text', text: JSON.stringify(data, null, 2) },
+  ];
+
+  // Surface optimization feedback (instruction counts, texture samples, etc.)
+  // right after compile so the AI can react to shader cost. The `stats` block
+  // is produced by the UE-side material_compile handler from the recompiled
+  // FMaterialResource shader map; older plugin builds omit it (feedback skipped).
+  const stats = (data as { stats?: MaterialStats } | null | undefined)?.stats;
+  const feedback = formatOptimizationFeedback(stats);
+  if (feedback) content.push({ type: 'text', text: feedback });
+
+  return { content };
 }

--- a/mcp-tools/hayba-mcp/src/tools/material/material-stats.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/material/material-stats.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { formatOptimizationFeedback, maxInstructions, type MaterialStats } from './material-stats.js';
+
+describe('material-stats: maxInstructions', () => {
+  it('returns the peak across shader permutations', () => {
+    const stats: MaterialStats = {
+      shaders: [
+        { name: 'Base pass shader', instructions: 142 },
+        { name: 'Base pass shader with CSM', instructions: 188 },
+      ],
+    };
+    expect(maxInstructions(stats)).toBe(188);
+  });
+
+  it('returns 0 when no shaders', () => {
+    expect(maxInstructions({})).toBe(0);
+  });
+});
+
+describe('material-stats: formatOptimizationFeedback', () => {
+  it('returns null when stats are absent', () => {
+    expect(formatOptimizationFeedback(undefined)).toBeNull();
+    expect(formatOptimizationFeedback(null)).toBeNull();
+    expect(formatOptimizationFeedback({})).toBeNull();
+  });
+
+  it('renders instruction counts and a peak', () => {
+    const out = formatOptimizationFeedback({
+      shaders: [
+        { name: 'Base pass shader', instructions: 142 },
+        { name: 'Base pass shader with CSM', instructions: 156 },
+      ],
+      texture_samples: 4,
+      samplers: 3,
+      max_samplers: 16,
+      interpolators_used: 8,
+      interpolators_max: 16,
+    });
+    expect(out).toContain('OPTIMIZATION FEEDBACK');
+    expect(out).toContain('peak: 156');
+    expect(out).toContain('Base pass shader: 142');
+    expect(out).toContain('Texture samples: 4');
+    expect(out).toContain('Samplers: 3/16');
+    expect(out).toContain('Interpolator scalars: 8/16');
+  });
+
+  it('emits a high-instruction hint past the high threshold', () => {
+    const out = formatOptimizationFeedback({
+      shaders: [{ name: 'Base pass shader', instructions: 400 }],
+    });
+    expect(out).toContain('Hints:');
+    expect(out).toMatch(/instruction count is high/i);
+  });
+
+  it('emits a warning hint in the warn band but not the high hint', () => {
+    const out = formatOptimizationFeedback({
+      shaders: [{ name: 'Base pass shader', instructions: 250 }],
+    });
+    expect(out).toMatch(/getting heavy/i);
+    expect(out).not.toMatch(/instruction count is high/i);
+  });
+
+  it('warns on heavy texture sampling', () => {
+    const out = formatOptimizationFeedback({
+      shaders: [{ name: 'Base pass shader', instructions: 50 }],
+      texture_samples: 12,
+    });
+    expect(out).toMatch(/texture samples/i);
+    expect(out).toMatch(/packing channels/i);
+  });
+
+  it('warns when the sampler budget is reached', () => {
+    const out = formatOptimizationFeedback({
+      shaders: [{ name: 'Base pass shader', instructions: 50 }],
+      samplers: 16,
+      max_samplers: 16,
+    });
+    expect(out).toMatch(/Sampler budget reached/i);
+  });
+
+  it('shows dependent-lookup detail when texture_lookups differs', () => {
+    const out = formatOptimizationFeedback({
+      texture_samples: 4,
+      texture_lookups: 6,
+    });
+    expect(out).toContain('Texture samples: 4 (6 lookups incl. dependent)');
+  });
+
+  it('renders even when only numeric stats are present (no shaders array)', () => {
+    const out = formatOptimizationFeedback({ samplers: 2, max_samplers: 16 });
+    expect(out).toContain('OPTIMIZATION FEEDBACK');
+    expect(out).toContain('Samplers: 2/16');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/material/material-stats.ts
+++ b/mcp-tools/hayba-mcp/src/tools/material/material-stats.ts
@@ -1,0 +1,138 @@
+// Optimization feedback for material_compile. The UE-side material_compile
+// handler returns a `stats` object (instruction counts per shader, texture
+// samples, samplers, interpolators) gathered from the FMaterialResource shader
+// map after recompilation — the same numbers the Material Editor's Stats panel
+// shows. This module turns that raw data into a concise, AI-readable
+// optimization briefing with threshold-based hints, so the agent gets feedback
+// on shader cost right after it compiles a material via MCP.
+
+/** One shader permutation's instruction count, as reported by UE. */
+export interface ShaderInstructionStat {
+  /** Shader/permutation description, e.g. "Base pass shader". */
+  name: string;
+  /** Estimated instruction count for that permutation. */
+  instructions: number;
+}
+
+/** Raw material stats block as returned by the UE material_compile handler. */
+export interface MaterialStats {
+  shaders?: ShaderInstructionStat[];
+  /** Estimated texture samples (base). */
+  texture_samples?: number;
+  /** Estimated texture lookups (incl. dependent). */
+  texture_lookups?: number;
+  /** Virtual texture lookups. */
+  virtual_texture_lookups?: number;
+  /** Samplers used. */
+  samplers?: number;
+  /** Sampler budget for the target platform. */
+  max_samplers?: number;
+  /** Vertex→pixel interpolator scalars used. */
+  interpolators_used?: number;
+  /** Interpolator scalar budget. */
+  interpolators_max?: number;
+  /** Shading model / blend mode echoed back for context (optional). */
+  shading_model?: string;
+  blend_mode?: string;
+}
+
+// Soft thresholds for hinting. These are deliberately conservative, generic
+// rules of thumb for a typical opaque PBR surface — they nudge, they don't gate.
+const INSTR_WARN = 200;   // "getting heavy"
+const INSTR_HIGH = 350;   // "expensive — consider simplifying"
+const SAMPLES_WARN = 8;   // many texture fetches → bandwidth-bound
+
+/** The peak instruction count across all reported shader permutations. */
+export function maxInstructions(stats: MaterialStats): number {
+  const shaders = stats.shaders ?? [];
+  return shaders.reduce((m, s) => Math.max(m, s.instructions ?? 0), 0);
+}
+
+/**
+ * Build a human/AI-readable optimization-feedback block from material stats.
+ * Returns null when there is nothing useful to report (no stats present), so
+ * callers can omit the block entirely for older UE builds.
+ */
+export function formatOptimizationFeedback(stats: MaterialStats | undefined | null): string | null {
+  if (!stats || typeof stats !== 'object') return null;
+  const shaders = Array.isArray(stats.shaders) ? stats.shaders : [];
+  const hasAnything =
+    shaders.length > 0 ||
+    typeof stats.texture_samples === 'number' ||
+    typeof stats.samplers === 'number' ||
+    typeof stats.interpolators_used === 'number';
+  if (!hasAnything) return null;
+
+  const lines: string[] = ['OPTIMIZATION FEEDBACK (post-compile shader stats)'];
+
+  if (shaders.length > 0) {
+    const peak = maxInstructions(stats);
+    lines.push(`  Instructions (peak: ${peak}):`);
+    for (const s of shaders) {
+      lines.push(`    - ${s.name}: ${s.instructions}`);
+    }
+  }
+
+  const t = stats.texture_samples;
+  const tl = stats.texture_lookups;
+  if (typeof t === 'number') {
+    const lookupPart = typeof tl === 'number' && tl !== t ? ` (${tl} lookups incl. dependent)` : '';
+    lines.push(`  Texture samples: ${t}${lookupPart}`);
+  }
+  if (typeof stats.virtual_texture_lookups === 'number' && stats.virtual_texture_lookups > 0) {
+    lines.push(`  Virtual texture lookups: ${stats.virtual_texture_lookups}`);
+  }
+  if (typeof stats.samplers === 'number') {
+    const budget = typeof stats.max_samplers === 'number' ? `/${stats.max_samplers}` : '';
+    lines.push(`  Samplers: ${stats.samplers}${budget}`);
+  }
+  if (typeof stats.interpolators_used === 'number') {
+    const budget = typeof stats.interpolators_max === 'number' ? `/${stats.interpolators_max}` : '';
+    lines.push(`  Interpolator scalars: ${stats.interpolators_used}${budget}`);
+  }
+
+  const hints = buildHints(stats);
+  if (hints.length > 0) {
+    lines.push('  Hints:');
+    for (const h of hints) lines.push(`    - ${h}`);
+  }
+
+  return lines.join('\n');
+}
+
+/** Threshold-based, generic optimization hints derived from the stats. */
+function buildHints(stats: MaterialStats): string[] {
+  const hints: string[] = [];
+  const peak = maxInstructions(stats);
+
+  if (peak >= INSTR_HIGH) {
+    hints.push(`Peak instruction count is high (${peak} >= ${INSTR_HIGH}). Consider baking constant sub-graphs, reducing math nodes, or moving work to a material instance/parameters.`);
+  } else if (peak >= INSTR_WARN) {
+    hints.push(`Instruction count is getting heavy (${peak} >= ${INSTR_WARN}). Watch added math/noise nodes on this material.`);
+  }
+
+  const t = stats.texture_samples;
+  if (typeof t === 'number' && t >= SAMPLES_WARN) {
+    hints.push(`${t} texture samples — texture fetches dominate cost here; consider packing channels (ORM/mask atlases) to cut samples.`);
+  }
+
+  if (
+    typeof stats.samplers === 'number' &&
+    typeof stats.max_samplers === 'number' &&
+    stats.max_samplers > 0 &&
+    stats.samplers >= stats.max_samplers
+  ) {
+    hints.push(`Sampler budget reached (${stats.samplers}/${stats.max_samplers}). Switch some textures to "Shared: Wrap/Clamp" sampler source to free dedicated samplers.`);
+  }
+
+  if (
+    typeof stats.interpolators_used === 'number' &&
+    typeof stats.interpolators_max === 'number' &&
+    stats.interpolators_max > 0 &&
+    stats.interpolators_used >= stats.interpolators_max
+  ) {
+    hints.push(`Interpolator budget reached (${stats.interpolators_used}/${stats.interpolators_max}). Reduce custom UVs / vertex-interpolated data.`);
+  }
+
+  return hints;
+}

--- a/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
+++ b/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
@@ -24,7 +24,7 @@ GRAPH CONSTRUCTION
   material_add_reroute_usage   Create a named-reroute usage bound to a declaration
 
 COMPILATION & INSPECTION
-  material_compile             Explicitly compile a material — apply staged settings + surface translator errors
+  material_compile             Explicitly compile a material — apply staged settings + surface translator errors + report shader optimization stats (instruction counts, texture samples, samplers) with hints
   material_get_info            Inspect a material or material instance: properties, parameters, connected expressions
   material_list                List materials and material instances in the project or a specific path
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/HaybaMCPToolkit.Build.cs
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/HaybaMCPToolkit.Build.cs
@@ -12,6 +12,12 @@ public class HaybaMCPToolkit : ModuleRules
         PublicSystemIncludePaths.Add(
             Path.Combine(EngineDir, "Source/Editor/LandscapeEditor/Private")
         );
+        // FShaderStatsInfo (material_compile optimization feedback) lives in
+        // MaterialEditor's private headers; FMaterialStatsUtils::ExtractMatertialStatsInfo
+        // is MATERIALEDITOR_API-exported and fills it.
+        PublicSystemIncludePaths.Add(
+            Path.Combine(EngineDir, "Source/Editor/MaterialEditor/Private")
+        );
 
         PublicDependencyModuleNames.AddRange(new string[] {
             "Core", "CoreUObject", "Engine", "Slate", "SlateCore",

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -46,6 +46,9 @@
 #include "Materials/MaterialExpressionComment.h"
 #include "Materials/MaterialExpressionNamedReroute.h"
 #include "MaterialShared.h"  // FMaterialResource, GetCompileErrors (material_compile)
+#include "MaterialStatsCommon.h" // FMaterialStatsUtils::ExtractMatertialStatsInfo (material_compile optimization feedback)
+#include "MaterialStats.h"       // FShaderStatsInfo (MaterialEditor private; include path added in Build.cs)
+#include "RHI.h"                 // GetExpectedFeatureLevelMaxTextureSamplers, GMaxRHIShaderPlatform
 #include "UObject/SavePackage.h"
 #include "HaybaMCPReflection.h"  // HaybaReflection::SetProp / SetStructField (generic, extracted from this handler)
 #include "HaybaMCPParams.h"      // HaybaParams::GetString / GetNumber / GetBool / GetVec3
@@ -1127,7 +1130,8 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCompile(const TSharedPtr<FJsonO
     UMaterialEditingLibrary::RecompileMaterial(Mat);
 
     TArray<TSharedPtr<FJsonValue>> Errs;
-    if (FMaterialResource* Res = Mat->GetMaterialResource(GMaxRHIShaderPlatform))
+    FMaterialResource* Res = Mat->GetMaterialResource(GMaxRHIShaderPlatform);
+    if (Res)
         for (const FString& E : Res->GetCompileErrors())
             Errs.Add(MakeShared<FJsonValueString>(E));
 
@@ -1139,6 +1143,96 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCompile(const TSharedPtr<FJsonO
     Out->SetBoolField(TEXT("has_errors"), Errs.Num() > 0);
     Out->SetBoolField(TEXT("saved"), bSaved);
     if (!bSaved) Out->SetStringField(TEXT("save_error"), SaveErr);
+
+    // ── Optimization feedback ────────────────────────────────────────────────
+    // After a clean recompile, read shader cost off the recompiled
+    // FMaterialResource — the same numbers the Material Editor Stats panel shows
+    // — so the AI building this material via MCP gets instruction counts,
+    // texture samples, samplers, and interpolator usage as actionable feedback.
+    if (Res && Errs.Num() == 0)
+    {
+        TSharedPtr<FJsonObject> Stats = MakeShared<FJsonObject>();
+
+        // Instruction counts per representative shader permutation.
+        // ExtractMatertialStatsInfo is MATERIALEDITOR_API-exported; it internally
+        // calls GetRepresentativeInstructionCounts (which is not exported).
+        FShaderStatsInfo Info;
+        FMaterialStatsUtils::ExtractMatertialStatsInfo(GMaxRHIShaderPlatform, Info, Res);
+
+        // Local name map — FMaterialStatsUtils::RepresentativeShaderTypeToString is
+        // not exported to plugins (link error), so map the (small, stable) enum here.
+        auto RepShaderName = [](ERepresentativeShader S) -> FString
+        {
+            switch (S)
+            {
+                case ERepresentativeShader::StationarySurface:            return TEXT("Stationary surface");
+                case ERepresentativeShader::StationarySurfaceCSM:         return TEXT("Stationary surface + CSM");
+                case ERepresentativeShader::StationarySurfaceNPointLights:return TEXT("Stationary surface + N point lights");
+                case ERepresentativeShader::DynamicallyLitObject:         return TEXT("Dynamically lit object");
+                case ERepresentativeShader::RuntimeVirtualTextureOutput:  return TEXT("Runtime virtual texture output");
+                case ERepresentativeShader::UIDefaultFragmentShader:      return TEXT("UI pixel shader");
+                case ERepresentativeShader::StaticMesh:                   return TEXT("Static mesh vertex shader");
+                case ERepresentativeShader::SkeletalMesh:                 return TEXT("Skeletal mesh vertex shader");
+                case ERepresentativeShader::SkinnedCloth:                 return TEXT("Skinned cloth vertex shader");
+                case ERepresentativeShader::UIDefaultVertexShader:        return TEXT("UI vertex shader");
+                case ERepresentativeShader::UIInstancedVertexShader:      return TEXT("UI instanced vertex shader");
+                case ERepresentativeShader::NaniteMesh:                   return TEXT("Nanite mesh shader");
+                default:                                                  return FString::Printf(TEXT("shader_%d"), (int32)S);
+            }
+        };
+
+        TArray<TSharedPtr<FJsonValue>> Shaders;
+        int32 PeakInstructions = 0;
+        for (const TPair<ERepresentativeShader, FShaderStatsInfo::FContent>& Pair : Info.ShaderInstructionCount)
+        {
+            // StrDescription is the bare instruction count (e.g. "142") or "n/a".
+            const FString& Desc = Pair.Value.StrDescription;
+            int32 Count = 0;
+            const bool bNumeric = Desc.IsNumeric() && (Count = FCString::Atoi(*Desc)) >= 0;
+            if (!bNumeric) continue;
+            PeakInstructions = FMath::Max(PeakInstructions, Count);
+
+            TSharedPtr<FJsonObject> ShaderObj = MakeShared<FJsonObject>();
+            ShaderObj->SetStringField(TEXT("name"), RepShaderName(Pair.Key));
+            ShaderObj->SetNumberField(TEXT("instructions"), Count);
+            Shaders.Add(MakeShared<FJsonValueObject>(ShaderObj));
+        }
+        Stats->SetArrayField(TEXT("shaders"), Shaders);
+        Stats->SetNumberField(TEXT("peak_instructions"), PeakInstructions);
+
+        // Numeric stats straight off the exported FMaterialResource getters.
+        uint32 NumVSTextureSamples = 0, NumPSTextureSamples = 0;
+        Res->GetEstimatedNumTextureSamples(NumVSTextureSamples, NumPSTextureSamples);
+        Stats->SetNumberField(TEXT("texture_samples"), (double)(NumVSTextureSamples + NumPSTextureSamples));
+        Stats->SetNumberField(TEXT("texture_samples_vs"), (double)NumVSTextureSamples);
+        Stats->SetNumberField(TEXT("texture_samples_ps"), (double)NumPSTextureSamples);
+        // Lookups: estimated samples + virtual-texture lookups.
+        const uint32 NumVTLookups = Res->GetEstimatedNumVirtualTextureLookups();
+        Stats->SetNumberField(TEXT("virtual_texture_lookups"), (double)NumVTLookups);
+        Stats->SetNumberField(TEXT("texture_lookups"), (double)(NumVSTextureSamples + NumPSTextureSamples + NumVTLookups));
+
+        const int32 SamplersUsed = FMath::Max(Res->GetSamplerUsage(), 0);
+        const int32 MaxSamplers = GetExpectedFeatureLevelMaxTextureSamplers(Res->GetFeatureLevel());
+        Stats->SetNumberField(TEXT("samplers"), SamplersUsed);
+        Stats->SetNumberField(TEXT("max_samplers"), MaxSamplers);
+
+        uint32 UVScalars = 0, CustomScalars = 0;
+        Res->GetUserInterpolatorUsage(UVScalars, CustomScalars);
+        const uint32 TotalScalars = UVScalars + CustomScalars;
+        const uint32 MaxScalars = FMath::DivideAndRoundUp(TotalScalars, 4u) * 4;
+        Stats->SetNumberField(TEXT("interpolators_used"), (double)TotalScalars);
+        Stats->SetNumberField(TEXT("interpolators_max"), (double)MaxScalars);
+
+        // Context echo. UMaterial::GetBlendModeString isn't exported to plugins;
+        // EBlendMode is a UENUM, so resolve the name via reflection (linkable).
+        FString BlendModeName = FString::Printf(TEXT("%d"), (int32)Mat->GetBlendMode());
+        if (const UEnum* BlendEnum = StaticEnum<EBlendMode>())
+            BlendModeName = BlendEnum->GetNameStringByValue((int64)Mat->GetBlendMode());
+        Stats->SetStringField(TEXT("blend_mode"), BlendModeName);
+
+        Out->SetObjectField(TEXT("stats"), Stats);
+    }
+
     return FHaybaHandlerResult::Ok(Out);
 }
 


### PR DESCRIPTION
`material_compile` now returns the Material Editor **Stats panel** numbers so an agent can react to shader cost.

- **UE C++** (`MatCompile`): after a clean recompile, reads the recompiled `FMaterialResource` and emits a `stats` block — per-shader instruction counts (`FMaterialStatsUtils::ExtractMatertialStatsInfo`), texture samples (VS/PS), virtual-texture lookups, samplers used/max, interpolator scalars used/max, blend mode. `Build.cs` adds the MaterialEditor private include path (same pattern as the existing LandscapeEditor one).
- **TS** (`material-stats.ts` + `material-compile.ts`): formats an `OPTIMIZATION FEEDBACK` block (peak instruction count + threshold hints) appended to the result. Backwards compatible — old plugin builds that omit `stats` produce no extra block.
- Tool description / meta / `returns` / material niche-briefing updated.

Two non-exported MaterialEditor symbols in the first draft (`UMaterial::GetBlendModeString`, `FMaterialStatsUtils::RepresentativeShaderTypeToString`) were caught by the plugin **link** step and replaced with linkable equivalents (`StaticEnum<EBlendMode>` reflection + a local `ERepresentativeShader` name map).

## Verification
- `RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**; `tsc` clean; `vitest` **76 files / 463 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Material compile tool now provides detailed shader optimization statistics including per-shader instruction counts, texture sampling metrics, sampler budget utilization, and interpolator usage information.
  * Added automatic optimization feedback with performance hints and warnings based on analysis of shader resource thresholds.

* **Tests**
  * Expanded test coverage for material compilation diagnostics and optimization feedback generation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->