### PR TITLE
feat(material): material_delete_comment + comments in material_get_info

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -47,6 +47,7 @@ import { materialAddNodeHandler, meta as materialAddNodeMeta } from './material/
 import { materialSetNodeHandler, meta as materialSetNodeMeta } from './material/material-set-node.js';
 import { materialDeleteNodeHandler, meta as materialDeleteNodeMeta } from './material/material-delete-node.js';
 import { materialAddCommentHandler, meta as materialAddCommentMeta } from './material/material-add-comment.js';
+import { materialDeleteCommentHandler, meta as materialDeleteCommentMeta } from './material/material-delete-comment.js';
 import { materialAddRerouteDeclarationHandler, meta as materialAddRerouteDeclarationMeta } from './material/material-add-reroute-declaration.js';
 import { materialAddRerouteUsageHandler, meta as materialAddRerouteUsageMeta } from './material/material-add-reroute-usage.js';
 import { assetDeleteHandler, meta as assetDeleteMeta } from './asset/asset-delete.js';
@@ -394,6 +395,20 @@ const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
         size: z.tuple([z.number(), z.number()]).optional().describe('Box size [width, height]'),
         color: z.array(z.number()).min(3).max(4).optional().describe('Box color [r, g, b] or [r, g, b, a] (0..1)'),
         font_size: z.number().int().optional().describe('Title font size (default 18)'),
