### PR TITLE
fix(idle): synchronous snapshot — remove UAF/deadlock-prone async ticker

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp
@@ -146,33 +146,6 @@ namespace HaybaIdle
         return Out;
     }
 
-    /** Runs on the game thread via FTSTicker. Returns false to unregister. */
-    static bool PollOnce(float /*Dt*/, FWaitState* S)
-    {
-        const double Now = FPlatformTime::Seconds();
-        const double DurationMs = (Now - S->T0Seconds) * 1000.0;
-
-        for (const FString& Sub : S->Subsystems)
-        {
-            if (S->SettledAtMs.Contains(Sub)) continue;
-            if (!IsBusy(Sub, *S))
-            {
-                S->SettledAtMs.Add(Sub, DurationMs);
-            }
-        }
-
-        const bool bAllSettled = (S->SettledAtMs.Num() == S->Subsystems.Num());
-        const bool bTimedOut = (Now - S->T0Seconds) >= S->TimeoutSeconds;
-
-        if (bAllSettled || bTimedOut)
-        {
-            S->bAllSettled = bAllSettled;
-            S->FinalDurationMs = DurationMs;
-            if (S->DoneEvent) S->DoneEvent->Trigger();
-            return false;
-        }
-        return true;
-    }
 }
 
 TArray<FString> FHaybaMCPIdleHandler::GetCommands() const
@@ -234,71 +207,32 @@ FHaybaHandlerResult FHaybaMCPIdleHandler::Handle(const FString& Command,
         }
     }
 
-    // ── Cross-thread event ────────────────────────────────────────────────
-    State.DoneEvent = FPlatformProcess::GetSynchEventFromPool(/*bIsManualReset=*/ false);
-    if (!State.DoneEvent) return FHaybaHandlerResult::Err(TEXT("Failed to allocate FEvent"));
-
-    // ── Schedule polling on the game thread ───────────────────────────────
-    // Shared ownership: the TCP thread (this scope) holds one ref, the
-    // game-thread ticker lambda holds another. Whichever releases last
-    // destructs FWaitState, which returns DoneEvent to the pool. This
-    // fixes a use-after-free where the TCP thread's FEvent wait could
-    // expire while the ticker was still polling, freeing the state out
-    // from under the next tick (crash: PollOnce reading freed Subsystems).
-    TSharedRef<FWaitState, ESPMode::ThreadSafe> SharedState =
-        MakeShared<FWaitState, ESPMode::ThreadSafe>(MoveTemp(State));
-
-    AsyncTask(ENamedThreads::GameThread, [SharedState]()
+    // ── Synchronous snapshot (no waiting) ─────────────────────────────────
+    // Commands run on the game thread (TcpServer drains the queue from the
+    // engine tick), so we read the busy predicates directly and return the
+    // CURRENT settle state. We deliberately do NOT block-and-wait:
+    //  * blocking the game thread can't let shaders/assets/GC progress anyway;
+    //  * the old AsyncTask + FEvent::Wait + FTSTicker design dead-locked under
+    //    this dispatch and use-after-freed (PollOnce ran on freed FWaitState).
+    // Callers poll this in a loop — the editor ticks between calls, so
+    // subsystems make progress and `ok` flips true once everything is idle.
+    ensure(IsInGameThread());
+    bool bAllSettled = true;
+    for (const FString& Sub : State.Subsystems)
     {
-        // GC nudge — only when gc requested. Queue once, before the first poll,
-        // so IsGCBusyImpl observes the pending pass briefly then sees it settle.
-        if (SharedState->Subsystems.Contains(TEXT("gc")) && GEngine)
+        const bool bBusy = IsBusy(Sub, State);
+        State.BusyOnEntry.Add(Sub, bBusy);
+        if (bBusy)
         {
-            GEngine->ForceGarbageCollection(/*bFullPurge=*/ false);
+            bAllSettled = false;
         }
-        // Capture busyOnEntry on the game thread (predicates are not thread-safe).
-        for (const FString& Sub : SharedState->Subsystems)
+        else
         {
-            SharedState->BusyOnEntry.Add(Sub, IsBusy(Sub, *SharedState));
+            State.SettledAtMs.Add(Sub, 0.0);
         }
-        SharedState->TickHandle = FTSTicker::GetCoreTicker().AddTicker(
-            FTickerDelegate::CreateLambda([SharedState](float Dt) { return PollOnce(Dt, &SharedState.Get()); }),
-            POLL_INTERVAL_SECONDS);
-    });
-
-    // ── Block this thread until polling completes or timeout fires ─────────
-    // FEvent wait timeout is in milliseconds. Allow timeout_s + 1s slack so
-    // the game-thread poller normally fires Done first.
-    const uint32 WaitTimeoutMs = (uint32)FMath::Clamp(SharedState->TimeoutSeconds * 1000.0 + 1000.0, 1.0, (double)MAX_uint32);
-    const bool bSignaled = SharedState->DoneEvent->Wait(WaitTimeoutMs);
-
-    // Build response (read game-thread-filled state — safe because the event
-    // signal serializes the write).
-    TSharedPtr<FJsonObject> Resp;
-    if (bSignaled)
-    {
-        Resp = BuildResponse(*SharedState);
     }
