### PR TITLE
feat(material): connectable Displacement output + enable_tessellation

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -364,7 +364,7 @@ const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
       niche: M,
       schema: {
         material_path: z.string().min(1).describe('Path to the master material asset'),
-        properties: z.record(z.string(), z.unknown()).describe('Settings; aliases: domain, blend_mode, shading_model, two_sided, opacity_mask_clip_value'),
+        properties: z.record(z.string(), z.unknown()).describe('Settings; aliases: domain, blend_mode, shading_model, two_sided, opacity_mask_clip_value, enable_tessellation'),
       },
     },
     {
@@ -470,7 +470,7 @@ const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
         to_input: z.string().optional().describe('Input pin name on the target node'),
         to_input_index: z.number().int().optional().describe('Target input pin by index (unnamed pins, e.g. Substrate slab inputs)'),
         from_output_index: z.number().int().optional().describe('Source output pin by index (default 0)'),
-        to_property: z.string().optional().describe('Target material property, e.g. base_color or front_material (Substrate)'),
+        to_property: z.string().optional().describe('Target material output, e.g. base_color, normal, front_material (Substrate), displacement (Nanite tessellation - needs material_set_property enable_tessellation=true)'),
       },
     },
     {

--- a/mcp-tools/hayba-mcp/src/tools/material/material-set-material-property.ts
+++ b/mcp-tools/hayba-mcp/src/tools/material/material-set-material-property.ts
@@ -17,7 +17,7 @@ export const schema = z.object({
   material_path: z.string().min(1).describe('Path to the master material asset'),
   properties: z.record(z.string(), z.unknown())
     .refine((p) => Object.keys(p).length > 0, { message: 'properties must be non-empty' })
-    .describe('Material settings. Friendly aliases: domain, blend_mode, shading_model, two_sided, opacity_mask_clip_value (e.g. blend_mode: "BLEND_Translucent"). Any UMaterial UPROPERTY name also accepted.'),
+    .describe('Material settings. Friendly aliases: domain, blend_mode, shading_model, two_sided, opacity_mask_clip_value, enable_tessellation (e.g. enable_tessellation: true for Nanite displacement). Any UMaterial UPROPERTY name also accepted.'),
 });
 
 export async function materialSetMaterialPropertyHandler(args: Record<string, unknown>, _session?: SessionManager): Promise<ToolResult> {

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -188,6 +188,7 @@ static bool TryParseProperty(const FString& In, EMaterialProperty& Out)
     if (S == TEXT("shading_model_from_node")) { Out = MP_ShadingModel; return true; }
     // Substrate (from fix/ci-test-suite-green)
     if (S == TEXT("front_material"))        { Out = MP_FrontMaterial; return true; }
+    if (S == TEXT("displacement"))          { Out = MP_Displacement; return true; }  // Nanite tessellation (needs material_set_property enable_tessellation=true)
     return false;
 }
 
@@ -1161,6 +1162,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatSetProperty(const TSharedPtr<FJ
         { TEXT("shading_model"),           TEXT("ShadingModel") },
         { TEXT("two_sided"),               TEXT("TwoSided") },
         { TEXT("opacity_mask_clip_value"), TEXT("OpacityMaskClipValue") },
+        { TEXT("enable_tessellation"),     TEXT("bEnableTessellation") },  // required for the displacement output to tessellate (Nanite)
     };
 
     TArray<TSharedPtr<FJsonValue>> Applied;


### PR DESCRIPTION
Adds the ability to wire the **Displacement** (Nanite tessellation) output from script — the pin the agent previously couldn't reach.

- `material_connect_nodes { to_property: "displacement" }` → `MP_Displacement`.
- `material_set_property { enable_tessellation: true }` → `bEnableTessellation` (the toggle the Displacement output needs to actually tessellate).
- Tool descriptions updated so both are discoverable.

Note: `Displacement` is **scalar tessellation along the surface normal** (needs a Nanite mesh + tessellation enabled + non-zero `DisplacementScaling.Magnitude`). For arbitrary-axis vertex offset use `world_position_offset` instead.

## Verification
- `RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated material property schema documentation to include additional supported aliases and expanded usage examples for better discoverability

* **Features**
  * Extended material operations with support for new property aliases, enabling configuration of displacement properties and tessellation controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->