### PR TITLE
feat(pcg): mesh-bond refinements + HaybaOpening helpers

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGMeshBond.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGMeshBond.cpp
@@ -16,17 +16,17 @@ FText UPCGMeshBondSettings::GetDefaultNodeTitle() const { return LOCTEXT("Title"
 FText UPCGMeshBondSettings::GetNodeTooltipText() const
 {
     return LOCTEXT("Tooltip",
-        "Bonds two dynamic meshes: cuts an opening in each wherever the other passes "
-        "through (once, twice, or N times) and merges them into one connected space. "
-        "The geometry half of Socket Bond, without the constraint solver.");
+        "Bonds N dynamic meshes on one pin: cuts an opening in each wherever another "
+        "crosses it (once, twice, N times) and merges them all into one connected space. "
+        "Host/branch-free; the geometry of Socket Bond without the constraint solver.");
 }
 #endif
 
 TArray<FPCGPinProperties> UPCGMeshBondSettings::InputPinProperties() const
 {
     TArray<FPCGPinProperties> Pins;
-    Pins.Emplace(FName(TEXT("A")), EPCGDataType::DynamicMesh, /*bAllowMultiple=*/false, /*bAllowMultipleData=*/false);
-    Pins.Emplace(FName(TEXT("B")), EPCGDataType::DynamicMesh, /*bAllowMultiple=*/false, /*bAllowMultipleData=*/false);
+    // One pin that accepts N shells (every spline's swept mesh) — host/branch-free.
+    Pins.Emplace(FName(TEXT("Meshes")), EPCGDataType::DynamicMesh, /*bAllowMultiple=*/true, /*bAllowMultipleData=*/true);
     return Pins;
 }
 
@@ -45,28 +45,33 @@ bool FPCGMeshBondElement::ExecuteInternal(FPCGContext* Context) const
     TRACE_CPUPROFILER_EVENT_SCOPE(FPCGMeshBondElement::Execute);
     check(Context);
 
-    FDynamicMesh3 A;
+    // Collect every shell on the Meshes pin (one per spline).
+    TArray<FDynamicMesh3> Meshes;
     TArray<UMaterialInterface*> Materials;
     TSet<FString> Tags;
-    if (!HaybaPCGMesh::CopyFirstMesh(Context, FName(TEXT("A")), A, &Materials, &Tags))
+    for (const FPCGTaggedData& D : Context->InputData.GetInputsByPin(FName(TEXT("Meshes"))))
     {
-        // No A to anchor on — pass B through if present so the cook still emits.
-        FDynamicMesh3 B;
-        if (HaybaPCGMesh::CopyFirstMesh(Context, FName(TEXT("B")), B, &Materials, &Tags))
+        const UPCGDynamicMeshData* DM = Cast<UPCGDynamicMeshData>(D.Data);
+        if (!DM) { continue; }
+        const UDynamicMesh* UM = DM->GetDynamicMesh();
+        if (!UM) { continue; }
+        Meshes.Add(UM->GetMeshRef());   // copy
+        if (Materials.IsEmpty())
         {
-            HaybaPCGMesh::Emit(Context, MoveTemp(B), Materials, Tags);
+            for (const TObjectPtr<UMaterialInterface>& M : DM->GetMaterials()) { Materials.Add(M); }
         }
-        return true;
+        Tags.Append(D.Tags);
     }
-
-    FDynamicMesh3 B;
-    if (HaybaPCGMesh::CopyFirstMesh(Context, FName(TEXT("B")), B))
+    if (Meshes.Num() == 0)
     {
-        // Trims each mesh by the other's bounds + merges; A becomes the bonded result.
-        HaybaOpening::CutSocket(A, B, HaybaOpening::FSocketCut{});
+        return true;   // nothing to bond
     }
 
-    HaybaPCGMesh::Emit(Context, MoveTemp(A), Materials, Tags);
+    // Cut openings at every crossing + merge into one connected mesh (N-way).
+    FDynamicMesh3 Out;
+    HaybaOpening::BondMeshes(Out, Meshes, HaybaOpening::ESeamStyle::Welded);
+
+    HaybaPCGMesh::Emit(Context, MoveTemp(Out), Materials, Tags);
     return true;
 }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaOpening.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/HaybaOpening.h
@@ -41,6 +41,17 @@ namespace HaybaOpening
         return FDynamicMesh3(&Gen);
     }
 
