### PR TITLE
fix(level): strip transient HLOD mesh refs before saving a map

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLevelHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLevelHandler.cpp
@@ -8,8 +8,63 @@
 #include "AssetRegistry/IAssetRegistry.h"
 #include "LevelEditor.h"
 #include "Engine/World.h"
+#include "Engine/StaticMesh.h"
+#include "Components/StaticMeshComponent.h"
+#include "UObject/Package.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogHaybaMCPLevel, Log, All);
+
+// ---------------------------------------------------------------------------
+// Transient-reference sanitizer
+//
+// Saving a .umap fails hard ("Illegal reference to private object") when a
+// component in the persistent level references a StaticMesh that lives in a
+// transient/private package — most commonly a stale HLOD proxy
+// (LandscapeMeshProxyComponent on an "HLOD0_Instancing" actor) carried over
+// from the OpenWorld template, whose mesh was built into /Temp/... rather than
+// a saved asset. Those proxy meshes are derived data: clearing the dangling
+// reference lets the map save, and a real BuildHLODs regenerates them.
+//
+// We clear the offending StaticMesh reference (rather than destroying the
+// actor) so nothing legitimate is lost, and report what was cleaned.
+// ---------------------------------------------------------------------------
+static bool IsTransientPackageRef(const UObject* Obj)
+{
+    if (!Obj) return false;
+    const UPackage* Pkg = Obj->GetOutermost();
+    if (!Pkg) return false;
+    if (Pkg == GetTransientPackage()) return true;
+    if (Obj->HasAnyFlags(RF_Transient) || Pkg->HasAnyFlags(RF_Transient)) return true;
+    const FString PkgName = Pkg->GetName();
+    // Not a persistable content/engine asset path → illegal to reference on save.
+    return PkgName.StartsWith(TEXT("/Temp/")) || PkgName.StartsWith(TEXT("/Engine/Transient"));
+}
+
+static int32 SanitizeTransientStaticMeshRefs(UWorld* World, TArray<FString>& OutCleaned)
+{
+    if (!World) return 0;
+    int32 Count = 0;
+    for (TActorIterator<AActor> It(World); It; ++It)
+    {
+        AActor* A = *It;
+        if (!A) continue;
+        TArray<UStaticMeshComponent*> Comps;
+        A->GetComponents(Comps);
+        for (UStaticMeshComponent* C : Comps)
+        {
+            if (!C) continue;
+            UStaticMesh* SM = C->GetStaticMesh();
+            if (SM && IsTransientPackageRef(SM))
+            {
+                C->Modify();
+                C->SetStaticMesh(nullptr);
+                OutCleaned.Add(FString::Printf(TEXT("%s.%s -> %s"), *A->GetName(), *C->GetName(), *SM->GetName()));
+                ++Count;
+            }
+        }
+    }
+    return Count;
+}
 
 // File-static bookmark store — avoids adding state to the handler class.
 static TMap<FString, FTransform> GHaybaBookmarkMap;
@@ -95,9 +150,22 @@ FHaybaHandlerResult FHaybaMCPLevelHandler::LevelLoad(const TSharedPtr<FJsonObjec
 // ---------------------------------------------------------------------------
 FHaybaHandlerResult FHaybaMCPLevelHandler::LevelSave(const TSharedPtr<FJsonObject>& P)
 {
+    // Strip dangling transient mesh refs (stale HLOD proxies) that would
+    // otherwise fail the save with "Illegal reference to private object".
+    TArray<FString> Cleaned;
+    if (GEditor)
+        if (UWorld* World = GEditor->GetEditorWorldContext().World())
+            SanitizeTransientStaticMeshRefs(World, Cleaned);
+
     bool bSaved = FEditorFileUtils::SaveCurrentLevel();
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetBoolField(TEXT("saved"), bSaved);
+    if (Cleaned.Num() > 0)
+    {
+        TArray<TSharedPtr<FJsonValue>> Arr;
+        for (const FString& C : Cleaned) Arr.Add(MakeShared<FJsonValueString>(C));
+        Out->SetArrayField(TEXT("cleaned_transient_refs"), Arr);
+    }
     return FHaybaHandlerResult::Ok(Out);
 }
 
@@ -117,6 +185,12 @@ FHaybaHandlerResult FHaybaMCPLevelHandler::LevelCreate(const TSharedPtr<FJsonObj
     UWorld* World = GEditor->GetEditorWorldContext().World();
     if (!World)
         return FHaybaHandlerResult::Err(TEXT("level_create: no editor world after CreateNewMapForEditing"));
+
+    // Defensive: a freshly created map is clean, but if a template world is ever
+    // used here, strip stale transient HLOD refs so the first save can't fail.
+    TArray<FString> Cleaned;
+    SanitizeTransientStaticMeshRefs(World, Cleaned);
+
     bool bSaved = FEditorFileUtils::SaveLevel(World->GetCurrentLevel(), *Path);
     if (!bSaved)
         return FHaybaHandlerResult::Err(FString::Printf(TEXT("level_create: SaveLevel failed for path: %s"), *Path));


### PR DESCRIPTION
## Crash / save failure
```
Can't save NewMap1.umap: Illegal reference to private object:
StaticMesh /Temp/Untitled_1_InstanceOf_/Engine/__ExternalActors__/Maps/Templates/OpenWorld/.../StaticMesh_HLOD0_Instancing_0
referenced by LandscapeMeshProxyComponent_0 (at PersistentLevel.HLOD0_Instancing_...)
```
A stale HLOD proxy actor carried over from the OpenWorld template references a `StaticMesh` that was built into a **transient/private package** (`/Temp/...`). The save validator rejects any reference to a non-persistable object, so AI-built maps can never be saved.

## Fix
`level_save` and `level_create` now run `SanitizeTransientStaticMeshRefs` before saving: walk every actor and, for any `StaticMeshComponent` (incl. `LandscapeMeshProxyComponent`) whose mesh lives in the transient package / is `RF_Transient` / sits under `/Temp/` or `/Engine/Transient`, clear the dangling reference (`Modify()` + `SetStaticMesh(nullptr)`). The save then succeeds. Cleared refs are returned as `cleaned_transient_refs`. The meshes are derived HLOD data — a real BuildHLODs regenerates them.

## Verification
- `RunUAT BuildPlugin` (UE_5.7) BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced level saving and creation stability by automatically detecting and clearing stale temporary mesh references that could cause failures. The system now defensively sanitizes invalid mesh asset references before critical operations and reports cleaned references in save responses when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->