### PR TITLE
fix(plumb): key profiles/constraints by full object path (Studio lookup match)

### DIFF
--- a/mcp-tools/hayba-mcp/src/plumb/constraint-store.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/constraint-store.ts
@@ -7,6 +7,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { Constraint } from './contracts.js';
+import { toObjectPath } from './contracts.js';
 import { primitivesById } from './primitives.js';
 
 let PATH_OVERRIDE: string | null = null;
@@ -71,8 +72,13 @@ export function validateConstraint(c: Partial<Constraint>): ValidationError[] {
 export function upsertConstraint(c: Constraint): { ok: boolean; errors: ValidationError[] } {
   const errors = validateConstraint(c);
   if (errors.length) return { ok: false, errors };
-  const list = loadConstraints().filter(x => x.id !== c.id);
-  list.push({ enabled: true, ...c });
+  // Normalize an asset binding to the full object path so the in-editor Studio
+  // (which queries constraints by the suffixed object path) actually matches it.
+  const normalized: Constraint = c.binding?.asset
+    ? { ...c, binding: { ...c.binding, asset: toObjectPath(c.binding.asset) } }
+    : c;
+  const list = loadConstraints().filter(x => x.id !== normalized.id);
+  list.push({ enabled: true, ...normalized });
   writeAll(list);
   return { ok: true, errors: [] };
 }
@@ -87,9 +93,10 @@ export function removeConstraint(id: string): boolean {
 
 /** Constraints whose binding could apply to a given asset/tag set. */
 export function constraintsFor(asset?: string, tags?: Record<string, string>): Constraint[] {
+  const assetObj = asset ? toObjectPath(asset) : asset;
   return loadConstraints().filter(c => {
     if (c.enabled === false) return false;
-    if (c.binding.asset) return c.binding.asset === asset;
+    if (c.binding.asset) return c.binding.asset === assetObj;
     if (c.binding.tag) return tags?.[c.binding.tag.axis] === c.binding.tag.value;
     return false;
   });

--- a/mcp-tools/hayba-mcp/src/plumb/contracts.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/contracts.ts
@@ -190,3 +190,18 @@ export interface InstanceState {
 export interface SceneContext {
   instances: InstanceState[];         // every instance (clearance/proximity/count)
 }
+
+/**
+ * Normalize a UE content path to its full OBJECT path (`<package>.<assetName>`),
+ * matching how the in-editor Semantic Studio keys its lookups
+ * (LoadProfile does an exact TryGetObjectField on the suffixed object path).
+ * A package path like "/Game/Foo/Bar" becomes "/Game/Foo/Bar.Bar"; a path that
+ * already carries a ".Name" suffix (or isn't a /-content path) is returned as-is.
+ */
+export function toObjectPath(assetPath: string): string {
+  if (typeof assetPath !== 'string' || !assetPath.startsWith('/')) return assetPath;
+  const lastSlash = assetPath.lastIndexOf('/');
+  const tail = assetPath.slice(lastSlash + 1);
+  if (tail.length === 0 || tail.includes('.')) return assetPath; // already an object path
+  return `${assetPath}.${tail}`;
+}

--- a/mcp-tools/hayba-mcp/src/plumb/profile-store.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/profile-store.ts
@@ -8,6 +8,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { Profile, Mask } from './contracts.js';
+import { toObjectPath } from './contracts.js';
 
 let PATH_OVERRIDE: string | null = null;
 
@@ -43,7 +44,7 @@ export function loadProfiles(): Profile[] {
 }
 
 export function getProfile(assetId: string): Profile | null {
-  return readAll()[assetId] ?? null;
+  return readAll()[toObjectPath(assetId)] ?? null;
 }
 
 export function profileMap(): Map<string, Profile> {
@@ -52,7 +53,11 @@ export function profileMap(): Map<string, Profile> {
 
 export function putProfile(profile: Profile): void {
   const all = readAll();
-  all[profile.asset_id] = profile;
+  // Key (and store) by the full object path so the in-editor Studio's exact
+  // object-path lookup finds it; package-path keys silently miss.
+  const objectPath = toObjectPath(profile.asset_id);
+  const stored: Profile = { ...profile, asset_id: objectPath };
+  all[objectPath] = stored;
   writeAll(all);
 }
 
@@ -64,6 +69,7 @@ export function annotateProfile(
   opts: { lock?: string[]; auto?: boolean } = {},
 ): Profile | null {
   const all = readAll();
+  assetId = toObjectPath(assetId);
   const base = all[assetId];
   if (!base) return null;
   const edited: string[] = [...base.provenance.edited_fields];
@@ -84,6 +90,7 @@ export function annotateProfile(
 
 export function removeProfile(assetId: string): boolean {
   const all = readAll();
+  assetId = toObjectPath(assetId);
   if (!(assetId in all)) return false;
   delete all[assetId];
   writeAll(all);
@@ -97,6 +104,7 @@ export function getMask(assetId: string, maskId: string): Mask | null {
 
 export function addMask(assetId: string, mask: Mask): Profile | null {
   const all = readAll();
+  assetId = toObjectPath(assetId);
   const base = all[assetId];
   if (!base) return null;
   const masks = (base.masks ?? []).filter(m => m.id !== mask.id);
@@ -109,6 +117,7 @@ export function addMask(assetId: string, mask: Mask): Profile | null {
 
 export function removeMask(assetId: string, maskId: string): boolean {
   const all = readAll();
+  assetId = toObjectPath(assetId);
   const base = all[assetId];
   if (!base?.masks) return false;
   const next = base.masks.filter(m => m.id !== maskId);


### PR DESCRIPTION
## Bug
The in-editor Semantic Studio looks up a profile by the **full object path** (`<package>/<name>.<name>` — `LoadProfile` does an exact `TryGetObjectField`), but the MCP `plumb_*` tools keyed profiles by **package path** (no `.<name>` suffix) and bound constraints by package path. So the Studio's lookups missed everything: authored profiles showed as absent, constraints never matched.

## Fix
- New `toObjectPath()` normalizer in `contracts.ts` (`/Game/Foo/Bar` → `/Game/Foo/Bar.Bar`; already-suffixed/non-content paths pass through).
- `profile-store`: normalize the map key **and** `Profile.asset_id` on `putProfile`; normalize on `getProfile`/`annotateProfile`/`removeProfile`/`addMask`/`removeMask`.
- `constraint-store`: normalize `binding.asset` on `upsertConstraint`, and the query asset in `constraintsFor`.

Re-authoring the 6 rubble profiles/constraints now lands under the keys the Studio reads.

## Verification
- `tsc` clean; plumb tests **33/33**. (TS-only — takes effect on MCP server reload.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)