### PR TITLE
fix(idle): guard TObjectIterator<UPCGComponent> against CDO/garbage objects

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPIdleHandler.cpp
@@ -56,7 +56,13 @@ namespace HaybaIdle
         for (TObjectIterator<UPCGComponent> It; It; ++It)
         {
             UPCGComponent* Comp = *It;
-            if (!Comp || Comp->GetWorld() != World) continue;
+            // TObjectIterator visits CDOs, archetypes, and objects mid-construct or
+            // pending-kill. During PCG generation components churn fast, so a plain
+            // null check is not enough — calling GetWorld()/IsGenerating() on a
+            // garbage object derefs near-null (crash: reading 0x1). Guard hard.
+            if (!IsValid(Comp)) continue;
+            if (Comp->HasAnyFlags(RF_ClassDefaultObject | RF_ArchetypeObject)) continue;
+            if (Comp->GetWorld() != World) continue;
             AActor* Owner = Comp->GetOwner();
             if (!Owner) continue;
             if (ScopedActorPaths.Num() > 0)


### PR DESCRIPTION
`IsPCGBusyImpl` (wait_for_idle's PCG predicate) iterated `TObjectIterator<UPCGComponent>` with only a null check. The iterator also visits **CDOs, archetypes, and mid-construct/pending-kill** objects; during PCG generation components churn fast, so calling `GetWorld()`/`IsGenerating()` on a garbage component derefs near-null (crash reading 0x1). Now guards `IsValid(Comp)` + skips `RF_ClassDefaultObject|RF_ArchetypeObject` before any access.

(Was a local host-repo fix; pushing so it's not lost.) Compiles in the full editor build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)