### PR TITLE
feat(material): surface named-reroute names in material_get_info

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -333,7 +333,7 @@ const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
       meta: materialGetInfoMeta,
       handler: materialGetInfoHandler,
       cost: 'low',
-      returns: "{kind, name, expressions:[{id,class,x,y,output_consumed,reachable_from_output,inputs:[{name,index,connected,from_node,from_output}],outputs:[{name,index}]}], dead_nodes:[{id,class}], comments} | instance:{kind,name,parent,parameters:[{name,type,value}]}. outputs[] gives a node's real output pin order (esp. MaterialFunctionCall, whose order follows FunctionOutput sort priority, NOT the visual layout) — wire from_output by these names/indices so multi-output nodes don't get swapped.",
+      returns: "{kind, name, expressions:[{id,class,x,y,output_consumed,reachable_from_output,reroute_name?,reroute_kind?,inputs:[{name,index,connected,from_node,from_output}],outputs:[{name,index}]}], dead_nodes:[{id,class}], comments} | instance:{kind,name,parent,parameters:[{name,type,value}]}. Named-reroute nodes report reroute_name + reroute_kind('declaration'|'usage') so you can bind a usage to a declaration WITHOUT scanning expressions in python. outputs[] gives a node's real output pin order (esp. MaterialFunctionCall, whose order follows FunctionOutput sort priority, NOT the visual layout) — wire from_output by these.",
       niche: M,
       schema: {
         path: z.string().min(1).describe('Path to the material or material instance to inspect'),

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -790,6 +790,21 @@ static TArray<TSharedPtr<FJsonValue>> SerializeMaterialExpressions(
         if (Consumed)  Entry->SetBoolField(TEXT("output_consumed"), Consumed->Contains(Expr));
         if (Reachable) Entry->SetBoolField(TEXT("reachable_from_output"), Reachable->Contains(Expr));
 
+        // Named-reroute variable name — the single most-hand-rolled thing in
+        // python_run (agents loop expressions reading variable_name to find a
+        // declaration to bind a usage to). Surface it directly: declarations
+        // report their own Name; usages report the name they resolve to.
+        if (const UMaterialExpressionNamedRerouteDeclaration* Decl = Cast<UMaterialExpressionNamedRerouteDeclaration>(Expr))
+        {
+            Entry->SetStringField(TEXT("reroute_name"), Decl->Name.ToString());
+            Entry->SetStringField(TEXT("reroute_kind"), TEXT("declaration"));
+        }
+        else if (const UMaterialExpressionNamedRerouteUsage* Usage = Cast<UMaterialExpressionNamedRerouteUsage>(Expr))
+        {
+            Entry->SetStringField(TEXT("reroute_name"), Usage->Declaration ? Usage->Declaration->Name.ToString() : FString());
+            Entry->SetStringField(TEXT("reroute_kind"), TEXT("usage"));
+        }
+
         TArray<TSharedPtr<FJsonValue>> Inputs;
         int32 InputIdx = 0;
         for (FExpressionInputIterator It{Expr}; It; ++It)


### PR DESCRIPTION
Driven by data: an archived 206-call ToolStream showed `python_run` was **100/206** calls, and the single biggest hand-rolled pattern (**35 scripts**) was looping a material''s `expressions` to read each `NamedRerouteDeclaration`''s name + position so a usage could be bound — pure introspection the API should provide.

`material_get_info` now reports per expression: **`reroute_name`** (the declaration''s `Name`; usages resolve to their declaration''s name) + **`reroute_kind`** (`"declaration"`|`"usage"`). Agents bind reroutes directly instead of scanning the graph in Python — eliminating the largest `python_run` cluster in the trace.

Verification: `tsc` clean · `RunUAT BuildPlugin` (UE_5.7) Succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)