+    // A clean CLOSED box mesh from an arbitrary axis-aligned box (TrimInside cutter).
+    inline UE::Geometry::FDynamicMesh3 BoxMeshFromAABB(const UE::Geometry::FAxisAlignedBox3d& B)
+    {
+        using namespace UE::Geometry;
+        FGridBoxMeshGenerator Gen;
+        Gen.Box = FOrientedBox3d(FFrame3d(B.Center()), B.Extents());
+        Gen.EdgeVertices = FIndex3i(1, 1, 1);
+        Gen.Generate();
+        return FDynamicMesh3(&Gen);
+    }
+
     // Trim away the part of A that lies inside the closed cutter Cutter (in place).
     inline void TrimInsideBy(UE::Geometry::FDynamicMesh3& A, const UE::Geometry::FDynamicMesh3& Cutter)
     {
@@ -83,6 +94,58 @@ namespace HaybaOpening
         }
         FMeshNormals::QuickRecomputeOverlayNormals(Host);
         return Host.TriangleCount();
+    }
+
+    // Bond N open shells into one connected space — the host/branch-free generalization
+    // of CutSocket. For every pair whose bounds overlap, trim BOTH shells by the OVERLAP
+    // box (localized to the crossing, unlike CutSocket's full-bounds trim which only
+    // suits a short branch): each shell gets an opening where another crosses it and the
+    // overlapping interiors are removed so the spaces merge. Then append all + weld.
+    // Writes the merged mesh into Out; returns its triangle count.
+    inline int32 BondMeshes(UE::Geometry::FDynamicMesh3& Out,
+                            const TArray<UE::Geometry::FDynamicMesh3>& Meshes, ESeamStyle Seam)
+    {
+        using namespace UE::Geometry;
+        const int32 N = Meshes.Num();
+        if (N == 0) { return 0; }
+        if (N == 1) { Out = Meshes[0]; return Out.TriangleCount(); }
+
+        TArray<FAxisAlignedBox3d> Boxes;
+        Boxes.Reserve(N);
+        for (const FDynamicMesh3& M : Meshes) { Boxes.Add(M.GetBounds()); }
+
+        TArray<FDynamicMesh3> Work = Meshes;   // copies we trim per crossing
+        for (int32 i = 0; i < N; ++i)
+        {
+            for (int32 j = 0; j < N; ++j)
+            {
+                if (i == j) { continue; }
+                const FAxisAlignedBox3d& A  = Boxes[i];
+                const FAxisAlignedBox3d& Bx = Boxes[j];
+                const FVector3d Mn(FMath::Max(A.Min.X, Bx.Min.X), FMath::Max(A.Min.Y, Bx.Min.Y), FMath::Max(A.Min.Z, Bx.Min.Z));
+                const FVector3d Mx(FMath::Min(A.Max.X, Bx.Max.X), FMath::Min(A.Max.Y, Bx.Max.Y), FMath::Min(A.Max.Z, Bx.Max.Z));
+                if (Mn.X < Mx.X && Mn.Y < Mx.Y && Mn.Z < Mx.Z)   // non-empty overlap
+                {
+                    const FDynamicMesh3 OverlapBox = BoxMeshFromAABB(FAxisAlignedBox3d(Mn, Mx));
+                    TrimInsideBy(Work[i], OverlapBox);
+                }
+            }
+        }
+
+        Out = Work[0];
+        FDynamicMeshEditor Editor(&Out);
+        for (int32 i = 1; i < N; ++i)
+        {
+            FMeshIndexMappings Map;
+            Editor.AppendMesh(&Work[i], Map);
+        }
+        if (Seam != ESeamStyle::ButtJoint)
+        {
+            FMergeCoincidentMeshEdges Merge(&Out);
+            Merge.Apply();
+        }
+        FMeshNormals::QuickRecomputeOverlayNormals(Out);
+        return Out.TriangleCount();
     }
 
     inline int32 PunchDoorway(UE::Geometry::FDynamicMesh3& Mesh, const FTransform& BondXf,

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGMeshBond.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGMeshBond.h
@@ -1,6 +1,6 @@
-// Generic mesh primitive: bond two dynamic meshes — cut an opening in each wherever
-// the other passes through (once, twice, or N times) and merge them into one connected
-// space. The geometry half of Socket Bond, decoupled from the constraint solver.
+// Generic mesh primitive: bond N dynamic meshes — cut an opening in each wherever
+// another passes through it (once, twice, N times) and merge them all into one
+// connected space. Host/branch-free N-way geometry; the solver-free half of Socket Bond.
 #pragma once
 
 #include "PCGSettings.h"


### PR DESCRIPTION
Captures the in-progress PCG mesh work that was sitting uncommitted in the working tree.

- `HaybaOpening.h` — +63 lines of opening/cut helper declarations
- `PCGMeshBond.cpp` / `.h` — mesh-bond node refinements

Build-clean: these files were part of the editor-target rebuild that just succeeded (loading the rest of the session''s toolkit work). Left open for review — this is in-progress PCG node work, not a finished feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)