### PR TITLE
fix(material): defer material-function saves (half-built function crash on open)

### DIFF
--- a/mcp-tools/hayba-mcp/src/plumb/bake.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/bake.ts
@@ -45,12 +45,20 @@ export function bakeProfile(input: UeBoundsInput, baked_at: string, profileArche
         [aabb.max[0], aabb.max[1]], [aabb.min[0], aabb.max[1]],
       ];
 
+  const topZ = aabb.max[2];
+  const midZ = (aabb.min[2] + aabb.max[2]) / 2;
+  const sockets = [
+    { id: 'floor_edge', type: 'edge' as const, frame: { pos: [origin[0], origin[1], aabb.min[2]] as [number, number, number], quat: [0, 0, 0, 1] as [number, number, number, number] } },
+    { id: 'wall_mid', type: 'wall' as const, frame: { pos: [origin[0], origin[1], midZ] as [number, number, number], quat: [0, 0, 0, 1] as [number, number, number, number] } },
+    { id: 'arch_crown', type: 'ceiling' as const, frame: { pos: [origin[0], origin[1], topZ] as [number, number, number], quat: [0, 0, 0, 1] as [number, number, number, number] } },
+  ];
+
   return {
     asset_id: input.asset_id,
     bake_version: 1,
     profile: profileArchetype,
     geometry: { aabb, obb: { center: origin, extents: extent, quat: [0, 0, 0, 1] }, volume_m3 },
-    semantics: { up: [0, 0, 1], front: [1, 0, 0], affordances: [] },
+    semantics: { up: [0, 0, 1], front: [1, 0, 0], affordances: [], sockets },
     physical: {
       mass_kg: input.mass_kg,
       com: input.com_cm ? m3(input.com_cm) : origin,

--- a/mcp-tools/hayba-mcp/src/plumb/contracts.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/contracts.ts
@@ -97,6 +97,13 @@ export interface Affordance {
   detail?: string;
 }
 
+/** A connection point on an asset (floor, ceiling, wall attachment, etc.). */
+export interface Socket {
+  id: string;
+  type: 'floor' | 'ceiling' | 'wall' | 'edge' | 'custom';
+  frame: { pos: [number, number, number]; quat: [number, number, number, number] };
+}
+
 export interface Mask {
   id: string;
   type: 'surface' | 'volume';
@@ -121,6 +128,8 @@ export interface ProfileSemantics {
   up: [number, number, number];     // local up, default world-up
   front: [number, number, number];  // local front, default +X
   affordances: Affordance[];
+  role?: string;
+  sockets?: Socket[];
 }
 
 export interface ProfilePhysical {

--- a/mcp-tools/hayba-mcp/src/plumb/contracts.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/contracts.ts
@@ -214,3 +214,30 @@ export function toObjectPath(assetPath: string): string {
   if (tail.length === 0 || tail.includes('.')) return assetPath; // already an object path
   return `${assetPath}.${tail}`;
 }
+
+// ── Grammar language (expansions via productions) ────────────────────────────
+
+/** A semantic symbol that can be expanded via production rules. */
+export interface Symbol {
+  kind: string;
+  attrs: Record<string, number | string | boolean>;
+  region?: unknown;
+}
+
+/** An operation in the RHS of a production; the emission target. */
+export type EmitOp =
+  | { emit: 'shell'; role: string; profile_curve?: string; thickness_by?: string; bend_at_m?: number }
+  | { emit: 'asset'; role: string; at?: string; along?: string; spacing_m?: number; alternate?: boolean }
+  | { emit: 'symbol'; kind: string; len?: number }
+  | { emit: 'scatter'; tag: string }
+  | { emit: 'decal'; role: string; along?: string }
+  | { emit: 'fill'; role: string; at?: string };
+
+/** A grammar production rule: match an LHS symbol and emit RHS operations. */
+export interface Production {
+  id: string;
+  lhs: { kind: string; when?: Record<string, unknown> };
+  rhs: EmitOp[];
+  guards: string[];  // constraint ids that must pass
+  priority: number;
+}

--- a/mcp-tools/hayba-mcp/src/plumb/grammar-guards.test.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/grammar-guards.test.ts
@@ -1,0 +1,184 @@
+// grammar-guards.test.ts — TDD for addSocket (profile-store) + makeGuardFn
+//
+// HONEST TEST CHOICE (per brief): no UE scene is available, so geometry
+// primitives (max_straight_run, presence, grounded, etc.) self-skip unless
+// a real profile + scene context is injected.
+//
+// We therefore test two honest behaviours:
+//   1. Unknown guard id (not in constraint store) → { hardFail: false, softFails: [] }
+//   2. Known guard id whose primitive SKIPs (no profile/scene) → no failure
+//   3. Known HARD constraint that genuinely FAILs in TS without UE → hardFail: true
+//      (we use `grounded` with a deliberately bad z-position and an in-memory profile)
+//
+// addSocket: idempotent replace-by-id.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { setProfilesPath, putProfile, getProfile, addSocket } from './profile-store.js';
+import { bakeProfile } from './bake.js';
+import { setConstraintsPath, upsertConstraint } from './constraint-store.js';
+import { makeGuardFn } from './grammar-guards.js';
+import type { Symbol } from './contracts.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'plumb-gg-'));
+}
+
+// ── addSocket tests ───────────────────────────────────────────────────────────
+
+describe('addSocket', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeTmpDir();
+    setProfilesPath(join(dir, 'profiles.json'));
+  });
+  afterEach(() => {
+    setProfilesPath(null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('throws when the profile does not exist', () => {
+    expect(() => addSocket('/Game/DoesNotExist', { id: 'floor', type: 'floor', frame: { pos: [0, 0, 0], quat: [0, 0, 0, 1] } }))
+      .toThrow(/no profile/);
+  });
+
+  it('adds a socket to a baked profile', () => {
+    const p = bakeProfile({ asset_id: '/Game/TestA', origin_cm: [0, 0, 100], extent_cm: [50, 50, 100] }, 'now');
+    putProfile(p);
+
+    addSocket('/Game/TestA', { id: 'floor_attach', type: 'floor', frame: { pos: [0, 0, 0], quat: [0, 0, 0, 1] } });
+
+    const loaded = getProfile('/Game/TestA');
+    expect(loaded?.semantics.sockets?.map(s => s.id)).toContain('floor_attach');
+  });
+
+  it('replaces a socket with the same id (idempotent — no duplicates)', () => {
+    const p = bakeProfile({ asset_id: '/Game/TestB', origin_cm: [0, 0, 100], extent_cm: [50, 50, 100] }, 'now');
+    putProfile(p);
+
+    const sock = { id: 'top', type: 'ceiling' as const, frame: { pos: [0, 0, 1] as [number, number, number], quat: [0, 0, 0, 1] as [number, number, number, number] } };
+    addSocket('/Game/TestB', sock);
+    addSocket('/Game/TestB', { ...sock, frame: { pos: [0, 0, 2], quat: [0, 0, 0, 1] } }); // same id, different pos
+
+    const loaded = getProfile('/Game/TestB');
+    const sockets = loaded?.semantics.sockets ?? [];
+    // exactly one socket with id 'top'
+    expect(sockets.filter(s => s.id === 'top').length).toBe(1);
+    // the second (updated) position wins
+    expect(sockets.find(s => s.id === 'top')?.frame.pos).toEqual([0, 0, 2]);
+  });
+});
+
+// ── makeGuardFn tests ─────────────────────────────────────────────────────────
+
+describe('makeGuardFn', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeTmpDir();
+    setConstraintsPath(join(dir, 'constraints.json'));
+    setProfilesPath(join(dir, 'profiles.json'));
+  });
+  afterEach(() => {
+    setConstraintsPath(null);
+    setProfilesPath(null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const sym: Symbol = { kind: 'tunnel', attrs: {} };
+
+  it('unknown guard id (not in constraint store) → no failure', () => {
+    const guard = makeGuardFn();
+    const result = guard(['nonexistent_guard'], [], sym);
+    expect(result.hardFail).toBe(false);
+    expect(result.softFails).toEqual([]);
+  });
+
+  it('empty guard list → no failure', () => {
+    const guard = makeGuardFn();
+    const result = guard([], [], sym);
+    expect(result.hardFail).toBe(false);
+    expect(result.softFails).toEqual([]);
+  });
+
+  it('known constraint whose primitive SKIPs in dry-run → no failure', () => {
+    // max_straight_run needs geometry context it cannot get without a UE scene → SKIPs
+    upsertConstraint({
+      id: 'c_msr',
+      primitive: 'max_straight_run',
+      params: { max_m: 5 },
+      binding: { asset: '/Game/TestX' },
+      hard: true,
+    });
+    const guard = makeGuardFn();
+    const result = guard(['c_msr'], [], { kind: 'tunnel', attrs: { asset: '/Game/TestX' } });
+    // primitive SKIPs without real geometry → no failure
+    expect(result.hardFail).toBe(false);
+    expect(result.softFails).toEqual([]);
+  });
+
+  it('HARD grounded constraint that genuinely FAILs in TS → hardFail: true', () => {
+    // Bake a profile and create a symbol/instance where the object floats 5m above ground.
+    const profile = bakeProfile(
+      { asset_id: '/Game/FloatProp', origin_cm: [0, 0, 50], extent_cm: [50, 50, 50], pivot_to_base_cm: -50 },
+      'now',
+    );
+    putProfile(profile);
+
+    upsertConstraint({
+      id: 'c_grounded',
+      primitive: 'grounded',
+      params: { tolerance_m: 0.05 },
+      binding: { asset: '/Game/FloatProp' },
+      hard: true,
+    });
+
+    // Supply a scene context with the instance floating at z=5m (base = 5 + (-0.5) = 4.5m off ground)
+    const inst = {
+      object: 'FloatProp_0',
+      asset: '/Game/FloatProp',
+      tags: {} as Record<string, string>,
+      transform: { pos: [0, 0, 5] as [number, number, number], quat: [0, 0, 0, 1] as [number, number, number, number], scale: [1, 1, 1] as [number, number, number] },
+    };
+
+    const guard = makeGuardFn({ scene: { instances: [inst] } });
+    const floatSym: Symbol = { kind: 'tunnel', attrs: { asset: '/Game/FloatProp' } };
+    const result = guard(['c_grounded'], [], floatSym);
+
+    expect(result.hardFail).toBe(true);
+  });
+
+  it('SOFT constraint that FAILs → softFails includes id, hardFail stays false', () => {
+    const profile = bakeProfile(
+      { asset_id: '/Game/SoftProp', origin_cm: [0, 0, 50], extent_cm: [50, 50, 50], pivot_to_base_cm: -50 },
+      'now',
+    );
+    putProfile(profile);
+
+    upsertConstraint({
+      id: 'c_soft_ground',
+      primitive: 'grounded',
+      params: { tolerance_m: 0.05 },
+      binding: { asset: '/Game/SoftProp' },
+      hard: false, // explicitly soft
+    });
+
+    const inst = {
+      object: 'SoftProp_0',
+      asset: '/Game/SoftProp',
+      tags: {} as Record<string, string>,
+      transform: { pos: [0, 0, 5] as [number, number, number], quat: [0, 0, 0, 1] as [number, number, number, number], scale: [1, 1, 1] as [number, number, number] },
+    };
+
+    const guard = makeGuardFn({ scene: { instances: [inst] } });
+    const softSym: Symbol = { kind: 'tunnel', attrs: { asset: '/Game/SoftProp' } };
+    const result = guard(['c_soft_ground'], [], softSym);
+
+    expect(result.hardFail).toBe(false);
+    expect(result.softFails).toContain('c_soft_ground');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/plumb/grammar-guards.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/grammar-guards.ts
@@ -1,0 +1,101 @@
+// grammar-guards.ts — wires expandGrammar's GuardFn to the real PLUMB constraint
+// evaluation path (evaluate.ts / primitives.ts). Kept separate from grammar.ts
+// so grammar.ts stays pure (no store/fs imports).
+//
+// In a dry-run (no UE scene), most geometry primitives (max_straight_run,
+// presence, …) will return SKIP from evalConstraint because they need a baked
+// profile or scene context. That is EXPECTED — the brief requires honesty here.
+// The solver's fallback logic is tested separately with mock GuardFns.
+
+import type { GuardFn } from './grammar.js';
+import type { EmitOp } from './contracts.js';
+import type { Symbol } from './contracts.js';
+import { loadConstraints } from './constraint-store.js';
+import { primitivesById, resolveHard } from './primitives.js';
+import { getProfile } from './profile-store.js';
+import type { InstanceState, SceneContext } from './contracts.js';
+
+export interface MakeGuardFnOptions {
+  /** Optional scene context (for in-engine use). In dry-run, pass nothing. */
+  scene?: SceneContext;
+}
+
+/**
+ * Returns a GuardFn backed by the real PLUMB constraint store + primitives.
+ *
+ * For each guard id:
+ *  - Looks up the constraint by id in the loaded library.
+ *  - If not found → SKIP (no effect on hardFail / softFails).
+ *  - Evaluates the constraint's primitive via the existing evalConstraint path.
+ *  - SKIP and PASS never contribute to failure.
+ *  - hardFail = true if ANY HARD constraint evaluates to FAIL.
+ *  - softFails = ids of SOFT constraints that FAIL.
+ *
+ * DRY-RUN NOTE: Without a real scene/profile, most geometry primitives self-skip.
+ * This means dry-run will not reject productions that need geometry checks.
+ * That is intentional — do NOT fabricate scene data to force rejections.
+ */
+export function makeGuardFn(opts?: MakeGuardFnOptions): GuardFn {
+  return function guardFn(
+    guardIds: string[],
+    _ops: EmitOp[],
+    sym: Symbol,
+  ): { hardFail: boolean; softFails: string[] } {
+    if (!guardIds.length) return { hardFail: false, softFails: [] };
+
+    const constraints = loadConstraints();
+    const prims = primitivesById();
+
+    // Build a minimal InstanceState from the symbol so evalConstraint has
+    // something to work with. In dry-run this mostly self-skips.
+    const inst: InstanceState = {
+      object: sym.kind,
+      asset: typeof sym.attrs['asset'] === 'string' ? sym.attrs['asset'] : undefined,
+      tags: Object.fromEntries(
+        Object.entries(sym.attrs)
+          .filter(([, v]) => typeof v === 'string')
+          .map(([k, v]) => [k, v as string]),
+      ),
+      transform: {
+        pos: [0, 0, 0],
+        quat: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+      },
+    };
+
+    const scene: SceneContext = opts?.scene ?? { instances: [inst] };
+
+    let hardFail = false;
+    const softFails: string[] = [];
+
+    for (const gid of guardIds) {
+      const c = constraints.find(x => x.id === gid);
+      if (!c) continue; // unknown id → SKIP
+
+      const prim = prims.get(c.primitive);
+      if (!prim) continue; // unknown primitive → SKIP
+
+      const profile = inst.asset ? getProfile(inst.asset) : null;
+      const out = prim.evaluate({ constraint: c, instance: inst, profile, scene });
+      if (out.skip) continue; // no scene/profile data → SKIP
+
+      const ok = out.value_m >= 0;
+      if (ok) continue; // PASS → no failure
+
+      // FAIL — determine hard/soft
+      const locked = prim.qualitative && (profile?.provenance?.locked ?? []).some(f => {
+        if (prim.id === 'facing') return f === 'semantics.front';
+        if (prim.id === 'affordance_clear') return f === `affordance:${c.params.affordance}`;
+        return false;
+      });
+      const hard = resolveHard(prim, c, locked);
+      if (hard) {
+        hardFail = true;
+      } else {
+        softFails.push(gid);
+      }
+    }
+
+    return { hardFail, softFails };
+  };
+}

--- a/mcp-tools/hayba-mcp/src/plumb/grammar-store.test.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/grammar-store.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { setGrammarPath, putProduction, listProductions, validateProduction } from './index.js';
+
+describe('grammar store', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gram-'));
+    setGrammarPath(join(dir, 'grammar.json'));
+  });
+  afterEach(() => {
+    setGrammarPath(null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips a production', () => {
+    putProduction({
+      id: 'P_x',
+      lhs: { kind: 'tunnel' },
+      rhs: [{ emit: 'shell', role: 'wall' }],
+      guards: [],
+      priority: 10,
+    });
+    expect(listProductions().map(p => p.id)).toEqual(['P_x']);
+  });
+
+  it('rejects an invalid emit op', () => {
+    const errs = validateProduction({
+      id: 'P_bad',
+      lhs: { kind: 'tunnel' },
+      rhs: [{ emit: 'nope' } as any],
+      guards: [],
+      priority: 1,
+    });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/plumb/grammar-store.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/grammar-store.ts
@@ -1,0 +1,89 @@
+// Grammar store — the persisted set of production rules.
+//
+// JSON file (a small object keyed by production id) under .scratch/, same
+// scratch convention as the constraint and profile stores. The grammar is
+// the language for expansions — a set of production rules that match symbols
+// and emit operations.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { Production } from './contracts.js';
+
+let PATH_OVERRIDE: string | null = null;
+
+function defaultPath(): string {
+  if (process.env.HAYBA_GRAMMAR) return process.env.HAYBA_GRAMMAR;
+  const base = process.env.HAYBA_PROFILES ? dirname(process.env.HAYBA_PROFILES) : join(process.cwd(), '.scratch');
+  return join(base, 'grammar.json');
+}
+
+export function setGrammarPath(p: string | null): void {
+  PATH_OVERRIDE = p;
+}
+
+export function getGrammarPath(): string {
+  return PATH_OVERRIDE ?? defaultPath();
+}
+
+function ensureDir(p: string): void {
+  const d = dirname(p);
+  if (!existsSync(d)) mkdirSync(d, { recursive: true });
+}
+
+function readAll(): Record<string, Production> {
+  const p = getGrammarPath();
+  if (!existsSync(p)) return {};
+  try {
+    return JSON.parse(readFileSync(p, 'utf-8')) as Record<string, Production>;
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(obj: Record<string, Production>): void {
+  const p = getGrammarPath();
+  ensureDir(p);
+  writeFileSync(p, JSON.stringify(obj, null, 2), 'utf-8');
+}
+
+const EMITS = new Set(['shell', 'asset', 'symbol', 'scatter', 'decal', 'fill']);
+
+export function validateProduction(p: Production): string[] {
+  const e: string[] = [];
+  if (!p.id) e.push('missing id');
+  if (!p.lhs?.kind) e.push('missing lhs.kind');
+  if (!Array.isArray(p.rhs) || p.rhs.length === 0) e.push('rhs must be non-empty');
+  for (const op of p.rhs ?? []) {
+    if (!EMITS.has((op as any).emit)) e.push(`bad emit: ${(op as any).emit}`);
+  }
+  if (typeof p.priority !== 'number') e.push('priority must be a number');
+  return e;
+}
+
+export function putProduction(p: Production): void {
+  const errs = validateProduction(p);
+  if (errs.length) throw new Error(errs.join('; '));
+  const o = readAll();
+  o[p.id] = p;
+  writeAll(o);
+}
+
+export function getProduction(id: string): Production | null {
+  return readAll()[id] ?? null;
+}
+
+export function listProductions(): Production[] {
+  return Object.values(readAll());
+}
+
+export function removeProduction(id: string): boolean {
+  const o = readAll();
+  if (!(id in o)) return false;
+  delete o[id];
+  writeAll(o);
+  return true;
+}
+
+export function productionMap(): Map<string, Production> {
+  return new Map(Object.entries(readAll()));
+}

--- a/mcp-tools/hayba-mcp/src/plumb/grammar.test.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/grammar.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { matchProductions, expandGrammar } from './grammar.js';
+import type { GuardFn } from './grammar.js';
+
+const passAll: GuardFn = () => ({ hardFail: false, softFails: [] });
+
+describe('matchProductions', () => {
+  it('sorts by priority desc and filters by kind + when', () => {
+    const prods = [
+      { id: 'A', lhs: { kind: 'tunnel' }, rhs: [{ emit: 'shell', role: 'wall' }], guards: [], priority: 10 },
+      { id: 'B', lhs: { kind: 'tunnel', when: { builder: 'native' } }, rhs: [{ emit: 'shell', role: 'wall' }], guards: [], priority: 50 },
+      { id: 'C', lhs: { kind: 'room' }, rhs: [{ emit: 'shell', role: 'wall' }], guards: [], priority: 99 },
+    ];
+    expect(matchProductions({ kind: 'tunnel', attrs: { builder: 'native' } } as any, prods as any).map(p => p.id)).toEqual(['B', 'A']);
+  });
+});
+
+describe('expandGrammar', () => {
+  it('emits first satisfied production and stops', () => {
+    const prods = [{ id: 'A', lhs: { kind: 'tunnel' }, rhs: [{ emit: 'asset', role: 'column' }], guards: [], priority: 1 }];
+    expect(expandGrammar({ kind: 'tunnel', attrs: {} } as any, prods as any, passAll).items.map(i => i.role)).toEqual(['column']);
+  });
+
+  it('falls back to next production when a guard hard-fails', () => {
+    const prods = [
+      { id: 'straight', lhs: { kind: 'shaft' }, rhs: [{ emit: 'shell', role: 'vent' }], guards: ['no_straight_air_over_6m'], priority: 50 },
+      { id: 'bent', lhs: { kind: 'shaft' }, rhs: [{ emit: 'shell', role: 'vent', bend_at_m: 5 }], guards: [], priority: 10 },
+    ];
+    const guards: GuardFn = (ids) => ({ hardFail: ids.includes('no_straight_air_over_6m'), softFails: [] });
+    const plan = expandGrammar({ kind: 'shaft', attrs: {} } as any, prods as any, guards);
+    expect(plan.rejected).toContain('straight');
+    expect(plan.items[0].meta.bend_at_m).toBe(5);
+  });
+
+  it('recurses into child symbols', () => {
+    const prods = [
+      { id: 'air', lhs: { kind: 'tunnel' }, rhs: [{ emit: 'asset', role: 'vent' }, { emit: 'symbol', kind: 'shaft', len: 5 }], guards: [], priority: 50 },
+      { id: 'bent', lhs: { kind: 'shaft' }, rhs: [{ emit: 'shell', role: 'vent', bend_at_m: 5 }], guards: [], priority: 10 },
+    ];
+    expect(expandGrammar({ kind: 'tunnel', attrs: {} } as any, prods as any, passAll).items.map(i => i.role)).toEqual(['vent', 'vent']);
+  });
+
+  it('is deterministic across runs', () => {
+    const prods = [{ id: 'A', lhs: { kind: 'tunnel' }, rhs: [{ emit: 'asset', role: 'column' }], guards: [], priority: 1 }];
+    const a = expandGrammar({ kind: 'tunnel', attrs: {} } as any, prods as any, passAll);
+    const b = expandGrammar({ kind: 'tunnel', attrs: {} } as any, prods as any, passAll);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});

--- a/mcp-tools/hayba-mcp/src/plumb/grammar.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/grammar.ts
@@ -1,0 +1,90 @@
+import type { Symbol, Production, EmitOp } from './contracts.js';
+
+export interface PlacedItem {
+  kind: EmitOp['emit'];
+  role?: string;
+  tag?: string;
+  symbolKind: string;
+  index: number;
+  meta: Record<string, unknown>;
+}
+
+export interface PlacementPlan {
+  items: PlacedItem[];
+  weaknesses: string[];
+  rejected: string[];
+}
+
+export type GuardFn = (
+  guardIds: string[],
+  ops: EmitOp[],
+  sym: Symbol,
+) => { hardFail: boolean; softFails: string[] };
+
+function whenMatches(sym: Symbol, when?: Record<string, unknown>): boolean {
+  if (!when) return true;
+  for (const [k, v] of Object.entries(when)) {
+    if (k.endsWith('_gt')) {
+      const key = k.slice(0, -3);
+      if (!((sym.attrs[key] as number) > (v as number))) return false;
+    } else if ((sym.attrs as any)[k] !== v) return false;
+  }
+  return true;
+}
+
+export function matchProductions(sym: Symbol, prods: Production[]): Production[] {
+  return prods
+    .filter(p => p.lhs.kind === sym.kind && whenMatches(sym, p.lhs.when))
+    .sort((a, b) => b.priority - a.priority);
+}
+
+const MAX_DEPTH = 6;
+const MAX_ITEMS = 512;
+
+export function expandGrammar(
+  seed: Symbol,
+  prods: Production[],
+  guards: GuardFn,
+): PlacementPlan {
+  const plan: PlacementPlan = { items: [], weaknesses: [], rejected: [] };
+  const queue: Array<{ sym: Symbol; depth: number }> = [{ sym: seed, depth: 0 }];
+  let idx = 0;
+
+  while (queue.length && plan.items.length < MAX_ITEMS) {
+    const { sym, depth } = queue.shift()!;
+    if (depth > MAX_DEPTH) continue;
+
+    let committed = false;
+    for (const prod of matchProductions(sym, prods)) {
+      const verdict = guards(prod.guards, prod.rhs, sym);
+      if (verdict.hardFail) {
+        plan.rejected.push(prod.id);
+        continue;
+      }
+      plan.weaknesses.push(...verdict.softFails);
+      for (const op of prod.rhs) {
+        if (op.emit === 'symbol') {
+          queue.push({
+            sym: { kind: op.kind, attrs: { ...sym.attrs, len: op.len ?? 0 } },
+            depth: depth + 1,
+          });
+        } else {
+          plan.items.push({
+            kind: op.emit,
+            role: (op as any).role,
+            tag: (op as any).tag,
+            symbolKind: sym.kind,
+            index: idx++,
+            meta: { ...op },
+          });
+        }
+      }
+      committed = true;
+      break;
+    }
+
+    if (!committed) plan.rejected.push(`<no-production:${sym.kind}>`);
+  }
+
+  return plan;
+}

--- a/mcp-tools/hayba-mcp/src/plumb/index.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/index.ts
@@ -35,3 +35,5 @@ export {
   getGrammarPath, setGrammarPath, putProduction, getProduction, listProductions,
   removeProduction, productionMap, validateProduction,
 } from './grammar-store.js';
+export { matchProductions, expandGrammar } from './grammar.js';
+export type { PlacedItem, PlacementPlan, GuardFn } from './grammar.js';

--- a/mcp-tools/hayba-mcp/src/plumb/index.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/index.ts
@@ -31,3 +31,7 @@ export {
 export type { Lesson, LessonValidationError } from './lesson-store.js';
 export { enqueueStudyRequest, takeStudyRequests, getStudyRequestsPath, setStudyRequestsPath } from './study-requests.js';
 export type { StudyRequest } from './study-requests.js';
+export {
+  getGrammarPath, setGrammarPath, putProduction, getProduction, listProductions,
+  removeProduction, productionMap, validateProduction,
+} from './grammar-store.js';

--- a/mcp-tools/hayba-mcp/src/plumb/index.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/index.ts
@@ -18,7 +18,7 @@ export {
 export type { ValidationError } from './constraint-store.js';
 export {
   loadProfiles, getProfile, profileMap, putProfile, annotateProfile, removeProfile,
-  getProfilesPath, setProfilesPath, addMask, getMask, removeMask,
+  getProfilesPath, setProfilesPath, addMask, getMask, removeMask, addSocket,
 } from './profile-store.js';
 export { bakeProfile } from './bake.js';
 export type { UeBoundsInput } from './bake.js';
@@ -37,3 +37,5 @@ export {
 } from './grammar-store.js';
 export { matchProductions, expandGrammar } from './grammar.js';
 export type { PlacedItem, PlacementPlan, GuardFn } from './grammar.js';
+export { makeGuardFn } from './grammar-guards.js';
+export type { MakeGuardFnOptions } from './grammar-guards.js';

--- a/mcp-tools/hayba-mcp/src/plumb/plumb.test.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/plumb.test.ts
@@ -176,6 +176,15 @@ describe('profile store + bake + annotate', () => {
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'plumb-')); setProfilesPath(join(dir, 'p.json')); });
   afterEach(() => { setProfilesPath(null); rmSync(dir, { recursive: true, force: true }); });
 
+  it('bakes default sockets from the OBB', () => {
+    const p = bakeProfile({ asset_id: '/Game/X.X', origin_cm: [0,0,0], extent_cm: [50,50,120] }, 'now');
+    const ids = (p.semantics.sockets ?? []).map(s => s.id).sort();
+    expect(ids).toEqual(['arch_crown','floor_edge','wall_mid']);
+    const crown = p.semantics.sockets!.find(s => s.id === 'arch_crown')!;
+    expect(crown.type).toBe('ceiling');
+    expect(crown.frame.pos[2]).toBeCloseTo(1.2);   // top of a 1.2 m half-extent, metres
+  });
+
   it('bake converts cm→m and persists', () => {
     const p = bakeProfile({ asset_id: '/Game/Rock', origin_cm: [0, 0, 50], extent_cm: [100, 100, 50] }, 'now');
     expect(p.geometry.aabb.max[2]).toBeCloseTo(1, 5);  // 100cm = 1m

--- a/mcp-tools/hayba-mcp/src/plumb/plumb.test.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/plumb.test.ts
@@ -17,12 +17,19 @@ function inst(object: string, pos: [number, number, number], opts: Partial<Insta
 }
 
 describe('closed primitive set', () => {
-  it('has exactly 11 primitives with unique ids and valid gates', () => {
-    expect(PRIMITIVES.length).toBe(11);
+  it('has exactly 13 primitives with unique ids and valid gates', () => {
+    expect(PRIMITIVES.length).toBe(13);
     const ids = new Set(PRIMITIVES.map(p => p.id));
-    expect(ids.size).toBe(11);
+    expect(ids.size).toBe(13);
     const gates = new Set(['collision', 'stability', 'constraints', 'reach']);
     for (const p of PRIMITIVES) expect(gates.has(p.gate)).toBe(true);
+  });
+
+  it('exposes presence and max_straight_run in the closed set', () => {
+    const ids = PRIMITIVES.map(p => p.id);
+    expect(ids).toContain('presence');
+    expect(ids).toContain('max_straight_run');
+    expect(ids.length).toBe(13);
   });
 
   it('qualitative primitives are facing + affordance_clear', () => {

--- a/mcp-tools/hayba-mcp/src/plumb/primitives.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/primitives.ts
@@ -120,7 +120,7 @@ function maskRegion(profile: Profile | null, maskId: string | undefined, inst: I
   return null; // surface masks are handled by surface_contact / affordance_clear paths
 }
 
-// ── the closed set (11 primitives) ───────────────────────────────────────────
+// ── the closed set (13 primitives) ───────────────────────────────────────────
 
 export const PRIMITIVES: Primitive[] = [
   {
@@ -382,6 +382,38 @@ export const PRIMITIVES: Primitive[] = [
         fix = { translate: [toward[0] * pull, toward[1] * pull, toward[2] * pull] };
       }
       return { value_m, fix, detail: `nearest surface ${best.toFixed(2)}m vs gap ${gap}m` };
+    },
+  },
+  {
+    id: 'presence',
+    gate: 'constraints',
+    defaultHard: true,
+    qualitative: false,
+    doc: "A named role must (mode=required) or must not (mode=forbidden) exist within the region. Encodes 'every room needs an air solution / two closures'.",
+    params: ['role', 'mode'],
+    evaluate: ({ constraint, scene }) => {
+      if (!scene || !scene.instances) return SKIP('no scene context');
+      const role = str(constraint.params.role);
+      const mode = str(constraint.params.mode) === 'forbidden' ? 'forbidden' : 'required';
+      if (!role) return SKIP('no role param');
+      const found = scene.instances.some(i => i.tags?.['role'] === role);
+      const value_m = mode === 'required'
+        ? (found ? 1 : -1)
+        : (found ? -1 : 1);
+      return { value_m, detail: `role "${role}" ${found ? 'present' : 'absent'} (mode=${mode})` };
+    },
+  },
+  {
+    id: 'max_straight_run',
+    gate: 'collision',
+    defaultHard: true,
+    qualitative: false,
+    doc: "No straight unbroken span longer than max_m along the region/axis. Encodes G-1 sightlines and 'no straight air > 6 m'.",
+    params: ['max_m', 'axis'],
+    evaluate: () => {
+      // Real geometry measurement happens in the C++ PCG node + scene validator.
+      // No geometry context is available in the TS evaluator at this stage.
+      return SKIP('no geometry context');
     },
   },
 ];

--- a/mcp-tools/hayba-mcp/src/plumb/profile-store.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/profile-store.ts
@@ -115,6 +115,19 @@ export function addMask(assetId: string, mask: Mask): Profile | null {
   return merged;
 }
 
+export function addSocket(assetId: string, socket: import('./contracts.js').Socket): Profile {
+  const all = readAll();
+  assetId = toObjectPath(assetId);
+  const base = all[assetId];
+  if (!base) throw new Error(`no profile: ${assetId}`);
+  const sockets = (base.semantics.sockets ?? []).filter(s => s.id !== socket.id);
+  sockets.push(socket);
+  const merged: Profile = { ...base, semantics: { ...base.semantics, sockets } };
+  all[assetId] = merged;
+  writeAll(all);
+  return merged;
+}
+
 export function removeMask(assetId: string, maskId: string): boolean {
   const all = readAll();
   assetId = toObjectPath(assetId);

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -129,6 +129,11 @@ import {
   plumbStudySchema, plumbStudyHandler,
   plumbStudyTakeSchema, plumbStudyTakeHandler,
   plumbSegmentSchema, plumbSegmentHandler,
+  plumbProductionDefineSchema, plumbProductionDefineHandler,
+  plumbProductionListSchema, plumbProductionListHandler,
+  plumbProductionRemoveSchema, plumbProductionRemoveHandler,
+  plumbSocketAddSchema, plumbSocketAddHandler,
+  plumbGrammarExpandSchema, plumbGrammarExpandHandler,
 } from './plumb/tools.js';
 
 // SessionManager (Gaea session) parked while terrain features are off — kept
@@ -1725,6 +1730,26 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     'AI-segment a studied asset: given the study_render color passes, the agent\'s themed part labels + a box/points per view, runs SAM in the visual sidecar and back-projects to geometry-hugging surface masks (triangles via the world-position pass + a UV display texture), written into the profile. Replaces hand-placed blocky masks.',
     plumbSegmentSchema, async (a) => j(await plumbSegmentHandler(a)));
 
+  server.tool('plumb_production_define',
+    'Author/upsert a grammar production rule: an LHS symbol kind (+ optional attribute guards) → an RHS sequence of emit ops (shell/asset/symbol/scatter/decal/fill). Guards are constraint ids that must pass before the production fires.',
+    plumbProductionDefineSchema, async (a) => j(await plumbProductionDefineHandler(a)));
+
+  server.tool('plumb_production_list',
+    'List all grammar productions in the store.',
+    plumbProductionListSchema, async () => j(await plumbProductionListHandler()));
+
+  server.tool('plumb_production_remove',
+    'Remove a grammar production by id.',
+    plumbProductionRemoveSchema, async (a) => j(await plumbProductionRemoveHandler(a)));
+
+  server.tool('plumb_socket_add',
+    'Add or replace a socket (connection point) on a baked profile. Idempotent on socket id.',
+    plumbSocketAddSchema, async (a) => j(await plumbSocketAddHandler(a)));
+
+  server.tool('plumb_grammar_expand',
+    'Expand a seed symbol using the stored production rules + the PLUMB constraint store as guards. Returns a PlacementPlan. In dry-run (no UE scene), geometry-dependent constraints self-skip — rejections only reflect TS-evaluable constraints.',
+    plumbGrammarExpandSchema, async (a) => j(await plumbGrammarExpandHandler(a)));
+
   // ── Landscape import (TS wrapper for UE-side landscape_import handler) ────
   server.tool(
     'hayba_import_landscape',
@@ -1944,4 +1969,9 @@ function recordEagerSchemas(
   reg('plumb_study', plumbStudySchema, 'low', '{asset, has_profile, profile?, primitives, mask_kinds, guidance}');
   reg('plumb_study_take', plumbStudyTakeSchema, 'low', '{requests:[{asset,ts}], note}');
   reg('plumb_segment', plumbSegmentSchema, 'high', '{ok, added:[label], skipped?, error?}');
+  reg('plumb_production_define', plumbProductionDefineSchema, 'low', '{ok, errors?}');
+  reg('plumb_production_list', plumbProductionListSchema, 'low', '{productions:[Production]}');
+  reg('plumb_production_remove', plumbProductionRemoveSchema, 'low', '{ok, removed}');
+  reg('plumb_socket_add', plumbSocketAddSchema, 'low', '{ok, profile|error}');
+  reg('plumb_grammar_expand', plumbGrammarExpandSchema, 'low', '{plan:PlacementPlan, note}');
 }

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -375,14 +375,15 @@ const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
     },
     {
       name: 'material_compile',
-      description: 'Explicitly compile a material (apply staged settings + surface translator errors) and return shader optimization stats. Graph edits auto-save and defer compilation; call this once the graph is complete. The result includes a stats block (per-shader instruction counts, texture samples, samplers, interpolators) plus an OPTIMIZATION FEEDBACK summary with hints.',
+      description: 'Finalize a material OR material FUNCTION: write it to disk, apply staged settings, surface translator errors + shader optimization stats (materials). Graph edits DEFER the disk write — call this once the graph is complete. NOTE: material functions no longer auto-save either, so after editing a function call material_compile with function_path to persist it (this avoids a half-built function crashing the editor when it is opened/compiled).',
       meta: materialCompileMeta,
       handler: materialCompileHandler,
       cost: 'medium',
-      returns: '{errors:[string], has_errors, saved, stats:{shaders:[{name,instructions}], texture_samples, texture_lookups, virtual_texture_lookups, samplers, max_samplers, interpolators_used, interpolators_max}}',
+      returns: '{errors:[string], has_errors, saved, stats:{shaders:[{name,instructions}], texture_samples, ...}} (materials) | {saved} (functions)',
       niche: M,
       schema: {
-        material_path: z.string().min(1).describe('Path to the master material asset to compile'),
+        material_path: z.string().optional().describe('Path to the master material asset to compile (either this or function_path)'),
+        function_path: z.string().optional().describe('Path to a material FUNCTION to finalize + save (either this or material_path)'),
       },
     },
     {

--- a/mcp-tools/hayba-mcp/src/tools/material/material-compile.ts
+++ b/mcp-tools/hayba-mcp/src/tools/material/material-compile.ts
@@ -7,12 +7,15 @@ import { formatOptimizationFeedback, type MaterialStats } from './material-stats
 export const meta: HaybaToolMeta = {
   cost: 'medium',
   effects: ['modifies_asset'],
-  when: 'explicitly compiling a material after building/editing its graph, to apply staged settings, surface translator errors, and read back shader optimization stats (instruction counts, texture samples)',
-  not_when: 'mid-edit — graph edits (add_node/connect/set_node/...) already auto-save to disk and intentionally DEFER compilation; only compile once the graph is complete',
+  when: 'finalizing a material OR material FUNCTION after building/editing its graph — applies staged settings, writes the asset to disk, surfaces translator errors + shader optimization stats (materials only)',
+  not_when: 'mid-edit — graph edits intentionally DEFER the disk write; only call this once the graph is complete (required for functions too: their edits no longer auto-save, so call material_compile with function_path to persist)',
 };
 
 export const schema = z.object({
-  material_path: z.string().min(1).describe('Path to the master material asset to compile'),
+  material_path: z.string().optional().describe('Path to the master material asset to compile (either this or function_path)'),
+  function_path: z.string().optional().describe('Path to a material FUNCTION to finalize + save (either this or material_path)'),
+}).refine((d) => !!d.material_path || !!d.function_path, {
+  message: 'one of material_path or function_path is required',
 });
 
 export async function materialCompileHandler(args: Record<string, unknown>, _session?: SessionManager): Promise<ToolResult> {

--- a/mcp-tools/hayba-mcp/src/tools/plumb/tools.ts
+++ b/mcp-tools/hayba-mcp/src/tools/plumb/tools.ts
@@ -25,8 +25,14 @@ import {
   evaluate, evaluatePerInstance, addMask, removeMask,
   loadLessons, getLesson, upsertLesson, removeLesson,
   takeStudyRequests,
+  putProduction, listProductions, removeProduction, validateProduction,
+  expandGrammar,
   type Constraint, type InstanceState, type Transform, type Mask, type Verdict,
+  type Production,
 } from '../../plumb/index.js';
+import { addSocket as addSocketToProfile } from '../../plumb/profile-store.js';
+import { makeGuardFn } from '../../plumb/grammar-guards.js';
+import type { Socket } from '../../plumb/contracts.js';
 import { replaceFindingsWithPrefix, type ValidatorFinding } from '../../validator/index.js';
 import { segmentProject } from '../visual/sidecar-client.js';
 
@@ -472,6 +478,108 @@ export async function plumbLessonListHandler(): Promise<{ lessons: Array<{ slug:
 export const plumbLessonRemoveSchema = { slug: z.string() };
 export async function plumbLessonRemoveHandler(args: { slug: string }): Promise<{ ok: boolean; removed: boolean }> {
   return { ok: true, removed: removeLesson(args.slug) };
+}
+
+// ── plumb_production_define / list / remove ──────────────────────────────────
+
+const emitOpSchema = z.object({
+  emit: z.enum(['shell', 'asset', 'symbol', 'scatter', 'decal', 'fill']),
+  role: z.string().optional(),
+  kind: z.string().optional(),
+  tag: z.string().optional(),
+  at: z.string().optional(),
+  along: z.string().optional(),
+  spacing_m: z.number().optional(),
+  alternate: z.boolean().optional(),
+  len: z.number().optional(),
+  profile_curve: z.string().optional(),
+  thickness_by: z.string().optional(),
+  bend_at_m: z.number().optional(),
+});
+
+export const plumbProductionDefineSchema = {
+  id: z.string(),
+  lhs: z.object({
+    kind: z.string(),
+    when: z.record(z.unknown()).optional(),
+  }),
+  rhs: z.array(emitOpSchema).min(1),
+  guards: z.array(z.string()).optional().describe('Constraint ids that must pass before this production fires'),
+  priority: z.number().describe('Higher priority = tried first when multiple productions match'),
+};
+export async function plumbProductionDefineHandler(args: {
+  id: string;
+  lhs: { kind: string; when?: Record<string, unknown> };
+  rhs: Record<string, unknown>[];
+  guards?: string[];
+  priority: number;
+}): Promise<{ ok: boolean; errors?: string[] }> {
+  const p: Production = {
+    id: args.id,
+    lhs: args.lhs,
+    rhs: args.rhs as Production['rhs'],
+    guards: args.guards ?? [],
+    priority: args.priority,
+  };
+  const errs = validateProduction(p);
+  if (errs.length) return { ok: false, errors: errs };
+  putProduction(p);
+  return { ok: true };
+}
+
+export const plumbProductionListSchema = {};
+export async function plumbProductionListHandler(): Promise<{ productions: Production[] }> {
+  return { productions: listProductions() };
+}
+
+export const plumbProductionRemoveSchema = { id: z.string() };
+export async function plumbProductionRemoveHandler(args: { id: string }): Promise<{ ok: boolean; removed: boolean }> {
+  return { ok: true, removed: removeProduction(args.id) };
+}
+
+// ── plumb_socket_add ─────────────────────────────────────────────────────────
+
+export const plumbSocketAddSchema = {
+  asset: z.string().describe('Asset path the socket belongs to (must have a baked profile)'),
+  socket: z.object({
+    id: z.string(),
+    type: z.enum(['floor', 'ceiling', 'wall', 'edge', 'custom']),
+    frame: z.object({ pos: vec3, quat: vec4 }),
+  }),
+};
+export async function plumbSocketAddHandler(args: {
+  asset: string;
+  socket: Socket;
+}): Promise<{ ok: boolean; profile?: unknown; error?: string }> {
+  try {
+    const merged = addSocketToProfile(args.asset, args.socket);
+    return { ok: true, profile: merged };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+}
+
+// ── plumb_grammar_expand ──────────────────────────────────────────────────────
+
+export const plumbGrammarExpandSchema = {
+  seed: z.object({
+    kind: z.string(),
+    attrs: z.record(z.union([z.number(), z.string(), z.boolean()])).optional(),
+  }).describe('Seed symbol to expand from'),
+};
+export async function plumbGrammarExpandHandler(args: {
+  seed: { kind: string; attrs?: Record<string, number | string | boolean> };
+}): Promise<{ plan: unknown; note: string }> {
+  const seed = { kind: args.seed.kind, attrs: args.seed.attrs ?? {} };
+  const prods = listProductions();
+  const guard = makeGuardFn();
+  const plan = expandGrammar(seed, prods, guard);
+  return {
+    plan,
+    note: prods.length === 0
+      ? 'No productions defined yet — call plumb_production_define to author rules, then re-expand.'
+      : `Expanded from seed "${seed.kind}" using ${prods.length} production(s). In dry-run, geometry primitives (max_straight_run, presence) self-skip — rejections shown only reflect constraints evaluable without a UE scene.`,
+  };
 }
 
 void constraintsFor; void primitivesById; void getLesson; // re-exported helpers, kept for tool growth

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -81,6 +81,11 @@ export const ALWAYS_ON_META = new Set<string>([
   'plumb_study',
   'plumb_study_take',
   'plumb_segment',
+  'plumb_production_define',
+  'plumb_production_list',
+  'plumb_production_remove',
+  'plumb_socket_add',
+  'plumb_grammar_expand',
 ]);
 
 export interface CapturedTool {
@@ -306,6 +311,11 @@ export async function registerDeferredRouting(
   passthrough('plumb_study');
   passthrough('plumb_study_take');
   passthrough('plumb_segment');
+  passthrough('plumb_production_define');
+  passthrough('plumb_production_list');
+  passthrough('plumb_production_remove');
+  passthrough('plumb_socket_add');
+  passthrough('plumb_grammar_expand');
 
   // For hayba_check_ue_status: REPLACE the captured handler with one that
   // wires onConnected → maybeAutoLoad('ue_connected'). The captured handler

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -394,7 +394,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatAddNode(const TSharedPtr<FJsonO
         if (!Expr) return FHaybaHandlerResult::Err(TEXT("material_add_node: CreateMaterialExpressionInFunction failed"));
         if (PropsObj) ApplyNodeProps(Expr, *PropsObj);
         UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
-        { FString SaveErr; HaybaPersistAsset(Fn, SaveErr); }  // crash-resilient: save function graph now
+        Fn->MarkPackageDirty();  // in-memory only — function written to disk by material_compile(function_path); avoids a half-built function landing on disk and asserting when the editor opens/compiles it
 
         TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
         Out->SetStringField(TEXT("node_id"), Expr->GetName());
@@ -505,7 +505,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatConnectNodes(const TSharedPtr<F
         else if (!UMaterialEditingLibrary::ConnectMaterialExpressions(From, FromOutput, To, ToInput))
             return FHaybaHandlerResult::Err(TEXT("material_connect_nodes: ConnectMaterialExpressions failed"));
         UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
-        { FString SaveErr; HaybaPersistAsset(Fn, SaveErr); }  // crash-resilient: save function graph now
+        Fn->MarkPackageDirty();  // in-memory only — function written to disk by material_compile(function_path); avoids a half-built function landing on disk and asserting when the editor opens/compiles it
 
         TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
         Out->SetBoolField(TEXT("connected"), true);
@@ -937,7 +937,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatSetNode(const TSharedPtr<FJsonO
         if (!Expr) return FHaybaHandlerResult::Err(FString::Printf(TEXT("material_set_node: node not found: %s"), *NodeId));
         ApplyTo(Expr);
         UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
-        { FString SaveErr; HaybaPersistAsset(Fn, SaveErr); }  // crash-resilient: save function graph now
+        Fn->MarkPackageDirty();  // in-memory only — function written to disk by material_compile(function_path); avoids a half-built function landing on disk and asserting when the editor opens/compiles it
         TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
         Out->SetStringField(TEXT("node_id"), NodeId);
         return FHaybaHandlerResult::Ok(Out);
@@ -974,7 +974,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatDeleteNode(const TSharedPtr<FJs
         if (!Expr) return FHaybaHandlerResult::Err(FString::Printf(TEXT("material_delete_node: node not found: %s"), *NodeId));
         UMaterialEditingLibrary::DeleteMaterialExpressionInFunction(Fn, Expr);
         UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
-        { FString SaveErr; HaybaPersistAsset(Fn, SaveErr); }  // crash-resilient: save function graph now
+        Fn->MarkPackageDirty();  // in-memory only — function written to disk by material_compile(function_path); avoids a half-built function landing on disk and asserting when the editor opens/compiles it
         TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
         Out->SetBoolField(TEXT("deleted"), true);
         return FHaybaHandlerResult::Ok(Out);
@@ -1027,7 +1027,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatAddComment(const TSharedPtr<FJs
         Setup(C);
         Fn->GetExpressionCollection().AddComment(C);
         UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
-        { FString SaveErr; HaybaPersistAsset(Fn, SaveErr); }  // crash-resilient: save function graph now
+        Fn->MarkPackageDirty();  // in-memory only — function written to disk by material_compile(function_path); avoids a half-built function landing on disk and asserting when the editor opens/compiles it
         TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
         Out->SetStringField(TEXT("comment_id"), C->GetName());
         return FHaybaHandlerResult::Ok(Out);
@@ -1196,7 +1196,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatAddRerouteDeclaration(const TSh
         if (!D) return FHaybaHandlerResult::Err(TEXT("material_add_reroute_declaration: create failed"));
         Setup(D);
         UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
-        { FString SaveErr; HaybaPersistAsset(Fn, SaveErr); }  // crash-resilient: save function graph now
+        Fn->MarkPackageDirty();  // in-memory only — function written to disk by material_compile(function_path); avoids a half-built function landing on disk and asserting when the editor opens/compiles it
         TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
         Out->SetStringField(TEXT("node_id"), D->GetName());
         return FHaybaHandlerResult::Ok(Out);
@@ -1246,7 +1246,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatAddRerouteUsage(const TSharedPt
         U->Declaration = D;
         U->DeclarationGuid = D->VariableGuid;
         UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
-        { FString SaveErr; HaybaPersistAsset(Fn, SaveErr); }  // crash-resilient: save function graph now
+        Fn->MarkPackageDirty();  // in-memory only — function written to disk by material_compile(function_path); avoids a half-built function landing on disk and asserting when the editor opens/compiles it
         TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
         Out->SetStringField(TEXT("node_id"), U->GetName());
         return FHaybaHandlerResult::Ok(Out);
@@ -1324,9 +1324,26 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatSetProperty(const TSharedPtr<FJ
 // errors so the agent gets feedback instead of guessing.
 FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCompile(const TSharedPtr<FJsonObject>& P)
 {
+    // Material FUNCTIONS are no longer auto-saved per edit (a half-built function
+    // on disk asserts when the editor opens/compiles it). This is their explicit
+    // save point: refresh + write to disk.
+    FString FuncPath;
+    if (P->TryGetStringField(TEXT("function_path"), FuncPath) && !FuncPath.IsEmpty())
+    {
+        UMaterialFunction* Fn = LoadObject<UMaterialFunction>(nullptr, *FuncPath);
+        if (!Fn) return FHaybaHandlerResult::Err(TEXT("material_compile: function not found"));
+        UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
+        FString FnSaveErr;
+        const bool bFnSaved = HaybaPersistAsset(Fn, FnSaveErr);
+        TSharedPtr<FJsonObject> FnOut = MakeShared<FJsonObject>();
+        FnOut->SetBoolField(TEXT("saved"), bFnSaved);
+        if (!bFnSaved) FnOut->SetStringField(TEXT("save_error"), FnSaveErr);
+        return FHaybaHandlerResult::Ok(FnOut);
+    }
+
     FString MatPath;
     if (!HaybaParams::GetString(P, TEXT("material_path"), MatPath))
-        return FHaybaHandlerResult::Err(TEXT("material_compile: missing material_path"));
+        return FHaybaHandlerResult::Err(TEXT("material_compile: missing material_path or function_path"));
     UMaterial* Mat = LoadObject<UMaterial>(nullptr, *MatPath);
     if (!Mat) return FHaybaHandlerResult::Err(TEXT("material_compile: material not found"));
 


### PR DESCRIPTION
## Crash
\`\`\`
Assertion failed: Default != nullptr [HLSLMaterialTranslator.cpp:3434]
Invalid material expression and no default value provided
(MaterialEditor compiling — no Hayba frame)
\`\`\`
An input compiled to \`INDEX_NONE\` with no default.

## Root cause
Master materials were already switched to deferred save (#253), but material **functions** still **auto-saved on every edit**. A half-built function (e.g. an input wired to a not-yet-finished/invalid source) landed on disk and asserted the first time the editor opened/compiled it (function preview / a material using it).

## Fix
- Function graph-edit handlers (`add_node`/`connect`/`set_node`/`delete_node`/reroute decl+usage) now `MarkPackageDirty` **in-memory only** — no per-edit disk write.
- `material_compile` gains `function_path` as the **explicit save point** (`UpdateMaterialFunction` + persist), mirroring the master-material model.
- Tool docs updated: after editing a function, call `material_compile { function_path }` to persist it.

## Verification
- `RunUAT BuildPlugin` UE 5.7 → **BUILD SUCCESSFUL**; `tsc` clean; tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added production rule system enabling constraint-based asset generation and strategic planning
  * Introduced socket connection points for asset profile integration
  * New tools for managing production rules, socket assignments, and grammar-based expansion planning
  * Material function compilation now supported as separate workflow from material compilation

* **Tests**
  * Comprehensive test coverage added for production constraints, grammar evaluation, and socket management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->