### PR TITLE
fix(ambientcg): resolve zip downloads (include=downloadData + object folders)

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { assetInfoUrl, pickZipUrl } from './ambientcg-download.js';
+
+// Real v2 full_json shape: downloadFolders is an OBJECT keyed by folder name,
+// each with a downloadFiletypeCategories.zip.downloads[] list.
+const SAMPLE = {
+  foundAssets: [
+    {
+      assetId: 'Ground037',
+      downloadFolders: {
+        default: {
+          downloadFiletypeCategories: {
+            zip: {
+              downloads: [
+                { attribute: '1K-JPG', fullDownloadPath: 'https://ambientcg.com/get?file=Ground037_1K-JPG.zip' },
+                { attribute: '2K-JPG', fullDownloadPath: 'https://ambientcg.com/get?file=Ground037_2K-JPG.zip' },
+                { attribute: '4K-PNG', downloadLink: 'https://ambientcg.com/get?file=Ground037_4K-PNG.zip' },
+              ],
+            },
+          },
+        },
+      },
+    },
+  ],
+};
+
+describe('ambientcg-download', () => {
+  it('requests include=downloadData (else downloadFolders is empty)', () => {
+    expect(assetInfoUrl('Ground037')).toContain('include=downloadData');
+  });
+
+  it('resolves an exact attribute match from the object-shaped folders', () => {
+    expect(pickZipUrl(SAMPLE, '2K-JPG')).toBe('https://ambientcg.com/get?file=Ground037_2K-JPG.zip');
+  });
+
+  it('is case-insensitive on the attribute', () => {
+    expect(pickZipUrl(SAMPLE, '2k-jpg')).toBe('https://ambientcg.com/get?file=Ground037_2K-JPG.zip');
+  });
+
+  it('falls back to downloadLink when fullDownloadPath is absent', () => {
+    expect(pickZipUrl(SAMPLE, '4K-PNG')).toBe('https://ambientcg.com/get?file=Ground037_4K-PNG.zip');
+  });
+
+  it('falls back to the first available zip for an unknown attribute', () => {
+    expect(pickZipUrl(SAMPLE, 'nope')).toBe('https://ambientcg.com/get?file=Ground037_1K-JPG.zip');
+  });
+
+  it('returns null when there are no download folders', () => {
+    expect(pickZipUrl({ foundAssets: [{ downloadFolders: {} }] }, '2K-JPG')).toBeNull();
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.ts
@@ -22,6 +22,9 @@ const API = 'https://ambientCG.com/api/v2';
 export function assetInfoUrl(assetId: string): string {
   const qs = new URLSearchParams();
   qs.set('id', assetId);
+  // Without include=downloadData the v2 API returns an EMPTY downloadFolders, so
+  // no zip can ever be resolved ("can't resolve its zips"). Request it explicitly.
+  qs.set('include', 'downloadData');
   return `${API}/full_json?${qs.toString()}`;
 }
 
@@ -29,21 +32,27 @@ export function assetInfoUrl(assetId: string): string {
 export function pickZipUrl(assetJson: any, resolution: string): string | null {
   const found = Array.isArray(assetJson?.foundAssets) ? assetJson.foundAssets : [];
   const asset = found[0] ?? assetJson;
-  const folders = asset?.downloadFolders ?? [];
-  for (const folder of folders) {
+  // downloadFolders is an OBJECT keyed by folder name (e.g. "default"), not an
+  // array — Object.values() so `for..of` actually iterates it. Same for the
+  // category map. Path field is fullDownloadPath, with downloadLink as fallback.
+  const folders = Object.values(asset?.downloadFolders ?? {});
+  const pathOf = (d: any): string | null => (d?.fullDownloadPath ?? d?.downloadLink) || null;
+  // Preferred: exact attribute match (case-insensitive).
+  for (const folder of folders as any[]) {
     const cats = folder?.downloadFiletypeCategories ?? {};
     const zip = cats?.zip ?? cats?.Zip;
-    const downloads = zip?.downloads ?? [];
-    for (const d of downloads) {
-      if (d?.attribute === resolution && d?.fullDownloadPath) return d.fullDownloadPath;
+    for (const d of (zip?.downloads ?? [])) {
+      if (typeof d?.attribute === 'string' && d.attribute.toLowerCase() === resolution.toLowerCase() && pathOf(d)) {
+        return pathOf(d);
+      }
     }
   }
-  // Fallback: first available zip
-  for (const folder of folders) {
+  // Fallback: first available zip in any folder.
+  for (const folder of folders as any[]) {
     const cats = folder?.downloadFiletypeCategories ?? {};
     const zip = cats?.zip ?? cats?.Zip;
-    const first = zip?.downloads?.[0];
-    if (first?.fullDownloadPath) return first.fullDownloadPath;
+    const first = (zip?.downloads ?? [])[0];
+    if (pathOf(first)) return pathOf(first);
   }
   return null;
 }


### PR DESCRIPTION
The ambientCG connector could never resolve its zips. Two bugs, both confirmed against the live v2 API:

1. `full_json` was requested **without `include=downloadData`**, so `downloadFolders` came back empty → no zip findable. Now requests `include=downloadData`.
2. `downloadFolders` is an **object** keyed by folder name, not an array — the old `for…of` over it iterated nothing (or threw). Now uses `Object.values`, with case-insensitive attribute matching and a `downloadLink` fallback.

## Verification
- Live: `Ground037` resolves `2K-JPG`, `4K-PNG`, and the unknown→first-zip fallback.
- 6 unit tests (`ambientcg-download.test.ts`); `tsc` clean.
- TS-only (MCP server) — takes effect on MCP server reload, no UE rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)