### PR TITLE
fix(material): SEH-guard material_compile recompile so a native AV cannot kill the editor

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSeh.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSeh.cpp
@@ -1,0 +1,25 @@
+#include "HaybaMCPSeh.h"
+#if PLATFORM_WINDOWS
+#include <excpt.h>   // EXCEPTION_EXECUTE_HANDLER
+#endif
+
+namespace HaybaSeh
+{
+    void RunGuarded(void (*Thunk)(void*), void* Context, bool& bOutCrashed)
+    {
+        bOutCrashed = false;
+        if (!Thunk) return;
+#if PLATFORM_WINDOWS
+        __try
+        {
+            Thunk(Context);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            bOutCrashed = true;
+        }
+#else
+        Thunk(Context);
+#endif
+    }
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -46,6 +46,7 @@
 #include "Materials/MaterialExpressionComment.h"
 #include "Materials/MaterialExpressionNamedReroute.h"
 #include "Materials/MaterialExpressionRerouteBase.h" // TraceInputsToRealExpression — graph validation
+#include "HaybaMCPSeh.h"                              // SEH guard for fault-prone recompile/PostEditChange
 #include "MaterialShared.h"  // FMaterialResource, GetCompileErrors (material_compile)
 #include "MaterialStatsCommon.h" // FMaterialStatsUtils::ExtractMatertialStatsInfo (material_compile optimization feedback)
 #include "MaterialStats.h"       // FShaderStatsInfo (MaterialEditor private; include path added in Build.cs)
@@ -1592,7 +1593,20 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCompile(const TSharedPtr<FJsonO
             return FHaybaHandlerResult::Ok(Bad);
         }
 
-        UMaterialEditingLibrary::UpdateMaterialFunction(Fn, nullptr);
+        // UpdateMaterialFunction recompiles the function + broadcasts editor
+        // notifications — same dead-Python-delegate AV risk as material recompile.
+        bool bFnCrashed = false;
+        HaybaSeh::RunGuarded(+[](void* P)
+        {
+            UMaterialEditingLibrary::UpdateMaterialFunction(static_cast<UMaterialFunction*>(P), nullptr);
+        }, Fn, bFnCrashed);
+        if (bFnCrashed)
+        {
+            TSharedPtr<FJsonObject> Bad = MakeShared<FJsonObject>();
+            Bad->SetBoolField(TEXT("saved"), false);
+            Bad->SetStringField(TEXT("crash_guarded"), TEXT("material_compile(function): native access violation during UpdateMaterialFunction — commonly a stale Python-registered editor delegate firing on a GC'd target. Editor kept alive by the SEH guard; function NOT saved."));
+            return FHaybaHandlerResult::Ok(Bad);
+        }
         FString FnSaveErr;
         const bool bFnSaved = HaybaPersistAsset(Fn, FnSaveErr);
         TSharedPtr<FJsonObject> FnOut = MakeShared<FJsonObject>();
@@ -1628,8 +1642,28 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCompile(const TSharedPtr<FJsonO
         }
     }
 
-    Mat->PostEditChange();
-    UMaterialEditingLibrary::RecompileMaterial(Mat);
+    // PostEditChange + RecompileMaterial broadcast editor change notifications
+    // (FCoreUObjectDelegates, MaterialEditor). If a Python script registered a
+    // delegate whose target was since garbage-collected/destroyed, that broadcast
+    // dereferences freed memory — a native access violation that would kill the
+    // editor (not a catchable C++/Python exception). Guard it.
+    {
+        bool bCompileCrashed = false;
+        HaybaSeh::RunGuarded(+[](void* P)
+        {
+            UMaterial* M = static_cast<UMaterial*>(P);
+            M->PostEditChange();
+            UMaterialEditingLibrary::RecompileMaterial(M);
+        }, Mat, bCompileCrashed);
+        if (bCompileCrashed)
+        {
+            TSharedPtr<FJsonObject> Bad = MakeShared<FJsonObject>();
+            Bad->SetBoolField(TEXT("saved"), false);
+            Bad->SetBoolField(TEXT("has_errors"), true);
+            Bad->SetStringField(TEXT("crash_guarded"), TEXT("material_compile: native access violation during recompile/PostEditChange — commonly a stale Python-registered editor delegate firing on a garbage-collected target, or a re-entrant property broadcast. The editor was kept alive by the SEH guard and the material was NOT saved. Do not register UE editor delegates from python_run whose targets can be GC'd."));
+            return FHaybaHandlerResult::Ok(Bad);
+        }
+    }
 
     TArray<TSharedPtr<FJsonValue>> Errs;
     FMaterialResource* Res = Mat->GetMaterialResource(GMaxRHIShaderPlatform);
