### PR TITLE
fix(studio): semantic library lists every SM with an entry (not just baked profiles)

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPMemoryPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPMemoryPanel.cpp
@@ -121,6 +121,7 @@ void SHaybaMCPMemoryPanel::Reload()
         }
     }
 
+    TSet<FString> Seen;
     for (const auto& Pair : ReadObj(ProfilesFile())->Values)
     {
         const TSharedPtr<FJsonObject> P = Pair.Value->AsObject();
@@ -137,6 +138,18 @@ void SHaybaMCPMemoryPanel::Reload()
             if ((*Prov)->TryGetArrayField(TEXT("locked"), Locked)) E->LockedCount = Locked->Num();
         }
         E->ConstraintCount = ConstraintCounts.FindRef(E->AssetId);
+        Seen.Add(E->AssetId);
+        AllEntries.Add(E);
+    }
+
+    // Also list assets that have ONLY constraints (no baked profile yet) — they
+    // are still "in the library", so the panel must show every SM with any entry.
+    for (const TPair<FString, int32>& CC : ConstraintCounts)
+    {
+        if (Seen.Contains(CC.Key)) continue;
+        TSharedPtr<FHaybaLibraryEntry> E = MakeShared<FHaybaLibraryEntry>();
+        E->AssetId = CC.Key;
+        E->ConstraintCount = CC.Value;
         AllEntries.Add(E);
     }
     RebuildTree();


### PR DESCRIPTION
The Memory / Semantic-Library panel built its list **only from `profiles.json` keys** (constraints were used only for counts), so a static mesh with **constraints but no baked profile** never showed — "doesn't list out all SM with library entries."

Now it lists the **union** of profile-keyed assets and constraint-bound assets (a minimal entry is added for constraints-only assets). Together with the object-path key normalization (#267), profiles and constraints key consistently, so the constraint counts line up too.

`RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**. (C++ — needs the editor-target rebuilt to take effect.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate entries appearing in the Memory Panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->