### PR TITLE
feat(studio): fainter mask volume fill so the mesh texture reads through

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Studio/SHaybaStudioViewport.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Studio/SHaybaStudioViewport.cpp
@@ -65,8 +65,10 @@ UMaterialInstanceDynamic* SHaybaStudioViewport::GetColorFill(const FLinearColor&
     if (MID)
     {
         // GeomMaterial is the engine's translucent debug material; its "Color"
-        // vector param drives both tint and (alpha) translucency.
-        MID->SetVectorParameterValue(TEXT("Color"), FLinearColor(Color.R, Color.G, Color.B, 0.35f));
+        // vector param drives both tint and (alpha) translucency. Keep the fill
+        // FAINT (0.15) so the mesh's texture reads through the volume — the
+        // SDPG_Foreground wireframe still marks the mask bounds clearly.
+        MID->SetVectorParameterValue(TEXT("Color"), FLinearColor(Color.R, Color.G, Color.B, 0.15f));
         FillMaterials.Add(Key, MID);
     }
     return MID;


### PR DESCRIPTION
QoL: the Semantic Studio mask volume fill alpha was `0.35` — opaque enough to wash out the asset's texture under the volume (see report). Lowered to `0.15` so the mesh's texture reads through, while the bright `SDPG_Foreground` wireframe still marks the mask bounds.

`RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**. (C++ — needs the editor-target rebuilt to take effect.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)