-    else
-    {
-        // FEvent timed out before the game-thread poller. Stop the ticker
-        // first so it cannot keep mutating SharedState while we read it;
-        // RemoveTicker is safe from any thread but does not wait on an
-        // in-flight tick — the shared ownership above is what makes that
-        // safe (no use-after-free regardless of in-flight ticks).
-        if (SharedState->TickHandle.IsValid())
-        {
-            FTSTicker::GetCoreTicker().RemoveTicker(SharedState->TickHandle);
-            SharedState->TickHandle.Reset();
-        }
-        SharedState->FinalDurationMs = (FPlatformTime::Seconds() - SharedState->T0Seconds) * 1000.0;
-        SharedState->bAllSettled = false;
-        Resp = BuildResponse(*SharedState);
-    }
+    State.bAllSettled = bAllSettled;
+    State.FinalDurationMs = 0.0;
 
-    // No manual cleanup: when this scope's SharedState ref drops and the
-    // game-thread ticker drops its lambda ref (whichever happens last),
-    // FWaitState's destructor returns DoneEvent to the pool.
-
-    return FHaybaHandlerResult::Ok(Resp);
+    return FHaybaHandlerResult::Ok(BuildResponse(State));
 }


### PR DESCRIPTION
## Crash
\`\`\`
EXCEPTION_ACCESS_VIOLATION
HaybaIdle::PollOnce() [HaybaMCPIdleHandler.cpp:172]
\`\`\`
`PollOnce` ran on a **freed `FWaitState`**.

## Root cause
The idle handler was built for `ProcessCommand` running on a **worker thread**: `AsyncTask(GameThread)` registers an `FTSTicker` `PollOnce`, the handler blocks on `FEvent::Wait`, with shared ownership bridging the two threads. But after #261, commands run on the **game thread** from the TcpServer drain ticker — so this design dead-locks (blocked game thread can't run the ticker), the timeout path leaks/races the ticker onto freed state (the UAF), and it can't safely pump (`FTSTicker` re-entrancy).

## Fix
`wait_for_idle` / `wait_for_shaders` now take a **synchronous snapshot**: read the busy predicates inline on the game thread, return the current settle state. No `AsyncTask`, no `FEvent`, no `FTSTicker`, no shared state, no raw pointer. Callers poll in a loop — the editor ticks between calls, so subsystems progress and `ok` flips true once idle. Removed the dead `PollOnce`.

## Verification
- `RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated idle handler to return immediate status snapshots instead of asynchronous polling
  * Optimized subsystem busy state evaluation with simplified internal mechanisms
  * Improved responsiveness of idle status reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->