### PR TITLE
fix(pcg): create_graph fully-loads + overwrites existing package (partial-load save error)

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp
@@ -600,6 +600,21 @@ FHaybaHandlerResult FHaybaMCPLegacyHandler::Cmd_CreateGraph(const TSharedPtr<FJs
         return FHaybaHandlerResult::Err(TEXT("Failed to create package"));
     }
 
+    // If this asset already exists on disk, CreatePackage returns the existing
+    // package which may be only PARTIALLY loaded — and UPackage::SavePackage
+    // refuses a partially-loaded package ("cannot be saved as it has only been
+    // partially loaded"). Fully load it, then move any existing object of the
+    // same name out of the way so we cleanly create-or-overwrite.
+    if (!Package->IsFullyLoaded())
+    {
+        Package->FullyLoad();
+    }
+    if (UObject* Existing = StaticFindObject(UObject::StaticClass(), Package, *SafeName))
+    {
+        Existing->Rename(nullptr, GetTransientPackage(),
+            REN_DontCreateRedirectors | REN_NonTransactional | REN_DoNotDirty);
+    }
+
     UPCGGraph* NewGraph = NewObject<UPCGGraph>(Package, *SafeName, RF_Public | RF_Standalone);
     if (!NewGraph)
     {


### PR DESCRIPTION
## Error
\`\`\`
Asset 'PCG_TunnelGenerator.uasset' cannot be saved as it has only been partially loaded
... FHaybaMCPLegacyHandler::Cmd_CreateGraph() ...
\`\`\`

## Root cause
`create_graph` calls `CreatePackage`. When the target asset already exists on disk, `CreatePackage` returns the existing **partially-loaded** package, and `UPackage::SavePackage` refuses to save a partially-loaded package.

## Fix
After `CreatePackage`: `Package->FullyLoad()` if not already fully loaded, then move any existing object of the same name aside (`Rename` to the transient package). `create_graph` now cleanly **create-or-overwrites** regardless of prior load state.

## Verification
- `RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**.

> Note: this needs a full plugin rebuild on the host to take effect — the crashing binary was a Live Coding hot-patch from before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)