@@ -1659,7 +1693,17 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCompile(const TSharedPtr<FJsonO
         // ExtractMatertialStatsInfo is MATERIALEDITOR_API-exported; it internally
         // calls GetRepresentativeInstructionCounts (which is not exported).
         FShaderStatsInfo Info;
-        FMaterialStatsUtils::ExtractMatertialStatsInfo(GMaxRHIShaderPlatform, Info, Res);
+        // Also MaterialEditor — guard it; on a fault Info stays empty and the
+        // loops below just emit empty stats (never crashes the editor).
+        {
+            struct FStatsCtx { FShaderStatsInfo* I; FMaterialResource* R; } Ctx{ &Info, Res };
+            bool bStatsCrashed = false;
+            HaybaSeh::RunGuarded(+[](void* P)
+            {
+                FStatsCtx* C = static_cast<FStatsCtx*>(P);
+                FMaterialStatsUtils::ExtractMatertialStatsInfo(GMaxRHIShaderPlatform, *C->I, C->R);
+            }, &Ctx, bStatsCrashed);
+        }
 
         // Local name map — FMaterialStatsUtils::RepresentativeShaderTypeToString is
         // not exported to plugins (link error), so map the (small, stable) enum here.

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPSeh.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPSeh.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "CoreMinimal.h"
+
+// Structured-exception guard for native calls that can fault the process.
+//
+// Some synchronous editor operations we invoke (RecompileMaterial,
+// PostEditChange, stat extraction, …) broadcast change notifications that can
+// reach a stale/destroyed callback — most often a Python-registered editor
+// delegate whose target was garbage-collected — and dereference freed memory.
+// That is a C-level access violation, NOT a C++/Python exception, so try/catch
+// cannot stop it: it takes the whole editor down. RunGuarded wraps the call in
+// Windows SEH and converts such a fault into a reported flag, keeping the
+// editor alive.
+//
+// The thunk takes a void* context so callers can pass a CAPTURELESS lambda
+// (which converts to a function pointer). TFunctionRef cannot be used: MSVC
+// C2712 forbids C++ object unwinding across __try, and even a TFunctionRef
+// parameter trips it on the 14.50 toolchain. Non-Windows runs the thunk directly.
+namespace HaybaSeh
+{
+    void RunGuarded(void (*Thunk)(void*), void* Context, bool& bOutCrashed);
+}


### PR DESCRIPTION
## Crash
`EXCEPTION_ACCESS_VIOLATION` — `MatCompile()` → `RecompileMaterial`/`PostEditChange` → `MaterialEditor` → `CoreUObject` → **python311**.

## Cause
The recompile broadcasts editor change notifications. If a `python_run` script registered a UE editor delegate whose target was since **garbage-collected/destroyed**, the broadcast dereferences freed memory — a native access violation, not a catchable C++/Python exception, so it took the whole editor down. Same class as the `python_run` AV (#283), different uncovered call site.

## Fix
- New reusable **`HaybaSeh::RunGuarded`** (`Public/HaybaMCPSeh.h` + private cpp): wraps a captureless thunk in Windows SEH, converting a structured exception into a reported flag. Raw-pointer/`void*` signature (no `TFunctionRef`) to satisfy MSVC **C2712** on the 14.50 toolchain.
- `material_compile` now guards the three MaterialEditor/CoreUObject calls: material **PostEditChange + RecompileMaterial**, the function-path **UpdateMaterialFunction**, and the **stat extraction** (`ExtractMatertialStatsInfo` — on fault `Info` stays empty → empty stats). A caught fault returns `{crash_guarded, saved:false}` with guidance ("don''t register UE editor delegates from python_run whose targets can be GC''d") instead of crashing.

Reusable so future fault-prone native call sites get the same protection.

## Verification
- `RunUAT BuildPlugin` (UE_5.7) — Result: Succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)