### PR TITLE
feat(mesh): mesh_list_dynamic — enumerate scene DynamicMeshComponents

### DIFF
--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -58,6 +58,21 @@
       "has_ts_wrapper": false,
       "notes": "Stats-only alias of mesh_extract (raw geometry arrays forced off). Use to get a fast weld/winding/holes verdict: non_manifold_vertices==0 && degenerate_triangles==0 && connected_components==1 && a small explainable boundary_edges == healthy."
     },
+    "mesh_list_dynamic": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPStaticMeshHandler::MeshListDynamic",
+      "params": [
+        { "name": "label_contains", "type": "string", "required": false, "description": "Only list components on actors whose label contains this substring" }
+      ],
+      "returns": { "shape": "object", "fields": [
+        { "name": "dynamic_meshes", "type": "array", "description": "[{actor_label, component, triangles, vertices, num_materials, empty}]" },
+        { "name": "count", "type": "number" },
+        { "name": "total_triangles", "type": "number" }
+      ] },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Enumerate every UDynamicMeshComponent in the editor level with tri/vert/material counts — replaces the hand-rolled 'loop all actors -> DynamicMeshComponent -> tris' python_run for inspecting PCG/grammar output. Pair with mesh_topology_stats(actor_label=...) for a full weld/manifold verdict on a specific one."
+    },
     "object_get_property": {
       "aliases": [],
       "handler_cpp": "FHaybaMCPAssetHandler::ObjectGetProperty",

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPStaticMeshHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPStaticMeshHandler.cpp
@@ -32,7 +32,8 @@ TArray<FString> FHaybaMCPStaticMeshHandler::GetCommands() const
         TEXT("mesh_set_lod"),
         TEXT("mesh_list"),
         TEXT("mesh_extract"),
-        TEXT("mesh_topology_stats")
+        TEXT("mesh_topology_stats"),
+        TEXT("mesh_list_dynamic")
     };
 }
 
@@ -520,6 +521,59 @@ static FHaybaHandlerResult MeshExtract(const TSharedPtr<FJsonObject>& P, bool bS
     return FHaybaHandlerResult::Ok(Out);
 }
 
+// ---------------------------------------------------------------------------
+// mesh_list_dynamic — enumerate every UDynamicMeshComponent in the editor level
+// with tri/vert/material counts. Replaces the hand-rolled "loop all level actors
+// -> get_components_by_class(DynamicMeshComponent) -> print tris" python_run that
+// agents run constantly to inspect PCG / grammar output.
+// ---------------------------------------------------------------------------
+static FHaybaHandlerResult MeshListDynamic(const TSharedPtr<FJsonObject>& P)
+{
+#if WITH_EDITOR
+    if (!GEditor) return FHaybaHandlerResult::Err(TEXT("mesh_list_dynamic: GEditor is null"));
+    UWorld* World = GEditor->GetEditorWorldContext().World();
+    if (!World) return FHaybaHandlerResult::Err(TEXT("mesh_list_dynamic: no editor world"));
+
+    FString LabelContains;
+    if (P.IsValid()) P->TryGetStringField(TEXT("label_contains"), LabelContains);
+
+    TArray<TSharedPtr<FJsonValue>> Items;
+    int32 TotalTris = 0;
+    for (TActorIterator<AActor> It(World); It; ++It)
+    {
+        AActor* A = *It;
+        if (!A) continue;
+        if (!LabelContains.IsEmpty() && !A->GetActorLabel().Contains(LabelContains)) continue;
+        TArray<UDynamicMeshComponent*> Comps;
+        A->GetComponents(Comps);
+        for (UDynamicMeshComponent* C : Comps)
+        {
+            if (!C) continue;
+            UDynamicMesh* DM = C->GetDynamicMesh();
+            const int32 Tris  = DM ? DM->GetMeshRef().TriangleCount() : 0;
+            const int32 Verts = DM ? DM->GetMeshRef().VertexCount()   : 0;
+            TotalTris += Tris;
+            TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>();
+            E->SetStringField(TEXT("actor_label"), A->GetActorLabel());
+            E->SetStringField(TEXT("component"), C->GetName());
+            E->SetNumberField(TEXT("triangles"), Tris);
+            E->SetNumberField(TEXT("vertices"), Verts);
+            E->SetNumberField(TEXT("num_materials"), C->GetNumMaterials());
+            E->SetBoolField(TEXT("empty"), Tris == 0);
+            Items.Add(MakeShared<FJsonValueObject>(E.ToSharedRef()));
+        }
+    }
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetArrayField(TEXT("dynamic_meshes"), Items);
+    Out->SetNumberField(TEXT("count"), Items.Num());
+    Out->SetNumberField(TEXT("total_triangles"), TotalTris);
+    return FHaybaHandlerResult::Ok(Out);
+#else
+    return FHaybaHandlerResult::Err(TEXT("mesh_list_dynamic: editor-only"));
+#endif
+}
+
 FHaybaHandlerResult FHaybaMCPStaticMeshHandler::Handle(const FString& Cmd, const TSharedPtr<FJsonObject>& Params)
 {
     if (Cmd == TEXT("mesh_get_info")) return MeshGetInfo(Params);
@@ -527,5 +581,6 @@ FHaybaHandlerResult FHaybaMCPStaticMeshHandler::Handle(const FString& Cmd, const
     if (Cmd == TEXT("mesh_list"))     return MeshList(Params);
     if (Cmd == TEXT("mesh_extract"))         return MeshExtract(Params, /*bStatsOnly=*/false);
     if (Cmd == TEXT("mesh_topology_stats"))  return MeshExtract(Params, /*bStatsOnly=*/true);
+    if (Cmd == TEXT("mesh_list_dynamic"))    return MeshListDynamic(Params);
     return FHaybaHandlerResult::Err(FString::Printf(TEXT("StaticMeshHandler: unknown command %s"), *Cmd));
 }


### PR DESCRIPTION
From the 2026-06-26 ToolStream analysis: agents repeatedly hand-roll "loop all level actors → `get_components_by_class(DynamicMeshComponent)` → print tris" in `python_run` to inspect PCG/grammar output.

First-class command: `mesh_list_dynamic {label_contains?}` → `{dynamic_meshes:[{actor_label, component, triangles, vertices, num_materials, empty}], count, total_triangles}`. Pairs with `mesh_topology_stats(actor_label=...)` for a full weld/manifold verdict on a specific one.

Verification: `lint:legacy-wrappers` OK (72 entries) · `RunUAT BuildPlugin` (UE_5.7) Succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to list dynamic mesh components in the editor.
  * Results now include mesh counts, triangle totals, and component details, with optional filtering by actor label.
  * The command is available for agent use and is routed through the existing command set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->