### PR TITLE
fix(tcp): dispatch commands from a game-thread ticker, not an AsyncTask task

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPTcpServer.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPTcpServer.cpp
@@ -59,6 +59,15 @@ bool FHaybaMCPTcpServer::Start()
     }
 
     bIsRunning = true;
+
+    // Drain queued commands on the game thread from the engine tick (NOT a
+    // task-graph task) — see header note: running ProcessCommand inside an
+    // AsyncTask(GameThread) task crashes when a handler re-enters the task graph
+    // (python_run -> Interchange import: check(RecursionGuard==1)). AddTicker
+    // must run on the game thread; Start() is called during game-thread plugin init.
+    DrainTickerHandle = FTSTicker::GetCoreTicker().AddTicker(
+        FTickerDelegate::CreateRaw(this, &FHaybaMCPTcpServer::DrainPendingCommands), 0.0f);
+
     Thread = FRunnableThread::Create(this, TEXT("HaybaMCPTCPServer"), 0, TPri_Normal);
 
     UE_LOG(LogHaybaMCPTCP, Log, TEXT("TCP server started on port %d"), Port);
@@ -70,6 +79,12 @@ void FHaybaMCPTcpServer::Shutdown()
     if (!bIsRunning) return;
 
     bIsRunning = false;
+
+    if (DrainTickerHandle.IsValid())
+    {
+        FTSTicker::GetCoreTicker().RemoveTicker(DrainTickerHandle);
+        DrainTickerHandle.Reset();
+    }
 
     if (Thread)
     {
@@ -128,22 +143,35 @@ void FHaybaMCPTcpServer::HandleClientConnection(FHaybaMCPClientConnectionPtr Con
             return;
         }
 
-        // Capture Conn by value so the socket outlives this read loop; the
-        // task bails if the client disconnected before the command finished.
-        AsyncTask(ENamedThreads::GameThread, [this, Message, Conn]()
-        {
-            if (!Conn->bAlive || !CommandHandler.IsValid())
-            {
-                return;
-            }
-            FString ResponseString = CommandHandler->ProcessCommand(Message);
-            SendMessage(Conn, ResponseString);
-        });
+        // Enqueue for the game-thread ticker drain (Conn captured by value so the
+        // socket outlives this read loop). NOT AsyncTask(GameThread) — see header:
+        // running a handler inside a task-graph task crashes when it re-enters the
+        // task graph (python_run -> Interchange import).
+        PendingCommands.Enqueue(FHaybaMCPPendingCommand{ Message, Conn });
     }
 
     // Server is shutting down while this client is still connected.
     Conn->bAlive = false;
     ClientCount.Decrement();
+}
+
+bool FHaybaMCPTcpServer::DrainPendingCommands(float /*DeltaTime*/)
+{
+    // Runs on the game thread from the engine tick (outside task-graph task
+    // execution), so a handler may safely pump the task graph (asset import etc).
+    // Drain all pending commands this tick — each command is one game-thread
+    // command, matching the historical one-task-per-command behaviour.
+    FHaybaMCPPendingCommand Cmd;
+    while (PendingCommands.Dequeue(Cmd))
+    {
+        if (!Cmd.Conn.IsValid() || !Cmd.Conn->bAlive || !CommandHandler.IsValid())
+        {
+            continue;
+        }
+        const FString ResponseString = CommandHandler->ProcessCommand(Cmd.Message);
+        SendMessage(Cmd.Conn, ResponseString);
+    }
+    return true; // keep ticking
 }
 
 bool FHaybaMCPTcpServer::ReadMessage(FSocket* Socket, FString& OutMessage)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPTcpServer.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPTcpServer.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "HAL/Runnable.h"
 #include "HAL/ThreadSafeBool.h"
+#include "Containers/Queue.h"
+#include "Containers/Ticker.h"
 #include "Networking.h"
 
 class FHaybaMCPCommandHandler;
@@ -25,6 +27,13 @@ struct FHaybaMCPClientConnection
 };
 
 using FHaybaMCPClientConnectionPtr = TSharedPtr<FHaybaMCPClientConnection, ESPMode::ThreadSafe>;
+
+/** A received command awaiting execution on the game thread. */
+struct FHaybaMCPPendingCommand
+{
+	FString Message;
+	FHaybaMCPClientConnectionPtr Conn;
+};
 
 class FHaybaMCPTcpServer : public FRunnable
 {
@@ -61,6 +70,16 @@ private:
 	// data race the compiler may hoist, never seeing shutdown).
 	FThreadSafeBool bIsRunning{ false };
 	FThreadSafeCounter ClientCount;
+
+	// Commands run on the game thread via a TICKER drain (not AsyncTask). Running
+	// inside an AsyncTask(GameThread) *task* makes any handler that itself pumps
+	// the game-thread task graph (e.g. python_run -> Interchange asset import)
+	// re-enter task-graph processing -> check(RecursionGuard==1) crash. A ticker
+	// runs in the normal engine tick, outside task-graph task execution, so such
+	// work is safe. Connection (background) threads enqueue; the ticker drains.
+	TQueue<FHaybaMCPPendingCommand, EQueueMode::Mpsc> PendingCommands;
+	FTSTicker::FDelegateHandle DrainTickerHandle;
+	bool DrainPendingCommands(float DeltaTime);
 
 	void HandleClientConnection(FHaybaMCPClientConnectionPtr Conn);
 	bool ReadMessage(FSocket* Socket, FString& OutMessage);


### PR DESCRIPTION
## Crash
\`\`\`
Assertion failed: ++Queue(QueueIndex).RecursionGuard == 1 [TaskGraph.cpp:689]
... InterchangeEngine ... AssetTools ... PythonScriptPlugin ...
HaybaMCPPythonHandler::Run() -> ProcessCommand() -> TcpServer::HandleClientConnection lambda
\`\`\`

## Root cause
Commands ran inside `AsyncTask(ENamedThreads::GameThread, ...)` (`TcpServer.cpp:133`) — i.e. inside a **task-graph task**. A `python_run` that triggers an Interchange asset import causes the import to **pump the game-thread task graph**, which re-enters task-graph processing while already inside a task → `check(RecursionGuard == 1)` → editor crash.

## Fix
Connection threads now **enqueue** commands into an MPSC queue; a game-thread **`FTSTicker`** (registered in `Start`, removed in `Shutdown`) drains the queue and runs `ProcessCommand` + `SendMessage`. A ticker fires from the normal engine tick — **outside** task-graph task execution — so a handler may freely pump the task graph (asset import, Interchange, etc.). Commands still run on the game thread, serialized, exactly as before; only the execution context changes (no longer nested in a task).

## Verification
- `RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)