### PR TITLE
fix(material): stop material-function outputs wiring to the wrong inputs

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -313,7 +313,7 @@ const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
       meta: materialGetInfoMeta,
       handler: materialGetInfoHandler,
       cost: 'low',
-      returns: '{kind, name, expressions:[{id,class,x,y,output_consumed,reachable_from_output,inputs:[{name,index,connected,from_node,from_output}]}], dead_nodes:[{id,class}], comments} | instance:{kind,name,parent,parameters:[{name,type,value}]}',
+      returns: "{kind, name, expressions:[{id,class,x,y,output_consumed,reachable_from_output,inputs:[{name,index,connected,from_node,from_output}],outputs:[{name,index}]}], dead_nodes:[{id,class}], comments} | instance:{kind,name,parent,parameters:[{name,type,value}]}. outputs[] gives a node's real output pin order (esp. MaterialFunctionCall, whose order follows FunctionOutput sort priority, NOT the visual layout) — wire from_output by these names/indices so multi-output nodes don't get swapped.",
       niche: M,
       schema: {
         path: z.string().min(1).describe('Path to the material or material instance to inspect'),
@@ -549,7 +549,7 @@ const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
     },
     {
       name: 'material_connect_nodes',
-      description: 'Connect two nodes in a material graph or connect a node output to a material property. May return clutter-prevention suggestions: use named reroutes when a source fans out to 2+ targets, or a reroute knee node when a wire would run backward/over another node.',
+      description: "Connect two nodes in a material graph or connect a node output to a material property. IMPORTANT for multi-output sources (esp. MaterialFunctionCall): you MUST pick the output pin with from_output (the pin NAME) or from_output_index — otherwise the call is rejected, because defaulting to the first output silently swaps function outputs (e.g. Albedo<->F0). Get the real pin names/order from material_get_info.expressions[].outputs[]. May return clutter-prevention suggestions: use named reroutes when a source fans out to 2+ targets, or a reroute knee node when a wire would run backward/over another node.",
       meta: materialConnectNodesMeta,
       handler: materialConnectNodesHandler,
       cost: 'low',
@@ -559,7 +559,7 @@ const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
         material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
         function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
         from_node: z.string().min(1).describe('ID or name of the source node'),
-        from_output: z.string().optional().describe('Output pin name on the source node'),
+        from_output: z.string().optional().describe('Output pin NAME on the source node (from material_get_info.expressions[].outputs[].name). REQUIRED when the source has >1 output (e.g. a material function) unless you pass from_output_index.'),
         to_node: z.string().optional().describe('ID or name of the target node'),
         to_input: z.string().optional().describe('Input pin name on the target node'),
         to_input_index: z.number().int().optional().describe('Target input pin by index (unnamed pins, e.g. Substrate slab inputs)'),

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -464,6 +464,27 @@ static bool WireLooksLikeSpaghetti(UMaterial* Mat, UMaterialExpression* From, UM
     return false;
 }
 
+// A source node with >1 output (most importantly a MaterialFunctionCall) MUST
+// have its output pin chosen explicitly — otherwise both the name path
+// (ConnectMaterialExpressions with "") and the index path (FromOutputIndex=0)
+// silently default to the FIRST output, which mis-wires/swaps function outputs
+// (e.g. Albedo and F0 ending up crossed). Refuse and list the real pins.
+static bool RequireOutputChoice(UMaterialExpression* From, const FString& FromOutput, bool bHasFromOutputIndex, FString& OutErr)
+{
+    if (!From) return true;
+    const TArray<FExpressionOutput>& Outs = From->GetOutputs();
+    if (Outs.Num() <= 1) return true;                 // unambiguous
+    if (!FromOutput.IsEmpty() || bHasFromOutputIndex) return true; // caller chose
+    TArray<FString> Names;
+    for (int32 i = 0; i < Outs.Num(); ++i)
+        Names.Add(FString::Printf(TEXT("[%d] %s"), i,
+            Outs[i].OutputName.IsNone() ? TEXT("(unnamed)") : *Outs[i].OutputName.ToString()));
+    OutErr = FString::Printf(
+        TEXT("material_connect_nodes: '%s' has %d outputs (%s) — specify which with from_output (the pin NAME) or from_output_index. Defaulting to the first output silently swaps multi-output nodes like material functions."),
+        *From->GetName(), Outs.Num(), *FString::Join(Names, TEXT(", ")));
+    return false;
+}
+
 FHaybaHandlerResult FHaybaMCPMaterialHandler::MatConnectNodes(const TSharedPtr<FJsonObject>& P)
 {
     FString FromNode;
@@ -481,8 +502,9 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatConnectNodes(const TSharedPtr<F
     // slab/operator inputs report as input_N). to_input_index targets the Nth
     // input; from_output_index picks the source output (default 0).
     int32 ToInputIndex = -1, FromOutputIndex = 0;
+    bool bHasFromOutputIndex = false;
     { double D; if (P->TryGetNumberField(TEXT("to_input_index"), D)) ToInputIndex = (int32)D; }
-    { double D; if (P->TryGetNumberField(TEXT("from_output_index"), D)) FromOutputIndex = (int32)D; }
+    { double D; if (P->TryGetNumberField(TEXT("from_output_index"), D)) { FromOutputIndex = (int32)D; bHasFromOutputIndex = true; } }
     auto ConnectByIndex = [&](UMaterialExpression* From, UMaterialExpression* To) -> bool {
         FExpressionInput* In = To->GetInput(ToInputIndex);
         if (!In) return false;
@@ -498,6 +520,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatConnectNodes(const TSharedPtr<F
         if (!Fn) return FHaybaHandlerResult::Err(TEXT("material_connect_nodes: function not found"));
         UMaterialExpression* From = FindExprByNameInFunction(Fn, FromNode);
         if (!From) return FHaybaHandlerResult::Err(FString::Printf(TEXT("material_connect_nodes: from_node not found: %s"), *FromNode));
+        { FString OutErr; if (!RequireOutputChoice(From, FromOutput, bHasFromOutputIndex, OutErr)) return FHaybaHandlerResult::Err(OutErr); }
         if (!bHasTo) return FHaybaHandlerResult::Err(TEXT("material_connect_nodes: function connections require to_node"));
         UMaterialExpression* To = FindExprByNameInFunction(Fn, ToNode);
         if (!To) return FHaybaHandlerResult::Err(FString::Printf(TEXT("material_connect_nodes: to_node not found: %s"), *ToNode));
@@ -522,6 +545,7 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatConnectNodes(const TSharedPtr<F
 
     UMaterialExpression* From = FindExprByName(Mat, FromNode);
     if (!From) return FHaybaHandlerResult::Err(FString::Printf(TEXT("material_connect_nodes: from_node not found: %s"), *FromNode));
+    { FString OutErr; if (!RequireOutputChoice(From, FromOutput, bHasFromOutputIndex, OutErr)) return FHaybaHandlerResult::Err(OutErr); }
 
     UMaterialExpression* To = nullptr;  // null when connecting to a material property
     if (bHasProp)
@@ -790,6 +814,28 @@ static TArray<TSharedPtr<FJsonValue>> SerializeMaterialExpressions(
             Inputs.Add(MakeShared<FJsonValueObject>(InEntry.ToSharedRef()));
         }
         Entry->SetArrayField(TEXT("inputs"), Inputs);
+
+        // OUTPUT pins (name + index). Critical for multi-output nodes — most
+        // importantly MaterialFunctionCall, whose output order follows the
+        // function's FunctionOutput SortPriority, NOT the visual top-to-bottom
+        // order. Without this, a caller guesses the index and silently swaps
+        // wires (e.g. Albedo->F0, F0->Diffuse). Connect with from_output set to
+        // the NAME here (preferred) or from_output_index = this index.
+        TArray<TSharedPtr<FJsonValue>> Outputs;
+        {
+            const TArray<FExpressionOutput>& Outs = Expr->GetOutputs();
+            for (int32 OutIdx = 0; OutIdx < Outs.Num(); ++OutIdx)
+            {
+                TSharedPtr<FJsonObject> OutEntry = MakeShared<FJsonObject>();
+                const FName OutName = Outs[OutIdx].OutputName;
+                OutEntry->SetStringField(TEXT("name"),
+                    OutName.IsNone() ? FString::Printf(TEXT("output_%d"), OutIdx) : OutName.ToString());
+                OutEntry->SetNumberField(TEXT("index"), OutIdx);
+                Outputs.Add(MakeShared<FJsonValueObject>(OutEntry.ToSharedRef()));
+            }
+        }
+        Entry->SetArrayField(TEXT("outputs"), Outputs);
+
         Exprs.Add(MakeShared<FJsonValueObject>(Entry.ToSharedRef()));
     }
     return Exprs;


### PR DESCRIPTION
## Symptom
New material functions come out with outputs **crossed** — e.g. the MF''s `Albedo` output wired into the Slab''s `F0` and `F0` into `Diffuse Albedo` (see report image).

## Cause
`material_get_info` exposed node **inputs** (with edges, since #279) but **not outputs**, so a caller had to *guess* a `MaterialFunctionCall`''s output index. MaterialFunctionCall output order follows the `FunctionOutput` **SortPriority**, not the visual top-to-bottom layout — so the guess is often wrong. And both connect paths silently defaulted to the first output (name path: `ConnectMaterialExpressions("")`; index path: `from_output_index` default 0), so a multi-output source got swapped.

## Fix
- `material_get_info` now emits `expressions[].outputs[] = {name, index}` — the real pin order — so wiring can target the correct pin by name/index.
- `material_connect_nodes` **refuses** to connect FROM a node with >1 output unless `from_output` (name) or `from_output_index` is supplied, and lists the real pins in the error instead of silently picking output 0.

## Verification
- `tsc --noEmit` clean · `RunUAT BuildPlugin` (UE_5.7) BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node connections so multi-output expressions no longer connect to the wrong output by default.
  * If a source has multiple outputs, you’ll now be prompted to choose the specific output to connect, reducing wiring mistakes.
  * Expanded returned expression information to include output pin details and more connection metadata for better graph inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->