### PR TITLE
fix(pcg): accept dynamic pins on the graph Input/Output node in create_graph validation

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp
@@ -906,7 +906,11 @@ TArray<TSharedPtr<FJsonValue>> FHaybaMCPLegacyHandler::ValidateGraphJson(const T
             if (FromCDO)
             {
                 TArray<FPCGPinProperties> OutPins = FromCDO->OutputPinProperties();
-                bool bFoundPin = false;
+                // PCGGraphInputOutputSettings (the graph Input/Output node) exposes its pins
+                // dynamically per-graph (Input/Actor/Landscape/custom), so the CDO pin list is
+                // empty. Accept any pin on it and skip type-compat instead of false-rejecting.
+                const bool bFromIsIO = (*FromClass)->GetName().Contains(TEXT("GraphInputOutput")); // dynamic-pin I/O node
+                bool bFoundPin = bFromIsIO;
                 FPCGDataTypeIdentifier FromPinType = FPCGDataTypeIdentifier{EPCGDataType::None};
                 for (const FPCGPinProperties& Pin : OutPins)
                 {
@@ -929,8 +933,8 @@ TArray<TSharedPtr<FJsonValue>> FHaybaMCPLegacyHandler::ValidateGraphJson(const T
                         FString::Printf(TEXT("Output pin '%s' does not exist on %s. Available: %s"), *FromPin, *NodeClassMap[FromNode], *AvailablePins));
                 }
 
-                // Pin compatibility
-                if (bFoundPin && ToClass && *ToClass)
+                // Pin compatibility (skip when source is the dynamic I/O node)
+                if (bFoundPin && !bFromIsIO && ToClass && *ToClass)
                 {
                     const UPCGSettings* ToCDO = (*ToClass)->GetDefaultObject<UPCGSettings>();
                     if (ToCDO)
@@ -965,7 +969,9 @@ TArray<TSharedPtr<FJsonValue>> FHaybaMCPLegacyHandler::ValidateGraphJson(const T
             if (ToCDO)
             {
                 TArray<FPCGPinProperties> InPins = ToCDO->InputPinProperties();
-                bool bFoundPin = false;
+                // Same dynamic-pin exception for the graph Input/Output node.
+                const bool bToIsIO = (*ToClass)->GetName().Contains(TEXT("GraphInputOutput"));
+                bool bFoundPin = bToIsIO;
                 for (const FPCGPinProperties& Pin : InPins)
                 {
                     if (Pin.Label.ToString() == ToPin)


### PR DESCRIPTION
The PCG graph Input/Output node (`PCGGraphInputOutputSettings`) exposes its pins **dynamically per-graph** (Input/Actor/Landscape/custom), so its CDO pin list is empty. `create_graph`'s `ValidateGraphJson` was therefore **false-rejecting** valid edges to/from the I/O node (and running type-compat against an empty pin set). Now it accepts any pin on the I/O node and skips type-compat when the I/O node is the source/target.

(This had been a local working-tree fix on the host; pushing it to origin so it's not lost.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced graph connection validation to properly support nodes with dynamic input/output capabilities, preventing incorrect rejection of valid connections during graph validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->