+      },
+    },
+    {
+      name: 'material_delete_comment',
+      description: 'Delete a comment box from a material or function graph (comment_id from material_get_info.comments[].id). Named reroutes are nodes — use material_delete_node for those.',
+      meta: materialDeleteCommentMeta,
+      handler: materialDeleteCommentHandler,
+      cost: 'low',
+      returns: '{deleted}',
+      niche: M,
+      schema: {
+        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
+        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
+        comment_id: z.string().min(1).describe('Comment id to delete (from material_get_info.comments[].id)'),
       },
     },
     {

--- a/mcp-tools/hayba-mcp/src/tools/material/material-delete-comment.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/material/material-delete-comment.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../tool-executor.js', () => ({
+  executeCommand: vi.fn(async () => ({ deleted: true })),
+}));
+
+import { executeCommand } from '../tool-executor.js';
+import { materialDeleteCommentHandler } from './material-delete-comment.js';
+
+describe('material_delete_comment', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('forwards material_delete_comment with material_path + comment_id', async () => {
+    const r = await materialDeleteCommentHandler({ material_path: '/Game/M', comment_id: 'MaterialExpressionComment_0' });
+    expect(executeCommand).toHaveBeenCalledWith('material_delete_comment', expect.objectContaining({ comment_id: 'MaterialExpressionComment_0' }));
+    expect(r.isError).toBeFalsy();
+  });
+
+  it('rejects missing comment_id', async () => {
+    const r = await materialDeleteCommentHandler({ material_path: '/Game/M' });
+    expect(r.isError).toBe(true);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('rejects when neither material_path nor function_path given', async () => {
+    const r = await materialDeleteCommentHandler({ comment_id: 'X' });
+    expect(r.isError).toBe(true);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/material/material-delete-comment.ts
+++ b/mcp-tools/hayba-mcp/src/tools/material/material-delete-comment.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { ToolResult, SessionManager } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['modifies_asset'],
+  when: 'removing a comment box from a material or material-function graph (comment_id from material_get_info.comments[].id)',
+  not_when: 'removing a functional node or a named reroute (use material_delete_node — those are expressions)',
+};
+
+export const schema = z.object({
+  material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
+  function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
+  comment_id: z.string().min(1).describe('Comment id to delete (from material_get_info.comments[].id or material_add_comment.comment_id)'),
+}).refine((d) => !!d.material_path || !!d.function_path, {
+  message: 'one of material_path or function_path is required',
+});
+
+export async function materialDeleteCommentHandler(args: Record<string, unknown>, _session?: SessionManager): Promise<ToolResult> {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('material_delete_comment', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -65,6 +65,7 @@ TArray<FString> FHaybaMCPMaterialHandler::GetCommands() const
         TEXT("material_set_property"),
         TEXT("material_delete_node"),
         TEXT("material_add_comment"),
+        TEXT("material_delete_comment"),
         TEXT("material_add_reroute_declaration"),
         TEXT("material_add_reroute_usage"),
         TEXT("material_connect_nodes"),
@@ -87,6 +88,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::Handle(const FString& Cmd, const T
     if (Cmd == TEXT("material_set_property"))   return MatSetProperty(P);
     if (Cmd == TEXT("material_delete_node"))    return MatDeleteNode(P);
     if (Cmd == TEXT("material_add_comment"))    return MatAddComment(P);
+    if (Cmd == TEXT("material_delete_comment")) return MatDeleteComment(P);
     if (Cmd == TEXT("material_add_reroute_declaration")) return MatAddRerouteDeclaration(P);
     if (Cmd == TEXT("material_add_reroute_usage"))       return MatAddRerouteUsage(P);
     if (Cmd == TEXT("material_connect_nodes"))  return MatConnectNodes(P);
@@ -708,6 +710,26 @@ static TArray<TSharedPtr<FJsonValue>> SerializeMaterialExpressions(const TExprRa
     return Exprs;
 }
 
+// Serialize the comment boxes (id/text/pos/size) so callers can discover
+// comment ids to pass to material_delete_comment.
+static TArray<TSharedPtr<FJsonValue>> SerializeComments(TConstArrayView<TObjectPtr<UMaterialExpressionComment>> InComments)
+{
+    TArray<TSharedPtr<FJsonValue>> Out;
+    for (const TObjectPtr<UMaterialExpressionComment>& C : InComments)
+    {
+        if (!C) continue;
+        TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>();
+        E->SetStringField(TEXT("id"), C->GetName());
+        E->SetStringField(TEXT("text"), C->Text);
+        E->SetNumberField(TEXT("x"), C->MaterialExpressionEditorX);
+        E->SetNumberField(TEXT("y"), C->MaterialExpressionEditorY);
+        E->SetNumberField(TEXT("size_x"), C->SizeX);
+        E->SetNumberField(TEXT("size_y"), C->SizeY);
+        Out.Add(MakeShared<FJsonValueObject>(E.ToSharedRef()));
+    }
+    return Out;
+}
+
 FHaybaHandlerResult FHaybaMCPMaterialHandler::MatGetInfo(const TSharedPtr<FJsonObject>& P)
 {
     FString Path;
@@ -721,6 +743,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatGetInfo(const TSharedPtr<FJsonO
         Out->SetStringField(TEXT("kind"), TEXT("material"));
         Out->SetStringField(TEXT("name"), Mat->GetName());
         Out->SetArrayField(TEXT("expressions"), SerializeMaterialExpressions(Mat->GetExpressions()));
+        Out->SetArrayField(TEXT("comments"), SerializeComments(Mat->GetEditorComments()));
         Out->SetNumberField(TEXT("shading_model"), (int32)Mat->GetShadingModels().GetFirstShadingModel());
         return FHaybaHandlerResult::Ok(Out);
     }
@@ -732,6 +755,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatGetInfo(const TSharedPtr<FJsonO
         Out->SetStringField(TEXT("name"), Fn->GetName());
         Out->SetStringField(TEXT("description"), Fn->Description);
         Out->SetArrayField(TEXT("expressions"), SerializeMaterialExpressions(Fn->GetExpressions()));
+        Out->SetArrayField(TEXT("comments"), SerializeComments(Fn->GetEditorComments()));
         return FHaybaHandlerResult::Ok(Out);
     }
 
@@ -956,6 +980,55 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatAddComment(const TSharedPtr<FJs
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("comment_id"), C->GetName());
     return FHaybaHandlerResult::Ok(Out);
+}
+
+// Delete a comment BOX by id. Comments live in the expression collection's
+// EditorComments array (not Expressions), so material_delete_node can't reach
+// them — this is the dedicated remover. (Named-reroute declaration/usage nodes
+// ARE expressions, so material_delete_node already deletes those.)
+FHaybaHandlerResult FHaybaMCPMaterialHandler::MatDeleteComment(const TSharedPtr<FJsonObject>& P)
+{
+    FString CommentId;
+    if (!P->TryGetStringField(TEXT("comment_id"), CommentId) || CommentId.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("material_delete_comment: missing comment_id"));
+
+    FString FuncPath;
+    if (P->TryGetStringField(TEXT("function_path"), FuncPath) && !FuncPath.IsEmpty())
+    {
+        UMaterialFunction* Fn = LoadObject<UMaterialFunction>(nullptr, *FuncPath);
+        if (!Fn) return FHaybaHandlerResult::Err(TEXT("material_delete_comment: function not found"));
+        for (const TObjectPtr<UMaterialExpressionComment>& C : Fn->GetEditorComments())
+        {
+            if (C && C->GetName() == CommentId)
+            {
+                Fn->GetExpressionCollection().RemoveComment(C);
+                UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
+                { FString SaveErr; HaybaPersistAsset(Fn, SaveErr); }
+                TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+                Out->SetBoolField(TEXT("deleted"), true);
+                return FHaybaHandlerResult::Ok(Out);
+            }
+        }
+        return FHaybaHandlerResult::Err(FString::Printf(TEXT("material_delete_comment: comment not found: %s"), *CommentId));
+    }
+
+    FString MatPath;
+    if (!HaybaParams::GetString(P, TEXT("material_path"), MatPath))
+        return FHaybaHandlerResult::Err(TEXT("material_delete_comment: missing material_path or function_path"));
+    UMaterial* Mat = LoadObject<UMaterial>(nullptr, *MatPath);
+    if (!Mat) return FHaybaHandlerResult::Err(TEXT("material_delete_comment: material not found"));
+    for (const TObjectPtr<UMaterialExpressionComment>& C : Mat->GetEditorComments())
+    {
+        if (C && C->GetName() == CommentId)
+        {
+            Mat->GetExpressionCollection().RemoveComment(C);
+            Mat->MarkPackageDirty();  // comments don't affect compilation; in-memory per the deferred-compile model
+            TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+            Out->SetBoolField(TEXT("deleted"), true);
+            return FHaybaHandlerResult::Ok(Out);
+        }
+    }
+    return FHaybaHandlerResult::Err(FString::Printf(TEXT("material_delete_comment: comment not found: %s"), *CommentId));
 }
 
 // Create a Named-Reroute DECLARATION node (the source anchor). Lands in the

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.h
@@ -14,6 +14,7 @@ private:
     FHaybaHandlerResult MatSetNode(const TSharedPtr<FJsonObject>& P);
     FHaybaHandlerResult MatDeleteNode(const TSharedPtr<FJsonObject>& P);
     FHaybaHandlerResult MatAddComment(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult MatDeleteComment(const TSharedPtr<FJsonObject>& P);
     FHaybaHandlerResult MatAddRerouteDeclaration(const TSharedPtr<FJsonObject>& P);
     FHaybaHandlerResult MatAddRerouteUsage(const TSharedPtr<FJsonObject>& P);
     FHaybaHandlerResult MatConnectNodes(const TSharedPtr<FJsonObject>& P);


### PR DESCRIPTION
Adds the ability to **delete comment boxes** (the gap called out: comments live in a separate collection with no delete in the toolset, so they lingered as empty labeled regions).

- **`material_delete_comment { material_path|function_path, comment_id }`** — removes a comment via `FMaterialExpressionCollection::RemoveComment` (material or function).
- **`material_get_info`** now returns a `comments` array (`id`/`text`/`x`/`y`/`size_x`/`size_y`) so an agent can discover comment ids to delete across sessions.
- **Named reroutes** (declaration/usage) are `UMaterialExpression` nodes, so `material_delete_node` already deletes them — no change needed.

## Verification
- `RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**; `tsc` clean; `vitest` **466 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)