### PR TITLE
feat(mesh): robust comprehensive topology readout + expose inline test runner

### DIFF
--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -24,7 +24,7 @@
         "fields": [
           { "name": "source", "type": "string", "description": "'dynamic_mesh_component' | 'static_mesh'" },
           { "name": "counts", "type": "object", "description": "{triangles, vertices, edges}" },
-          { "name": "topology", "type": "object", "description": "dynamic mesh: {boundary_edges, non_manifold_vertices (bowties), degenerate_triangles, connected_components, has_open_boundaries, is_valid}; static mesh: {note}" },
+          { "name": "topology", "type": "object", "description": "Both dynamic AND static sources (static is welded from the render LOD first): {boundary_edges, boundary_loops (hole count), non_manifold_vertices (bowties), degenerate_triangles, connected_components, component_triangle_counts[], has_open_boundaries, is_closed, is_valid, surface_area, volume, euler_characteristic, genus (only when single closed manifold)}" },
           { "name": "bounds", "type": "object", "description": "{min,max,extents}" },
           { "name": "triangles", "type": "array", "description": "present only when include_triangles" },
           { "name": "vertices", "type": "array", "description": "present only when include_positions" },
@@ -50,13 +50,60 @@
         "shape": "object",
         "fields": [
           { "name": "counts", "type": "object", "description": "{triangles, vertices, edges}" },
-          { "name": "topology", "type": "object", "description": "{boundary_edges, non_manifold_vertices, degenerate_triangles, connected_components, has_open_boundaries, is_valid}" },
+          { "name": "topology", "type": "object", "description": "{boundary_edges, boundary_loops, non_manifold_vertices, degenerate_triangles, connected_components, component_triangle_counts[], has_open_boundaries, is_closed, is_valid, surface_area, volume, euler_characteristic, genus}" },
           { "name": "bounds", "type": "object" }
         ]
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": "Stats-only alias of mesh_extract (raw geometry arrays forced off). Use to get a fast weld/winding/holes verdict: non_manifold_vertices==0 && degenerate_triangles==0 && connected_components==1 && a small explainable boundary_edges == healthy."
+    },
+    "test_list": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPTestHandler::Handle",
+      "params": [
+        { "name": "filter_pattern", "type": "string", "required": false, "description": "Substring filter on display name or full path" },
+        { "name": "category", "type": "string", "required": false, "description": "Full-path prefix filter, e.g. 'Hayba.Socket'" }
+      ],
+      "returns": { "shape": "object", "fields": [
+        { "name": "tests", "type": "array", "description": "[{name, full_test_path, file_name, line_number}]" },
+        { "name": "count", "type": "number" },
+        { "name": "total_discovered", "type": "number" }
+      ] },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Enumerate registered automation tests via FAutomationTestFramework directly (no controller/session-frontend needed)."
+    },
+    "test_run": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPTestHandler::Handle",
+      "params": [
+        { "name": "test_names", "type": "array", "required": false, "description": "Test names/full-paths to run, or the single string 'all'. Accepts a string or array." },
+        { "name": "smoke_only", "type": "boolean", "required": false, "description": "Restrict to SmokeFilter-tagged tests" },
+        { "name": "timeout_seconds", "type": "number", "required": false, "description": "Per-test latent-command drain timeout (default 120)" }
+      ],
+      "returns": { "shape": "object", "fields": [
+        { "name": "passed", "type": "array" },
+        { "name": "failed", "type": "array", "description": "[{name, duration_seconds, errors[]}]" },
+        { "name": "skipped", "type": "array" },
+        { "name": "elapsed_seconds", "type": "number" },
+        { "name": "total", "type": "number" }
+      ] },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Run automation tests INLINE on the calling thread via FAutomationTestFramework::StartTestByName -> ExecuteLatentCommands (drained to completion or timeout) -> StopTest. Bypasses the controller/worker session queue (FAutomationControllerManager::Tick), so it works in a normal GUI editor without opening the Session Frontend / Test Automation tab — the queue that otherwise sits at 'Queued' forever. Use this instead of the console 'Automation RunTests' command."
+    },
+    "test_get_log": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPTestHandler::Handle",
+      "params": [],
+      "returns": { "shape": "object", "fields": [
+        { "name": "tests", "type": "array", "description": "[{name, success, duration_seconds, errors[], warnings[]}] from the most recent test_run" },
+        { "name": "count", "type": "number" }
+      ] },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Full entries (errors + warnings) from the last test_run."
     },
     "ping": {
       "aliases": [],

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaOpeningTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaOpeningTest.cpp
@@ -1,0 +1,48 @@
+#include "Misc/AutomationTest.h"
+#include "pcg/HaybaOpening.h"
+#include "DynamicMesh/DynamicMesh3.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaOpeningUnitTest,
+    "Hayba.Socket.Opening",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaOpeningUnitTest::RunTest(const FString& Parameters)
+{
+    using namespace UE::Geometry;
+
+    // Build a 600cm-wide x 400cm-tall wall as 12x8 quads (= 192 triangles).
+    FDynamicMesh3 Wall;
+    HaybaOpening::AppendWallGrid(Wall, /*HalfWidth=*/300.0, /*Height=*/400.0, /*Cols=*/12, /*Rows=*/8);
+    const int32 Before = Wall.TriangleCount();
+    TestEqual(TEXT("wall has 192 tris"), Before, 192);
+
+    // Punch a 120x200 doorway centered laterally, at the floor, identity bond xf.
+    const int32 Removed = HaybaOpening::PunchDoorway(Wall, FTransform::Identity,
+        /*Width=*/120.0, /*Height=*/200.0, /*Depth=*/50.0);
+    TestTrue(TEXT("some triangles removed"), Removed > 0);
+    TestEqual(TEXT("triangle count dropped by Removed"), Wall.TriangleCount(), Before - Removed);
+
+    // The doorway centre must now be empty: no triangle centroid inside the hole.
+    bool bCentreEmpty = true;
+    for (const int32 tid : Wall.TriangleIndicesItr())
+    {
+        const FVector3d C = Wall.GetTriCentroid(tid);
+        if (FMath::Abs(C.Y) <= 60.0 && C.Z >= 0.0 && C.Z <= 200.0 && FMath::Abs(C.X) <= 25.0)
+        {
+            bCentreEmpty = false; break;
+        }
+    }
+    TestTrue(TEXT("doorway interior is empty"), bCentreEmpty);
+
+    // A wall corner (outside the doorway) must survive.
+    bool bCornerSurvives = false;
+    for (const int32 tid : Wall.TriangleIndicesItr())
+    {
+        const FVector3d C = Wall.GetTriCentroid(tid);
+        if (C.Y > 200.0 && C.Z > 300.0) { bCornerSurvives = true; break; }
+    }
+    TestTrue(TEXT("far corner survives"), bCornerSurvives);
+
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketContractTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketContractTest.cpp
@@ -1,0 +1,49 @@
+#include "Misc/AutomationTest.h"
+#include "pcg/HaybaSocketContract.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaSocketContractUnitTest,
+    "Hayba.Socket.Contract",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaSocketContractUnitTest::RunTest(const FString& Parameters)
+{
+    const TArray<FString> NeighborProvides = { TEXT("Connection.Bore"), TEXT("Style.Native") };
+
+    // Satisfied: requires a tag the neighbor provides (directly).
+    {
+        FHaybaRequire Req; Req.All = { TEXT("Connection.Bore") };
+        const FHaybaRequireResult R = HaybaSocketContract::Evaluate(Req, NeighborProvides);
+        TestTrue(TEXT("satisfied"), R.bSatisfied);
+        TestEqual(TEXT("no missing"), R.MissingRequired.Num(), 0);
+    }
+    // Satisfied by ancestry: requires "Connection", neighbor provides "Connection.Bore".
+    {
+        FHaybaRequire Req; Req.All = { TEXT("Connection") };
+        TestTrue(TEXT("satisfied by ancestor"), HaybaSocketContract::Evaluate(Req, NeighborProvides).bSatisfied);
+    }
+    // Unsatisfied: requires a tag absent from the neighbor — the unsat case.
+    {
+        FHaybaRequire Req; Req.All = { TEXT("Connection.Road") };
+        const FHaybaRequireResult R = HaybaSocketContract::Evaluate(Req, NeighborProvides);
+        TestFalse(TEXT("unsatisfied"), R.bSatisfied);
+        TestEqual(TEXT("one missing"), R.MissingRequired.Num(), 1);
+        TestEqual(TEXT("names the missing tag"), R.MissingRequired[0], FString(TEXT("Connection.Road")));
+    }
+    // Exclude hit: neighbor provides an excluded tag.
+    {
+        FHaybaRequire Req; Req.All = { TEXT("Connection.Bore") }; Req.Exclude = { TEXT("Style.Native") };
+        const FHaybaRequireResult R = HaybaSocketContract::Evaluate(Req, NeighborProvides);
+        TestFalse(TEXT("excluded -> unsatisfied"), R.bSatisfied);
+        TestEqual(TEXT("one excluded hit"), R.HitExcluded.Num(), 1);
+    }
+    // Sorted expanded provides are stable + de-duplicated. The two provided tags
+    // "Connection.Bore" and "Style.Native" expand to 4 ancestors total:
+    // {Connection, Connection.Bore, Style, Style.Native}.
+    {
+        const TArray<FString> S = HaybaSocketContract::SortedExpandedProvides(NeighborProvides);
+        TestEqual(TEXT("expanded count"), S.Num(), 4);
+        TestTrue(TEXT("sorted ascending"), S == TArray<FString>({ TEXT("Connection"), TEXT("Connection.Bore"), TEXT("Style"), TEXT("Style.Native") }));
+    }
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketSolverTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketSolverTest.cpp
@@ -1,0 +1,86 @@
+#include "Misc/AutomationTest.h"
+#include "pcg/HaybaSocketSolver.h"
+
+namespace
+{
+    static FHaybaSocketContract MakeSocket(const TCHAR* Name, const TArray<FString>& Provides,
+        const TArray<FString>& RequiresAll, bool bRelaxable, const TArray<FString>& Exclude = {})
+    {
+        FHaybaSocketContract C;
+        C.Name = FName(Name);
+        C.Provides = Provides;
+        C.Requires.All = RequiresAll;
+        C.Requires.Exclude = Exclude;
+        C.bRelaxable = bRelaxable;
+        return C;
+    }
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaSocketSolverUnitTest,
+    "Hayba.Socket.Solver",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaSocketSolverUnitTest::RunTest(const FString& Parameters)
+{
+    using namespace HaybaSocketSolver;
+
+    // CLEAN: both sides satisfied -> cost 0, bonded, not relaxed.
+    {
+        const FHaybaSocketContract F = MakeSocket(TEXT("main_wall"),
+            { TEXT("Connection.Bore"), TEXT("Style.Native") }, { TEXT("Connection.Bore") }, true);
+        const FHaybaSocketContract C = MakeSocket(TEXT("branch_mouth"),
+            { TEXT("Connection.Bore"), TEXT("Style.Native") }, { TEXT("Connection.Bore") }, true);
+        const FHaybaBondOutcome O = SolveBond(F, { C });
+        TestTrue (TEXT("clean: ok"), O.bOk);
+        TestFalse(TEXT("clean: not relaxed"), O.bRelaxed);
+        TestEqual(TEXT("clean: cost 0"), O.Cost, 0.0);
+        TestEqual(TEXT("clean: chose index 0"), O.ChosenIndex, 0);
+    }
+
+    // HARD FAIL: branch (hard) requires Connection.Road; main does not provide it.
+    {
+        const FHaybaSocketContract Main = MakeSocket(TEXT("main_wall"),
+            { TEXT("Connection.Bore"), TEXT("Style.Native") }, { TEXT("Connection.Bore") }, true);
+        const FHaybaSocketContract Branch = MakeSocket(TEXT("branch_mouth"),
+            { TEXT("Connection.Bore"), TEXT("Style.Native") }, { TEXT("Connection.Road") }, /*relaxable=*/false);
+        const FHaybaBondOutcome O = SolveBond(Branch, { Main }); // frontier=branch (the requirer)
+        TestFalse(TEXT("hard: not ok"), O.bOk);
+        TestTrue (TEXT("hard: cost >= HardPenalty"), O.Cost >= HardPenalty);
+        TestEqual(TEXT("hard: requirer is branch_mouth"), O.RequirerName, FName(TEXT("branch_mouth")));
+        TestEqual(TEXT("hard: provider is main_wall"),    O.ProviderName, FName(TEXT("main_wall")));
+        TestEqual(TEXT("hard: one missing tag"), O.MissingRequired.Num(), 1);
+        TestEqual(TEXT("hard: missing is Connection.Road"), O.MissingRequired[0], FString(TEXT("Connection.Road")));
+        TestTrue (TEXT("hard: provided lists Connection.Bore"),
+            O.NeighborProvided.Contains(TEXT("Connection.Bore")));
+    }
+
+    // RELAXED: same mismatch but branch is relaxable -> bonded by downgrade.
+    {
+        const FHaybaSocketContract Main = MakeSocket(TEXT("main_wall"),
+            { TEXT("Connection.Bore") }, { TEXT("Connection.Bore") }, true);
+        const FHaybaSocketContract Branch = MakeSocket(TEXT("branch_mouth"),
+            { TEXT("Connection.Bore") }, { TEXT("Connection.Road") }, /*relaxable=*/true);
+        const FHaybaBondOutcome O = SolveBond(Branch, { Main });
+        TestTrue (TEXT("relaxed: ok"), O.bOk);
+        TestTrue (TEXT("relaxed: flagged relaxed"), O.bRelaxed);
+        TestTrue (TEXT("relaxed: cost in [Relaxable,Hard)"),
+            O.Cost >= RelaxablePenalty && O.Cost < HardPenalty);
+        TestEqual(TEXT("relaxed: still names the downgraded tag"), O.MissingRequired[0], FString(TEXT("Connection.Road")));
+    }
+
+    // CHOICE: lowest-cost candidate wins (clean beats relaxable-miss).
+    {
+        const FHaybaSocketContract F = MakeSocket(TEXT("f"),
+            { TEXT("Connection.Bore") }, { TEXT("Connection.Bore") }, true);
+        const FHaybaSocketContract Bad  = MakeSocket(TEXT("bad"),
+            { TEXT("Connection.Bore") }, { TEXT("Connection.Road") }, true); // relaxable miss
+        const FHaybaSocketContract Good = MakeSocket(TEXT("good"),
+            { TEXT("Connection.Bore") }, { TEXT("Connection.Bore") }, true); // clean
+        const FHaybaBondOutcome O = SolveBond(F, { Bad, Good });
+        TestTrue (TEXT("choice: ok"), O.bOk);
+        TestEqual(TEXT("choice: picked the clean one (index 1)"), O.ChosenIndex, 1);
+        TestEqual(TEXT("choice: cost 0"), O.Cost, 0.0);
+    }
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketSolverTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketSolverTest.cpp
@@ -82,5 +82,38 @@ bool FHaybaSocketSolverUnitTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("choice: picked the clean one (index 1)"), O.ChosenIndex, 1);
         TestEqual(TEXT("choice: cost 0"), O.Cost, 0.0);
     }
+
+    // MULTI-MISS: a relaxable frontier missing TWO required tags costs RelaxablePenalty * 2.
+    {
+        const FHaybaSocketContract F = MakeSocket(TEXT("f"),
+            { TEXT("X") }, { TEXT("A"), TEXT("B") }, /*relaxable=*/true); // requires A,B (relaxable)
+        const FHaybaSocketContract C = MakeSocket(TEXT("c"),
+            { TEXT("X") }, {}, true);                                     // provides neither A nor B; requires nothing
+        const FHaybaBondOutcome O = SolveBond(F, { C });
+        TestTrue (TEXT("multi-miss: ok (relaxed)"), O.bOk);
+        TestTrue (TEXT("multi-miss: relaxed"), O.bRelaxed);
+        TestEqual(TEXT("multi-miss: cost == RelaxablePenalty*2"), O.Cost, RelaxablePenalty * 2.0);
+        TestEqual(TEXT("multi-miss: two missing tags"), O.MissingRequired.Num(), 2);
+    }
+
+    // EMPTY CANDIDATES: no bond, INDEX_NONE.
+    {
+        const FHaybaSocketContract F = MakeSocket(TEXT("f"), { TEXT("X") }, {}, true);
+        const TArray<FHaybaSocketContract> None;
+        const FHaybaBondOutcome O = SolveBond(F, None);
+        TestFalse(TEXT("empty candidates: not ok"), O.bOk);
+        TestEqual(TEXT("empty candidates: INDEX_NONE"), O.ChosenIndex, (int32)INDEX_NONE);
+    }
+
+    // EXCLUDE HIT: a provided excluded tag hard-fails (never relaxed).
+    {
+        FHaybaSocketContract F = MakeSocket(TEXT("f"), { TEXT("X") }, {}, /*relaxable=*/true);
+        F.Requires.Exclude = { TEXT("Style.Native") };                 // exclude
+        const FHaybaSocketContract C = MakeSocket(TEXT("c"),
+            { TEXT("Style.Native") }, {}, true);                       // provides the excluded tag
+        const FHaybaBondOutcome O = SolveBond(F, { C });
+        TestFalse(TEXT("exclude hit: not ok"), O.bOk);
+        TestTrue (TEXT("exclude hit: cost >= HardPenalty"), O.Cost >= HardPenalty);
+    }
     return true;
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketStoreTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketStoreTest.cpp
@@ -1,0 +1,49 @@
+#include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformFileManager.h"
+#include "pcg/HaybaSocketStore.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaSocketStoreUnitTest,
+    "Hayba.Socket.Store",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaSocketStoreUnitTest::RunTest(const FString& Parameters)
+{
+    const FString Tmp = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("HaybaSocketStoreTest.json"));
+    const FString Json = TEXT(R"JSON(
+{
+  "sockets": {
+    "main_wall":    { "provides": ["Connection.Bore","Style.Native"], "requires_all": ["Connection.Bore"], "requires_exclude": [], "polarity": "female", "cost_weight": 1.0, "relaxable": true },
+    "branch_mouth": { "provides": ["Connection.Bore","Style.Native"], "requires_all": ["Connection.Road"], "requires_exclude": [], "polarity": "male",   "cost_weight": 1.0, "relaxable": false }
+  },
+  "bond": { "frontier": "branch_mouth", "candidate": "main_wall" }
+}
+)JSON");
+    TestTrue(TEXT("write temp"), FFileHelper::SaveStringToFile(Json, *Tmp));
+
+    FHaybaSocketSet Set; FString Err;
+    const bool bOk = HaybaSocketStore::Load(Tmp, Set, Err);
+    TestTrue(FString::Printf(TEXT("load ok (%s)"), *Err), bOk);
+    TestEqual(TEXT("two sockets"), Set.Sockets.Num(), 2);
+    TestEqual(TEXT("bond frontier"),  Set.BondFrontier,  FName(TEXT("branch_mouth")));
+    TestEqual(TEXT("bond candidate"), Set.BondCandidate, FName(TEXT("main_wall")));
+
+    const FHaybaSocketContract* Branch = Set.Sockets.Find(FName(TEXT("branch_mouth")));
+    TestNotNull(TEXT("branch present"), Branch);
+    if (Branch)
+    {
+        TestEqual(TEXT("branch requires Road"), Branch->Requires.All.Num() == 1 ? Branch->Requires.All[0] : FString(), FString(TEXT("Connection.Road")));
+        TestFalse(TEXT("branch is hard (relaxable=false)"), Branch->bRelaxable);
+        TestEqual(TEXT("branch polarity"), Branch->Polarity, FString(TEXT("male")));
+    }
+
+    // Missing file -> false + message, no crash.
+    FHaybaSocketSet Set2; FString Err2;
+    TestFalse(TEXT("missing file fails"), HaybaSocketStore::Load(Tmp + TEXT(".nope"), Set2, Err2));
+    TestTrue(TEXT("error message set"), !Err2.IsEmpty());
+
+    FPlatformFileManager::Get().GetPlatformFile().DeleteFile(*Tmp);
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketStoreTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaSocketStoreTest.cpp
@@ -15,7 +15,7 @@ bool FHaybaSocketStoreUnitTest::RunTest(const FString& Parameters)
     const FString Json = TEXT(R"JSON(
 {
   "sockets": {
-    "main_wall":    { "provides": ["Connection.Bore","Style.Native"], "requires_all": ["Connection.Bore"], "requires_exclude": [], "polarity": "female", "cost_weight": 1.0, "relaxable": true },
+    "main_wall":    { "provides": ["Connection.Bore","Style.Native"], "requires_all": ["Connection.Bore"], "requires_exclude": [], "polarity": "female", "cost_weight": 2.0, "relaxable": true },
     "branch_mouth": { "provides": ["Connection.Bore","Style.Native"], "requires_all": ["Connection.Road"], "requires_exclude": [], "polarity": "male",   "cost_weight": 1.0, "relaxable": false }
   },
   "bond": { "frontier": "branch_mouth", "candidate": "main_wall" }
@@ -39,10 +39,26 @@ bool FHaybaSocketStoreUnitTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("branch polarity"), Branch->Polarity, FString(TEXT("male")));
     }
 
+    const FHaybaSocketContract* Main = Set.Sockets.Find(FName(TEXT("main_wall")));
+    TestNotNull(TEXT("main present"), Main);
+    if (Main)
+    {
+        TestEqual(TEXT("main cost_weight parsed (non-default)"), Main->CostWeight, 2.0);
+        TestEqual(TEXT("main provides count"), Main->Provides.Num(), 2);
+    }
+
     // Missing file -> false + message, no crash.
     FHaybaSocketSet Set2; FString Err2;
     TestFalse(TEXT("missing file fails"), HaybaSocketStore::Load(Tmp + TEXT(".nope"), Set2, Err2));
     TestTrue(TEXT("error message set"), !Err2.IsEmpty());
+
+    // Zero sockets -> false + non-empty error (spec-mandated).
+    const FString Empty = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("HaybaSocketStoreEmpty.json"));
+    TestTrue(TEXT("write empty"), FFileHelper::SaveStringToFile(TEXT("{\"sockets\":{},\"bond\":{}}"), *Empty));
+    FHaybaSocketSet ESet; FString EErr;
+    TestFalse(TEXT("zero sockets -> false"), HaybaSocketStore::Load(Empty, ESet, EErr));
+    TestTrue(TEXT("zero sockets -> error message"), !EErr.IsEmpty());
+    FPlatformFileManager::Get().GetPlatformFile().DeleteFile(*Empty);
 
     FPlatformFileManager::Get().GetPlatformFile().DeleteFile(*Tmp);
     return true;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaTagTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaTagTest.cpp
@@ -18,6 +18,7 @@ bool FHaybaTagUnitTest::RunTest(const FString& Parameters)
     // Single segment and empty input.
     TestEqual(TEXT("single segment -> 1"), HaybaTag::ExpandAncestors(TEXT("A")).Num(), 1);
     TestEqual(TEXT("empty -> 0"),          HaybaTag::ExpandAncestors(TEXT("")).Num(), 0);
+    TestEqual(TEXT("double-dot collapses to 2"), HaybaTag::ExpandAncestors(TEXT("A..B")).Num(), 2);
 
     // ExpandAll unions and de-dups overlapping ancestry.
     const TSet<FString> All = HaybaTag::ExpandAll({ TEXT("Style.Imperial.Vent"), TEXT("Style.Imperial") });
@@ -31,6 +32,7 @@ bool FHaybaTagUnitTest::RunTest(const FString& Parameters)
     TestTrue (TEXT("provides Connection.Bore"),  HaybaTag::Provides(Prov, TEXT("Connection.Bore")));
     TestTrue (TEXT("provides Connection (anc.)"), HaybaTag::Provides(Prov, TEXT("Connection")));
     TestFalse(TEXT("does not provide Connection.Road"), HaybaTag::Provides(Prov, TEXT("Connection.Road")));
+    TestFalse(TEXT("empty required tag is not provided"), HaybaTag::Provides(Prov, TEXT("")));
 
     return true;
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaTagTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaTagTest.cpp
@@ -1,0 +1,36 @@
+#include "Misc/AutomationTest.h"
+#include "pcg/HaybaTag.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaTagUnitTest,
+    "Hayba.Socket.Tag",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaTagUnitTest::RunTest(const FString& Parameters)
+{
+    // Ancestor expansion: every dotted prefix is present.
+    const TSet<FString> Abc = HaybaTag::ExpandAncestors(TEXT("A.B.C"));
+    TestEqual(TEXT("A.B.C expands to 3"), Abc.Num(), 3);
+    TestTrue(TEXT("has A"),     Abc.Contains(TEXT("A")));
+    TestTrue(TEXT("has A.B"),   Abc.Contains(TEXT("A.B")));
+    TestTrue(TEXT("has A.B.C"), Abc.Contains(TEXT("A.B.C")));
+
+    // Single segment and empty input.
+    TestEqual(TEXT("single segment -> 1"), HaybaTag::ExpandAncestors(TEXT("A")).Num(), 1);
+    TestEqual(TEXT("empty -> 0"),          HaybaTag::ExpandAncestors(TEXT("")).Num(), 0);
+
+    // ExpandAll unions and de-dups overlapping ancestry.
+    const TSet<FString> All = HaybaTag::ExpandAll({ TEXT("Style.Imperial.Vent"), TEXT("Style.Imperial") });
+    TestTrue(TEXT("ExpandAll has Style"),                 All.Contains(TEXT("Style")));
+    TestTrue(TEXT("ExpandAll has Style.Imperial"),        All.Contains(TEXT("Style.Imperial")));
+    TestTrue(TEXT("ExpandAll has Style.Imperial.Vent"),   All.Contains(TEXT("Style.Imperial.Vent")));
+    TestEqual(TEXT("ExpandAll de-dups to 3"), All.Num(), 3);
+
+    // Provides: a required ancestor is satisfied by a deeper provided tag.
+    const TSet<FString> Prov = HaybaTag::ExpandAll({ TEXT("Connection.Bore"), TEXT("Style.Native") });
+    TestTrue (TEXT("provides Connection.Bore"),  HaybaTag::Provides(Prov, TEXT("Connection.Bore")));
+    TestTrue (TEXT("provides Connection (anc.)"), HaybaTag::Provides(Prov, TEXT("Connection")));
+    TestFalse(TEXT("does not provide Connection.Road"), HaybaTag::Provides(Prov, TEXT("Connection.Road")));
+
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaUnsatCoreTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaUnsatCoreTest.cpp
@@ -1,0 +1,44 @@
+#include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformFileManager.h"
+#include "pcg/HaybaUnsatCore.h"
+#include "pcg/HaybaSocketSolver.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaUnsatCoreUnitTest,
+    "Hayba.Socket.UnsatCore",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaUnsatCoreUnitTest::RunTest(const FString& Parameters)
+{
+    // Build a hard-fail outcome by hand (decoupled from the solver internals).
+    FHaybaBondOutcome O;
+    O.bOk = false; O.bRelaxed = false; O.Cost = HaybaSocketSolver::HardPenalty;
+    O.RequirerName = FName(TEXT("branch_mouth"));
+    O.ProviderName = FName(TEXT("main_wall"));
+    O.MissingRequired  = { TEXT("Connection.Road") };
+    O.NeighborProvided = { TEXT("Connection.Bore"), TEXT("Style.Native") };
+
+    const FString Human = HaybaUnsatCore::BuildHuman(O);
+    TestTrue(TEXT("human names requirer"),  Human.Contains(TEXT("branch_mouth")));
+    TestTrue(TEXT("human names provider"),  Human.Contains(TEXT("main_wall")));
+    TestTrue(TEXT("human names missing tag"), Human.Contains(TEXT("Connection.Road")));
+    TestTrue(TEXT("human lists provided"),  Human.Contains(TEXT("Connection.Bore")));
+    TestTrue(TEXT("human says REJECTED"),   Human.Contains(TEXT("REJECTED")));
+
+    // Write + read back the JSON report.
+    const FString Tmp = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("HaybaUnsatCoreTest.json"));
+    FString Err;
+    TestTrue(TEXT("write report"),
+        HaybaUnsatCore::Write(O, FName(TEXT("branch_mouth")), FName(TEXT("main_wall")), Tmp, Err));
+
+    FString Back;
+    TestTrue(TEXT("read back"), FFileHelper::LoadFileToString(Back, *Tmp));
+    TestTrue(TEXT("json has ok:false"), Back.Contains(TEXT("\"ok\": false")) || Back.Contains(TEXT("\"ok\":false")));
+    TestTrue(TEXT("json has missing tag"), Back.Contains(TEXT("Connection.Road")));
+    TestTrue(TEXT("json has human"), Back.Contains(TEXT("REJECTED")));
+
+    FPlatformFileManager::Get().GetPlatformFile().DeleteFile(*Tmp);
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaUnsatCoreTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaUnsatCoreTest.cpp
@@ -27,6 +27,22 @@ bool FHaybaUnsatCoreUnitTest::RunTest(const FString& Parameters)
     TestTrue(TEXT("human lists provided"),  Human.Contains(TEXT("Connection.Bore")));
     TestTrue(TEXT("human says REJECTED"),   Human.Contains(TEXT("REJECTED")));
 
+    // Clean branch — exact format.
+    {
+        FHaybaBondOutcome Ok; Ok.bOk = true; Ok.bRelaxed = false; Ok.Cost = 0.5;
+        Ok.RequirerName = FName(TEXT("A")); Ok.ProviderName = FName(TEXT("B"));
+        TestEqual(TEXT("clean human exact"), HaybaUnsatCore::BuildHuman(Ok),
+            FString(TEXT("Bond OK  [A] OK [B]  cost 0.50")));
+    }
+    // Relaxed branch — exact format (note: solver guarantees bRelaxed implies bOk).
+    {
+        FHaybaBondOutcome Rx; Rx.bOk = true; Rx.bRelaxed = true; Rx.Cost = 1000.0;
+        Rx.RequirerName = FName(TEXT("A")); Rx.ProviderName = FName(TEXT("B"));
+        Rx.MissingRequired = { TEXT("Tag.X") };
+        TestEqual(TEXT("relaxed human exact"), HaybaUnsatCore::BuildHuman(Rx),
+            FString(TEXT("Bond RELAXED  [A] ~ [B]:  downgraded 'Tag.X'  (seam logged)")));
+    }
+
     // Write + read back the JSON report.
     const FString Tmp = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("HaybaUnsatCoreTest.json"));
     FString Err;
@@ -38,6 +54,9 @@ bool FHaybaUnsatCoreUnitTest::RunTest(const FString& Parameters)
     TestTrue(TEXT("json has ok:false"), Back.Contains(TEXT("\"ok\": false")) || Back.Contains(TEXT("\"ok\":false")));
     TestTrue(TEXT("json has missing tag"), Back.Contains(TEXT("Connection.Road")));
     TestTrue(TEXT("json has human"), Back.Contains(TEXT("REJECTED")));
+    TestTrue(TEXT("json schema_version"), Back.Contains(TEXT("\"schema_version\": \"0.1.0\"")));
+    TestTrue(TEXT("json relaxed:false"), Back.Contains(TEXT("\"relaxed\": false")) || Back.Contains(TEXT("\"relaxed\":false")));
+    TestTrue(TEXT("json frontier field"), Back.Contains(TEXT("\"frontier\"")));
 
     FPlatformFileManager::Get().GetPlatformFile().DeleteFile(*Tmp);
     return true;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPStaticMeshHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPStaticMeshHandler.cpp
@@ -12,6 +12,9 @@
 // mesh_extract — read back geometry + topology health from a dynamic/static mesh
 #include "DynamicMesh/DynamicMesh3.h"
 #include "Selections/MeshConnectedComponents.h"
+#include "MeshBoundaryLoops.h"                         // FMeshBoundaryLoops — open-hole loop count
+#include "MeshQueries.h"                               // TMeshQueries::GetVolumeArea
+#include "DynamicMesh/Operations/MergeCoincidentMeshEdges.h" // weld render verts -> real topology
 #include "Components/DynamicMeshComponent.h"   // UDynamicMeshComponent (GeometryFramework)
 #include "UDynamicMesh.h"                        // UDynamicMesh::GetMeshRef (GeometryFramework)
 #include "IndexTypes.h"                          // FIndex3i
@@ -229,11 +232,33 @@ namespace
         using namespace UE::Geometry;
 
         // ── counts ────────────────────────────────────────────────────────────
+        const int32 NumT = Mesh.TriangleCount();
+        const int32 NumV = Mesh.VertexCount();
+        const int32 NumE = Mesh.EdgeCount();
         auto Counts = MakeShared<FJsonObject>();
-        Counts->SetNumberField(TEXT("triangles"), Mesh.TriangleCount());
-        Counts->SetNumberField(TEXT("vertices"), Mesh.VertexCount());
-        Counts->SetNumberField(TEXT("edges"), Mesh.EdgeCount());
+        Counts->SetNumberField(TEXT("triangles"), NumT);
+        Counts->SetNumberField(TEXT("vertices"), NumV);
+        Counts->SetNumberField(TEXT("edges"), NumE);
         Out->SetObjectField(TEXT("counts"), Counts);
+
+        auto Topo = MakeShared<FJsonObject>();
+
+        // Empty-mesh guard: report zeros instead of running loops/measures on nothing.
+        if (NumT == 0)
+        {
+            Topo->SetNumberField(TEXT("boundary_edges"), 0);
+            Topo->SetNumberField(TEXT("boundary_loops"), 0);
+            Topo->SetNumberField(TEXT("non_manifold_vertices"), 0);
+            Topo->SetNumberField(TEXT("degenerate_triangles"), 0);
+            Topo->SetNumberField(TEXT("connected_components"), 0);
+            Topo->SetBoolField(TEXT("has_open_boundaries"), false);
+            Topo->SetBoolField(TEXT("is_closed"), false);
+            Topo->SetBoolField(TEXT("is_valid"), true);
+            Topo->SetStringField(TEXT("note"), TEXT("empty mesh (0 triangles)"));
+            Out->SetObjectField(TEXT("topology"), Topo);
+            Out->SetObjectField(TEXT("bounds"), Box3dToJson(Mesh.GetBounds()));
+            return;
+        }
 
         // ── topology health (whole mesh, never capped) ─────────────────────────
         int32 BoundaryEdges = 0;
@@ -258,20 +283,44 @@ namespace
             if ((B - A).Cross(C - A).SquaredLength() < 1e-12) ++Degenerate;
         }
 
+        // Connected components + per-component triangle counts, so an unwelded
+        // shell ("4 patches, not 1 solid") is diagnosable at a glance.
         FMeshConnectedComponents Components(&Mesh);
         Components.FindConnectedTriangles();
         const int32 NumComponents = Components.Num();
+        TArray<TSharedPtr<FJsonValue>> CompSizes;
+        for (int32 ci = 0; ci < NumComponents; ++ci)
+            CompSizes.Add(MakeShared<FJsonValueNumber>(Components.GetComponent(ci).Indices.Num()));
 
+        // Open-boundary LOOP count (holes), not just edges: 4 loops = 4 holes.
+        FMeshBoundaryLoops Loops(&Mesh, /*bAutoCompute=*/true);
+        const int32 NumBoundaryLoops = Loops.GetLoopCount();
+
+        const bool bClosed = (BoundaryEdges == 0);
         const bool bValid = Mesh.CheckValidity(
             FDynamicMesh3::FValidityOptions(), EValidityCheckFailMode::ReturnOnly);
 
-        auto Topo = MakeShared<FJsonObject>();
+        // Surface area + signed volume (volume only physically meaningful when closed).
+        const FVector2d VolArea = TMeshQueries<FDynamicMesh3>::GetVolumeArea(Mesh);
+
+        // Euler characteristic V-E+F; genus for a clean closed orientable single
+        // shell: X = 2 - 2g - b  =>  g = (2 - b - X) / 2.
+        const int32 Euler = NumV - NumE + NumT;
+
         Topo->SetNumberField(TEXT("boundary_edges"), BoundaryEdges);
+        Topo->SetNumberField(TEXT("boundary_loops"), NumBoundaryLoops);
         Topo->SetNumberField(TEXT("non_manifold_vertices"), NonManifoldVerts);
         Topo->SetNumberField(TEXT("degenerate_triangles"), Degenerate);
         Topo->SetNumberField(TEXT("connected_components"), NumComponents);
+        Topo->SetArrayField(TEXT("component_triangle_counts"), CompSizes);
         Topo->SetBoolField(TEXT("has_open_boundaries"), BoundaryEdges > 0);
+        Topo->SetBoolField(TEXT("is_closed"), bClosed);
         Topo->SetBoolField(TEXT("is_valid"), bValid);
+        Topo->SetNumberField(TEXT("surface_area"), VolArea.Y);
+        Topo->SetNumberField(TEXT("volume"), VolArea.X);
+        Topo->SetNumberField(TEXT("euler_characteristic"), Euler);
+        if (NumComponents == 1 && NonManifoldVerts == 0 && bClosed)
+            Topo->SetNumberField(TEXT("genus"), (2 - NumBoundaryLoops - Euler) / 2);
         Out->SetObjectField(TEXT("topology"), Topo);
 
         Out->SetObjectField(TEXT("bounds"), Box3dToJson(Mesh.GetBounds()));
@@ -438,70 +487,36 @@ static FHaybaHandlerResult MeshExtract(const TSharedPtr<FJsonObject>& P, bool bS
     Out->SetStringField(TEXT("path"), Path);
     Out->SetNumberField(TEXT("lod"), Lod);
 
-    const int32 NumV = LOD.GetNumVertices();
-    const int32 NumT = LOD.GetNumTriangles();
-    auto Counts = MakeShared<FJsonObject>();
-    Counts->SetNumberField(TEXT("triangles"), NumT);
-    Counts->SetNumberField(TEXT("vertices"), NumV);
-    Out->SetObjectField(TEXT("counts"), Counts);
-
-    // Render vertices are split at UV/normal seams, so manifold topology on them
-    // is unreliable — report counts + bounds here. Use the dynamic-mesh path
-    // (actor_label) for weld/winding verdicts.
-    auto Topo = MakeShared<FJsonObject>();
-    Topo->SetStringField(TEXT("note"), TEXT("topology health (welds/manifold) requires a dynamic-mesh source via actor_label; static render data is vertex-split"));
-    Out->SetObjectField(TEXT("topology"), Topo);
-
-    const FBoxSphereBounds B = SMesh->GetBounds();
-    auto Bounds = MakeShared<FJsonObject>();
-    Bounds->SetObjectField(TEXT("min"), Vec3ToJson(B.Origin - B.BoxExtent));
-    Bounds->SetObjectField(TEXT("max"), Vec3ToJson(B.Origin + B.BoxExtent));
-    Bounds->SetObjectField(TEXT("extents"), Vec3ToJson(B.BoxExtent));
-    Out->SetObjectField(TEXT("bounds"), Bounds);
-
-    if (bIncTris || bIncPos)
+    // Build a welded FDynamicMesh3 from the render LOD so static meshes get the
+    // SAME rigorous topology as the dynamic-mesh path. Render vertices are split
+    // at UV/normal seams; FMergeCoincidentMeshEdges re-welds coincident edges to
+    // recover the authoring connectivity (real components / boundaries / genus).
+    using namespace UE::Geometry;
+    FDynamicMesh3 DMesh;
     {
+        const FPositionVertexBuffer& PosBuf = LOD.VertexBuffers.PositionVertexBuffer;
+        const uint32 NV = PosBuf.GetNumVertices();
+        TArray<int32> VMap; VMap.Reserve(NV);
+        for (uint32 i = 0; i < NV; ++i)
+            VMap.Add(DMesh.AppendVertex((FVector3d)(FVector)PosBuf.VertexPosition(i)));
         TArray<uint32> Indices;
         LOD.IndexBuffer.GetCopy(Indices);
-        const FPositionVertexBuffer& PosBuf = LOD.VertexBuffers.PositionVertexBuffer;
-        bool bTruncated = false;
-
-        if (bIncTris)
+        for (int32 i = 0; i + 2 < Indices.Num(); i += 3)
         {
-            TArray<TSharedPtr<FJsonValue>> Tris;
-            int32 Emitted = 0;
-            for (int32 i = 0; i + 2 < Indices.Num(); i += 3)
-            {
-                if (Emitted >= MaxElements) { bTruncated = true; break; }
-                TArray<TSharedPtr<FJsonValue>> IJK = {
-                    MakeShared<FJsonValueNumber>(Indices[i]),
-                    MakeShared<FJsonValueNumber>(Indices[i + 1]),
-                    MakeShared<FJsonValueNumber>(Indices[i + 2]) };
-                Tris.Add(MakeShared<FJsonValueArray>(IJK));
-                ++Emitted;
-            }
-            Out->SetArrayField(TEXT("triangles"), Tris);
+            const int32 A = VMap.IsValidIndex(Indices[i])     ? VMap[Indices[i]]     : INDEX_NONE;
+            const int32 B = VMap.IsValidIndex(Indices[i + 1]) ? VMap[Indices[i + 1]] : INDEX_NONE;
+            const int32 C = VMap.IsValidIndex(Indices[i + 2]) ? VMap[Indices[i + 2]] : INDEX_NONE;
+            if (A != INDEX_NONE && B != INDEX_NONE && C != INDEX_NONE)
+                DMesh.AppendTriangle(FIndex3i(A, B, C));
         }
-        if (bIncPos)
-        {
-            TArray<TSharedPtr<FJsonValue>> Verts;
-            int32 Emitted = 0;
-            for (uint32 i = 0; i < PosBuf.GetNumVertices(); ++i)
-            {
-                if ((int32)Emitted >= MaxElements) { bTruncated = true; break; }
-                const FVector V = (FVector)PosBuf.VertexPosition(i);
-                TArray<TSharedPtr<FJsonValue>> XYZ = {
-                    MakeShared<FJsonValueNumber>(V.X),
-                    MakeShared<FJsonValueNumber>(V.Y),
-                    MakeShared<FJsonValueNumber>(V.Z) };
-                Verts.Add(MakeShared<FJsonValueArray>(XYZ));
-                ++Emitted;
-            }
-            Out->SetArrayField(TEXT("vertices"), Verts);
-        }
-        Out->SetBoolField(TEXT("truncated"), bTruncated);
     }
+    FMergeCoincidentMeshEdges Merger(&DMesh);
+    Merger.Apply();
 
+    // Report the pre-weld render vertex count too, so the UV/normal-split count
+    // is still visible alongside the true (welded) vertex count in counts{}.
+    Out->SetNumberField(TEXT("render_vertices"), LOD.GetNumVertices());
+    FillDynamicMeshResult(DMesh, bIncTris, bIncPos, bIncNorm, MaxElements, bHasBBox, BBoxMin, BBoxMax, Out);
     return FHaybaHandlerResult::Ok(Out);
 }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/HaybaSocketStore.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/HaybaSocketStore.cpp
@@ -2,7 +2,7 @@
 
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
-#include "HAL/PlatformProcess.h"
+#include "HAL/PlatformMisc.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
 #include "Dom/JsonObject.h"
@@ -39,7 +39,7 @@ bool HaybaSocketStore::Load(const FString& Path, FHaybaSocketSet& Out, FString& 
     FString Raw;
     if (!FFileHelper::LoadFileToString(Raw, *Path))
     {
-        OutError = FString::Printf(TEXT("sockets.json not found at %s"), *Path);
+        OutError = FString::Printf(TEXT("sockets.json could not read %s"), *Path);
         return false;
     }
     TSharedPtr<FJsonObject> Root;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/HaybaSocketStore.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/HaybaSocketStore.cpp
@@ -1,0 +1,87 @@
+#include "pcg/HaybaSocketStore.h"
+
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformProcess.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Dom/JsonObject.h"
+
+namespace
+{
+    // JSON string array -> TArray<FString>; absent/!array -> empty.
+    static TArray<FString> ReadStrArray(const TSharedPtr<FJsonObject>& Obj, const FString& Field)
+    {
+        TArray<FString> Out;
+        const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+        if (Obj.IsValid() && Obj->TryGetArrayField(Field, Arr) && Arr)
+        {
+            for (const TSharedPtr<FJsonValue>& V : *Arr)
+            {
+                FString S;
+                if (V.IsValid() && V->TryGetString(S)) { Out.Add(S); }
+            }
+        }
+        return Out;
+    }
+}
+
+FString HaybaSocketStore::ResolvePath(const FString& SettingsPath)
+{
+    if (!SettingsPath.IsEmpty()) { return SettingsPath; }
+    const FString Env = FPlatformMisc::GetEnvironmentVariable(TEXT("HAYBA_SOCKETS"));
+    if (!Env.IsEmpty()) { return Env; }
+    return FPaths::Combine(FPaths::ProjectDir(), TEXT(".scratch"), TEXT("sockets.json"));
+}
+
+bool HaybaSocketStore::Load(const FString& Path, FHaybaSocketSet& Out, FString& OutError)
+{
+    FString Raw;
+    if (!FFileHelper::LoadFileToString(Raw, *Path))
+    {
+        OutError = FString::Printf(TEXT("sockets.json not found at %s"), *Path);
+        return false;
+    }
+    TSharedPtr<FJsonObject> Root;
+    const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Raw);
+    if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+    {
+        OutError = FString::Printf(TEXT("sockets.json malformed at %s"), *Path);
+        return false;
+    }
+
+    const TSharedPtr<FJsonObject>* Sockets = nullptr;
+    if (Root->TryGetObjectField(TEXT("sockets"), Sockets) && Sockets)
+    {
+        for (const auto& Pair : (*Sockets)->Values)
+        {
+            const TSharedPtr<FJsonObject> S = Pair.Value.IsValid() ? Pair.Value->AsObject() : nullptr;
+            if (!S.IsValid()) { continue; }
+
+            FHaybaSocketContract C;
+            C.Name             = FName(*Pair.Key);
+            C.Provides         = ReadStrArray(S, TEXT("provides"));
+            C.Requires.All     = ReadStrArray(S, TEXT("requires_all"));
+            C.Requires.Exclude = ReadStrArray(S, TEXT("requires_exclude"));
+            S->TryGetStringField(TEXT("polarity"), C.Polarity);
+            double CW = 1.0; S->TryGetNumberField(TEXT("cost_weight"), CW); C.CostWeight = CW;
+            bool   RX = true; S->TryGetBoolField(TEXT("relaxable"),   RX); C.bRelaxable = RX;
+            Out.Sockets.Add(C.Name, C);
+        }
+    }
+
+    const TSharedPtr<FJsonObject>* Bond = nullptr;
+    if (Root->TryGetObjectField(TEXT("bond"), Bond) && Bond)
+    {
+        FString F, Cand;
+        if ((*Bond)->TryGetStringField(TEXT("frontier"),  F))    { Out.BondFrontier  = FName(*F); }
+        if ((*Bond)->TryGetStringField(TEXT("candidate"), Cand)) { Out.BondCandidate = FName(*Cand); }
+    }
+
+    if (Out.Sockets.Num() == 0)
+    {
+        OutError = TEXT("sockets.json parsed but contained no sockets");
+        return false;
+    }
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/HaybaUnsatCore.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/HaybaUnsatCore.cpp
@@ -1,0 +1,80 @@
+#include "pcg/HaybaUnsatCore.h"
+#include "pcg/HaybaSocketSolver.h"
+
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "Dom/JsonObject.h"
+
+namespace
+{
+    static FString JoinBraced(const TArray<FString>& Items)
+    {
+        return FString::Printf(TEXT("{ %s }"), *FString::Join(Items, TEXT(", ")));
+    }
+    static FString JoinQuoted(const TArray<FString>& Items)
+    {
+        return FString::Join(Items, TEXT(","));
+    }
+}
+
+FString HaybaUnsatCore::BuildHuman(const FHaybaBondOutcome& O)
+{
+    if (O.bOk && !O.bRelaxed)
+    {
+        return FString::Printf(TEXT("Bond OK  [%s] OK [%s]  cost %.2f"),
+            *O.RequirerName.ToString(), *O.ProviderName.ToString(), O.Cost);
+    }
+    if (O.bRelaxed)
+    {
+        return FString::Printf(TEXT("Bond RELAXED  [%s] ~ [%s]:  downgraded '%s'  (seam logged)"),
+            *O.RequirerName.ToString(), *O.ProviderName.ToString(), *JoinQuoted(O.MissingRequired));
+    }
+    return FString::Printf(TEXT("Bond REJECTED  [%s] X [%s]:  required '%s'  -  neighbor provided %s"),
+        *O.RequirerName.ToString(), *O.ProviderName.ToString(),
+        *JoinQuoted(O.MissingRequired), *JoinBraced(O.NeighborProvided));
+}
+
+FString HaybaUnsatCore::ResolvePath()
+{
+    return FPaths::Combine(FPaths::ProjectDir(), TEXT(".scratch"), TEXT("unsat-core.json"));
+}
+
+bool HaybaUnsatCore::Write(const FHaybaBondOutcome& O, const FName& Frontier, const FName& Candidate,
+                           const FString& Path, FString& OutError)
+{
+    const TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>();
+    Root->SetStringField(TEXT("schema_version"), TEXT("0.1.0"));
+    Root->SetBoolField  (TEXT("ok"),       O.bOk);
+    Root->SetBoolField  (TEXT("relaxed"),  O.bRelaxed);
+    Root->SetStringField(TEXT("frontier"),  Frontier.ToString());
+    Root->SetStringField(TEXT("candidate"), Candidate.ToString());
+    Root->SetNumberField(TEXT("cost"),     O.Cost);
+    Root->SetStringField(TEXT("requirer"), O.RequirerName.ToString());
+    Root->SetStringField(TEXT("provider"), O.ProviderName.ToString());
+
+    TArray<TSharedPtr<FJsonValue>> Missing;
+    for (const FString& M : O.MissingRequired) { Missing.Add(MakeShared<FJsonValueString>(M)); }
+    Root->SetArrayField(TEXT("missing_required"), Missing);
+
+    TArray<TSharedPtr<FJsonValue>> Provided;
+    for (const FString& P : O.NeighborProvided) { Provided.Add(MakeShared<FJsonValueString>(P)); }
+    Root->SetArrayField(TEXT("neighbor_provided"), Provided);
+
+    Root->SetStringField(TEXT("human"), BuildHuman(O));
+
+    FString Out;
+    const TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+    if (!FJsonSerializer::Serialize(Root, Writer))
+    {
+        OutError = TEXT("failed to serialize unsat-core json");
+        return false;
+    }
+    if (!FFileHelper::SaveStringToFile(Out, *Path))
+    {
+        OutError = FString::Printf(TEXT("failed to write %s"), *Path);
+        return false;
+    }
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGSocketBond.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGSocketBond.cpp
@@ -1,0 +1,180 @@
+#include "pcg/PCGSocketBond.h"
+
+#include "PCGContext.h"
+#include "PCGPin.h"
+#include "PCGCommon.h"
+#include "Data/PCGDynamicMeshData.h"
+#include "Materials/MaterialInterface.h"
+#include "DrawDebugHelpers.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+
+#include "DynamicMesh/DynamicMesh3.h"
+// NOTE(API-DEVIATION): DynamicMeshEditor.h lives at
+// GeometryCore/Public/DynamicMeshEditor.h (not inside a DynamicMesh/ subdir).
+// The brief flagged "DynamicMesh/DynamicMeshEditor.h" as uncertain — confirmed:
+// the real path in UE 5.7 is "DynamicMeshEditor.h".
+#include "DynamicMeshEditor.h"
+
+// UDynamicMesh (GetMeshRef) — comes from GeometryFramework via the PCGDynamicMeshData header
+#include "UDynamicMesh.h"
+
+#include "pcg/HaybaSocketStore.h"
+#include "pcg/HaybaSocketSolver.h"
+#include "pcg/HaybaUnsatCore.h"
+#include "pcg/HaybaOpening.h"
+#include "pcg/HaybaMeshOps.h"
+
+#include UE_INLINE_GENERATED_CPP_BY_NAME(PCGSocketBond)
+
+#define LOCTEXT_NAMESPACE "PCGSocketBond"
+
+#if WITH_EDITOR
+FText UPCGSocketBondSettings::GetDefaultNodeTitle() const { return LOCTEXT("Title", "Socket Bond"); }
+FText UPCGSocketBondSettings::GetNodeTooltipText() const
+{
+    return LOCTEXT("Tooltip",
+        "Bonds the Host and Branch shells by socket-contract cost-min (reads "
+        ".scratch/sockets.json). On success, punches an opening in Host at the bond and welds "
+        "Branch in. On failure, writes .scratch/unsat-core.json and draws the human-readable "
+        "tag mismatch at the junction; Host is emitted unchanged (the shells stay sealed).");
+}
+#endif
+
+TArray<FPCGPinProperties> UPCGSocketBondSettings::InputPinProperties() const
+{
+    TArray<FPCGPinProperties> Pins;
+    Pins.Emplace(FName(TEXT("Host")),   EPCGDataType::DynamicMesh, /*bAllowMultiple=*/false, /*bAllowMultipleData=*/false);
+    Pins.Emplace(FName(TEXT("Branch")), EPCGDataType::DynamicMesh, /*bAllowMultiple=*/false, /*bAllowMultipleData=*/false);
+    return Pins;
+}
+
+TArray<FPCGPinProperties> UPCGSocketBondSettings::OutputPinProperties() const
+{
+    TArray<FPCGPinProperties> Pins;
+    Pins.Emplace(PCGPinConstants::DefaultOutputLabel, EPCGDataType::DynamicMesh, false, false);
+    return Pins;
+}
+
+FPCGElementPtr UPCGSocketBondSettings::CreateElement() const { return MakeShared<FPCGSocketBondElement>(); }
+
+namespace
+{
+    // First DynamicMesh on a named input pin (copied, so we can mutate it).
+    static bool CopyMeshFromPin(FPCGContext* Context, const FName& Pin, UE::Geometry::FDynamicMesh3& Out)
+    {
+        const TArray<FPCGTaggedData> In = Context->InputData.GetInputsByPin(Pin);
+        for (const FPCGTaggedData& D : In)
+        {
+            if (const UPCGDynamicMeshData* DM = Cast<UPCGDynamicMeshData>(D.Data))
+            {
+                // GetDynamicMesh() returns const UDynamicMesh*; GetMeshRef() copies the
+                // underlying FDynamicMesh3 by value so we can mutate our local copy safely.
+                Out = DM->GetDynamicMesh()->GetMeshRef(); // copy
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+bool FPCGSocketBondElement::ExecuteInternal(FPCGContext* Context) const
+{
+    TRACE_CPUPROFILER_EVENT_SCOPE(FPCGSocketBondElement::Execute);
+    check(Context);
+    using namespace UE::Geometry;
+
+    const UPCGSocketBondSettings* Settings = Context->GetInputSettings<UPCGSocketBondSettings>();
+    check(Settings);
+
+    FDynamicMesh3 Host, Branch;
+    const bool bHasHost   = CopyMeshFromPin(Context, FName(TEXT("Host")),   Host);
+    const bool bHasBranch = CopyMeshFromPin(Context, FName(TEXT("Branch")), Branch);
+    if (!bHasHost)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("SocketBond: no Host mesh; nothing to emit."));
+        return true;
+    }
+
+    // ---- Load contracts + solve the one named bond.
+    const FString SocketsFile = HaybaSocketStore::ResolvePath(Settings->SocketsPath);
+    FHaybaSocketSet Set; FString LoadErr;
+    FHaybaBondOutcome Outcome;
+    FName Frontier = NAME_None, Candidate = NAME_None;
+    if (HaybaSocketStore::Load(SocketsFile, Set, LoadErr))
+    {
+        Frontier  = Set.BondFrontier;
+        Candidate = Set.BondCandidate;
+        const FHaybaSocketContract* F = Set.Sockets.Find(Frontier);
+        const FHaybaSocketContract* C = Set.Sockets.Find(Candidate);
+        if (F && C)
+        {
+            TArray<FHaybaSocketContract> Cands = { *C };
+            Outcome = HaybaSocketSolver::SolveBond(*F, Cands);
+            // SolveBond fills Requirer/Provider from the offending direction; for a clean
+            // bond those are NAME_None, so stamp the named endpoints for the OK overlay.
+            if (Outcome.bOk && !Outcome.bRelaxed)
+            {
+                Outcome.RequirerName = Frontier;
+                Outcome.ProviderName = Candidate;
+            }
+        }
+        else
+        {
+            UE_LOG(LogTemp, Warning, TEXT("SocketBond: bond endpoints %s/%s not found in %s"),
+                *Frontier.ToString(), *Candidate.ToString(), *SocketsFile);
+        }
+    }
+    else
+    {
+        UE_LOG(LogTemp, Warning, TEXT("SocketBond: %s"), *LoadErr);
+    }
+
+    // ---- Derive the bond transform from the branch mouth (SP-1 simplification).
+    FTransform BondXf = FTransform::Identity;
+    if (bHasBranch)
+    {
+        const FAxisAlignedBox3d B = Branch.GetBounds();
+        BondXf = FTransform(FQuat::Identity, FVector(B.Center()) + Settings->BondLocalOffset);
+    }
+
+    // ---- Always write the unsat-core report (the test oracle).
+    {
+        FString WriteErr;
+        HaybaUnsatCore::Write(Outcome, Frontier, Candidate, HaybaUnsatCore::ResolvePath(), WriteErr);
+    }
+
+    // ---- Draw the human line at the junction.
+    if (AActor* TargetActor = Context->GetTargetActor(nullptr))
+    {
+        if (UWorld* World = TargetActor->GetWorld())
+        {
+            const FColor Col = Outcome.bOk ? (Outcome.bRelaxed ? FColor::Yellow : FColor::Green) : FColor::Red;
+            DrawDebugString(World, BondXf.GetLocation() + FVector(0, 0, 50.0),
+                HaybaUnsatCore::BuildHuman(Outcome), nullptr, Col, /*Duration=*/0.f, /*DrawShadow=*/true);
+        }
+    }
+
+    // ---- Realize geometry.
+    FDynamicMesh3 Result = Host;
+    if (Outcome.bOk && bHasBranch)
+    {
+        HaybaOpening::PunchDoorway(Result, BondXf, Settings->DoorWidthCm, Settings->DoorHeightCm, Settings->WallDepthCm);
+        FDynamicMeshEditor Editor(&Result);
+        FMeshIndexMappings Map;
+        Editor.AppendMesh(&Branch, Map);
+        FHaybaMeshOps::WeldAndNormals(Result);
+    }
+
+    UPCGDynamicMeshData* OutData = FPCGContext::NewObject_AnyThread<UPCGDynamicMeshData>(Context);
+    TArray<UMaterialInterface*> Materials;
+    if (UMaterialInterface* M = Settings->ShellMaterial.LoadSynchronous()) { Materials.Add(M); }
+    OutData->Initialize(MoveTemp(Result), Materials);
+
+    FPCGTaggedData& Out = Context->OutputData.TaggedData.Emplace_GetRef();
+    Out.Data = OutData;
+    Out.Pin  = PCGPinConstants::DefaultOutputLabel;
+    return true;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGSocketBond.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGSocketBond.cpp
@@ -35,9 +35,10 @@ FText UPCGSocketBondSettings::GetNodeTooltipText() const
 {
     return LOCTEXT("Tooltip",
         "Bonds the Host and Branch shells by socket-contract cost-min (reads "
-        ".scratch/sockets.json). On success, punches an opening in Host at the bond and welds "
-        "Branch in. On failure, writes .scratch/unsat-core.json and draws the human-readable "
-        "tag mismatch at the junction; Host is emitted unchanged (the shells stay sealed).");
+        ".scratch/sockets.json). Always writes .scratch/unsat-core.json (the test oracle) and "
+        "draws the human-readable bond status at the junction. On success, punches an opening in "
+        "Host at the bond and welds Branch in; on failure, Host is emitted unchanged (the shells "
+        "stay sealed).");
 }
 #endif
 
@@ -68,10 +69,16 @@ namespace
         {
             if (const UPCGDynamicMeshData* DM = Cast<UPCGDynamicMeshData>(D.Data))
             {
-                // GetDynamicMesh() returns const UDynamicMesh*; GetMeshRef() copies the
-                // underlying FDynamicMesh3 by value so we can mutate our local copy safely.
-                Out = DM->GetDynamicMesh()->GetMeshRef(); // copy
-                return true;
+                // GetDynamicMesh() returns const UDynamicMesh*; an upstream node can emit a
+                // bare (un-Initialize'd) UPCGDynamicMeshData whose inner UDynamicMesh is null,
+                // so guard it — chaining ->GetMeshRef() on null is a cook-time crash.
+                if (const UDynamicMesh* UM = DM->GetDynamicMesh())
+                {
+                    // GetMeshRef() copies the underlying FDynamicMesh3 by value so we can
+                    // mutate our local copy safely.
+                    Out = UM->GetMeshRef(); // copy
+                    return true;
+                }
             }
         }
         return false;
@@ -138,10 +145,15 @@ bool FPCGSocketBondElement::ExecuteInternal(FPCGContext* Context) const
         BondXf = FTransform(FQuat::Identity, FVector(B.Center()) + Settings->BondLocalOffset);
     }
 
-    // ---- Always write the unsat-core report (the test oracle).
+    // ---- Always write the unsat-core report (the test oracle). The Task 9 gate
+    //      reads this file, so a silent write failure must not pass unnoticed.
     {
         FString WriteErr;
-        HaybaUnsatCore::Write(Outcome, Frontier, Candidate, HaybaUnsatCore::ResolvePath(), WriteErr);
+        if (!HaybaUnsatCore::Write(Outcome, Frontier, Candidate, HaybaUnsatCore::ResolvePath(), WriteErr)
+            || !WriteErr.IsEmpty())
+        {
+            UE_LOG(LogTemp, Warning, TEXT("SocketBond: unsat-core write failed: %s"), *WriteErr);
+        }
     }
 
     // ---- Draw the human line at the junction.

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGSweepShell.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGSweepShell.cpp
@@ -57,7 +57,7 @@ bool FPCGSweepShellElement::ExecuteInternal(FPCGContext* Context) const
 	UMaterialInterface* Mat = Settings->Material.LoadSynchronous();
 	const double BaseW = Settings->ProfileWidthCm;
 	const double BaseH = Settings->ProfileHeightCm;
-	const double Spacing = FMath::Max(10.0f, Settings->SampleSpacingCm);
+	const double Spacing = FMath::Max(10.0, Settings->SampleSpacingCm);
 
 	const TArray<FPCGTaggedData> Inputs = Context->InputData.GetInputsByPin(PCGPinConstants::DefaultInputLabel);
 	for (const FPCGTaggedData& In : Inputs)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGSweepShell.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGSweepShell.cpp
@@ -1,0 +1,219 @@
+#include "pcg/PCGSweepShell.h"
+
+#include "PCGContext.h"
+#include "PCGPin.h"
+#include "PCGCommon.h"
+#include "Data/PCGSplineData.h"
+#include "Data/PCGDynamicMeshData.h"
+#include "Materials/MaterialInterface.h"
+
+#include "DynamicMesh/DynamicMesh3.h"
+#include "DynamicMesh/MeshNormals.h"
+#include "IndexTypes.h"
+
+#include UE_INLINE_GENERATED_CPP_BY_NAME(PCGSweepShell)
+
+#define LOCTEXT_NAMESPACE "PCGSweepShell"
+
+#if WITH_EDITOR
+FText UPCGSweepShellSettings::GetDefaultNodeTitle() const
+{
+	return LOCTEXT("Title", "Sweep Shell");
+}
+FText UPCGSweepShellSettings::GetNodeTooltipText() const
+{
+	return LOCTEXT("Tooltip", "Sweeps a profile along the input spline into a single welded inward shell. Per-control-point scale (Y=width, Z=height) drives hard-stepped sections with risers.");
+}
+#endif
+
+TArray<FPCGPinProperties> UPCGSweepShellSettings::InputPinProperties() const
+{
+	TArray<FPCGPinProperties> Pins;
+	Pins.Emplace(PCGPinConstants::DefaultInputLabel, EPCGDataType::Spline);
+	return Pins;
+}
+
+TArray<FPCGPinProperties> UPCGSweepShellSettings::OutputPinProperties() const
+{
+	TArray<FPCGPinProperties> Pins;
+	Pins.Emplace(PCGPinConstants::DefaultOutputLabel, EPCGDataType::DynamicMesh, /*bAllowMultipleConnections=*/false, /*bAllowMultipleData=*/false);
+	return Pins;
+}
+
+FPCGElementPtr UPCGSweepShellSettings::CreateElement() const
+{
+	return MakeShared<FPCGSweepShellElement>();
+}
+
+bool FPCGSweepShellElement::ExecuteInternal(FPCGContext* Context) const
+{
+	using namespace UE::Geometry; // variable-height via per-CP scale
+	TRACE_CPUPROFILER_EVENT_SCOPE(FPCGSweepShellElement::Execute);
+	check(Context);
+
+	const UPCGSweepShellSettings* Settings = Context->GetInputSettings<UPCGSweepShellSettings>();
+	check(Settings);
+
+	UMaterialInterface* Mat = Settings->Material.LoadSynchronous();
+	const double BaseW = Settings->ProfileWidthCm;
+	const double BaseH = Settings->ProfileHeightCm;
+	const double Spacing = FMath::Max(10.0f, Settings->SampleSpacingCm);
+
+	const TArray<FPCGTaggedData> Inputs = Context->InputData.GetInputsByPin(PCGPinConstants::DefaultInputLabel);
+	for (const FPCGTaggedData& In : Inputs)
+	{
+		const UPCGSplineData* Spline = Cast<UPCGSplineData>(In.Data);
+		if (!Spline)
+		{
+			continue;
+		}
+
+		const FPCGSplineStruct& SS = Spline->SplineStruct;
+		const double TotalLen = SS.GetSplineLength();
+		const int32 NumCP = SS.GetNumberOfPoints();
+		if (TotalLen < 1.0 || NumCP < 2)
+		{
+			continue;
+		}
+
+		// Per-control-point: distance along spline + size (from point scale: Y=width, Z=height mult).
+		const FInterpCurveVector& ScaleCurve = SS.GetSplinePointsScale();
+		TArray<double> CPDist; CPDist.Reserve(NumCP);
+		TArray<double> CPW, CPH; CPW.Reserve(NumCP); CPH.Reserve(NumCP);
+		for (int32 i = 0; i < NumCP; ++i)
+		{
+			CPDist.Add(SS.GetDistanceAlongSplineAtSplinePoint(i));
+			const FVector S = ScaleCurve.Points.IsValidIndex(i) ? ScaleCurve.Points[i].OutVal : FVector(1, 1, 1);
+			CPW.Add(BaseW * (S.Y > KINDA_SMALL_NUMBER ? S.Y : 1.0));
+			CPH.Add(BaseH * (S.Z > KINDA_SMALL_NUMBER ? S.Z : 1.0));
+		}
+
+		FDynamicMesh3 Mesh;
+		Mesh.EnableAttributes();
+
+		// Frame (loc, right, up, tangent) at a world distance along the spline.
+		auto Frame = [&](double D, FVector& Loc, FVector& Right, FVector& Up, FVector& Tan)
+		{
+			const float A = (float)FMath::Clamp(D / TotalLen, 0.0, 1.0);
+			const FTransform T = Spline->GetTransformAtAlpha(A);
+			Loc = T.GetLocation();
+			Right = T.GetUnitAxis(EAxis::Y);
+			Up = T.GetUnitAxis(EAxis::Z);
+			Tan = T.GetUnitAxis(EAxis::X);
+		};
+
+		// Append a quad (4 world points) with UE-correct winding so the front face
+		// points toward ND (the shell interior). Replicates the proven sweep math.
+		auto AddQuad = [&](const FVector& P0, const FVector& P1, const FVector& P2, const FVector& P3, const FVector& ND)
+		{
+			const int32 A = Mesh.AppendVertex(FVector3d(P0));
+			const int32 B = Mesh.AppendVertex(FVector3d(P1));
+			const int32 C = Mesh.AppendVertex(FVector3d(P2));
+			const int32 Dd = Mesh.AppendVertex(FVector3d(P3));
+			const FVector3d g = (FVector3d(P1) - FVector3d(P0)).Cross(FVector3d(P2) - FVector3d(P0));
+			if (g.Dot(FVector3d(ND)) < 0)
+			{
+				Mesh.AppendTriangle(FIndex3i(A, B, C));
+				Mesh.AppendTriangle(FIndex3i(A, C, Dd));
+			}
+			else
+			{
+				Mesh.AppendTriangle(FIndex3i(A, C, B));
+				Mesh.AppendTriangle(FIndex3i(A, Dd, C));
+			}
+		};
+
+		// Build the 4 inner walls for a constant-size section [DStart, DEnd], welded along length.
+		auto AddSection = [&](double DStart, double DEnd, double W, double H)
+		{
+			const double hw = W * 0.5;
+			const int32 N = FMath::Max(1, FMath::CeilToInt((DEnd - DStart) / Spacing));
+			// wall defs: {y0,z0, y1,z1, signNd, axis(0=up,1=right)}
+			const double Walls[4][6] = {
+				{ -hw, 0, hw, 0, +1, 0 }, // floor   -> +up
+				{ -hw, H, hw, H, -1, 0 }, // ceiling -> -up
+				{ -hw, 0, -hw, H, +1, 1 }, // left    -> +right
+				{  hw, 0,  hw, H, -1, 1 }  // right   -> -right
+			};
+			for (int32 w = 0; w < 4; ++w)
+			{
+				int32 prevA = -1, prevB = -1;
+				for (int32 i = 0; i <= N; ++i)
+				{
+					const double D = DStart + (DEnd - DStart) * (double)i / (double)N;
+					FVector Loc, R, U, Tn; Frame(D, Loc, R, U, Tn);
+					const FVector P0 = Loc + R * Walls[w][0] + U * Walls[w][1];
+					const FVector P1 = Loc + R * Walls[w][2] + U * Walls[w][3];
+					const int32 A = Mesh.AppendVertex(FVector3d(P0));
+					const int32 B = Mesh.AppendVertex(FVector3d(P1));
+					if (i > 0)
+					{
+						const FVector ND = (Walls[w][5] == 0) ? (U * Walls[w][4]) : (R * Walls[w][4]);
+						const FVector3d p0 = Mesh.GetVertex(prevA), p1 = Mesh.GetVertex(A), p2 = Mesh.GetVertex(B);
+						const FVector3d g = (p1 - p0).Cross(p2 - p0);
+						if (g.Dot(FVector3d(ND)) < 0)
+						{
+							Mesh.AppendTriangle(FIndex3i(prevA, A, B));
+							Mesh.AppendTriangle(FIndex3i(prevA, B, prevB));
+						}
+						else
+						{
+							Mesh.AppendTriangle(FIndex3i(prevA, B, A));
+							Mesh.AppendTriangle(FIndex3i(prevA, prevB, B));
+						}
+					}
+					prevA = A; prevB = B;
+				}
+			}
+		};
+
+		// Riser frame at a section boundary (the inverted-U step connecting the two
+		// inner rects, sharing the floor), facing toward the larger section.
+		auto AddRiser = [&](double D, double Wa, double Ha, double Wb, double Hb)
+		{
+			FVector Loc, R, U, Tn; Frame(D, Loc, R, U, Tn);
+			const double bigW = FMath::Max(Wa, Wb), bigH = FMath::Max(Ha, Hb);
+			const double smW = FMath::Min(Wa, Wb), smH = FMath::Min(Ha, Hb);
+			const FVector ND = (Wa * Ha >= Wb * Hb) ? (Tn * -1.0) : Tn;
+			auto P = [&](double y, double z) { return Loc + R * y + U * z; };
+			if (bigH > smH + 1.0)
+			{
+				AddQuad(P(-smW / 2, smH), P(smW / 2, smH), P(smW / 2, bigH), P(-smW / 2, bigH), ND);
+			}
+			if (bigW > smW + 1.0)
+			{
+				AddQuad(P(-bigW / 2, 0), P(-smW / 2, 0), P(-smW / 2, bigH), P(-bigW / 2, bigH), ND);
+				AddQuad(P(smW / 2, 0), P(bigW / 2, 0), P(bigW / 2, bigH), P(smW / 2, bigH), ND);
+			}
+		};
+
+		// Build each segment between consecutive control points at the start point's
+		// size (hold-until-next = hard step), with a riser at every interior step.
+		for (int32 s = 0; s < NumCP - 1; ++s)
+		{
+			AddSection(CPDist[s], CPDist[s + 1], CPW[s], CPH[s]);
+			if (s > 0 && (!FMath::IsNearlyEqual(CPW[s], CPW[s - 1]) || !FMath::IsNearlyEqual(CPH[s], CPH[s - 1])))
+			{
+				AddRiser(CPDist[s], CPW[s - 1], CPH[s - 1], CPW[s], CPH[s]);
+			}
+		}
+
+		FMeshNormals::QuickRecomputeOverlayNormals(Mesh);
+
+		UPCGDynamicMeshData* OutData = FPCGContext::NewObject_AnyThread<UPCGDynamicMeshData>(Context);
+		TArray<UMaterialInterface*> Materials;
+		if (Mat)
+		{
+			Materials.Add(Mat);
+		}
+		OutData->Initialize(MoveTemp(Mesh), Materials);
+
+		FPCGTaggedData& Out = Context->OutputData.TaggedData.Emplace_GetRef();
+		Out.Data = OutData;
+		Out.Tags = In.Tags;
+	}
+
+	return true;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaOpening.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaOpening.h
@@ -15,12 +15,18 @@ namespace HaybaOpening
         const double HalfW = WidthCm * 0.5;
         const double HalfD = DepthCm * 0.5;
 
+        // Keep all math double-precision: SP-1's real junction sits at world
+        // coordinates, not origin, so narrowing the centroid through float before
+        // the inverse-transform would misclassify boundary triangles. Build the
+        // double-precision bond transform once, outside the loop.
+        const FTransform3d BondXf3d(BondXf);
+
         // Collect first (do not mutate the mesh while iterating its triangle set).
         TArray<int32> ToRemove;
         for (const int32 tid : Mesh.TriangleIndicesItr())
         {
             const FVector3d Cw = Mesh.GetTriCentroid(tid);
-            const FVector L = BondXf.InverseTransformPosition(FVector(Cw));
+            const FVector3d L = BondXf3d.InverseTransformPosition(Cw);
             if (FMath::Abs(L.Y) <= HalfW && L.Z >= 0.0 && L.Z <= HeightCm && FMath::Abs(L.X) <= HalfD)
             {
                 ToRemove.Add(tid);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaOpening.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaOpening.h
@@ -1,0 +1,68 @@
+// Deterministic doorway opening: remove every triangle whose centroid falls
+// inside an oriented door box in BondXf-local space. Open-mesh-safe (no boolean,
+// no plane-cut) — the SP-1 realization of "punch a hole where the bores connect".
+// Local axes match the tunnel frame: x=tangent(depth), y=right(width), z=up(height).
+#pragma once
+
+#include "CoreMinimal.h"
+#include "DynamicMesh/DynamicMesh3.h"
+
+namespace HaybaOpening
+{
+    inline int32 PunchDoorway(UE::Geometry::FDynamicMesh3& Mesh, const FTransform& BondXf,
+                              double WidthCm, double HeightCm, double DepthCm)
+    {
+        const double HalfW = WidthCm * 0.5;
+        const double HalfD = DepthCm * 0.5;
+
+        // Collect first (do not mutate the mesh while iterating its triangle set).
+        TArray<int32> ToRemove;
+        for (const int32 tid : Mesh.TriangleIndicesItr())
+        {
+            const FVector3d Cw = Mesh.GetTriCentroid(tid);
+            const FVector L = BondXf.InverseTransformPosition(FVector(Cw));
+            if (FMath::Abs(L.Y) <= HalfW && L.Z >= 0.0 && L.Z <= HeightCm && FMath::Abs(L.X) <= HalfD)
+            {
+                ToRemove.Add(tid);
+            }
+        }
+        for (const int32 tid : ToRemove)
+        {
+            Mesh.RemoveTriangle(tid, /*bRemoveIsolatedVertices=*/true, /*bPreserveManifold=*/false);
+        }
+        return ToRemove.Num();
+    }
+
+    // Flat wall in the Y-Z plane at x=0: y in [-HalfWidth, HalfWidth], z in [0, Height].
+    inline void AppendWallGrid(UE::Geometry::FDynamicMesh3& Mesh, double HalfWidthCm, double HeightCm,
+                               int32 Cols, int32 Rows)
+    {
+        using namespace UE::Geometry;
+        Cols = FMath::Max(1, Cols);
+        Rows = FMath::Max(1, Rows);
+        // (Cols+1)x(Rows+1) vertex grid.
+        TArray<int32> V; V.SetNum((Cols + 1) * (Rows + 1));
+        auto Idx = [Cols](int32 c, int32 r) { return r * (Cols + 1) + c; };
+        for (int32 r = 0; r <= Rows; ++r)
+        {
+            const double z = HeightCm * (double)r / (double)Rows;
+            for (int32 c = 0; c <= Cols; ++c)
+            {
+                const double y = -HalfWidthCm + (2.0 * HalfWidthCm) * (double)c / (double)Cols;
+                V[Idx(c, r)] = Mesh.AppendVertex(FVector3d(0.0, y, z));
+            }
+        }
+        for (int32 r = 0; r < Rows; ++r)
+        {
+            for (int32 c = 0; c < Cols; ++c)
+            {
+                const int32 A = V[Idx(c,     r)];
+                const int32 B = V[Idx(c + 1, r)];
+                const int32 C = V[Idx(c + 1, r + 1)];
+                const int32 D = V[Idx(c,     r + 1)];
+                Mesh.AppendTriangle(FIndex3i(A, B, C));
+                Mesh.AppendTriangle(FIndex3i(A, C, D));
+            }
+        }
+    }
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaSocketContract.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaSocketContract.h
@@ -1,0 +1,64 @@
+// A socket contract: what a connection point PROVIDES (dotted tags) and what it
+// REQUIRES of a neighbor (Require-All conjunction + Exclude list). Compatibility
+// is Boolean set-intersection over expanded-ancestor tag sets (spec §5). Pure.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "pcg/HaybaTag.h"
+
+struct FHaybaRequire
+{
+    TArray<FString> All;     // every tag here must be provided by the neighbor
+    TArray<FString> Exclude; // none of these may be provided by the neighbor
+};
+
+struct FHaybaSocketContract
+{
+    FName            Name;
+    TArray<FString>  Provides;
+    FHaybaRequire    Requires;
+    FString          Polarity;          // "male"/"female"/"" — recorded, not gated in SP-1
+    double           CostWeight = 1.0;  // soft weight (reserved; cost is 0/penalty in SP-1)
+    bool             bRelaxable = true; // a hard Require-All miss may be downgraded
+};
+
+struct FHaybaRequireResult
+{
+    bool            bSatisfied = false;
+    TArray<FString> MissingRequired; // Require-All tags the neighbor does not provide
+    TArray<FString> HitExcluded;     // Exclude tags the neighbor wrongly provides
+};
+
+namespace HaybaSocketContract
+{
+    // Evaluate Req against a neighbor's RAW provides (expanded internally).
+    inline FHaybaRequireResult Evaluate(const FHaybaRequire& Req, const TArray<FString>& NeighborProvides)
+    {
+        const TSet<FString> Expanded = HaybaTag::ExpandAll(NeighborProvides);
+        FHaybaRequireResult R;
+        for (const FString& Need : Req.All)
+        {
+            if (!HaybaTag::Provides(Expanded, Need))
+            {
+                R.MissingRequired.Add(Need);
+            }
+        }
+        for (const FString& Ban : Req.Exclude)
+        {
+            if (HaybaTag::Provides(Expanded, Ban))
+            {
+                R.HitExcluded.Add(Ban);
+            }
+        }
+        R.bSatisfied = (R.MissingRequired.Num() == 0) && (R.HitExcluded.Num() == 0);
+        return R;
+    }
+
+    // Stable, de-duplicated, ascending expansion — used for human-readable reports.
+    inline TArray<FString> SortedExpandedProvides(const TArray<FString>& Provides)
+    {
+        TArray<FString> Out = HaybaTag::ExpandAll(Provides).Array();
+        Out.Sort(); // FString::operator< — lexicographic, deterministic
+        return Out;
+    }
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaSocketSolver.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaSocketSolver.h
@@ -1,0 +1,104 @@
+// The SP-1 solver: cost/energy minimization over candidate bonds. A bond's cost
+// is the sum of its two directional requirement checks. A satisfied direction
+// costs 0; an unsatisfied Require-All term costs RelaxablePenalty if the requiring
+// socket is relaxable (downgrade -> a logged seam) else HardPenalty (+inf); an
+// Exclude hit always costs HardPenalty. Pick the lowest-cost candidate. This one
+// mechanism is scoring + bias + the substrate for repair (spec §3.2). Pure.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "pcg/HaybaSocketContract.h"
+
+struct FHaybaBondOutcome
+{
+    bool   bOk          = false;       // a bond was committed (clean or relaxed)
+    bool   bRelaxed     = false;       // committed only by downgrading a relaxable requirement
+    int32  ChosenIndex  = INDEX_NONE;  // index into the candidate array
+    double Cost         = 0.0;
+
+    // Unsat-core payload — populated when !bOk OR bRelaxed (the offending direction):
+    FName           RequirerName;      // the socket whose Require-All term failed
+    FName           ProviderName;      // the neighbor that failed to provide it
+    TArray<FString> MissingRequired;   // the unmet Require-All tags
+    TArray<FString> NeighborProvided;  // provider's sorted expanded provides
+};
+
+namespace HaybaSocketSolver
+{
+    constexpr double HardPenalty      = 1e30;
+    constexpr double RelaxablePenalty = 1000.0;
+
+    // One directional check: does Provider satisfy Requirer's requirements?
+    // Returns the cost contribution and, on failure, the offending detail.
+    struct FDirCost
+    {
+        double          Cost = 0.0;
+        bool            bRelaxedHere = false;
+        TArray<FString> Missing;       // unmet Require-All tags
+        bool            bExcludeHit = false;
+    };
+
+    inline FDirCost ScoreDirection(const FHaybaSocketContract& Requirer, const FHaybaSocketContract& Provider)
+    {
+        FDirCost D;
+        const FHaybaRequireResult R = HaybaSocketContract::Evaluate(Requirer.Requires, Provider.Provides);
+        if (R.HitExcluded.Num() > 0)
+        {
+            D.Cost = HardPenalty;
+            D.bExcludeHit = true;
+            return D;
+        }
+        if (R.MissingRequired.Num() > 0)
+        {
+            D.Missing = R.MissingRequired;
+            if (Requirer.bRelaxable)
+            {
+                D.Cost = RelaxablePenalty * R.MissingRequired.Num();
+                D.bRelaxedHere = true;
+            }
+            else
+            {
+                D.Cost = HardPenalty;
+            }
+        }
+        return D;
+    }
+
+    // Solve one frontier against its candidates; pick the lowest-cost bond.
+    inline FHaybaBondOutcome SolveBond(const FHaybaSocketContract& Frontier, TArrayView<const FHaybaSocketContract> Candidates)
+    {
+        FHaybaBondOutcome Best;
+        Best.Cost = HardPenalty * 4.0; // sentinel above any single-bond cost
+
+        for (int32 i = 0; i < Candidates.Num(); ++i)
+        {
+            const FHaybaSocketContract& Cand = Candidates[i];
+            const FDirCost FwdDir = ScoreDirection(Frontier, Cand); // frontier requires of candidate
+            const FDirCost RevDir = ScoreDirection(Cand, Frontier); // candidate requires of frontier
+            const double   Total  = FMath::Min(FwdDir.Cost + RevDir.Cost, HardPenalty * 4.0);
+
+            if (Total < Best.Cost)
+            {
+                Best = FHaybaBondOutcome{};
+                Best.ChosenIndex = i;
+                Best.Cost        = Total;
+                Best.bOk         = Total < HardPenalty;
+                Best.bRelaxed    = Best.bOk && Total >= RelaxablePenalty;
+
+                // Capture the offending direction for the unsat-core (forward first, else reverse).
+                const bool bFwdOffends = (FwdDir.Cost > 0.0);
+                const FDirCost& Off = bFwdOffends ? FwdDir : RevDir;
+                if (Off.Cost > 0.0)
+                {
+                    const FHaybaSocketContract& Req = bFwdOffends ? Frontier : Cand;
+                    const FHaybaSocketContract& Prv = bFwdOffends ? Cand : Frontier;
+                    Best.RequirerName     = Req.Name;
+                    Best.ProviderName     = Prv.Name;
+                    Best.MissingRequired  = Off.Missing;
+                    Best.NeighborProvided = HaybaSocketContract::SortedExpandedProvides(Prv.Provides);
+                }
+            }
+        }
+        return Best;
+    }
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaSocketStore.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaSocketStore.h
@@ -1,0 +1,19 @@
+// Reads .scratch/sockets.json into socket contracts + the one named bond (SP-1).
+// Mirrors the grammar.json load idiom in PCGGrammarSolver.cpp.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "pcg/HaybaSocketContract.h"
+
+struct FHaybaSocketSet
+{
+    TMap<FName, FHaybaSocketContract> Sockets;
+    FName BondFrontier  = NAME_None;
+    FName BondCandidate = NAME_None;
+};
+
+namespace HaybaSocketStore
+{
+    FString ResolvePath(const FString& SettingsPath);
+    bool    Load(const FString& Path, FHaybaSocketSet& Out, FString& OutError);
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaTag.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaTag.h
@@ -1,0 +1,49 @@
+// Dotted-string tag utilities — the SP-1 stand-in for GameplayTag hierarchy.
+// A tag "A.B.C" implicitly provides every ancestor prefix {A, A.B, A.B.C}, so a
+// rule on "Style.Imperial" is satisfied by a socket that provides
+// "Style.Imperial.Vent". UObject-free so the solver core stays headlessly testable.
+#pragma once
+
+#include "CoreMinimal.h"
+
+namespace HaybaTag
+{
+    // "A.B.C" -> {"A","A.B","A.B.C"}. "" -> {}. Whitespace-tolerant on segments.
+    inline TSet<FString> ExpandAncestors(const FString& DottedTag)
+    {
+        TSet<FString> Out;
+        if (DottedTag.IsEmpty())
+        {
+            return Out;
+        }
+        TArray<FString> Parts;
+        DottedTag.ParseIntoArray(Parts, TEXT("."), /*InCullEmpty=*/true);
+        FString Prefix;
+        for (const FString& Part : Parts)
+        {
+            const FString Seg = Part.TrimStartAndEnd();
+            if (Seg.IsEmpty()) { continue; }
+            Prefix = Prefix.IsEmpty() ? Seg : (Prefix + TEXT(".") + Seg);
+            Out.Add(Prefix);
+        }
+        return Out;
+    }
+
+    // Union of ExpandAncestors over a list of provided tags (de-duplicated).
+    inline TSet<FString> ExpandAll(const TArray<FString>& Tags)
+    {
+        TSet<FString> Out;
+        for (const FString& T : Tags)
+        {
+            Out.Append(ExpandAncestors(T));
+        }
+        return Out;
+    }
+
+    // True iff RequiredTag (or, by ancestry, an expanded prefix of a provided tag)
+    // is present in the already-expanded provided set.
+    inline bool Provides(const TSet<FString>& ExpandedProvides, const FString& RequiredTag)
+    {
+        return !RequiredTag.IsEmpty() && ExpandedProvides.Contains(RequiredTag);
+    }
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaUnsatCore.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaUnsatCore.h
@@ -1,0 +1,15 @@
+// Renders a bond outcome to (a) a one-line human string for the viewport overlay
+// and (b) .scratch/unsat-core.json — the deterministic test oracle for the moat.
+#pragma once
+
+#include "CoreMinimal.h"
+
+struct FHaybaBondOutcome;
+
+namespace HaybaUnsatCore
+{
+    FString BuildHuman(const FHaybaBondOutcome& O);
+    FString ResolvePath();
+    bool    Write(const FHaybaBondOutcome& O, const FName& Frontier, const FName& Candidate,
+                  const FString& Path, FString& OutError);
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGSocketBond.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGSocketBond.h
@@ -1,6 +1,6 @@
 // SP-1 junction node: bonds two shells by socket-contract cost-min, punches
-// the opening on success, and writes/draws the unsat-core on failure.
-// Reads .scratch/sockets.json; writes .scratch/unsat-core.json. Never cached.
+// the opening on success, and always writes/draws the unsat-core report.
+// Reads .scratch/sockets.json; always writes .scratch/unsat-core.json. Never cached.
 #pragma once
 
 #include "PCGSettings.h"

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGSocketBond.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGSocketBond.h
@@ -1,0 +1,56 @@
+// SP-1 junction node: bonds two shells by socket-contract cost-min, punches
+// the opening on success, and writes/draws the unsat-core on failure.
+// Reads .scratch/sockets.json; writes .scratch/unsat-core.json. Never cached.
+#pragma once
+
+#include "PCGSettings.h"
+#include "PCGSocketBond.generated.h"
+
+class UMaterialInterface;
+
+UCLASS(BlueprintType, ClassGroup = (Procedural))
+class UPCGSocketBondSettings : public UPCGSettings
+{
+    GENERATED_BODY()
+public:
+#if WITH_EDITOR
+    virtual FName GetDefaultNodeName() const override { return FName(TEXT("SocketBond")); }
+    virtual FText GetDefaultNodeTitle() const override;
+    virtual FText GetNodeTooltipText() const override;
+    virtual EPCGSettingsType GetType() const override { return EPCGSettingsType::DynamicMesh; }
+#endif
+
+    /** Path to sockets.json. Empty => <ProjectDir>/.scratch/sockets.json. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Bond)
+    FString SocketsPath;
+
+    /** Local nudge applied to the derived bond transform (cm). */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Bond)
+    FVector BondLocalOffset = FVector::ZeroVector;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Bond, meta = (ClampMin = "20"))
+    double DoorWidthCm = 180.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Bond, meta = (ClampMin = "20"))
+    double DoorHeightCm = 220.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Bond, meta = (ClampMin = "10"))
+    double WallDepthCm = 80.0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Bond)
+    TSoftObjectPtr<UMaterialInterface> ShellMaterial;
+
+protected:
+    virtual TArray<FPCGPinProperties> InputPinProperties() const override;
+    virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
+    virtual FPCGElementPtr CreateElement() const override;
+};
+
+class FPCGSocketBondElement : public IPCGElement
+{
+protected:
+    virtual bool ExecuteInternal(FPCGContext* InContext) const override;
+    virtual bool IsCacheable(const UPCGSettings*) const override { return false; }
+    // Reads/writes files + touches the world (DrawDebugString) — main thread only.
+    virtual bool CanExecuteOnlyOnMainThread(FPCGContext*) const override { return true; }
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGSweepShell.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGSweepShell.h
@@ -39,15 +39,15 @@ public:
 
 	/** Profile width (cm). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Shell, meta = (ClampMin = "50"))
-	float ProfileWidthCm = 600.f;
+	double ProfileWidthCm = 600.0;
 
 	/** Profile height (cm). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Shell, meta = (ClampMin = "50"))
-	float ProfileHeightCm = 400.f;
+	double ProfileHeightCm = 400.0;
 
 	/** Ring spacing along the spline (cm) — smaller = smoother curve. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Shell, meta = (ClampMin = "10"))
-	float SampleSpacingCm = 60.f;
+	double SampleSpacingCm = 60.0;
 
 	/** Material applied to the generated shell. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Shell)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGSweepShell.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGSweepShell.h
@@ -1,0 +1,68 @@
+// Generic profile-sweep PCG node — sweeps ONE continuous (seamless) dynamic mesh
+// shell along the input spline. Unlike spline-mesh tiling, this is a
+// single welded mesh: no segment joints, no seams. Inner-wall only (the player
+// is always inside), single-sided winding for economy.
+
+#pragma once
+
+#include "PCGSettings.h"
+#include "PCGSweepShell.generated.h"
+
+/** Shape vocabulary for the swept profile. SP-1 uses Box only; Arch/Vault are reserved for SP-5. */
+UENUM(BlueprintType)
+enum class EHaybaProfileShape : uint8
+{
+	Box   UMETA(DisplayName = "Box"),
+	Arch  UMETA(DisplayName = "Arch (reserved)"),
+	Vault UMETA(DisplayName = "Vault (reserved)")
+};
+
+/**
+ * Sweeps a profile along the input spline into a single welded inward shell.
+ */
+UCLASS(BlueprintType, ClassGroup = (Procedural))
+class UPCGSweepShellSettings : public UPCGSettings
+{
+	GENERATED_BODY()
+
+public:
+#if WITH_EDITOR
+	virtual FName GetDefaultNodeName() const override { return FName(TEXT("SweepShell")); }
+	virtual FText GetDefaultNodeTitle() const override;
+	virtual FText GetNodeTooltipText() const override;
+	virtual EPCGSettingsType GetType() const override { return EPCGSettingsType::DynamicMesh; }
+#endif
+
+	/** Profile cross-section shape. Box = rectangular; Arch/Vault reserved for SP-5. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Shell)
+	EHaybaProfileShape ProfileShape = EHaybaProfileShape::Box;
+
+	/** Profile width (cm). */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Shell, meta = (ClampMin = "50"))
+	float ProfileWidthCm = 600.f;
+
+	/** Profile height (cm). */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Shell, meta = (ClampMin = "50"))
+	float ProfileHeightCm = 400.f;
+
+	/** Ring spacing along the spline (cm) — smaller = smoother curve. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Shell, meta = (ClampMin = "10"))
+	float SampleSpacingCm = 60.f;
+
+	/** Material applied to the generated shell. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Shell)
+	TSoftObjectPtr<UMaterialInterface> Material;
+
+protected:
+	virtual TArray<FPCGPinProperties> InputPinProperties() const override;
+	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
+	virtual FPCGElementPtr CreateElement() const override;
+};
+
+class FPCGSweepShellElement : public IPCGElement
+{
+protected:
+	virtual bool ExecuteInternal(FPCGContext* InContext) const override;
+	// Building geometry — never cache.
+	virtual bool IsCacheable(const UPCGSettings*) const override { return false; }
+};


### PR DESCRIPTION
## Topology reasoning — made comprehensive & crash-safe
`mesh_extract` / `mesh_topology_stats` now return a rigorous topology block:
- **boundary_loops** (hole count, not just edges), **is_closed**, **surface_area**, signed **volume**, **euler_characteristic**, **genus** (single closed manifold only)
- **component_triangle_counts[]** — per-component sizes, so an unwelded shell (e.g. "4 patches, not 1 solid" — exactly what we saw on `GB_SP1_HostSpline`) is diagnosable at a glance
- existing: boundary_edges, non_manifold_vertices (bowties), degenerate_triangles, connected_components, is_valid
- **empty-mesh guard** (0 tris → zeros + note; no measure/loop on nothing)
- **static-mesh path now computes REAL topology**: welds the render LOD into an `FDynamicMesh3` via `FMergeCoincidentMeshEdges` and runs the identical readout, instead of the old "needs a dynamic mesh" disclaimer. Pre-weld count surfaced as `render_vertices`; bad indices guarded.

## Automation queue fix — expose the inline runner
Root cause (confirmed): console `Automation RunTests` only enqueues into the controller/worker session layer (`FAutomationControllerManager::Tick`), which nothing pumps in a GUI editor unless the Session Frontend tab is open → tests sit at `Queued` forever.

The in-process plugin **already** has the correct bypass (`FHaybaMCPTestHandler`: `StartTestByName` → `ExecuteLatentCommands` drained to completion/timeout → `StopTest`) — it was just not agent-callable. Added **`test_list` / `test_run` / `test_get_log`** to the sidecar (`agent_callable`), so agents run tests inline on the calling thread with no Session Frontend and no stuck queue.

## Verification
- `npm run lint:legacy-wrappers` OK (69 entries) · `RunUAT BuildPlugin` (UE_5.7) BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new PCG nodes for generating welded inward shell meshes and bonding socket-driven geometry.
  * Added support for loading socket definitions from a JSON file and resolving default file paths automatically.
  * Added a new test command set for listing, running, and viewing logs.

* **Bug Fixes**
  * Improved mesh topology reporting for static and dynamic meshes, including better handling of empty meshes and more detailed validity metrics.
  * Enhanced doorway punching and socket matching behavior for more consistent results.

* **Tests**
  * Added broader automation coverage for tags, socket contracts, solver behavior, mesh openings, and unsatisfied bond reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->