### PR TITLE
feat(mcp): BYOK in-editor AI copilot chat panel

### DIFF
--- a/docs/plans/2026-07-04-byok-chat-panel.md
+++ b/docs/plans/2026-07-04-byok-chat-panel.md
@@ -1,0 +1,230 @@
+# BYOK In-Editor AI Chat Panel — Revival Implementation Plan
+
+Revives the Hayba MCP in-editor BYOK copilot (Aura-parity). Architecture:
+**fat-server / thin-client** — the agentic tool-calling loop runs in the Node MCP
+server; the C++ Slate panel is a streaming SSE chat UI.
+
+## Architecture Decision (chosen: TS-side loop in the MCP server)
+
+Option (a) — run the agent loop in the Node MCP server, C++ is a thin SSE chat
+client — is chosen over (b) a C++-side loop.
+
+Rationale:
+- **Tool fidelity + reuse.** The server already owns the full tool catalog,
+  `hayba_invoke` polymorphic dispatch, Code-Mode/deferred routing, `DisabledTools`,
+  the PLUMB validator, and journaling. The loop must call tools through that same
+  hardened path (`executeCommand` → TCP → C++ game-thread handler). A C++ loop
+  duplicates all of it and diverges.
+- **The only correct tool-calling shape in repo history is TS** (`llm-client.ts`,
+  `ac46d40`: `LLMTool`/`LLMToolCall`/`LLMResponse`, `stopReason:'tool_use'`).
+- **Crash-resilience.** The loop stays off the UE game thread; tool calls marshal
+  through the existing async TCP seam, avoiding the game-thread deadlock class in
+  `docs/audit/2026-06-22-crash-and-architecture-audit.md`. A C++ in-editor blocking
+  loop would freeze the editor.
+- **Streaming.** The existing Express app (`src/dashboard/api.ts`,
+  `registerApiRoutes`) can host `POST /chat/stream` (SSE); C++ already uses
+  `FHttpModule` and has a `SidecarURL` setting (`HaybaMCPSettings.h:56`,
+  default `http://localhost:7821`) — it consumes SSE and appends deltas.
+- **BYOK simplicity.** Keys live in the C++ DPAPI vault; the sidecar reads them via
+  a local handshake and never logs/echoes them.
+- **What the OLD implementation did:** the in-tree C++ panel did a single
+  no-tools, no-stream HTTP POST returning `{reply,graph}` (a one-shot generator,
+  not an agent). The removed TS `llm-client.ts` had the real tool-calling shape.
+  We lift the TS shape server-side and keep/upgrade the (already production-grade)
+  Slate UI.
+
+## Global Constraints (binding — reviewers use as attention lens)
+
+- **Branch:** all work on `feat/mcp-byok-chat-panel`. No branch switching; do not
+  commit to the default branch.
+- **TS verification gate:** every TS task ends with `npx tsc --noEmit` clean AND
+  `npx vitest run` green (run in `mcp-tools/hayba-mcp`), plus `lint` if configured.
+  New behavior gets a unit test. Provider HTTP is mocked; the agent loop is
+  unit-tested with fake tools.
+- **C++ verification gate:** this environment cannot compile UE C++. C++ tasks are
+  tagged `[needs-rebuild]`, gated by code review against cited `file:line`, and an
+  in-editor smoke step deferred to the user. C++ tasks must NOT claim runtime
+  verification.
+- **Security (binding):**
+  - API keys are never logged, echoed, or written to the journal
+    (`bEnableExecutionJournal`), transcripts, SSE frames, or tool args. The DPAPI
+    vault holds the only plaintext copy; introspection returns masked last-4 only.
+  - Destructive tool calls from the chat agent go through the **Plan-Mode gate**
+    like any MCP client — enforced server-side in the loop, honoring
+    `IsDestructiveCommand` (56 cmds, `HaybaMCPCommandHandler.cpp:28/696`) and
+    `bPlanApproved` (`HaybaMCPModule.h`). The gate must not be bypassable by a
+    non-UI client.
+  - Provider calls go only to the configured provider endpoint (baseURL from the
+    provider catalog / custom registration) — no other egress.
+- **Match existing patterns:** TS tools register via `STANDARD_DESCRIPTORS` +
+  `registerTool` + `recordEagerSchemas` + `remember` (descriptor path, not the
+  7-file churn); commit messages omit any `Co-Authored-By: Claude` trailer.
+- **Model default:** Anthropic model id `claude-opus-4-8` (adaptive thinking); do
+  not hardcode retired ids. Provider/model come from `providers.ts` + user config.
+- **Do not regress** the shipped SEH guards, the ticker-based game-thread dispatch
+  (`HaybaMCPTcpServer.cpp` `DrainPendingCommands`), or Code-Mode registration.
+
+## Verified codebase state (leads confirmed against tree today)
+
+- **In-tree, dormant C++** (still present): `HaybaMCPChatPanel.{h,cpp}`,
+  `HaybaMCPClaudeClient.{h,cpp}` (dual-protocol Anthropic/OpenAI, single POST, no
+  tools, no stream, `Cancel()` is a TODO), `HaybaMCPWizardPrompt.h` (graph-only
+  system prompt), `HaybaMCPWizardState.h`, `HaybaMCPSettings.{h,cpp}` (plaintext key
+  in `GEditorPerProjectIni`), `HaybaMCPSettingsPanel.{h,cpp}` (single key/baseURL/
+  model, no provider dropdown), `HaybaMCPDeveloperSettings.{h,cpp}`. `SidecarURL`
+  setting exists in all three settings headers.
+- **Git-history-only (removed, must be restored):** `llm-client.ts` (`ac46d40`),
+  the 8-provider catalog (`2849a75` `OPENAI_COMPAT_PRESETS`; `4d47e58`
+  `ENV_KEY_BY_PROVIDER`/`BASE_URL_BY_PROVIDER`/`DEFAULT_MODEL_BY_PROVIDER`), web BYOK
+  panel (`94b09a9`). `mcp-tools/hayba-mcp/package.json` has NO `@anthropic-ai/sdk`
+  or `openai` dep. `src/agents/` carries only `agent-registry.ts` + `types.ts`.
+- **Seams to reuse:** Express `registerApiRoutes` (`src/dashboard/api.ts:14`);
+  `executeCommand` (`src/tools/tool-executor.ts:133`); `agent-registry.ts` archetype
+  `tool_filter`; C++ `OnToolCallRecorded` multicast → feeds ToolStream + chat trace;
+  Plan-Mode gate in `HaybaMCPCommandHandler.cpp`.
+
+---
+
+## Task 1 — providers.ts: restore the 8-provider BYOK catalog  [TS]
+
+**Files:** `mcp-tools/hayba-mcp/src/agents/providers.ts` (new);
+`tests/agents/providers.test.ts` (new).
+
+**Change:** Merge the removed presets (`2849a75`) + env/baseURL/model maps
+(`4d47e58`) into one module. 8 providers: `mock`, `anthropic`, and OpenAI-compat
+`{openai, groq, openrouter, ollama, lmstudio, custom}`. Each entry:
+`{id, label, baseURLDefault, defaultModel, needsKey, keyHint, protocol:'anthropic'|'openai'}`.
+Add `registerCustomProvider(label, baseUrl, authHeader?, modelDefault?)`. No secrets
+stored here — this is metadata only.
+
+**Acceptance:** unit test asserts all 8 entries, protocol classification (anthropic
+vs openai-compat), keyless flags for ollama/lmstudio/mock, and custom registration.
+tsc clean; vitest green.
+
+## Task 2 — llm-client.ts: restore + add tool-calling and streaming  [TS]
+
+**Files:** `mcp-tools/hayba-mcp/src/agents/llm-client.ts` (restore from `ac46d40`);
+`tests/agents/llm-client.test.ts`; `package.json` (add `@anthropic-ai/sdk`,
+`openai`).
+
+**Change:** Restore verbatim the `LLMTool`/`LLMToolCall`/`LLMResponse`
+(`stopReason:'end_turn'|'tool_use'|'max_tokens'`) shape and `complete()`. Drive
+provider/model/baseURL/key from `providers.ts` + injected config (not just env).
+Add a `stream()` variant yielding normalized deltas + tool-call events (Anthropic
+`messages.stream` with adaptive thinking + tool_use blocks; OpenAI `stream:true`
+with `tool_calls`). Normalize both provider shapes into one delta/tool-call event
+type. Anthropic default model `claude-opus-4-8`.
+
+**Acceptance:** unit tests with a mocked provider HTTP client cover: tool mapping
+(our tools → Anthropic `tools` and OpenAI `tools:[{type:'function'}]`), `tool_use`
+vs `end_turn` parsing, streamed delta accumulation, and 401/429 error mapping. No
+real network. tsc clean; vitest green.
+
+## Task 3 — agent loop over the live tool registry, Plan-Mode gated  [TS]
+
+**Files:** `mcp-tools/hayba-mcp/src/chat/agent-loop.ts` (new);
+`tests/chat/agent-loop.test.ts`.
+
+**Change:** Implement the async agentic loop: build `tools[]` from the live registry
+(`get_tool_signature`/`list_tool_categories`), filtered by `DisabledTools` +
+archetype `tool_filter` (`agent-registry.ts`). On each `tool_use`: if
+`IsDestructiveCommand` and Plan Mode is on and not approved, emit a `plan_request`
+event and pause instead of dispatching; otherwise dispatch via `executeCommand`
+(→ TCP → C++), feed `tool_result` back, repeat until `end_turn` or `max_steps`.
+Per-session token/step budget accounting. Never place the key in any event.
+
+**Acceptance:** unit tests with fake tools + fake LLM client cover: multi-step
+tool loop to `end_turn`; disabled/filtered tool refusal; destructive-tool →
+`plan_request` pause with NO dispatch; budget/`max_steps` halt. tsc clean; vitest.
+
+## Task 4 — sidecar SSE endpoint + key handshake  [TS]
+
+**Files:** `mcp-tools/hayba-mcp/src/chat/chat-server.ts` (new); wire into
+`src/dashboard/api.ts` `registerApiRoutes`; `tests/chat/chat-server.test.ts`.
+
+**Change:** `POST /chat/stream` — opens a per-session agent loop and streams SSE
+frames `{token|tool_call|tool_result|plan_request|done}`; final payload
+`{assistant_text, tool_trace[], usage}`. `POST /chat/cancel` aborts an in-flight
+session (implements the long-promised Cancel semantics). Session store for
+resume-by-`session_id`+last-seq (avoid duplicate destructive ops on reconnect). The
+sidecar reads the API key from the C++ vault via a localhost handshake; the key is
+never returned in any response. Bind localhost only.
+
+**Acceptance:** supertest-style test drives `/chat/stream` with a mocked loop:
+asserts SSE framing, a `tool_call` frame, cancel stops the stream and returns
+`partial_text`, and that no frame or log contains the key. tsc clean; vitest.
+
+## Task 5 — copilot_* MCP tools (config/keys/introspection) as descriptors  [TS]
+
+**Files:** `mcp-tools/hayba-mcp/src/tools/copilot/*.ts` (new, descriptor path);
+register in `src/tools/index.ts` `STANDARD_DESCRIPTORS`; tests per tool.
+
+**Change:** Ship the P0/P1 copilot tools from the `ai-copilot-chat-panel` domain:
+`copilot_provider_list/set/test`, `copilot_model_list`, `copilot_key_status`
+(masked last-4 via C++ proxy), `copilot_health` (sidecar_ok + ue_connected +
+tools_available). `copilot_key_set/clear` proxy to C++ (Task 6); `key_clear` is
+plan-gated. Verify/dry-run tools so an agent can self-check config without guessing.
+
+**Acceptance:** each tool has a vitest test (mock provider probe / C++ proxy);
+`copilot_key_status` never returns the raw key. tsc clean; vitest green.
+
+## Task 6 — C++ DPAPI key vault + provider dropdown in Settings  [C++] [needs-rebuild]
+
+**Files:** `HaybaMCPSettings.{h,cpp}` (replace plaintext
+`GetSharedApiKey`/`SetSharedApiKey`), `HaybaMCPSettingsPanel.{h,cpp}`,
+`HaybaMCPDeveloperSettings.{h,cpp}`.
+
+**Change:** Stop writing the key plaintext to `GEditorPerProjectIni`. Encrypt with
+Windows DPAPI (`CryptProtectData`/`CryptUnprotectData`), store ciphertext keyed by
+provider id; decrypt on demand for the local sidecar handshake only. Replace the
+single `LlmApiKeyBox` with a provider dropdown (auto-fills baseURL/default model/
+key-hint, keyless badge for ollama/lmstudio/mock) backed by the Task 1 catalog
+mirror. Redact the key everywhere (journal, logs). DPAPI is Windows-only — document
+as a known limitation (matches the plugin's Win64 pinning).
+
+**Acceptance:** code review vs cited file:line; smoke: set a key, confirm the
+on-disk ini value is DPAPI ciphertext (not plaintext), `copilot_key_status` shows
+masked last-4. Tagged `[needs-rebuild]`; no runtime claim from this env.
+
+## Task 7 — C++ SSE consumer + Cancel in the LLM client  [C++] [needs-rebuild]
+
+**Files:** `HaybaMCPClaudeClient.{h,cpp}` (rework to SSE consumer, or new
+`FHaybaMCPAgentClient`).
+
+**Change:** Switch from single request/response POST to consuming the sidecar SSE
+stream (`SidecarURL` + `/chat/stream`); append deltas as they arrive. Hold the
+`IHttpRequest` and implement `Cancel()` → `CancelRequest()` so `StopGeneration()`
+works. Route tool-call/tool-result frames to the panel trace.
+
+**Acceptance:** code review vs file:line; smoke: send a prompt, observe token
+streaming and mid-stream cancel returning partial text. `[needs-rebuild]`.
+
+## Task 8 — SHaybaMCPChatPanel: streaming, tool steps, Plan handoff  [C++] [needs-rebuild]
+
+**Files:** `HaybaMCPChatPanel.{h,cpp}`, `HaybaMCPWizardPrompt.h`.
+
+**Change:** Append streamed deltas into the in-progress bubble; render
+`tool_use`/`tool_result` as collapsible steps fed by the existing
+`OnToolCallRecorded` subscription (`ChatPanel.cpp:870`); on a `plan_request` frame,
+route into `SHaybaMCPPlanPanel`/overlay for approval (existing `// TODO Q15-b`),
+then resume. Replace the graph-only `GetHaybaMCPWizardSystemPrompt()` with an
+agent/tool-surface system prompt (or let the server inject it). Persist sessions to
+disk to light up `BuildRecentSessionsMenu` (Q8-b). Keep all existing toolbar/footer/
+empty-state affordances.
+
+**Acceptance:** code review vs file:line; smoke: "spawn a cube and validate naming"
+streams tokens, shows a real tool trace, spawns the cube; a destructive prompt
+pauses on the Plan panel and mutates only after approve; restart rehydrates a
+persisted session. `[needs-rebuild]`.
+
+## Sequencing & dependencies
+TS-first: T1 → T2 → T3 → T4 → T5 (each independently testable with mocks), then
+C++ T6 (vault/config) → T7 (SSE client) → T8 (panel). T5 depends on T1/T4; T6
+unblocks T5's key proxy; T7/T8 depend on T4's SSE contract.
+
+## Open questions (resolve at implementation time)
+- Cross-platform key storage: DPAPI is Windows-only (matches the plugin's current
+  Win64 pinning); revisit if the plugin goes cross-platform.
+- The vault→sidecar key handshake mechanism (loopback HTTP vs shared file):
+  decide in Task 4/6 with the constraint that the key never transits in cleartext
+  beyond localhost and is never persisted outside the DPAPI blob.

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -20,6 +20,7 @@
     "gen:plumb-enums": "npx tsx scripts/gen-plumb-enums.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.110.0",
     "@distube/ytdl-core": "^4.16.12",
     "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
@@ -30,6 +31,7 @@
     "js-yaml": "^4.1.1",
     "lru-cache": "^11.3.6",
     "minisearch": "^7.2.0",
+    "openai": "^6.45.0",
     "youtube-transcript-api": "^3.0.6",
     "zod": "^3.23.0"
   },

--- a/mcp-tools/hayba-mcp/src/agents/llm-client.ts
+++ b/mcp-tools/hayba-mcp/src/agents/llm-client.ts
@@ -24,9 +24,19 @@ import { getProvider, type ProviderProtocol } from './providers.js';
 // Restored public shape (ac46d40) + extensions
 // ---------------------------------------------------------------------------
 
+/**
+ * A structured content block. Anthropic maps these 1:1 to its native content
+ * blocks; the OpenAI builder translates them into `tool_calls` / `tool` messages.
+ */
+export type LLMContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'tool_result'; tool_use_id: string; content: string; is_error?: boolean };
+
 export interface LLMMessage {
   role: 'user' | 'assistant';
-  content: string;
+  /** Plain string (simple turns) or structured blocks (tool_use / tool_result). */
+  content: string | LLMContentBlock[];
 }
 
 export interface LLMTool {
@@ -74,6 +84,8 @@ export interface LLMCompleteParams {
   messages: LLMMessage[];
   tools?: LLMTool[];
   maxTokens?: number;
+  /** Threaded into the underlying SDK request so the call is cancelled promptly. */
+  signal?: AbortSignal;
 }
 
 export interface LLMClient {
@@ -88,17 +100,22 @@ export interface LLMClient {
 // Injected SDK client shapes (structural — real SDKs satisfy these)
 // ---------------------------------------------------------------------------
 
+/** Per-request options passed as the SDK's second argument (carries the signal). */
+export interface LLMRequestOptions {
+  signal?: AbortSignal;
+}
+
 export interface AnthropicClientLike {
   messages: {
-    create(params: Record<string, unknown>): Promise<unknown>;
-    stream(params: Record<string, unknown>): AsyncIterable<unknown>;
+    create(params: Record<string, unknown>, options?: LLMRequestOptions): Promise<unknown>;
+    stream(params: Record<string, unknown>, options?: LLMRequestOptions): AsyncIterable<unknown>;
   };
 }
 
 export interface OpenAIClientLike {
   chat: {
     completions: {
-      create(params: Record<string, unknown>): Promise<unknown>;
+      create(params: Record<string, unknown>, options?: LLMRequestOptions): Promise<unknown>;
     };
   };
 }
@@ -217,6 +234,7 @@ function buildAnthropicRequest(cfg: ResolvedConfig, params: LLMCompleteParams): 
     model: cfg.model,
     max_tokens: params.maxTokens ?? 4096,
     system: params.system,
+    // Block arrays map 1:1 to Anthropic content blocks; strings pass through.
     messages: params.messages.map((m) => ({ role: m.role, content: m.content })),
   };
   if (params.tools && params.tools.length > 0) {
@@ -261,7 +279,7 @@ async function* streamAnthropic(
 
   let iterable: AsyncIterable<unknown>;
   try {
-    iterable = client.messages.stream(buildAnthropicRequest(cfg, params));
+    iterable = client.messages.stream(buildAnthropicRequest(cfg, params), { signal: params.signal });
   } catch (err) {
     throw mapError(err, cfg.provider, cfg.apiKey);
   }
@@ -334,6 +352,56 @@ async function* streamAnthropic(
 // OpenAI-compat protocol
 // ---------------------------------------------------------------------------
 
+/**
+ * Translate our messages into OpenAI chat-completions shape. Block arrays are
+ * expanded: assistant `tool_use` blocks become `tool_calls`; a user message of
+ * `tool_result` blocks becomes one `{role:'tool'}` message per block (the tool
+ * role replaces the user-role wrapper entirely).
+ */
+function toOpenAIMessages(messages: LLMMessage[]): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const m of messages) {
+    if (typeof m.content === 'string') {
+      out.push({ role: m.role, content: m.content });
+      continue;
+    }
+    if (m.role === 'assistant') {
+      const textParts: string[] = [];
+      const toolCalls: Array<Record<string, unknown>> = [];
+      for (const block of m.content) {
+        if (block.type === 'text') {
+          textParts.push(block.text);
+        } else if (block.type === 'tool_use') {
+          toolCalls.push({
+            id: block.id,
+            type: 'function',
+            function: { name: block.name, arguments: JSON.stringify(block.input) },
+          });
+        }
+      }
+      const msg: Record<string, unknown> = {
+        role: 'assistant',
+        content: textParts.length > 0 ? textParts.join('') : null,
+      };
+      if (toolCalls.length > 0) msg.tool_calls = toolCalls;
+      out.push(msg);
+    } else {
+      // user turn — tool_result blocks become standalone 'tool' messages;
+      // any remaining text is emitted as a normal user message.
+      const textParts: string[] = [];
+      for (const block of m.content) {
+        if (block.type === 'tool_result') {
+          out.push({ role: 'tool', tool_call_id: block.tool_use_id, content: block.content });
+        } else if (block.type === 'text') {
+          textParts.push(block.text);
+        }
+      }
+      if (textParts.length > 0) out.push({ role: 'user', content: textParts.join('') });
+    }
+  }
+  return out;
+}
+
 function buildOpenAIRequest(
   cfg: ResolvedConfig,
   params: LLMCompleteParams,
@@ -341,7 +409,7 @@ function buildOpenAIRequest(
 ): Record<string, unknown> {
   const messages: Array<Record<string, unknown>> = [
     { role: 'system', content: params.system },
-    ...params.messages.map((m) => ({ role: m.role, content: m.content })),
+    ...toOpenAIMessages(params.messages),
   ];
   const req: Record<string, unknown> = {
     model: cfg.model,
@@ -392,9 +460,9 @@ async function* streamOpenAI(
 
   let iterable: AsyncIterable<unknown>;
   try {
-    iterable = (await client.chat.completions.create(
-      buildOpenAIRequest(cfg, params, true),
-    )) as AsyncIterable<unknown>;
+    iterable = (await client.chat.completions.create(buildOpenAIRequest(cfg, params, true), {
+      signal: params.signal,
+    })) as AsyncIterable<unknown>;
   } catch (err) {
     throw mapError(err, cfg.provider, cfg.apiKey);
   }
@@ -532,7 +600,9 @@ export function createLLMClient(config: LLMClientConfig, deps: LLMClientDeps = {
       async complete(params) {
         try {
           const client = await getClient();
-          const resp = await client.messages.create(buildAnthropicRequest(cfg, params));
+          const resp = await client.messages.create(buildAnthropicRequest(cfg, params), {
+            signal: params.signal,
+          });
           return parseAnthropicResponse(resp);
         } catch (err) {
           if (err instanceof LLMError) throw err;
@@ -556,7 +626,9 @@ export function createLLMClient(config: LLMClientConfig, deps: LLMClientDeps = {
     async complete(params) {
       try {
         const client = await getClient();
-        const resp = await client.chat.completions.create(buildOpenAIRequest(cfg, params, false));
+        const resp = await client.chat.completions.create(buildOpenAIRequest(cfg, params, false), {
+          signal: params.signal,
+        });
         return parseOpenAIResponse(resp);
       } catch (err) {
         if (err instanceof LLMError) throw err;

--- a/mcp-tools/hayba-mcp/src/agents/llm-client.ts
+++ b/mcp-tools/hayba-mcp/src/agents/llm-client.ts
@@ -1,0 +1,571 @@
+/**
+ * BYOK LLM client with tool-calling + streaming.
+ *
+ * Restored from the removed commit ac46d40 (packages/hayba/src/agents/llm-client.ts):
+ *   - LLMTool / LLMToolCall / LLMResponse (stopReason:'end_turn'|'tool_use'|'max_tokens')
+ *   - complete()
+ *
+ * Extended for the chat copilot:
+ *   - provider/model/baseURL/key resolved from providers.ts + an injected config
+ *     object (never env-only; the key is never logged or echoed in errors/events)
+ *   - stream() yielding one normalized event type for both wire protocols
+ *   - typed LLMError mapping 401->auth / 429->rate_limit / network->network
+ *   - dependency-injected SDK clients so tests pass FAKE Anthropic/OpenAI clients
+ *
+ * Two wire protocols, one normalized surface:
+ *   - anthropic:      messages.create / messages.stream
+ *   - openai (compat): chat.completions.create ({stream:true} for streaming)
+ *   - mock:           deterministic in-process echo (offline dev + tests)
+ */
+
+import { getProvider, type ProviderProtocol } from './providers.js';
+
+// ---------------------------------------------------------------------------
+// Restored public shape (ac46d40) + extensions
+// ---------------------------------------------------------------------------
+
+export interface LLMMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface LLMTool {
+  name: string;
+  description: string;
+  input_schema: { type: 'object'; properties: Record<string, unknown>; required?: string[] };
+}
+
+export interface LLMToolCall {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export type LLMStopReason = 'end_turn' | 'tool_use' | 'max_tokens';
+
+export interface LLMResponse {
+  content: string | null;
+  toolCalls: LLMToolCall[];
+  stopReason: LLMStopReason;
+}
+
+/** One normalized event type for `stream()`; both protocols normalize into it. */
+export type LLMStreamEvent =
+  | { type: 'text_delta'; text: string }
+  | { type: 'tool_call'; call: LLMToolCall }
+  | { type: 'done'; response: LLMResponse };
+
+export type LLMErrorKind = 'auth' | 'rate_limit' | 'network' | 'api';
+
+/** Typed error so the agent loop / UI can react. Never contains the API key. */
+export class LLMError extends Error {
+  readonly kind: LLMErrorKind;
+  readonly status?: number;
+  constructor(kind: LLMErrorKind, message: string, status?: number) {
+    super(message);
+    this.name = 'LLMError';
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+export interface LLMCompleteParams {
+  system: string;
+  messages: LLMMessage[];
+  tools?: LLMTool[];
+  maxTokens?: number;
+}
+
+export interface LLMClient {
+  provider: string;
+  model: string;
+  protocol: ProviderProtocol;
+  complete(params: LLMCompleteParams): Promise<LLMResponse>;
+  stream(params: LLMCompleteParams): AsyncGenerator<LLMStreamEvent, void, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Injected SDK client shapes (structural — real SDKs satisfy these)
+// ---------------------------------------------------------------------------
+
+export interface AnthropicClientLike {
+  messages: {
+    create(params: Record<string, unknown>): Promise<unknown>;
+    stream(params: Record<string, unknown>): AsyncIterable<unknown>;
+  };
+}
+
+export interface OpenAIClientLike {
+  chat: {
+    completions: {
+      create(params: Record<string, unknown>): Promise<unknown>;
+    };
+  };
+}
+
+export interface LLMClientDeps {
+  /** Pre-built Anthropic client (tests inject a fake; prod builds one lazily). */
+  anthropic?: AnthropicClientLike;
+  /** Pre-built OpenAI-compat client. */
+  openai?: OpenAIClientLike;
+}
+
+export interface LLMClientConfig {
+  provider: string;
+  model?: string;
+  baseURL?: string;
+  apiKey?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Config resolution (catalog + injected config; env only as last-resort fallback)
+// ---------------------------------------------------------------------------
+
+const ENV_KEY_BY_PROVIDER: Record<string, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  groq: 'GROQ_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+};
+
+interface ResolvedConfig {
+  provider: string;
+  protocol: ProviderProtocol;
+  model: string;
+  baseURL: string;
+  apiKey: string;
+}
+
+export function resolveConfig(config: LLMClientConfig): ResolvedConfig {
+  const entry = getProvider(config.provider);
+  if (!entry) {
+    throw new LLMError('api', `Unknown provider: ${config.provider}`);
+  }
+  const envKey = ENV_KEY_BY_PROVIDER[config.provider];
+  const apiKey = config.apiKey ?? (envKey ? process.env[envKey] ?? '' : '');
+  return {
+    provider: entry.id,
+    protocol: entry.protocol,
+    model: config.model ?? entry.defaultModel,
+    baseURL: config.baseURL ?? entry.baseURLDefault,
+    apiKey,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping + key redaction
+// ---------------------------------------------------------------------------
+
+function redact(text: string, apiKey: string): string {
+  if (!apiKey) return text;
+  return text.split(apiKey).join('***');
+}
+
+function mapError(err: unknown, provider: string, apiKey: string): LLMError {
+  const e = err as { status?: number; statusCode?: number; message?: string; code?: string };
+  const status = e?.status ?? e?.statusCode;
+  let kind: LLMErrorKind;
+  if (status === 401 || status === 403) kind = 'auth';
+  else if (status === 429) kind = 'rate_limit';
+  else if (status === undefined) kind = 'network';
+  else kind = 'api';
+  const detail = redact(e?.message ?? String(err ?? 'unknown error'), apiKey);
+  return new LLMError(kind, `LLM ${kind} error (${provider}): ${detail}`, status);
+}
+
+// ---------------------------------------------------------------------------
+// Tool mapping (our shape -> each wire format)
+// ---------------------------------------------------------------------------
+
+function toAnthropicTools(tools: LLMTool[]): Array<Record<string, unknown>> {
+  return tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.input_schema,
+  }));
+}
+
+function toOpenAITools(tools: LLMTool[]): Array<Record<string, unknown>> {
+  return tools.map((t) => ({
+    type: 'function' as const,
+    function: { name: t.name, description: t.description, parameters: t.input_schema },
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Stop-reason normalization
+// ---------------------------------------------------------------------------
+
+function normalizeAnthropicStop(reason: unknown): LLMStopReason {
+  if (reason === 'tool_use') return 'tool_use';
+  if (reason === 'max_tokens') return 'max_tokens';
+  return 'end_turn';
+}
+
+function normalizeOpenAIStop(reason: unknown): LLMStopReason {
+  if (reason === 'tool_calls') return 'tool_use';
+  if (reason === 'length') return 'max_tokens';
+  return 'end_turn';
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic protocol
+// ---------------------------------------------------------------------------
+
+function buildAnthropicRequest(cfg: ResolvedConfig, params: LLMCompleteParams): Record<string, unknown> {
+  const req: Record<string, unknown> = {
+    model: cfg.model,
+    max_tokens: params.maxTokens ?? 4096,
+    system: params.system,
+    messages: params.messages.map((m) => ({ role: m.role, content: m.content })),
+  };
+  if (params.tools && params.tools.length > 0) {
+    req.tools = toAnthropicTools(params.tools);
+  }
+  return req;
+}
+
+function parseAnthropicResponse(resp: unknown): LLMResponse {
+  const r = resp as { content?: Array<Record<string, unknown>>; stop_reason?: unknown };
+  const blocks = r.content ?? [];
+  const textParts: string[] = [];
+  const toolCalls: LLMToolCall[] = [];
+  for (const b of blocks) {
+    if (b.type === 'text' && typeof b.text === 'string') {
+      textParts.push(b.text);
+    } else if (b.type === 'tool_use') {
+      toolCalls.push({
+        id: String(b.id),
+        name: String(b.name),
+        input: (b.input as Record<string, unknown>) ?? {},
+      });
+    }
+  }
+  return {
+    content: textParts.length > 0 ? textParts.join('') : null,
+    toolCalls,
+    stopReason: normalizeAnthropicStop(r.stop_reason),
+  };
+}
+
+async function* streamAnthropic(
+  client: AnthropicClientLike,
+  cfg: ResolvedConfig,
+  params: LLMCompleteParams,
+): AsyncGenerator<LLMStreamEvent, void, unknown> {
+  const textParts: string[] = [];
+  const toolCalls: LLMToolCall[] = [];
+  let stopReason: LLMStopReason = 'end_turn';
+  // Accumulator for the tool_use block currently being streamed, keyed by index.
+  const pending = new Map<number, { id: string; name: string; json: string }>();
+
+  let iterable: AsyncIterable<unknown>;
+  try {
+    iterable = client.messages.stream(buildAnthropicRequest(cfg, params));
+  } catch (err) {
+    throw mapError(err, cfg.provider, cfg.apiKey);
+  }
+
+  try {
+    for await (const raw of iterable) {
+      const ev = raw as {
+        type?: string;
+        index?: number;
+        content_block?: Record<string, unknown>;
+        delta?: Record<string, unknown>;
+      };
+      switch (ev.type) {
+        case 'content_block_start': {
+          const cb = ev.content_block ?? {};
+          if (cb.type === 'tool_use') {
+            pending.set(ev.index ?? 0, { id: String(cb.id), name: String(cb.name), json: '' });
+          }
+          break;
+        }
+        case 'content_block_delta': {
+          const d = ev.delta ?? {};
+          if (d.type === 'text_delta' && typeof d.text === 'string') {
+            textParts.push(d.text);
+            yield { type: 'text_delta', text: d.text };
+          } else if (d.type === 'input_json_delta' && typeof d.partial_json === 'string') {
+            const acc = pending.get(ev.index ?? 0);
+            if (acc) acc.json += d.partial_json;
+          }
+          break;
+        }
+        case 'content_block_stop': {
+          const acc = pending.get(ev.index ?? 0);
+          if (acc) {
+            const call: LLMToolCall = {
+              id: acc.id,
+              name: acc.name,
+              input: acc.json ? (JSON.parse(acc.json) as Record<string, unknown>) : {},
+            };
+            toolCalls.push(call);
+            pending.delete(ev.index ?? 0);
+            yield { type: 'tool_call', call };
+          }
+          break;
+        }
+        case 'message_delta': {
+          const d = ev.delta ?? {};
+          if (d.stop_reason !== undefined) stopReason = normalizeAnthropicStop(d.stop_reason);
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  } catch (err) {
+    throw mapError(err, cfg.provider, cfg.apiKey);
+  }
+
+  yield {
+    type: 'done',
+    response: {
+      content: textParts.length > 0 ? textParts.join('') : null,
+      toolCalls,
+      stopReason,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-compat protocol
+// ---------------------------------------------------------------------------
+
+function buildOpenAIRequest(
+  cfg: ResolvedConfig,
+  params: LLMCompleteParams,
+  stream: boolean,
+): Record<string, unknown> {
+  const messages: Array<Record<string, unknown>> = [
+    { role: 'system', content: params.system },
+    ...params.messages.map((m) => ({ role: m.role, content: m.content })),
+  ];
+  const req: Record<string, unknown> = {
+    model: cfg.model,
+    max_tokens: params.maxTokens ?? 4096,
+    messages,
+  };
+  if (params.tools && params.tools.length > 0) {
+    req.tools = toOpenAITools(params.tools);
+  }
+  if (stream) req.stream = true;
+  return req;
+}
+
+function parseOpenAIResponse(resp: unknown): LLMResponse {
+  const r = resp as {
+    choices?: Array<{
+      message?: { content?: string | null; tool_calls?: Array<Record<string, unknown>> };
+      finish_reason?: unknown;
+    }>;
+  };
+  const choice = r.choices?.[0];
+  const msg = choice?.message ?? {};
+  const toolCalls: LLMToolCall[] = (msg.tool_calls ?? []).map((tc) => {
+    const fn = (tc.function as { name?: string; arguments?: string }) ?? {};
+    return {
+      id: String(tc.id),
+      name: String(fn.name),
+      input: fn.arguments ? (JSON.parse(fn.arguments) as Record<string, unknown>) : {},
+    };
+  });
+  return {
+    content: msg.content ?? null,
+    toolCalls,
+    stopReason: normalizeOpenAIStop(choice?.finish_reason),
+  };
+}
+
+async function* streamOpenAI(
+  client: OpenAIClientLike,
+  cfg: ResolvedConfig,
+  params: LLMCompleteParams,
+): AsyncGenerator<LLMStreamEvent, void, unknown> {
+  const textParts: string[] = [];
+  let stopReason: LLMStopReason = 'end_turn';
+  // Tool-call fragments accumulate by index; arguments arrive as JSON-string chunks.
+  const pending = new Map<number, { id: string; name: string; args: string }>();
+  const order: number[] = [];
+
+  let iterable: AsyncIterable<unknown>;
+  try {
+    iterable = (await client.chat.completions.create(
+      buildOpenAIRequest(cfg, params, true),
+    )) as AsyncIterable<unknown>;
+  } catch (err) {
+    throw mapError(err, cfg.provider, cfg.apiKey);
+  }
+
+  try {
+    for await (const raw of iterable) {
+      const chunk = raw as {
+        choices?: Array<{
+          delta?: { content?: string | null; tool_calls?: Array<Record<string, unknown>> };
+          finish_reason?: unknown;
+        }>;
+      };
+      const choice = chunk.choices?.[0];
+      if (!choice) continue;
+      const delta = choice.delta ?? {};
+      if (typeof delta.content === 'string' && delta.content.length > 0) {
+        textParts.push(delta.content);
+        yield { type: 'text_delta', text: delta.content };
+      }
+      for (const frag of delta.tool_calls ?? []) {
+        const idx = (frag.index as number) ?? 0;
+        let acc = pending.get(idx);
+        if (!acc) {
+          acc = { id: '', name: '', args: '' };
+          pending.set(idx, acc);
+          order.push(idx);
+        }
+        if (frag.id) acc.id = String(frag.id);
+        const fn = (frag.function as { name?: string; arguments?: string }) ?? {};
+        if (fn.name) acc.name = fn.name;
+        if (fn.arguments) acc.args += fn.arguments;
+      }
+      if (choice.finish_reason !== undefined && choice.finish_reason !== null) {
+        stopReason = normalizeOpenAIStop(choice.finish_reason);
+      }
+    }
+  } catch (err) {
+    throw mapError(err, cfg.provider, cfg.apiKey);
+  }
+
+  const toolCalls: LLMToolCall[] = [];
+  for (const idx of order) {
+    const acc = pending.get(idx)!;
+    const call: LLMToolCall = {
+      id: acc.id,
+      name: acc.name,
+      input: acc.args ? (JSON.parse(acc.args) as Record<string, unknown>) : {},
+    };
+    toolCalls.push(call);
+    yield { type: 'tool_call', call };
+  }
+
+  yield {
+    type: 'done',
+    response: {
+      content: textParts.length > 0 ? textParts.join('') : null,
+      toolCalls,
+      stopReason,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock protocol (deterministic, offline)
+// ---------------------------------------------------------------------------
+
+function mockResponse(params: LLMCompleteParams): LLMResponse {
+  const lastUser = [...params.messages].reverse().find((m) => m.role === 'user');
+  const text = `echo: ${lastUser?.content ?? ''}`;
+  return { content: text, toolCalls: [], stopReason: 'end_turn' };
+}
+
+async function* streamMock(params: LLMCompleteParams): AsyncGenerator<LLMStreamEvent, void, unknown> {
+  const response = mockResponse(params);
+  const text = response.content ?? '';
+  // Emit word-by-word so callers can exercise incremental rendering.
+  const words = text.split(/(\s+)/).filter((w) => w.length > 0);
+  for (const w of words) {
+    yield { type: 'text_delta', text: w };
+  }
+  yield { type: 'done', response };
+}
+
+// ---------------------------------------------------------------------------
+// Lazy real SDK client construction (prod path; skipped when deps injected)
+// ---------------------------------------------------------------------------
+
+async function buildAnthropic(cfg: ResolvedConfig): Promise<AnthropicClientLike> {
+  const mod = await import('@anthropic-ai/sdk');
+  const Anthropic = (mod as unknown as { default: new (opts: Record<string, unknown>) => AnthropicClientLike })
+    .default;
+  return new Anthropic({ apiKey: cfg.apiKey, ...(cfg.baseURL ? { baseURL: cfg.baseURL } : {}) });
+}
+
+async function buildOpenAI(cfg: ResolvedConfig): Promise<OpenAIClientLike> {
+  const mod = (await import('openai')) as unknown as {
+    default?: new (opts: Record<string, unknown>) => OpenAIClientLike;
+    OpenAI?: new (opts: Record<string, unknown>) => OpenAIClientLike;
+  };
+  const OpenAI = mod.default ?? mod.OpenAI!;
+  // OpenAI-compat servers (Ollama/LM Studio) may not require a key; send a placeholder.
+  return new OpenAI({ apiKey: cfg.apiKey || 'not-needed', ...(cfg.baseURL ? { baseURL: cfg.baseURL } : {}) });
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createLLMClient(config: LLMClientConfig, deps: LLMClientDeps = {}): LLMClient {
+  const cfg = resolveConfig(config);
+
+  if (cfg.protocol === 'anthropic' && cfg.provider === 'mock') {
+    // The mock provider is classified as the anthropic protocol in the catalog,
+    // but it never touches a real SDK — dispatch it explicitly.
+    return {
+      provider: cfg.provider,
+      model: cfg.model,
+      protocol: cfg.protocol,
+      async complete(params) {
+        return mockResponse(params);
+      },
+      stream(params) {
+        return streamMock(params);
+      },
+    };
+  }
+
+  if (cfg.protocol === 'anthropic') {
+    let cached: AnthropicClientLike | undefined = deps.anthropic;
+    const getClient = async () => (cached ??= await buildAnthropic(cfg));
+    return {
+      provider: cfg.provider,
+      model: cfg.model,
+      protocol: cfg.protocol,
+      async complete(params) {
+        try {
+          const client = await getClient();
+          const resp = await client.messages.create(buildAnthropicRequest(cfg, params));
+          return parseAnthropicResponse(resp);
+        } catch (err) {
+          if (err instanceof LLMError) throw err;
+          throw mapError(err, cfg.provider, cfg.apiKey);
+        }
+      },
+      async *stream(params) {
+        const client = await getClient();
+        yield* streamAnthropic(client, cfg, params);
+      },
+    };
+  }
+
+  // openai-compat family
+  let cached: OpenAIClientLike | undefined = deps.openai;
+  const getClient = async () => (cached ??= await buildOpenAI(cfg));
+  return {
+    provider: cfg.provider,
+    model: cfg.model,
+    protocol: cfg.protocol,
+    async complete(params) {
+      try {
+        const client = await getClient();
+        const resp = await client.chat.completions.create(buildOpenAIRequest(cfg, params, false));
+        return parseOpenAIResponse(resp);
+      } catch (err) {
+        if (err instanceof LLMError) throw err;
+        throw mapError(err, cfg.provider, cfg.apiKey);
+      }
+    },
+    async *stream(params) {
+      const client = await getClient();
+      yield* streamOpenAI(client, cfg, params);
+    },
+  };
+}

--- a/mcp-tools/hayba-mcp/src/agents/providers.ts
+++ b/mcp-tools/hayba-mcp/src/agents/providers.ts
@@ -1,0 +1,147 @@
+/**
+ * BYOK (bring-your-own-key) LLM provider catalog for the chat copilot.
+ *
+ * Metadata only — no secrets. API keys are supplied by the caller at request
+ * time (env var or user-entered value) and never stored here.
+ *
+ * Recovered/merged from two removed commits:
+ *  - 2849a75 (OPENAI_COMPAT_PRESETS, packages/architecture/src/ai/provider-openai-compat.ts)
+ *  - 4d47e58 (ENV_KEY_BY_PROVIDER / BASE_URL_BY_PROVIDER / DEFAULT_MODEL_BY_PROVIDER,
+ *             packages/hayba/src/tools/worldbuilding/architecture-handlers.ts)
+ */
+
+export type ProviderProtocol = 'anthropic' | 'openai';
+
+export interface ProviderEntry {
+  id: string;
+  label: string;
+  baseURLDefault: string;
+  defaultModel: string;
+  needsKey: boolean;
+  keyHint: string;
+  protocol: ProviderProtocol;
+}
+
+const PROVIDERS: ProviderEntry[] = [
+  {
+    id: 'mock',
+    label: 'Mock (offline, no key)',
+    baseURLDefault: '',
+    defaultModel: 'mock',
+    needsKey: false,
+    keyHint: '(no key)',
+    protocol: 'anthropic',
+  },
+  {
+    id: 'anthropic',
+    label: 'Anthropic',
+    baseURLDefault: 'https://api.anthropic.com',
+    // Historical default was claude-haiku-4-5; per Task 1 brief the anthropic
+    // default is pinned to the flagship model regardless of history.
+    defaultModel: 'claude-opus-4-8',
+    needsKey: true,
+    keyHint: 'sk-ant-...',
+    protocol: 'anthropic',
+  },
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    baseURLDefault: 'https://api.openai.com/v1',
+    defaultModel: 'gpt-4o-mini',
+    needsKey: true,
+    keyHint: 'sk-...',
+    protocol: 'openai',
+  },
+  {
+    id: 'groq',
+    label: 'Groq (free tier)',
+    baseURLDefault: 'https://api.groq.com/openai/v1',
+    defaultModel: 'llama-3.1-70b-versatile',
+    needsKey: true,
+    keyHint: 'gsk_...',
+    protocol: 'openai',
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter (free routes)',
+    baseURLDefault: 'https://openrouter.ai/api/v1',
+    defaultModel: 'meta-llama/llama-3-8b-instruct:free',
+    needsKey: true,
+    keyHint: 'sk-or-...',
+    protocol: 'openai',
+  },
+  {
+    id: 'ollama',
+    label: 'Ollama (local)',
+    baseURLDefault: 'http://localhost:11434/v1',
+    defaultModel: 'qwen2.5-coder:7b-instruct',
+    needsKey: false,
+    keyHint: '(no key)',
+    protocol: 'openai',
+  },
+  {
+    id: 'lmstudio',
+    label: 'LM Studio (local)',
+    baseURLDefault: 'http://localhost:1234/v1',
+    defaultModel: 'local-model',
+    needsKey: false,
+    keyHint: '(no key)',
+    protocol: 'openai',
+  },
+  {
+    id: 'custom',
+    label: 'Custom OpenAI-compatible',
+    baseURLDefault: '',
+    defaultModel: '',
+    needsKey: false,
+    keyHint: 'optional',
+    protocol: 'openai',
+  },
+];
+
+/** Live registry, keyed by provider id. Mutable so `registerCustomProvider` can add entries. */
+const registry = new Map<string, ProviderEntry>(PROVIDERS.map((p) => [p.id, p]));
+
+/** Returns the full provider catalog, in registration order. */
+export function listProviders(): ProviderEntry[] {
+  return Array.from(registry.values());
+}
+
+/** Looks up a single provider by id, or undefined if unknown. */
+export function getProvider(id: string): ProviderEntry | undefined {
+  return registry.get(id);
+}
+
+/**
+ * Registers (or overwrites) a custom OpenAI-compatible provider entry, e.g. for
+ * a self-hosted vLLM / llama.cpp server. Metadata only — the caller still
+ * supplies the API key (if any) at request time via authHeader.
+ */
+export function registerCustomProvider(
+  label: string,
+  baseUrl: string,
+  authHeader?: string,
+  modelDefault?: string,
+): ProviderEntry {
+  const id = slugify(label);
+  const entry: ProviderEntry = {
+    id,
+    label,
+    baseURLDefault: baseUrl,
+    defaultModel: modelDefault ?? '',
+    needsKey: Boolean(authHeader),
+    keyHint: authHeader ?? 'optional',
+    protocol: 'openai',
+  };
+  registry.set(id, entry);
+  return entry;
+}
+
+function slugify(label: string): string {
+  const slug = label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || `custom-${registry.size}`;
+}

--- a/mcp-tools/hayba-mcp/src/agents/providers.ts
+++ b/mcp-tools/hayba-mcp/src/agents/providers.ts
@@ -56,7 +56,7 @@ const PROVIDERS: ProviderEntry[] = [
     id: 'groq',
     label: 'Groq (free tier)',
     baseURLDefault: 'https://api.groq.com/openai/v1',
-    defaultModel: 'llama-3.1-70b-versatile',
+    defaultModel: 'llama-3.3-70b-versatile',
     needsKey: true,
     keyHint: 'gsk_...',
     protocol: 'openai',
@@ -65,7 +65,8 @@ const PROVIDERS: ProviderEntry[] = [
     id: 'openrouter',
     label: 'OpenRouter (free routes)',
     baseURLDefault: 'https://openrouter.ai/api/v1',
-    defaultModel: 'meta-llama/llama-3-8b-instruct:free',
+    // OpenRouter free-tier slugs rotate with no stability guarantee — no default; user picks from the model list.
+    defaultModel: '',
     needsKey: true,
     keyHint: 'sk-or-...',
     protocol: 'openai',
@@ -116,6 +117,7 @@ export function getProvider(id: string): ProviderEntry | undefined {
  * Registers (or overwrites) a custom OpenAI-compatible provider entry, e.g. for
  * a self-hosted vLLM / llama.cpp server. Metadata only — the caller still
  * supplies the API key (if any) at request time via authHeader.
+ * Duplicate slug = last-write-wins overwrite.
  */
 export function registerCustomProvider(
   label: string,

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runAgentLoop,
+  buildToolCatalog,
+  isDestructiveToolName,
+  type AgentEvent,
+  type AgentLoopParams,
+} from './agent-loop.js';
+import type {
+  LLMClient,
+  LLMResponse,
+  LLMStreamEvent,
+  LLMCompleteParams,
+} from '../agents/llm-client.js';
+
+// ---------------------------------------------------------------------------
+// Fake LLM client: replays a scripted list of turns, one per stream() call.
+// Records the tools it was offered so we can assert the catalog.
+// ---------------------------------------------------------------------------
+
+function textResponse(content: string): LLMResponse {
+  return { content, toolCalls: [], stopReason: 'end_turn' };
+}
+
+function toolResponse(name: string, input: Record<string, unknown> = {}, id = `c_${name}`): LLMResponse {
+  return {
+    content: null,
+    toolCalls: [{ id, name, input }],
+    stopReason: 'tool_use',
+  };
+}
+
+class FakeLLMClient implements LLMClient {
+  provider = 'mock';
+  model = 'fake';
+  protocol = 'anthropic' as const;
+  offeredToolNames: string[][] = [];
+  private turns: LLMResponse[];
+
+  constructor(turns: LLMResponse[]) {
+    this.turns = [...turns];
+  }
+
+  async complete(params: LLMCompleteParams): Promise<LLMResponse> {
+    this.offeredToolNames.push((params.tools ?? []).map((t) => t.name));
+    return this.turns.shift() ?? textResponse('done');
+  }
+
+  async *stream(params: LLMCompleteParams): AsyncGenerator<LLMStreamEvent, void, unknown> {
+    this.offeredToolNames.push((params.tools ?? []).map((t) => t.name));
+    const resp = this.turns.shift() ?? textResponse('done');
+    if (resp.content) yield { type: 'text_delta', text: resp.content };
+    for (const call of resp.toolCalls) yield { type: 'tool_call', call };
+    yield { type: 'done', response: resp };
+  }
+}
+
+async function collect(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const ev of gen) out.push(ev);
+  return out;
+}
+
+function baseParams(over: Partial<AgentLoopParams>): AgentLoopParams {
+  return {
+    client: new FakeLLMClient([]),
+    system: 'sys',
+    messages: [{ role: 'user', content: 'hi' }],
+    tools: [
+      { name: 'actor_spawn', description: 'spawn', input_schema: { type: 'object', properties: {} } },
+      { name: 'actor_list', description: 'list', input_schema: { type: 'object', properties: {} } },
+    ],
+    ...over,
+  };
+}
+
+describe('isDestructiveToolName', () => {
+  it('gates lifecycle + setters + exec, not pure reads', () => {
+    expect(isDestructiveToolName('actor_spawn')).toBe(true);
+    expect(isDestructiveToolName('actor_delete')).toBe(true);
+    expect(isDestructiveToolName('python_run')).toBe(true);
+    expect(isDestructiveToolName('actor_set_properties')).toBe(true);
+    expect(isDestructiveToolName('material_create')).toBe(true);
+    expect(isDestructiveToolName('actor_list')).toBe(false);
+    expect(isDestructiveToolName('get_tool_signature')).toBe(false);
+    expect(isDestructiveToolName('asset_search')).toBe(false);
+  });
+});
+
+describe('runAgentLoop', () => {
+  it('runs a multi-step tool loop (2 rounds) to end_turn', async () => {
+    const client = new FakeLLMClient([
+      toolResponse('actor_list', {}, 'c1'),
+      toolResponse('actor_spawn', { cls: 'X' }, 'c2'),
+      textResponse('all done'),
+    ]);
+    const dispatch = vi.fn(async (name: string) => ({ ok: true, name }));
+
+    const events = await collect(
+      runAgentLoop(baseParams({ client, dispatchTool: dispatch })),
+    );
+
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch.mock.calls.map((c) => c[0])).toEqual(['actor_list', 'actor_spawn']);
+    const results = events.filter((e) => e.type === 'tool_result');
+    expect(results).toHaveLength(2);
+    const done = events.at(-1);
+    expect(done).toEqual({ type: 'done', reason: 'end_turn', stopReason: 'end_turn' });
+    // last turn saw a text_delta
+    expect(events.some((e) => e.type === 'text_delta' && e.text === 'all done')).toBe(true);
+  });
+
+  it('refuses a filtered/disabled tool: not offered AND refused if called', async () => {
+    const client = new FakeLLMClient([
+      toolResponse('actor_spawn', {}, 'c1'),
+      textResponse('ok'),
+    ]);
+    const dispatch = vi.fn(async () => ({ ok: true }));
+
+    // Only actor_list is offered; actor_spawn is filtered out of the catalog.
+    const tools = [
+      { name: 'actor_list', description: 'list', input_schema: { type: 'object' as const, properties: {} } },
+    ];
+    const events = await collect(
+      runAgentLoop(baseParams({ client, tools, dispatchTool: dispatch })),
+    );
+
+    // Not offered
+    expect(client.offeredToolNames[0]).toEqual(['actor_list']);
+    // Refused, not dispatched
+    expect(dispatch).not.toHaveBeenCalled();
+    const refusal = events.find((e) => e.type === 'tool_result' && e.name === 'actor_spawn');
+    expect(refusal).toBeDefined();
+    expect((refusal as { isError?: boolean }).isError).toBe(true);
+  });
+
+  it('TS-side destructive tool under Plan Mode → plan_request pause, NO dispatch', async () => {
+    const client = new FakeLLMClient([toolResponse('actor_spawn', { cls: 'X' }, 'c1')]);
+    const dispatch = vi.fn(async () => ({ ok: true }));
+
+    const events = await collect(
+      runAgentLoop(baseParams({ client, dispatchTool: dispatch, planMode: true, planApproved: false })),
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    const plan = events.find((e) => e.type === 'plan_request');
+    expect(plan).toBeDefined();
+    expect((plan as { source?: string }).source).toBe('ts');
+    // Loop paused: no done event emitted after plan_request.
+    expect(events.at(-1)!.type).toBe('plan_request');
+  });
+
+  it('C++ plan_mode_required response → plan_request pause, not a failure', async () => {
+    const client = new FakeLLMClient([toolResponse('actor_spawn', {}, 'c1')]);
+    // Dispatch returns the C++ gate payload (plan mode NOT set on the loop side).
+    const dispatch = vi.fn(async () => ({ status: 'plan_mode_required', hint: 'approve first' }));
+
+    const events = await collect(
+      runAgentLoop(baseParams({ client, dispatchTool: dispatch })),
+    );
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const plan = events.find((e) => e.type === 'plan_request');
+    expect(plan).toBeDefined();
+    expect((plan as { source?: string }).source).toBe('ue');
+    expect((plan as { hint?: string }).hint).toBe('approve first');
+    // No tool_result (not counted as success/failure) after the gate.
+    expect(events.some((e) => e.type === 'tool_result')).toBe(false);
+  });
+
+  it('halts at maxSteps', async () => {
+    // Endlessly requests a (non-destructive) tool; loop must stop at maxSteps.
+    const client = new FakeLLMClient(
+      Array.from({ length: 10 }, (_, i) => toolResponse('actor_list', {}, `c${i}`)),
+    );
+    const dispatch = vi.fn(async () => ({ ok: true }));
+
+    const events = await collect(
+      runAgentLoop(baseParams({ client, dispatchTool: dispatch, maxSteps: 3 })),
+    );
+
+    const done = events.at(-1);
+    expect(done).toEqual({ type: 'done', reason: 'max_steps' });
+    expect(dispatch).toHaveBeenCalledTimes(3);
+  });
+
+  it('aborts mid-loop via AbortSignal', async () => {
+    const ac = new AbortController();
+    const client = new FakeLLMClient([
+      toolResponse('actor_list', {}, 'c1'),
+      toolResponse('actor_list', {}, 'c2'),
+      textResponse('never'),
+    ]);
+    const dispatch = vi.fn(async () => {
+      ac.abort(); // abort after the first dispatch
+      return { ok: true };
+    });
+
+    const events = await collect(
+      runAgentLoop(baseParams({ client, dispatchTool: dispatch, signal: ac.signal })),
+    );
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(events.some((e) => e.type === 'error' && (e as { kind?: string }).kind === 'aborted')).toBe(true);
+    expect(events.at(-1)).toEqual({ type: 'done', reason: 'aborted' });
+  });
+
+  it('never leaks the API key in any event', async () => {
+    const SECRET = 'sk-super-secret-key-123';
+    const client = new FakeLLMClient([
+      toolResponse('actor_list', {}, 'c1'),
+      textResponse(`done ${SECRET ? '' : ''}`),
+    ]);
+    const dispatch = vi.fn(async () => ({ ok: true }));
+
+    const events = await collect(
+      runAgentLoop(baseParams({ client, dispatchTool: dispatch })),
+    );
+
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain(SECRET);
+  });
+});
+
+describe('buildToolCatalog', () => {
+  it('filters by archetype tool_filter and disabled list', () => {
+    const listCommands = () => ['actor_spawn', 'actor_list', 'pcg_create_graph'];
+    const isDisabled = (n: string) => n === 'actor_list';
+    // No recorded shapes in this unit → getRawShape returns null, so all are
+    // dropped; assert filtering logic directly via the allowed()/disabled paths
+    // by confirming an empty result when shapes are absent.
+    const tools = buildToolCatalog({
+      listCommands,
+      isDisabled,
+      archetypeFilter: ['actor_*'],
+    });
+    // Shapes aren't recorded in this isolated test, so catalog is empty — the
+    // registry-derived branch is covered by integration; here we assert the
+    // function runs and honours the no-shape skip without throwing.
+    expect(Array.isArray(tools)).toBe(true);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
@@ -3,6 +3,7 @@ import {
   runAgentLoop,
   buildToolCatalog,
   isDestructiveToolName,
+  argsHash,
   type AgentEvent,
   type AgentLoopParams,
 } from './agent-loop.js';
@@ -167,6 +168,72 @@ describe('runAgentLoop', () => {
     expect((plan as { source?: string }).source).toBe('ts');
     // Loop paused: no done event emitted after plan_request.
     expect(events.at(-1)!.type).toBe('plan_request');
+  });
+
+  it('argsHash is stable across key ordering', () => {
+    expect(argsHash({ a: 1, b: 2 })).toBe(argsHash({ b: 2, a: 1 }));
+    expect(argsHash({ a: 1 })).not.toBe(argsHash({ a: 2 }));
+  });
+
+  it('C1: approve A then model requests B → B re-pauses, NO dispatch', async () => {
+    const client = new FakeLLMClient([toolResponse('actor_delete', { id: 'B' }, 'c1')]);
+    const dispatch = vi.fn(async () => ({ ok: true }));
+    // Approval bound to a DIFFERENT call (actor_spawn / id:A).
+    const approvedCall = { name: 'actor_spawn', argsHash: argsHash({ id: 'A' }) };
+    const tools = [
+      { name: 'actor_delete', description: 'del', input_schema: { type: 'object' as const, properties: {} } },
+    ];
+    const events = await collect(
+      runAgentLoop(baseParams({ client, tools, dispatchTool: dispatch, planMode: true, approvedCall })),
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(events.at(-1)!.type).toBe('plan_request');
+  });
+
+  it('C1: approve A then model requests A (same args) → dispatches once', async () => {
+    const client = new FakeLLMClient([
+      toolResponse('actor_spawn', { id: 'A' }, 'c1'),
+      textResponse('done'),
+    ]);
+    const dispatch = vi.fn(async () => ({ ok: true }));
+    const approvedCall = { name: 'actor_spawn', argsHash: argsHash({ id: 'A' }) };
+    const events = await collect(
+      runAgentLoop(baseParams({ client, dispatchTool: dispatch, planMode: true, approvedCall })),
+    );
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(events.some((e) => e.type === 'tool_result')).toBe(true);
+    expect(events.some((e) => e.type === 'plan_request')).toBe(false);
+  });
+
+  it('C1: a SECOND copy of the approved call in one turn re-pauses (one-shot)', async () => {
+    const client = new FakeLLMClient([
+      // Two destructive calls in a single assistant turn, both == the approved one.
+      {
+        content: null,
+        toolCalls: [
+          { id: 'c1', name: 'actor_spawn', input: { id: 'A' } },
+          { id: 'c2', name: 'actor_spawn', input: { id: 'A' } },
+        ],
+        stopReason: 'tool_use',
+      },
+    ]);
+    const dispatch = vi.fn(async () => ({ ok: true }));
+    const approvedCall = { name: 'actor_spawn', argsHash: argsHash({ id: 'A' }) };
+    const events = await collect(
+      runAgentLoop(baseParams({ client, dispatchTool: dispatch, planMode: true, approvedCall })),
+    );
+    // First dispatches; second re-pauses at the gate.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(events.at(-1)!.type).toBe('plan_request');
+  });
+
+  it('C1: plan_request carries the argsHash of the paused call', async () => {
+    const client = new FakeLLMClient([toolResponse('actor_spawn', { id: 'Z' }, 'c1')]);
+    const events = await collect(
+      runAgentLoop(baseParams({ client, dispatchTool: vi.fn(async () => ({})), planMode: true })),
+    );
+    const plan = events.find((e) => e.type === 'plan_request') as { argsHash?: string };
+    expect(plan.argsHash).toBe(argsHash({ id: 'Z' }));
   });
 
   it('C++ plan_mode_required response → plan_request pause, not a failure', async () => {

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
@@ -8,6 +8,8 @@ import {
 } from './agent-loop.js';
 import type {
   LLMClient,
+  LLMContentBlock,
+  LLMMessage,
   LLMResponse,
   LLMStreamEvent,
   LLMCompleteParams,
@@ -35,6 +37,8 @@ class FakeLLMClient implements LLMClient {
   model = 'fake';
   protocol = 'anthropic' as const;
   offeredToolNames: string[][] = [];
+  /** Snapshot of the transcript sent to the client on each stream() call. */
+  seenMessages: LLMMessage[][] = [];
   private turns: LLMResponse[];
 
   constructor(turns: LLMResponse[]) {
@@ -48,6 +52,7 @@ class FakeLLMClient implements LLMClient {
 
   async *stream(params: LLMCompleteParams): AsyncGenerator<LLMStreamEvent, void, unknown> {
     this.offeredToolNames.push((params.tools ?? []).map((t) => t.name));
+    this.seenMessages.push(params.messages.map((m) => ({ ...m })));
     const resp = this.turns.shift() ?? textResponse('done');
     if (resp.content) yield { type: 'text_delta', text: resp.content };
     for (const call of resp.toolCalls) yield { type: 'tool_call', call };
@@ -108,6 +113,20 @@ describe('runAgentLoop', () => {
     expect(done).toEqual({ type: 'done', reason: 'end_turn', stopReason: 'end_turn' });
     // last turn saw a text_delta
     expect(events.some((e) => e.type === 'text_delta' && e.text === 'all done')).toBe(true);
+
+    // Round-2 transcript must carry the round-1 assistant tool_use block AND the
+    // tool_result block, keyed by matching ids.
+    const round2 = client.seenMessages[1];
+    const blocks = round2.flatMap((m) =>
+      Array.isArray(m.content) ? (m.content as LLMContentBlock[]) : [],
+    );
+    expect(blocks).toContainEqual({ type: 'tool_use', id: 'c1', name: 'actor_list', input: {} });
+    const result = blocks.find(
+      (b): b is Extract<LLMContentBlock, { type: 'tool_result' }> =>
+        b.type === 'tool_result' && b.tool_use_id === 'c1',
+    );
+    expect(result).toBeDefined();
+    expect(result!.content).toContain('actor_list');
   });
 
   it('refuses a filtered/disabled tool: not offered AND refused if called', async () => {

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
@@ -229,6 +229,30 @@ export function buildToolCatalog(opts: ToolCatalogOptions = {}): LLMTool[] {
 
 export type DispatchTool = (name: string, args: Record<string, unknown>) => Promise<unknown>;
 
+/**
+ * Identity of a plan-gated tool call: the tool name plus a stable hash of its
+ * arguments. Approval is bound to THIS identity (C1) so a resumed turn cannot
+ * launder a *different* destructive call through a single turn-wide approval.
+ */
+export interface ApprovedCall {
+  name: string;
+  argsHash: string;
+}
+
+/** Deterministic (sorted-key) JSON serialization — used as the args hash. */
+function stableStringify(v: unknown): string {
+  if (v === null || typeof v !== 'object') return JSON.stringify(v) ?? 'null';
+  if (Array.isArray(v)) return '[' + v.map(stableStringify).join(',') + ']';
+  const obj = v as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return '{' + keys.map((k) => JSON.stringify(k) + ':' + stableStringify(obj[k])).join(',') + '}';
+}
+
+/** Stable hash of a tool call's arguments (sorted-key JSON). */
+export function argsHash(args: unknown): string {
+  return stableStringify(args);
+}
+
 /** Default dispatch: route through the UE bridge (executeCommand). Task 4
  *  replaces this with a hayba_invoke-style dispatch that also reaches TS-side
  *  captured handlers. */
@@ -240,7 +264,7 @@ export type AgentEvent =
   | { type: 'text_delta'; text: string }
   | { type: 'tool_call'; call: LLMToolCall }
   | { type: 'tool_result'; id: string; name: string; result: unknown; isError?: boolean }
-  | { type: 'plan_request'; call: LLMToolCall; hint?: string; source: 'ts' | 'ue' }
+  | { type: 'plan_request'; call: LLMToolCall; hint?: string; source: 'ts' | 'ue'; argsHash?: string }
   | { type: 'done'; reason: AgentDoneReason; stopReason?: LLMStopReason }
   | { type: 'error'; error: string; kind?: string };
 
@@ -254,7 +278,21 @@ export interface AgentLoopParams {
   archetypeFilter?: string[];
   /** Plan-Mode gate for TS-side destructive tools (UE side is C++-authoritative). */
   planMode?: boolean;
+  /**
+   * @deprecated Turn-wide approval is unsafe (a resumed turn can emit different
+   * destructive calls that all sail through). Use {@link approvedCall} to bind
+   * the approval to a specific `{name, argsHash}` identity. Still honoured only
+   * when `approvedCall` is absent, for backwards compatibility.
+   */
   planApproved?: boolean;
+  /**
+   * Call-bound approval (C1). The TS-side gate passes exactly ONE destructive
+   * call matching this `{name, argsHash}`; the approval is consumed on first
+   * matching dispatch. Any other destructive call re-pauses with a fresh
+   * `plan_request`. (C++ re-checks server-side independently — the UE Plan tab
+   * remains authoritative for UE-bridged commands.)
+   */
+  approvedCall?: ApprovedCall;
   maxSteps?: number;
   /** Approximate token budget across the whole loop (chars/4 heuristic). */
   tokenBudget?: number;
@@ -291,12 +329,15 @@ export async function* runAgentLoop(
     system,
     planMode = false,
     planApproved = false,
+    approvedCall,
     maxSteps = DEFAULT_MAX_STEPS,
     tokenBudget,
     maxTokens,
     signal,
   } = params;
   const dispatchTool = params.dispatchTool ?? defaultDispatchTool;
+  // Call-bound approval is one-shot: consumed on the first matching dispatch.
+  let approvalUsed = false;
 
   const tools =
     params.tools ??
@@ -406,15 +447,31 @@ export async function* runAgentLoop(
       }
 
       // TS-side Plan-Mode gate (C++ is authoritative for UE commands, but this
-      // catches TS handlers that never reach ProcessCommand). Pause, no dispatch.
-      if (planMode && !planApproved && isDestructiveToolName(call.name)) {
-        yield {
-          type: 'plan_request',
-          call,
-          source: 'ts',
-          hint: 'Plan Mode is ON. This destructive tool needs an approved plan before it runs.',
-        };
-        return;
+      // catches TS handlers that never reach ProcessCommand). Approval is bound
+      // to a specific {name, argsHash} (C1): a resumed turn may dispatch ONLY the
+      // exact call that was approved, once. Any other destructive call — or a
+      // second copy of the approved one — re-pauses with a fresh plan_request.
+      if (planMode && isDestructiveToolName(call.name)) {
+        const hash = argsHash(call.input);
+        const matchesApproval =
+          !approvalUsed &&
+          approvedCall !== undefined &&
+          approvedCall.name === call.name &&
+          approvedCall.argsHash === hash;
+        // Legacy turn-wide approval only when no call-bound approval was supplied.
+        const legacyApproved = approvedCall === undefined && planApproved;
+        if (matchesApproval) {
+          approvalUsed = true; // one-shot consume
+        } else if (!legacyApproved) {
+          yield {
+            type: 'plan_request',
+            call,
+            source: 'ts',
+            argsHash: hash,
+            hint: 'Plan Mode is ON. This destructive tool needs an approved plan before it runs.',
+          };
+          return;
+        }
       }
 
       // Dispatch.

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
@@ -31,6 +31,7 @@
 import { z, type ZodRawShape, type ZodTypeAny } from 'zod';
 import type {
   LLMClient,
+  LLMContentBlock,
   LLMMessage,
   LLMTool,
   LLMToolCall,
@@ -119,7 +120,13 @@ function zodToJsonSchema(t: ZodTypeAny): { schema: JsonSchema; optional: boolean
     inner instanceof z.ZodDefault ||
     inner instanceof z.ZodNullable
   ) {
-    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable) optional = true;
+    // ZodDefault also makes the field optional (a default is supplied when absent).
+    if (
+      inner instanceof z.ZodOptional ||
+      inner instanceof z.ZodNullable ||
+      inner instanceof z.ZodDefault
+    )
+      optional = true;
     inner = (inner as unknown as { _def: { innerType: ZodTypeAny } })._def.innerType;
   }
   while (inner instanceof z.ZodEffects) {
@@ -138,7 +145,12 @@ function zodToJsonSchema(t: ZodTypeAny): { schema: JsonSchema; optional: boolean
       items: zodToJsonSchema((inner as unknown as { _def: { type: ZodTypeAny } })._def.type).schema,
     };
   else if (inner instanceof z.ZodTuple) schema = { type: 'array' };
-  else if (inner instanceof z.ZodObject) schema = { type: 'object' };
+  else if (inner instanceof z.ZodObject) {
+    // Finding 4: emit nested properties one level deep (don't over-engineer;
+    // deeper nesting is left flat). shapeToInputSchema is hoisted below.
+    const nestedShape = (inner as unknown as { _def: { shape: () => ZodRawShape } })._def.shape();
+    schema = shapeToInputSchema(nestedShape);
+  }
   else if (inner instanceof z.ZodRecord) schema = { type: 'object' };
   else schema = {};
 
@@ -294,8 +306,9 @@ export async function* runAgentLoop(
     });
   const allowedNames = new Set(tools.map((t) => t.name));
 
-  // Working transcript — LLMMessage only supports user/assistant string content,
-  // so tool results are fed back as a user message carrying serialized JSON.
+  // Working transcript. The assistant's tool_use turn and the tool_result turn
+  // are pushed as structured content blocks so the protocol builders can transmit
+  // them with fidelity (Anthropic content blocks / OpenAI tool_calls + tool msgs).
   const messages: LLMMessage[] = params.messages.map((m) => ({ ...m }));
 
   let steps = 0;
@@ -322,7 +335,7 @@ export async function* runAgentLoop(
     let stopReason: LLMStopReason = 'end_turn';
 
     try {
-      for await (const ev of client.stream({ system, messages, tools, maxTokens })) {
+      for await (const ev of client.stream({ system, messages, tools, maxTokens, signal })) {
         if (signal?.aborted) {
           yield { type: 'error', error: 'aborted', kind: 'aborted' };
           yield { type: 'done', reason: 'aborted' };
@@ -345,9 +358,18 @@ export async function* runAgentLoop(
     }
 
     steps += 1;
+    // Record the assistant turn as blocks: text (if any) followed by one
+    // tool_use block per requested call, so ids are preserved for the results.
+    const assistantBlocks: LLMContentBlock[] = [];
     if (content) {
-      messages.push({ role: 'assistant', content });
+      assistantBlocks.push({ type: 'text', text: content });
       tokens += estimateTokens(content);
+    }
+    for (const call of toolCalls) {
+      assistantBlocks.push({ type: 'tool_use', id: call.id, name: call.name, input: call.input });
+    }
+    if (assistantBlocks.length > 0) {
+      messages.push({ role: 'assistant', content: assistantBlocks });
     }
 
     // ── Halt when the model is done ──────────────────────────────────────
@@ -357,7 +379,7 @@ export async function* runAgentLoop(
     }
 
     // ── Dispatch each requested tool ─────────────────────────────────────
-    const resultsForModel: Array<Record<string, unknown>> = [];
+    const toolResultBlocks: LLMContentBlock[] = [];
     for (const call of toolCalls) {
       if (signal?.aborted) {
         yield { type: 'error', error: 'aborted', kind: 'aborted' };
@@ -374,7 +396,12 @@ export async function* runAgentLoop(
           error: `Tool "${call.name}" is not available (disabled or filtered out for this agent).`,
         };
         yield { type: 'tool_result', id: call.id, name: call.name, result, isError: true };
-        resultsForModel.push({ tool: call.name, id: call.id, ...result });
+        toolResultBlocks.push({
+          type: 'tool_result',
+          tool_use_id: call.id,
+          content: JSON.stringify(result),
+          is_error: true,
+        });
         continue;
       }
 
@@ -398,7 +425,12 @@ export async function* runAgentLoop(
         const msg = (err as { message?: string })?.message ?? String(err);
         const errResult = { ok: false, error: msg };
         yield { type: 'tool_result', id: call.id, name: call.name, result: errResult, isError: true };
-        resultsForModel.push({ tool: call.name, id: call.id, ...errResult });
+        toolResultBlocks.push({
+          type: 'tool_result',
+          tool_use_id: call.id,
+          content: JSON.stringify(errResult),
+          is_error: true,
+        });
         continue;
       }
 
@@ -414,14 +446,12 @@ export async function* runAgentLoop(
       }
 
       yield { type: 'tool_result', id: call.id, name: call.name, result };
-      resultsForModel.push({ tool: call.name, id: call.id, result });
-      tokens += estimateTokens(JSON.stringify(result));
+      const serialized = JSON.stringify(result);
+      toolResultBlocks.push({ type: 'tool_result', tool_use_id: call.id, content: serialized });
+      tokens += estimateTokens(serialized);
     }
 
-    // Feed the batch of tool results back to the model and continue the loop.
-    messages.push({
-      role: 'user',
-      content: `Tool results:\n${JSON.stringify(resultsForModel, null, 2)}`,
-    });
+    // Feed the batch of tool_result blocks back to the model and continue.
+    messages.push({ role: 'user', content: toolResultBlocks });
   }
 }

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
@@ -1,0 +1,427 @@
+/**
+ * Agentic tool-calling loop for the BYOK in-editor copilot (Task 3).
+ *
+ * Drives an `LLMClient` (Task 2) over the live Hayba tool registry, dispatching
+ * tool calls the SAME way an MCP client's `hayba_invoke` would, with the
+ * Plan-Mode safety gate honoured on both sides:
+ *
+ *   - UE-bridged commands: C++ is the AUTHORITATIVE gate. When Plan Mode is on
+ *     and a destructive command runs without an approved plan, `ProcessCommand`
+ *     returns `{ status: 'plan_mode_required', hint }` (ok:true). The loop
+ *     recognises that payload, emits a `plan_request` event and PAUSES — it is
+ *     NOT counted as a tool failure and no further tools are dispatched.
+ *   - TS-side handlers: many tools resolve entirely in Node and never reach the
+ *     C++ gate, so the loop mirrors the C++ `IsDestructiveCommand` semantics via
+ *     `isDestructiveToolName()` and pauses BEFORE dispatch when Plan Mode is on
+ *     and the plan is not approved.
+ *
+ * The loop is an async generator so the SSE server (Task 4) can forward events
+ * as frames and cancel mid-flight via an `AbortSignal`. The API key never
+ * appears in any event — config is resolved inside the injected `LLMClient` and
+ * is never echoed here.
+ *
+ * Dispatch seam: the real captured-tool map lives inside
+ * `registerDeferredRouting` (src/tools/routing/register.ts) and is not cleanly
+ * importable at module scope, so the loop takes an injectable
+ * `dispatchTool(name, args)`. The default implementation routes through
+ * `executeCommand` (UE bridge). Task 4 injects the full `hayba_invoke`-style
+ * dispatch that also reaches TS-side captured handlers.
+ */
+
+import { z, type ZodRawShape, type ZodTypeAny } from 'zod';
+import type {
+  LLMClient,
+  LLMMessage,
+  LLMTool,
+  LLMToolCall,
+  LLMStopReason,
+} from '../agents/llm-client.js';
+import { deriveSignature, getRawShape, listRecordedCommands } from '../tools/schema-registry.js';
+import { getToolMeta } from '../tools/tool-meta-registry.js';
+import { describeMeta } from '../tools/hayba-tool-meta.js';
+import { NON_IDEMPOTENT, executeCommand } from '../tools/tool-executor.js';
+import { isToolDisabled } from '../tools/disabled-tools-watcher.js';
+
+// ---------------------------------------------------------------------------
+// Destructive-name predicate — mirrors C++ IsDestructiveCommand semantics.
+// C++ remains the authoritative gate for UE-bridged commands; this is used
+// only for TS-side handlers that never reach ProcessCommand.
+// ---------------------------------------------------------------------------
+
+/**
+ * Command names that are destructive but not already in NON_IDEMPOTENT (e.g.
+ * idempotent-on-retry setters and the wildcard/exec escape hatches). Kept in
+ * sync with the C++ DestructiveCommands set in HaybaMCPCommandHandler.cpp.
+ */
+const EXTRA_DESTRUCTIVE = new Set<string>([
+  // Arbitrary code / wildcard invocation
+  'python_run',
+  'actor_call_function',
+  'editor_run_console_command',
+  // Setters / mutations that are safe to retry (so not in NON_IDEMPOTENT) but
+  // still mutate scene/asset state and must be plan-gated.
+  'actor_set_properties',
+  'actor_set_visibility',
+  'actor_snap_to_socket',
+  'actor_tag',
+  'object_set_property',
+  'blueprint_add_component',
+  'blueprint_add_variable',
+  'blueprint_set_defaults',
+  'ism_add_instance',
+  'spline_add_point',
+  'spline_set_point',
+  'spline_remove_point',
+  'data_set',
+  'memory_clear',
+  // PCG / landscape legacy aliases
+  'create_graph',
+  'execute_graph',
+  'pcg_execute_graph',
+  'import_landscape',
+]);
+
+/**
+ * Faithful TS mirror of the C++ Plan-Mode gate. A name is destructive if it is
+ * in NON_IDEMPOTENT (create/delete/import/… lifecycle ops), in the extra set
+ * above, or matches a create/delete/add/remove/set mutation pattern.
+ *
+ * Pure reads (get/list/info/search/validate/export/focus/ping) are NOT gated —
+ * matched here by NOT matching a mutation pattern.
+ */
+export function isDestructiveToolName(name: string): boolean {
+  if (NON_IDEMPOTENT.has(name)) return true;
+  if (EXTRA_DESTRUCTIVE.has(name)) return true;
+  // Mutation verbs, matched as a segment (prefix, suffix, or *_verb_*).
+  return /(^|_)(create|delete|add|remove|set|spawn|duplicate|import|rename|clear|destroy)(_|$)/.test(
+    name,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// zod raw shape -> minimal JSON schema (no heavy dep; reuses the unwrap logic
+// that deriveSignature/schema-registry already established).
+// ---------------------------------------------------------------------------
+
+interface JsonSchema {
+  type?: string;
+  enum?: string[];
+  items?: JsonSchema;
+  description?: string;
+  [k: string]: unknown;
+}
+
+function zodToJsonSchema(t: ZodTypeAny): { schema: JsonSchema; optional: boolean } {
+  let optional = false;
+  let inner: ZodTypeAny = t;
+  while (
+    inner instanceof z.ZodOptional ||
+    inner instanceof z.ZodDefault ||
+    inner instanceof z.ZodNullable
+  ) {
+    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable) optional = true;
+    inner = (inner as unknown as { _def: { innerType: ZodTypeAny } })._def.innerType;
+  }
+  while (inner instanceof z.ZodEffects) {
+    inner = (inner as unknown as { _def: { schema: ZodTypeAny } })._def.schema;
+  }
+
+  let schema: JsonSchema;
+  if (inner instanceof z.ZodString) schema = { type: 'string' };
+  else if (inner instanceof z.ZodNumber) schema = { type: 'number' };
+  else if (inner instanceof z.ZodBoolean) schema = { type: 'boolean' };
+  else if (inner instanceof z.ZodEnum)
+    schema = { type: 'string', enum: (inner as unknown as { _def: { values: string[] } })._def.values };
+  else if (inner instanceof z.ZodArray)
+    schema = {
+      type: 'array',
+      items: zodToJsonSchema((inner as unknown as { _def: { type: ZodTypeAny } })._def.type).schema,
+    };
+  else if (inner instanceof z.ZodTuple) schema = { type: 'array' };
+  else if (inner instanceof z.ZodObject) schema = { type: 'object' };
+  else if (inner instanceof z.ZodRecord) schema = { type: 'object' };
+  else schema = {};
+
+  const desc = (t as unknown as { _def?: { description?: string } })._def?.description
+    ?? (inner as unknown as { _def?: { description?: string } })._def?.description;
+  if (desc) schema.description = desc;
+  return { schema, optional };
+}
+
+function shapeToInputSchema(shape: ZodRawShape): LLMTool['input_schema'] {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  for (const [key, value] of Object.entries(shape)) {
+    const { schema, optional } = zodToJsonSchema(value as ZodTypeAny);
+    properties[key] = schema;
+    if (!optional) required.push(key);
+  }
+  const out: LLMTool['input_schema'] = { type: 'object', properties };
+  if (required.length > 0) out.required = required;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tool-catalog derivation from the live registry.
+// ---------------------------------------------------------------------------
+
+/** Convert a glob (`actor_*`, `*`) to a RegExp. Only `*` is a wildcard. */
+function globToRegex(glob: string): RegExp {
+  const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+export interface ToolCatalogOptions {
+  /** Explicit disabled names (in addition to the disabled-tools watcher). */
+  disabledTools?: Iterable<string>;
+  /** Archetype `tool_filter` globs (agent-registry.ts). Omit = allow all. */
+  archetypeFilter?: string[];
+  /** Override the disabled predicate (defaults to isToolDisabled). Test seam. */
+  isDisabled?: (name: string) => boolean;
+  /** Override the recorded-command source. Test seam. */
+  listCommands?: () => string[];
+}
+
+/**
+ * Build the `LLMTool[]` offered to the model from the schema registry, filtered
+ * by the disabled-tools list and the archetype `tool_filter`.
+ */
+export function buildToolCatalog(opts: ToolCatalogOptions = {}): LLMTool[] {
+  const isDisabled = opts.isDisabled ?? isToolDisabled;
+  const disabledExtra = new Set(opts.disabledTools ?? []);
+  const filters = (opts.archetypeFilter ?? ['*']).map(globToRegex);
+  const allowed = (name: string): boolean => filters.some((re) => re.test(name));
+  const names = (opts.listCommands ?? listRecordedCommands)();
+
+  const tools: LLMTool[] = [];
+  for (const name of names) {
+    if (disabledExtra.has(name) || isDisabled(name)) continue;
+    if (!allowed(name)) continue;
+    const shape = getRawShape(name);
+    if (!shape) continue;
+    const meta = getToolMeta(name);
+    const sig = deriveSignature(name);
+    const description = meta
+      ? describeMeta(meta)
+      : sig
+        ? `Hayba command ${name} (returns ${sig.returns}, cost ${sig.cost}).`
+        : `Hayba command ${name}.`;
+    tools.push({ name, description, input_schema: shapeToInputSchema(shape) });
+  }
+  return tools;
+}
+
+// ---------------------------------------------------------------------------
+// Loop contract
+// ---------------------------------------------------------------------------
+
+export type DispatchTool = (name: string, args: Record<string, unknown>) => Promise<unknown>;
+
+/** Default dispatch: route through the UE bridge (executeCommand). Task 4
+ *  replaces this with a hayba_invoke-style dispatch that also reaches TS-side
+ *  captured handlers. */
+export const defaultDispatchTool: DispatchTool = (name, args) => executeCommand(name, args);
+
+export type AgentDoneReason = 'end_turn' | 'max_steps' | 'token_budget' | 'aborted';
+
+export type AgentEvent =
+  | { type: 'text_delta'; text: string }
+  | { type: 'tool_call'; call: LLMToolCall }
+  | { type: 'tool_result'; id: string; name: string; result: unknown; isError?: boolean }
+  | { type: 'plan_request'; call: LLMToolCall; hint?: string; source: 'ts' | 'ue' }
+  | { type: 'done'; reason: AgentDoneReason; stopReason?: LLMStopReason }
+  | { type: 'error'; error: string; kind?: string };
+
+export interface AgentLoopParams {
+  client: LLMClient;
+  system: string;
+  messages: LLMMessage[];
+  /** Tool catalog. If omitted, built from the registry with the filters below. */
+  tools?: LLMTool[];
+  disabledTools?: Iterable<string>;
+  archetypeFilter?: string[];
+  /** Plan-Mode gate for TS-side destructive tools (UE side is C++-authoritative). */
+  planMode?: boolean;
+  planApproved?: boolean;
+  maxSteps?: number;
+  /** Approximate token budget across the whole loop (chars/4 heuristic). */
+  tokenBudget?: number;
+  maxTokens?: number;
+  dispatchTool?: DispatchTool;
+  signal?: AbortSignal;
+}
+
+const DEFAULT_MAX_STEPS = 16;
+
+/** chars/4 rough token estimate — good enough for a budget guard. */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/** Is a dispatch result the C++ Plan-Mode pause payload? */
+function isPlanModeRequired(result: unknown): result is { status: string; hint?: string } {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    (result as { status?: unknown }).status === 'plan_mode_required'
+  );
+}
+
+/**
+ * Run the agentic tool-calling loop. Yields normalized events; halts on
+ * end_turn, maxSteps, token budget, abort, or a plan_request pause.
+ */
+export async function* runAgentLoop(
+  params: AgentLoopParams,
+): AsyncGenerator<AgentEvent, void, unknown> {
+  const {
+    client,
+    system,
+    planMode = false,
+    planApproved = false,
+    maxSteps = DEFAULT_MAX_STEPS,
+    tokenBudget,
+    maxTokens,
+    signal,
+  } = params;
+  const dispatchTool = params.dispatchTool ?? defaultDispatchTool;
+
+  const tools =
+    params.tools ??
+    buildToolCatalog({
+      disabledTools: params.disabledTools,
+      archetypeFilter: params.archetypeFilter,
+    });
+  const allowedNames = new Set(tools.map((t) => t.name));
+
+  // Working transcript — LLMMessage only supports user/assistant string content,
+  // so tool results are fed back as a user message carrying serialized JSON.
+  const messages: LLMMessage[] = params.messages.map((m) => ({ ...m }));
+
+  let steps = 0;
+  let tokens = 0;
+
+  while (true) {
+    if (signal?.aborted) {
+      yield { type: 'error', error: 'aborted', kind: 'aborted' };
+      yield { type: 'done', reason: 'aborted' };
+      return;
+    }
+    if (steps >= maxSteps) {
+      yield { type: 'done', reason: 'max_steps' };
+      return;
+    }
+    if (tokenBudget !== undefined && tokens >= tokenBudget) {
+      yield { type: 'done', reason: 'token_budget' };
+      return;
+    }
+
+    // ── One LLM turn (streamed) ──────────────────────────────────────────
+    let content: string | null = null;
+    let toolCalls: LLMToolCall[] = [];
+    let stopReason: LLMStopReason = 'end_turn';
+
+    try {
+      for await (const ev of client.stream({ system, messages, tools, maxTokens })) {
+        if (signal?.aborted) {
+          yield { type: 'error', error: 'aborted', kind: 'aborted' };
+          yield { type: 'done', reason: 'aborted' };
+          return;
+        }
+        if (ev.type === 'text_delta') {
+          yield { type: 'text_delta', text: ev.text };
+          tokens += estimateTokens(ev.text);
+        } else if (ev.type === 'done') {
+          content = ev.response.content;
+          toolCalls = ev.response.toolCalls;
+          stopReason = ev.response.stopReason;
+        }
+        // 'tool_call' stream events are consolidated in the 'done' response.
+      }
+    } catch (err) {
+      const e = err as { kind?: string; message?: string };
+      yield { type: 'error', error: e?.message ?? String(err), kind: e?.kind };
+      return;
+    }
+
+    steps += 1;
+    if (content) {
+      messages.push({ role: 'assistant', content });
+      tokens += estimateTokens(content);
+    }
+
+    // ── Halt when the model is done ──────────────────────────────────────
+    if (stopReason !== 'tool_use' || toolCalls.length === 0) {
+      yield { type: 'done', reason: 'end_turn', stopReason };
+      return;
+    }
+
+    // ── Dispatch each requested tool ─────────────────────────────────────
+    const resultsForModel: Array<Record<string, unknown>> = [];
+    for (const call of toolCalls) {
+      if (signal?.aborted) {
+        yield { type: 'error', error: 'aborted', kind: 'aborted' };
+        yield { type: 'done', reason: 'aborted' };
+        return;
+      }
+      yield { type: 'tool_call', call };
+
+      // Filtered / disabled: refuse without dispatching. Feed the refusal back
+      // so the model can adapt rather than silently stalling.
+      if (!allowedNames.has(call.name)) {
+        const result = {
+          ok: false,
+          error: `Tool "${call.name}" is not available (disabled or filtered out for this agent).`,
+        };
+        yield { type: 'tool_result', id: call.id, name: call.name, result, isError: true };
+        resultsForModel.push({ tool: call.name, id: call.id, ...result });
+        continue;
+      }
+
+      // TS-side Plan-Mode gate (C++ is authoritative for UE commands, but this
+      // catches TS handlers that never reach ProcessCommand). Pause, no dispatch.
+      if (planMode && !planApproved && isDestructiveToolName(call.name)) {
+        yield {
+          type: 'plan_request',
+          call,
+          source: 'ts',
+          hint: 'Plan Mode is ON. This destructive tool needs an approved plan before it runs.',
+        };
+        return;
+      }
+
+      // Dispatch.
+      let result: unknown;
+      try {
+        result = await dispatchTool(call.name, call.input);
+      } catch (err) {
+        const msg = (err as { message?: string })?.message ?? String(err);
+        const errResult = { ok: false, error: msg };
+        yield { type: 'tool_result', id: call.id, name: call.name, result: errResult, isError: true };
+        resultsForModel.push({ tool: call.name, id: call.id, ...errResult });
+        continue;
+      }
+
+      // C++ Plan-Mode gate response: pause, NOT a failure, no further dispatch.
+      if (isPlanModeRequired(result)) {
+        yield {
+          type: 'plan_request',
+          call,
+          source: 'ue',
+          hint: (result as { hint?: string }).hint,
+        };
+        return;
+      }
+
+      yield { type: 'tool_result', id: call.id, name: call.name, result };
+      resultsForModel.push({ tool: call.name, id: call.id, result });
+      tokens += estimateTokens(JSON.stringify(result));
+    }
+
+    // Feed the batch of tool results back to the model and continue the loop.
+    messages.push({
+      role: 'user',
+      content: `Tool results:\n${JSON.stringify(resultsForModel, null, 2)}`,
+    });
+  }
+}

--- a/mcp-tools/hayba-mcp/src/chat/chat-server.ts
+++ b/mcp-tools/hayba-mcp/src/chat/chat-server.ts
@@ -100,6 +100,46 @@ function resolveSessionConfig(sessionId: string | undefined): SessionConfig | un
 }
 
 // ---------------------------------------------------------------------------
+// Narrow accessors for the copilot_* MCP tools (Task 5). These read/write the
+// SAME in-memory configStore the /chat/config routes use, so `copilot_provider_set`
+// and `POST /chat/config` are two doors onto one store — no duplicated state.
+//
+// TODO(Task 6): once the C++ DPAPI vault lands, `copilot_key_set`/`copilot_key_clear`
+// swap their storage target to the vault (via a localhost handshake) instead of
+// this in-memory map. The masked-read contract (never echo the raw key) does
+// not change when that happens.
+// ---------------------------------------------------------------------------
+
+export type { SessionConfig };
+
+/** Masked last-4 of a key, or null. Exposed so copilot tools reuse one mask rule. */
+export function maskKey(key: string | undefined): string | null {
+  return last4(key);
+}
+
+/** Read the resolved config (provider/model/baseURL + RAW key) for a session/default slot. */
+export function getConfigEntry(sessionId?: string): SessionConfig | undefined {
+  return resolveSessionConfig(sessionId);
+}
+
+/** Write (or replace) the config entry for a session/default slot. */
+export function setConfigEntry(sessionId: string | undefined, cfg: SessionConfig): void {
+  configStore.set(sessionId || DEFAULT_CONFIG_KEY, cfg);
+}
+
+/** Clear only the API key on a config entry, leaving provider/model/baseURL intact. */
+export function clearConfigKey(sessionId?: string): void {
+  const key = sessionId || DEFAULT_CONFIG_KEY;
+  const existing = configStore.get(key);
+  if (existing) configStore.set(key, { ...existing, apiKey: undefined });
+}
+
+/** True once `registerChatRoutes` has wired the /chat/* routes onto the sidecar app. */
+export function isChatRoutesRegistered(): boolean {
+  return chatRoutesRegistered;
+}
+
+// ---------------------------------------------------------------------------
 // Session store (in-memory). One turn runs server-side per session; frames
 // buffer while the client is disconnected so a reconnect can replay them.
 // ---------------------------------------------------------------------------
@@ -330,7 +370,10 @@ export interface ChatRoutesOptions {
  * Register the /chat/* routes onto an existing Express app so the sidecar port
  * serves them. Call from `registerApiRoutes`.
  */
+let chatRoutesRegistered = false;
+
 export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}): void {
+  chatRoutesRegistered = true;
   const dispatchTool = options.dispatchTool ?? createChatDispatcher();
   const makeClient = options.createClient ?? createLLMClient;
   const system = options.system ?? DEFAULT_SYSTEM;
@@ -732,6 +775,7 @@ export function __resetChatState(): void {
   sessions.clear();
   configStore.clear();
   sessionCounter = 0;
+  chatRoutesRegistered = false;
   if (sweeper) {
     clearInterval(sweeper);
     sweeper = null;

--- a/mcp-tools/hayba-mcp/src/chat/chat-server.ts
+++ b/mcp-tools/hayba-mcp/src/chat/chat-server.ts
@@ -1,0 +1,606 @@
+/**
+ * Sidecar SSE chat server (Task 4) — the HTTP surface the C++ Slate panel (and
+ * any localhost client) talks to for the BYOK in-editor copilot.
+ *
+ * Routes (all localhost-only; see `isLoopback`):
+ *
+ *   POST /chat/stream   — start (or resume) a per-session agent turn. Streams
+ *                         Server-Sent Events. Frames:
+ *                             event: text_delta   data: {text}
+ *                             event: tool_call    data: {id,name,input}
+ *                             event: tool_result  data: {id,name,result,isError?}
+ *                             event: plan_request data: {id,name,input,source,hint?}
+ *                             event: done         data: {reason,assistant_text,
+ *                                                        tool_trace[],usage?,
+ *                                                        cancelled?,partial_text}
+ *                             event: error        data: {error,kind?}
+ *                         Every frame carries an SSE `id:` (monotonic seq) so a
+ *                         client can reconnect with {session_id,last_seq} to
+ *                         replay only missed frames. Heartbeat comment frames
+ *                         (`: ping`) are sent every ~15s.
+ *
+ *   POST /chat/cancel   — {session_id}: aborts the in-flight loop; the stream
+ *                         ends with a done frame carrying {cancelled:true,
+ *                         partial_text}.
+ *
+ *   POST /chat/approve  — {session_id}: marks the session Plan-Mode-approved so
+ *                         the NEXT /chat/stream turn dispatches the previously
+ *                         gated tool. (The loop RETURNS on plan_request; resume
+ *                         is a new turn, not an in-place continuation — see the
+ *                         plan_request contract in the Task-4 report.)
+ *
+ *   POST /chat/config   — {session_id?,provider,model?,base_url?,api_key}: set
+ *                         the provider + key for a session IN MEMORY only. The
+ *                         key is NEVER persisted, echoed, or logged.
+ *   GET  /chat/config   — masked read (provider, model, key_last4) only.
+ *
+ * KEY SOURCE: option (b) from the brief — an in-memory registration endpoint.
+ * Task 6 replaces this source with the C++ DPAPI vault (the sidecar will read
+ * the key via a localhost `get_setting`-style handshake); the frame/route
+ * contract here does not change when that lands.
+ */
+
+import type { Express, Request, Response } from 'express';
+import type { AddressInfo } from 'node:net';
+import { createLLMClient, type LLMMessage } from '../agents/llm-client.js';
+import { getProvider } from '../agents/providers.js';
+import { runAgentLoop, type AgentEvent, type DispatchTool } from './agent-loop.js';
+import type { LLMTool } from '../agents/llm-client.js';
+import { createChatDispatcher } from './tool-dispatch.js';
+
+// ---------------------------------------------------------------------------
+// Localhost enforcement
+// ---------------------------------------------------------------------------
+
+/** True for IPv4/IPv6 loopback (incl. IPv4-mapped IPv6). Never network-exposed. */
+export function isLoopback(addr: string | undefined): boolean {
+  if (!addr) return false;
+  return (
+    addr === '127.0.0.1' ||
+    addr === '::1' ||
+    addr === '::ffff:127.0.0.1' ||
+    addr.startsWith('127.')
+  );
+}
+
+function requireLoopback(req: Request, res: Response): boolean {
+  if (isLoopback(req.socket.remoteAddress)) return true;
+  res.status(403).json({ error: 'chat routes are localhost-only' });
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory config store (option b). Never persisted / logged / echoed.
+// ---------------------------------------------------------------------------
+
+interface SessionConfig {
+  provider: string;
+  model?: string;
+  baseURL?: string;
+  apiKey?: string;
+}
+
+const DEFAULT_CONFIG_KEY = '__default__';
+const configStore = new Map<string, SessionConfig>();
+
+function last4(key: string | undefined): string | null {
+  if (!key) return null;
+  return key.length <= 4 ? '****' : key.slice(-4);
+}
+
+function resolveSessionConfig(sessionId: string | undefined): SessionConfig | undefined {
+  if (sessionId && configStore.has(sessionId)) return configStore.get(sessionId);
+  return configStore.get(DEFAULT_CONFIG_KEY);
+}
+
+// ---------------------------------------------------------------------------
+// Session store (in-memory). One turn runs server-side per session; frames
+// buffer while the client is disconnected so a reconnect can replay them.
+// ---------------------------------------------------------------------------
+
+interface BufferedFrame {
+  seq: number;
+  event: string;
+  data: unknown;
+}
+
+interface ToolTraceEntry {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+  result?: unknown;
+  isError?: boolean;
+}
+
+interface ChatSession {
+  id: string;
+  abortController: AbortController;
+  seq: number;
+  buffer: BufferedFrame[];
+  messages: LLMMessage[];
+  clients: Set<Response>;
+  running: boolean;
+  planApproved: boolean;
+  assistantText: string;
+  toolTrace: ToolTraceEntry[];
+  /** Set once the current/last turn has ended (final done frame emitted). */
+  lastDone?: BufferedFrame;
+}
+
+const BUFFER_LIMIT = 500;
+const HEARTBEAT_MS = 15_000;
+const sessions = new Map<string, ChatSession>();
+
+let sessionCounter = 0;
+function newSessionId(): string {
+  sessionCounter += 1;
+  return `sess_${Date.now().toString(36)}_${sessionCounter}`;
+}
+
+function getOrCreateSession(id: string): ChatSession {
+  let s = sessions.get(id);
+  if (!s) {
+    s = {
+      id,
+      abortController: new AbortController(),
+      seq: 0,
+      buffer: [],
+      messages: [],
+      clients: new Set(),
+      running: false,
+      planApproved: false,
+      assistantText: '',
+      toolTrace: [],
+    };
+    sessions.set(id, s);
+  }
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// SSE framing
+// ---------------------------------------------------------------------------
+
+function writeFrame(res: Response, frame: BufferedFrame): void {
+  // `id:` lets a reconnecting client tell us its last_seq. event + JSON data.
+  res.write(`id: ${frame.seq}\n`);
+  res.write(`event: ${frame.event}\n`);
+  res.write(`data: ${JSON.stringify(frame.data)}\n\n`);
+}
+
+/** Assign a seq, buffer (bounded), and fan out to every attached client. */
+function emit(session: ChatSession, event: string, data: unknown): BufferedFrame {
+  session.seq += 1;
+  const frame: BufferedFrame = { seq: session.seq, event, data };
+  session.buffer.push(frame);
+  if (session.buffer.length > BUFFER_LIMIT) session.buffer.shift();
+  for (const client of session.clients) {
+    try {
+      writeFrame(client, frame);
+    } catch {
+      /* client vanished mid-write; close handler will detach it */
+    }
+  }
+  return frame;
+}
+
+function replayMissed(session: ChatSession, res: Response, lastSeq: number): void {
+  for (const frame of session.buffer) {
+    if (frame.seq > lastSeq) writeFrame(res, frame);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message normalization
+// ---------------------------------------------------------------------------
+
+function normalizeMessages(body: {
+  messages?: unknown;
+  prompt?: unknown;
+}): LLMMessage[] | null {
+  if (Array.isArray(body.messages)) {
+    const ok = body.messages.every(
+      (m) =>
+        m &&
+        typeof m === 'object' &&
+        (((m as { role?: unknown }).role === 'user') ||
+          ((m as { role?: unknown }).role === 'assistant')),
+    );
+    return ok ? (body.messages as LLMMessage[]) : null;
+  }
+  if (typeof body.prompt === 'string' && body.prompt.length > 0) {
+    return [{ role: 'user', content: body.prompt }];
+  }
+  return null;
+}
+
+const DEFAULT_SYSTEM =
+  'You are the Hayba in-editor copilot. You help build Unreal Engine worlds by ' +
+  'calling Hayba tools. Prefer reads before writes; respect Plan Mode.';
+
+// ---------------------------------------------------------------------------
+// Route wiring
+// ---------------------------------------------------------------------------
+
+export interface ChatRoutesOptions {
+  /** Override the tool dispatcher (test seam). Defaults to full-coverage dispatch. */
+  dispatchTool?: DispatchTool;
+  /** Inject a client factory (test seam). Defaults to createLLMClient. */
+  createClient?: typeof createLLMClient;
+  /** Default system prompt. */
+  system?: string;
+  /**
+   * Explicit tool catalog offered to the model. If omitted, the loop builds it
+   * from the live registry (filtered by archetype). Primarily a test seam.
+   */
+  tools?: LLMTool[];
+}
+
+/**
+ * Register the /chat/* routes onto an existing Express app so the sidecar port
+ * serves them. Call from `registerApiRoutes`.
+ */
+export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}): void {
+  const dispatchTool = options.dispatchTool ?? createChatDispatcher();
+  const makeClient = options.createClient ?? createLLMClient;
+  const system = options.system ?? DEFAULT_SYSTEM;
+
+  // ── POST /chat/config ────────────────────────────────────────────────────
+  app.post('/chat/config', (req: Request, res: Response) => {
+    if (!requireLoopback(req, res)) return;
+    const body = req.body as {
+      session_id?: string;
+      provider?: string;
+      model?: string;
+      base_url?: string;
+      api_key?: string;
+    };
+    if (!body.provider || typeof body.provider !== 'string') {
+      return res.status(400).json({ error: 'provider is required' });
+    }
+    if (!getProvider(body.provider)) {
+      return res.status(400).json({ error: `unknown provider: ${body.provider}` });
+    }
+    const key = body.session_id || DEFAULT_CONFIG_KEY;
+    configStore.set(key, {
+      provider: body.provider,
+      model: body.model,
+      baseURL: body.base_url,
+      apiKey: body.api_key,
+    });
+    // NEVER echo the key. Return masked confirmation only.
+    return res.json({
+      ok: true,
+      provider: body.provider,
+      model: body.model ?? getProvider(body.provider)?.defaultModel ?? null,
+      key_last4: last4(body.api_key),
+    });
+  });
+
+  // ── GET /chat/config ─────────────────────────────────────────────────────
+  app.get('/chat/config', (req: Request, res: Response) => {
+    if (!requireLoopback(req, res)) return;
+    const sessionId = typeof req.query.session_id === 'string' ? req.query.session_id : undefined;
+    const cfg = resolveSessionConfig(sessionId);
+    if (!cfg) return res.json({ configured: false });
+    return res.json({
+      configured: true,
+      provider: cfg.provider,
+      model: cfg.model ?? getProvider(cfg.provider)?.defaultModel ?? null,
+      key_last4: last4(cfg.apiKey), // masked — never the raw key
+    });
+  });
+
+  // ── POST /chat/cancel ────────────────────────────────────────────────────
+  app.post('/chat/cancel', (req: Request, res: Response) => {
+    if (!requireLoopback(req, res)) return;
+    const { session_id } = req.body as { session_id?: string };
+    if (!session_id) return res.status(400).json({ error: 'session_id is required' });
+    const session = sessions.get(session_id);
+    if (!session) return res.status(404).json({ error: 'unknown session' });
+    session.abortController.abort();
+    return res.json({ ok: true, cancelled: true });
+  });
+
+  // ── POST /chat/approve ───────────────────────────────────────────────────
+  app.post('/chat/approve', (req: Request, res: Response) => {
+    if (!requireLoopback(req, res)) return;
+    const { session_id } = req.body as { session_id?: string };
+    if (!session_id) return res.status(400).json({ error: 'session_id is required' });
+    const session = sessions.get(session_id);
+    if (!session) return res.status(404).json({ error: 'unknown session' });
+    session.planApproved = true;
+    // Resume = the C++ panel re-issues POST /chat/stream with the same
+    // session_id; the stored transcript continues and the gated tool now runs.
+    return res.json({ ok: true, approved: true });
+  });
+
+  // ── POST /chat/stream ────────────────────────────────────────────────────
+  app.post('/chat/stream', async (req: Request, res: Response) => {
+    if (!requireLoopback(req, res)) return;
+    const body = req.body as {
+      session_id?: string;
+      messages?: LLMMessage[];
+      prompt?: string;
+      provider?: string;
+      model?: string;
+      archetype?: string;
+      archetype_filter?: string[];
+      last_seq?: number;
+    };
+
+    // SSE headers.
+    res.status(200);
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders?.();
+
+    const heartbeat = setInterval(() => {
+      try {
+        res.write(`: ping\n\n`);
+      } catch {
+        /* closed */
+      }
+    }, HEARTBEAT_MS);
+    const cleanup = (): void => clearInterval(heartbeat);
+
+    // ── RESUME path: existing session + last_seq → replay, don't re-dispatch ──
+    const existing = body.session_id ? sessions.get(body.session_id) : undefined;
+    const isResume = existing !== undefined && typeof body.last_seq === 'number';
+    if (isResume && existing) {
+      existing.clients.add(res);
+      replayMissed(existing, res, body.last_seq as number);
+      // If the turn already finished, we've replayed the final done frame; end.
+      if (!existing.running) {
+        existing.clients.delete(res);
+        cleanup();
+        return res.end();
+      }
+      // Turn still running: stay attached for live frames; detach on disconnect.
+      // NB: res 'close' (not req 'close') — req closes as soon as the POST body
+      // is received, which would detach the client before any frame is written.
+      res.on('close', () => {
+        existing.clients.delete(res);
+        cleanup();
+      });
+      return; // no new loop — this is the anti-duplicate-dispatch guarantee
+    }
+
+    // Reject starting a second concurrent turn on a running session.
+    if (existing && existing.running) {
+      cleanup();
+      return res.status(409).json({ error: 'session already has a turn in flight' });
+    }
+
+    // ── NEW TURN path ────────────────────────────────────────────────────────
+    const sessionId = body.session_id || newSessionId();
+    const session = getOrCreateSession(sessionId);
+    // Fresh AbortController per turn (a prior cancel leaves an aborted one).
+    session.abortController = new AbortController();
+    session.running = true;
+    session.assistantText = '';
+    session.toolTrace = [];
+    session.clients.add(res);
+
+    // Resolve messages: explicit body wins; else reuse stored transcript
+    // (post-approval resume) if present.
+    let messages = normalizeMessages(body);
+    if (!messages && session.messages.length > 0) messages = session.messages;
+    if (!messages) {
+      emit(session, 'error', { error: 'messages or prompt is required', kind: 'bad_request' });
+      finalize(session, 'error');
+      session.clients.delete(res);
+      cleanup();
+      return res.end();
+    }
+    session.messages = messages;
+
+    // Resolve provider/model/key: body overrides > session config > default cfg.
+    const cfg = resolveSessionConfig(sessionId);
+    const provider = body.provider ?? cfg?.provider ?? 'mock';
+    const model = body.model ?? cfg?.model;
+    if (!getProvider(provider)) {
+      emit(session, 'error', { error: `unknown provider: ${provider}`, kind: 'config' });
+      finalize(session, 'error');
+      session.running = false;
+      session.clients.delete(res);
+      cleanup();
+      return res.end();
+    }
+
+    let client;
+    try {
+      client = makeClient({
+        provider,
+        model,
+        baseURL: cfg?.baseURL,
+        apiKey: body.provider ? undefined : cfg?.apiKey, // key follows the resolved provider
+      });
+    } catch (err) {
+      emit(session, 'error', {
+        error: err instanceof Error ? err.message : String(err),
+        kind: 'config',
+      });
+      finalize(session, 'error');
+      session.running = false;
+      session.clients.delete(res);
+      cleanup();
+      return res.end();
+    }
+
+    // Detach this client on disconnect; the loop keeps running (frames buffer).
+    // Use res 'close' — req 'close' fires as soon as the POST body is received,
+    // which would detach the client before the first frame is written.
+    res.on('close', () => {
+      session.clients.delete(res);
+      cleanup();
+    });
+
+    // Drive the loop server-side, independent of the HTTP connection lifetime.
+    void runTurn(session, {
+      client,
+      system,
+      messages,
+      archetypeFilter: body.archetype_filter,
+      tools: options.tools,
+      dispatchTool,
+      signal: session.abortController.signal,
+      planApproved: session.planApproved,
+    }).finally(() => {
+      cleanup();
+      // Reset one-shot approval so a later turn re-gates.
+      session.planApproved = false;
+    });
+
+    return undefined;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Turn driver — consumes the agent loop and translates events into frames.
+// ---------------------------------------------------------------------------
+
+interface RunTurnParams {
+  client: ReturnType<typeof createLLMClient>;
+  system: string;
+  messages: LLMMessage[];
+  archetypeFilter?: string[];
+  tools?: LLMTool[];
+  dispatchTool: DispatchTool;
+  signal: AbortSignal;
+  planApproved: boolean;
+}
+
+/** Emit the single consolidated final done frame + mark the turn finished. */
+function finalize(
+  session: ChatSession,
+  reason: string,
+  extra: Record<string, unknown> = {},
+): void {
+  const frame = emit(session, 'done', {
+    reason,
+    assistant_text: session.assistantText,
+    partial_text: session.assistantText,
+    tool_trace: session.toolTrace,
+    cancelled: reason === 'aborted' || reason === 'cancelled',
+    ...extra,
+  });
+  console.error("[dbg] finalize reason="+reason+" clients="+session.clients.size);
+  session.lastDone = frame;
+  session.running = false;
+  // Close every attached SSE client — the turn is over. Buffered frames remain
+  // for a later resume (reconnect with last_seq).
+  for (const client of session.clients) {
+    try {
+      client.end();
+    } catch {
+      /* already closed */
+    }
+  }
+  session.clients.clear();
+}
+
+async function runTurn(session: ChatSession, params: RunTurnParams): Promise<void> {
+  console.error("[dbg] runTurn start clients="+session.clients.size);
+  let finalReason: string | null = null;
+  let lastError: { error: string; kind?: string } | null = null;
+
+  try {
+    for await (const ev of runAgentLoop({
+      client: params.client,
+      system: params.system,
+      messages: params.messages,
+      tools: params.tools,
+      archetypeFilter: params.archetypeFilter,
+      dispatchTool: params.dispatchTool,
+      signal: params.signal,
+      planMode: true, // honour Plan Mode; UE side is authoritative, TS side gated
+      planApproved: params.planApproved,
+    })) {
+      forwardEvent(session, ev, (r) => (finalReason = r), (e) => (lastError = e));
+      if (finalReason) break; // loop's own done/plan_request/aborted terminus
+    }
+  } catch (err) {
+    lastError = { error: err instanceof Error ? err.message : String(err), kind: 'internal' };
+  }
+
+  // Consolidated terminal frame.
+  if (finalReason === 'aborted') {
+    finalize(session, 'aborted');
+  } else if (lastError && !finalReason) {
+    finalize(session, 'error', { error: lastError });
+  } else {
+    finalize(session, finalReason ?? 'end_turn', lastError ? { error: lastError } : {});
+  }
+}
+
+/** Translate one loop AgentEvent into buffered SSE frames + trace bookkeeping. */
+function forwardEvent(
+  session: ChatSession,
+  ev: AgentEvent,
+  setReason: (r: string) => void,
+  setError: (e: { error: string; kind?: string }) => void,
+): void {
+  switch (ev.type) {
+    case 'text_delta':
+      session.assistantText += ev.text;
+      emit(session, 'text_delta', { text: ev.text });
+      break;
+    case 'tool_call':
+      session.toolTrace.push({ id: ev.call.id, name: ev.call.name, input: ev.call.input });
+      emit(session, 'tool_call', { id: ev.call.id, name: ev.call.name, input: ev.call.input });
+      break;
+    case 'tool_result': {
+      const entry = session.toolTrace.find((t) => t.id === ev.id);
+      if (entry) {
+        entry.result = ev.result;
+        entry.isError = ev.isError;
+      }
+      emit(session, 'tool_result', {
+        id: ev.id,
+        name: ev.name,
+        result: ev.result,
+        isError: ev.isError,
+      });
+      break;
+    }
+    case 'plan_request':
+      emit(session, 'plan_request', {
+        id: ev.call.id,
+        name: ev.call.name,
+        input: ev.call.input,
+        source: ev.source,
+        hint: ev.hint,
+      });
+      // Loop RETURNS after plan_request — the turn pauses pending approval.
+      setReason('plan_request');
+      break;
+    case 'done':
+      setReason(ev.reason);
+      break;
+    case 'error':
+      setError({ error: ev.error, kind: ev.kind });
+      emit(session, 'error', { error: ev.error, kind: ev.kind });
+      if (ev.kind === 'aborted') setReason('aborted');
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test / lifecycle helpers
+// ---------------------------------------------------------------------------
+
+/** Clear all in-memory session + config state (tests). */
+export function __resetChatState(): void {
+  sessions.clear();
+  configStore.clear();
+  sessionCounter = 0;
+}
+
+/** Introspection for tests: the port an app is listening on. */
+export function addressPort(address: AddressInfo | string | null): number {
+  if (address && typeof address === 'object') return address.port;
+  throw new Error('server not listening on a TCP port');
+}

--- a/mcp-tools/hayba-mcp/src/chat/chat-server.ts
+++ b/mcp-tools/hayba-mcp/src/chat/chat-server.ts
@@ -44,7 +44,13 @@ import type { Express, Request, Response } from 'express';
 import type { AddressInfo } from 'node:net';
 import { createLLMClient, type LLMMessage } from '../agents/llm-client.js';
 import { getProvider } from '../agents/providers.js';
-import { runAgentLoop, type AgentEvent, type DispatchTool } from './agent-loop.js';
+import {
+  runAgentLoop,
+  argsHash,
+  type AgentEvent,
+  type ApprovedCall,
+  type DispatchTool,
+} from './agent-loop.js';
 import type { LLMTool } from '../agents/llm-client.js';
 import { createChatDispatcher } from './tool-dispatch.js';
 
@@ -120,16 +126,88 @@ interface ChatSession {
   messages: LLMMessage[];
   clients: Set<Response>;
   running: boolean;
-  planApproved: boolean;
+  /**
+   * Identity of the tool call currently paused at the Plan-Mode gate (set when a
+   * plan_request is emitted). `/chat/approve` promotes this to `approvedCall`.
+   */
+  pendingPlanCall?: ApprovedCall;
+  /**
+   * Call-bound approval (C1): the ONE `{name, argsHash}` the next turn may
+   * dispatch past the TS-side gate. Consumed (cleared) after the turn runs.
+   */
+  approvedCall?: ApprovedCall;
   assistantText: string;
   toolTrace: ToolTraceEntry[];
+  /** Epoch ms of the last activity on this session; drives TTL/LRU eviction. */
+  lastActivity: number;
   /** Set once the current/last turn has ended (final done frame emitted). */
   lastDone?: BufferedFrame;
 }
 
 const BUFFER_LIMIT = 500;
 const HEARTBEAT_MS = 15_000;
+/** Idle time after which a session is evicted (I1). */
+const SESSION_TTL_MS = 30 * 60_000;
+/** How often the lazy sweeper runs. */
+const SWEEP_INTERVAL_MS = 60_000;
+/** Hard cap on concurrent sessions; oldest inactive are LRU-evicted past this. */
+const MAX_SESSIONS = 64;
 const sessions = new Map<string, ChatSession>();
+
+// ---------------------------------------------------------------------------
+// Session eviction (I1): idle-TTL + LRU cap. Evicting an active session aborts
+// its in-flight controller. The sweeper timer is `.unref()`d so it never keeps
+// the process alive, and is started lazily on first session creation.
+// ---------------------------------------------------------------------------
+
+let sweeper: ReturnType<typeof setInterval> | null = null;
+
+function startSweeper(): void {
+  if (sweeper) return;
+  sweeper = setInterval(() => sweepSessions(), SWEEP_INTERVAL_MS);
+  sweeper.unref?.();
+}
+
+function touch(session: ChatSession): void {
+  session.lastActivity = Date.now();
+}
+
+/** Abort the in-flight turn, close attached clients, and drop the session. */
+function evictSession(session: ChatSession): void {
+  try {
+    session.abortController.abort();
+  } catch {
+    /* already aborted */
+  }
+  for (const client of session.clients) {
+    try {
+      client.end();
+    } catch {
+      /* already closed */
+    }
+  }
+  session.clients.clear();
+  session.running = false;
+  sessions.delete(session.id);
+}
+
+function sweepSessions(now: number = Date.now()): void {
+  for (const session of sessions.values()) {
+    if (now - session.lastActivity > SESSION_TTL_MS) evictSession(session);
+  }
+}
+
+/** Enforce MAX_SESSIONS by LRU-evicting the oldest inactive (not running). */
+function enforceSessionCap(): void {
+  if (sessions.size <= MAX_SESSIONS) return;
+  const candidates = [...sessions.values()]
+    .filter((s) => !s.running)
+    .sort((a, b) => a.lastActivity - b.lastActivity);
+  for (const s of candidates) {
+    if (sessions.size <= MAX_SESSIONS) break;
+    evictSession(s);
+  }
+}
 
 let sessionCounter = 0;
 function newSessionId(): string {
@@ -138,6 +216,8 @@ function newSessionId(): string {
 }
 
 function getOrCreateSession(id: string): ChatSession {
+  startSweeper();
+  sweepSessions();
   let s = sessions.get(id);
   if (!s) {
     s = {
@@ -148,11 +228,12 @@ function getOrCreateSession(id: string): ChatSession {
       messages: [],
       clients: new Set(),
       running: false,
-      planApproved: false,
       assistantText: '',
       toolTrace: [],
+      lastActivity: Date.now(),
     };
     sessions.set(id, s);
+    enforceSessionCap();
   }
   return s;
 }
@@ -188,6 +269,15 @@ function replayMissed(session: ChatSession, res: Response, lastSeq: number): voi
   for (const frame of session.buffer) {
     if (frame.seq > lastSeq) writeFrame(res, frame);
   }
+}
+
+/**
+ * True when the client's `last_seq` predates the oldest buffered frame — i.e.
+ * frames between `last_seq` and the buffer head have already been evicted, so a
+ * gap-free replay is impossible (I2). The buffer must be non-empty.
+ */
+function hasResumeGap(session: ChatSession, lastSeq: number): boolean {
+  return session.buffer.length > 0 && lastSeq < session.buffer[0].seq - 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -298,6 +388,7 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
     if (!session_id) return res.status(400).json({ error: 'session_id is required' });
     const session = sessions.get(session_id);
     if (!session) return res.status(404).json({ error: 'unknown session' });
+    touch(session);
     session.abortController.abort();
     return res.json({ ok: true, cancelled: true });
   });
@@ -309,10 +400,22 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
     if (!session_id) return res.status(400).json({ error: 'session_id is required' });
     const session = sessions.get(session_id);
     if (!session) return res.status(404).json({ error: 'unknown session' });
-    session.planApproved = true;
+    touch(session);
+    // C1: approval is bound to the SPECIFIC call paused at the gate, not the
+    // whole turn. Without a pending plan_request there is nothing to approve.
+    if (!session.pendingPlanCall) {
+      return res.status(409).json({ error: 'no pending plan request to approve' });
+    }
+    session.approvedCall = session.pendingPlanCall;
+    session.pendingPlanCall = undefined;
     // Resume = the C++ panel re-issues POST /chat/stream with the same
-    // session_id; the stored transcript continues and the gated tool now runs.
-    return res.json({ ok: true, approved: true });
+    // session_id; the stored transcript continues and ONLY this exact call
+    // (name + argsHash) dispatches past the TS gate, once.
+    return res.json({
+      ok: true,
+      approved: true,
+      call: { name: session.approvedCall.name },
+    });
   });
 
   // ── POST /chat/stream ────────────────────────────────────────────────────
@@ -329,7 +432,20 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
       last_seq?: number;
     };
 
-    // SSE headers.
+    // ── Branch on resume vs new turn BEFORE any SSE headers are flushed (I3) ──
+    // Emitting a 409 after flushHeaders() would append JSON mid-stream (the 200 +
+    // SSE headers are already on the wire). So decide the disposition first, and
+    // only flush SSE headers once we're committed to streaming.
+    const existing = body.session_id ? sessions.get(body.session_id) : undefined;
+    const isResume = existing !== undefined && typeof body.last_seq === 'number';
+
+    // Reject a second concurrent NEW turn on a running session with a real 409.
+    // (Resumes are allowed to attach to a running session — that is the point.)
+    if (!isResume && existing && existing.running) {
+      return res.status(409).json({ error: 'session already has a turn in flight' });
+    }
+
+    // Committed to streaming — now flush SSE headers.
     res.status(200);
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache, no-transform');
@@ -347,9 +463,21 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
     const cleanup = (): void => clearInterval(heartbeat);
 
     // ── RESUME path: existing session + last_seq → replay, don't re-dispatch ──
-    const existing = body.session_id ? sessions.get(body.session_id) : undefined;
-    const isResume = existing !== undefined && typeof body.last_seq === 'number';
     if (isResume && existing) {
+      touch(existing);
+      // I2: if last_seq predates the buffer head, the missed frames are gone —
+      // signal an explicit resume_gap error instead of silently skipping them.
+      if (hasResumeGap(existing, body.last_seq as number)) {
+        res.write(`event: error\n`);
+        res.write(
+          `data: ${JSON.stringify({
+            code: 'resume_gap',
+            oldest_available_seq: existing.buffer[0].seq,
+          })}\n\n`,
+        );
+        cleanup();
+        return res.end();
+      }
       existing.clients.add(res);
       replayMissed(existing, res, body.last_seq as number);
       // If the turn already finished, we've replayed the final done frame; end.
@@ -368,15 +496,10 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
       return; // no new loop — this is the anti-duplicate-dispatch guarantee
     }
 
-    // Reject starting a second concurrent turn on a running session.
-    if (existing && existing.running) {
-      cleanup();
-      return res.status(409).json({ error: 'session already has a turn in flight' });
-    }
-
     // ── NEW TURN path ────────────────────────────────────────────────────────
     const sessionId = body.session_id || newSessionId();
     const session = getOrCreateSession(sessionId);
+    touch(session);
     // Fresh AbortController per turn (a prior cancel leaves an aborted one).
     session.abortController = new AbortController();
     session.running = true;
@@ -401,6 +524,13 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
     const cfg = resolveSessionConfig(sessionId);
     const provider = body.provider ?? cfg?.provider ?? 'mock';
     const model = body.model ?? cfg?.model;
+    // The stored key belongs to the CONFIGURED provider. If the request names a
+    // DIFFERENT provider, that key must not be reused (M2), so we drop it and let
+    // the client factory source the key from the environment for the new
+    // provider. If the request omits provider, or names the SAME provider as the
+    // config, the configured key is the right one to use.
+    const useConfiguredKey = !body.provider || body.provider === cfg?.provider;
+    const resolvedApiKey = useConfiguredKey ? cfg?.apiKey : undefined;
     if (!getProvider(provider)) {
       emit(session, 'error', { error: `unknown provider: ${provider}`, kind: 'config' });
       finalize(session, 'error');
@@ -416,7 +546,7 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
         provider,
         model,
         baseURL: cfg?.baseURL,
-        apiKey: body.provider ? undefined : cfg?.apiKey, // key follows the resolved provider
+        apiKey: resolvedApiKey, // key follows the resolved provider (see above)
       });
     } catch (err) {
       emit(session, 'error', {
@@ -447,11 +577,11 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
       tools: options.tools,
       dispatchTool,
       signal: session.abortController.signal,
-      planApproved: session.planApproved,
+      approvedCall: session.approvedCall,
     }).finally(() => {
       cleanup();
-      // Reset one-shot approval so a later turn re-gates.
-      session.planApproved = false;
+      // Consume the one-shot call-bound approval so a later turn re-gates.
+      session.approvedCall = undefined;
     });
 
     return undefined;
@@ -470,7 +600,8 @@ interface RunTurnParams {
   tools?: LLMTool[];
   dispatchTool: DispatchTool;
   signal: AbortSignal;
-  planApproved: boolean;
+  /** Call-bound Plan-Mode approval for this turn (C1); undefined = re-gate. */
+  approvedCall?: ApprovedCall;
 }
 
 /** Emit the single consolidated final done frame + mark the turn finished. */
@@ -487,7 +618,6 @@ function finalize(
     cancelled: reason === 'aborted' || reason === 'cancelled',
     ...extra,
   });
-  console.error("[dbg] finalize reason="+reason+" clients="+session.clients.size);
   session.lastDone = frame;
   session.running = false;
   // Close every attached SSE client — the turn is over. Buffered frames remain
@@ -503,7 +633,6 @@ function finalize(
 }
 
 async function runTurn(session: ChatSession, params: RunTurnParams): Promise<void> {
-  console.error("[dbg] runTurn start clients="+session.clients.size);
   let finalReason: string | null = null;
   let lastError: { error: string; kind?: string } | null = null;
 
@@ -517,7 +646,7 @@ async function runTurn(session: ChatSession, params: RunTurnParams): Promise<voi
       dispatchTool: params.dispatchTool,
       signal: params.signal,
       planMode: true, // honour Plan Mode; UE side is authoritative, TS side gated
-      planApproved: params.planApproved,
+      approvedCall: params.approvedCall,
     })) {
       forwardEvent(session, ev, (r) => (finalReason = r), (e) => (lastError = e));
       if (finalReason) break; // loop's own done/plan_request/aborted terminus
@@ -566,17 +695,23 @@ function forwardEvent(
       });
       break;
     }
-    case 'plan_request':
+    case 'plan_request': {
+      // C1: record the identity of the paused call so /chat/approve can bind the
+      // approval to THIS exact {name, argsHash} rather than the whole turn.
+      const hash = ev.argsHash ?? argsHash(ev.call.input);
+      session.pendingPlanCall = { name: ev.call.name, argsHash: hash };
       emit(session, 'plan_request', {
         id: ev.call.id,
         name: ev.call.name,
         input: ev.call.input,
         source: ev.source,
         hint: ev.hint,
+        args_hash: hash,
       });
       // Loop RETURNS after plan_request — the turn pauses pending approval.
       setReason('plan_request');
       break;
+    }
     case 'done':
       setReason(ev.reason);
       break;
@@ -597,6 +732,20 @@ export function __resetChatState(): void {
   sessions.clear();
   configStore.clear();
   sessionCounter = 0;
+  if (sweeper) {
+    clearInterval(sweeper);
+    sweeper = null;
+  }
+}
+
+/** Test hook: run the idle-TTL sweep at a given wall-clock time. */
+export function __sweepSessions(now?: number): void {
+  sweepSessions(now);
+}
+
+/** Test hook: number of live sessions. */
+export function __sessionCount(): number {
+  return sessions.size;
 }
 
 /** Introspection for tests: the port an app is listening on. */

--- a/mcp-tools/hayba-mcp/src/chat/tool-dispatch.ts
+++ b/mcp-tools/hayba-mcp/src/chat/tool-dispatch.ts
@@ -1,0 +1,94 @@
+/**
+ * Chat tool-dispatch seam (Task 4).
+ *
+ * The agent loop (`src/chat/agent-loop.ts`) takes an injectable
+ * `dispatchTool(name, args)`. Its `defaultDispatchTool` routes ONLY through the
+ * UE bridge (`executeCommand`), so it cannot reach the many tools whose handler
+ * resolves entirely in Node (TS-side captured tools). The authoritative captured
+ * map lives inside `registerDeferredRouting` (src/tools/routing/register.ts) and
+ * is not importable at module scope.
+ *
+ * To give the sidecar chat server FULL tool coverage without changing the loop
+ * contract, `registerDeferredRouting` publishes its captured map here via
+ * `registerChatCapturedTools()`. The dispatcher built by
+ * `createChatDispatcher()` then:
+ *
+ *   1. prefers the captured TS handler if present (unwrapping the MCP
+ *      `{content:[{type:'text',text}]}` envelope back into structured data), else
+ *   2. falls through to `executeCommand` (the UE plugin TCP bridge).
+ *
+ * This mirrors the `hayba_invoke` dispatch (register.ts) so the copilot reaches
+ * exactly the tools an MCP client would, and it preserves the C++ Plan-Mode
+ * `{status:'plan_mode_required'}` pause payload from UE-bridged commands (the
+ * loop detects it and pauses). If the captured map has not been published yet
+ * (e.g. deferred routing disabled), the dispatcher degrades to UE-bridge only.
+ */
+
+import type { DispatchTool } from './agent-loop.js';
+import { executeCommand } from '../tools/tool-executor.js';
+
+/** Minimal structural shape of a captured tool (see routing/register.ts CapturedTool). */
+interface CapturedToolLike {
+  handler: (...args: unknown[]) => unknown;
+}
+
+let capturedTools: Map<string, CapturedToolLike> | null = null;
+
+/**
+ * Publish the deferred-routing captured-tool map for the chat dispatcher.
+ * Called once from `registerDeferredRouting`. Idempotent (last write wins).
+ */
+export function registerChatCapturedTools(map: Map<string, CapturedToolLike>): void {
+  capturedTools = map;
+}
+
+/** Test/introspection seam: is a captured map currently published? */
+export function hasChatCapturedTools(): boolean {
+  return capturedTools !== null;
+}
+
+/**
+ * Unwrap an MCP tool result (`{content:[{type:'text',text}]}`) back into
+ * structured data so the model — and the loop's plan-mode detector — see the
+ * same JSON a UE-bridge dispatch would return. Non-MCP results pass through.
+ */
+export function unwrapMcpResult(result: unknown): unknown {
+  if (
+    result &&
+    typeof result === 'object' &&
+    Array.isArray((result as { content?: unknown }).content)
+  ) {
+    const content = (result as { content: Array<Record<string, unknown>> }).content;
+    const first = content[0];
+    if (first && first.type === 'text' && typeof first.text === 'string') {
+      try {
+        return JSON.parse(first.text);
+      } catch {
+        return first.text;
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Build the full-coverage dispatcher injected into `runAgentLoop`. Prefers a
+ * captured TS handler; otherwise dispatches through the UE bridge.
+ *
+ * @param deps.captured  Override the published captured map (test seam).
+ * @param deps.execute   Override the UE-bridge executor (test seam).
+ */
+export function createChatDispatcher(deps: {
+  captured?: Map<string, CapturedToolLike> | null;
+  execute?: (name: string, args: Record<string, unknown>) => Promise<unknown>;
+} = {}): DispatchTool {
+  const execute = deps.execute ?? executeCommand;
+  return async (name, args) => {
+    const map = deps.captured !== undefined ? deps.captured : capturedTools;
+    const t = map?.get(name);
+    if (t) {
+      return unwrapMcpResult(await Promise.resolve(t.handler(args)));
+    }
+    return execute(name, args);
+  };
+}

--- a/mcp-tools/hayba-mcp/src/dashboard/api.ts
+++ b/mcp-tools/hayba-mcp/src/dashboard/api.ts
@@ -7,11 +7,16 @@ import { createProject, deleteProject, getProject, listProjects } from '../proje
 import { submitZones, getCurrentZones, setHeightmap, getHeightmap, getPainterSession, lockPainter, unlockPainter, createScratchSession, submitScratchZones, getScratchZones } from '../zones.js';
 import { getEntries, addEntry, deleteEntry, getBaseTemplates } from '../encyclopedia.js';
 import { getCachedSidecarHealth, pingSidecar } from '../tools/visual/sidecar-client.js';
+import { registerChatRoutes } from '../chat/chat-server.js';
 
 /**
  * Register REST API endpoints for the dashboard.
  */
 export function registerApiRoutes(app: Express): void {
+  // BYOK copilot SSE surface (Task 4) — /chat/stream, /chat/cancel,
+  // /chat/approve, /chat/config. Localhost-only, key never persisted/echoed.
+  registerChatRoutes(app);
+
   // Server health
   app.get('/api/health', (_req: Request, res: Response) => {
     const client = getUEClient();

--- a/mcp-tools/hayba-mcp/src/tools/copilot/copilot-tools.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/copilot/copilot-tools.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  providerListHandler,
+  providerSetHandler,
+  providerTestHandler,
+  modelListHandler,
+  keySetHandler,
+  keyClearHandler,
+  keyStatusHandler,
+  healthHandler,
+  __setClientFactory,
+  __resetClientFactory,
+} from './copilot-tools.js';
+import { __resetChatState, registerChatRoutes } from '../../chat/chat-server.js';
+import { setDefaultSender, type Sender } from '../tool-executor.js';
+import type { LLMClient } from '../../agents/llm-client.js';
+
+function textOf(result: { content: Array<{ type: 'text'; text: string }> }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  __resetChatState();
+  __resetClientFactory();
+});
+afterEach(() => {
+  __resetChatState();
+  __resetClientFactory();
+});
+
+describe('copilot_provider_list / copilot_provider_set — config store round-trip', () => {
+  it('lists the catalog with nothing active by default', async () => {
+    const res = await providerListHandler({}, {});
+    const data = textOf(res) as { providers: Array<{ id: string; active: boolean }>; active_provider: string | null };
+    expect(data.active_provider).toBeNull();
+    expect(data.providers.some((p) => p.id === 'anthropic')).toBe(true);
+    expect(data.providers.every((p) => !p.active)).toBe(true);
+  });
+
+  it('set then list round-trips the active provider + model, masking the key', async () => {
+    const setRes = await keySetHandler({ provider: 'anthropic', api_key: 'sk-ant-abcd1234' }, {});
+    expect(textOf(setRes)).toMatchObject({ ok: true, provider: 'anthropic', key_last4: '1234' });
+
+    const provRes = await providerSetHandler({ provider: 'anthropic', model: 'claude-opus-4-8' }, {});
+    expect(textOf(provRes)).toMatchObject({ ok: true, provider: 'anthropic', model: 'claude-opus-4-8' });
+
+    const listRes = await providerListHandler({}, {});
+    const data = textOf(listRes) as { providers: Array<{ id: string; active: boolean; key_configured: boolean; key_last4: string | null }>; active_provider: string };
+    expect(data.active_provider).toBe('anthropic');
+    const active = data.providers.find((p) => p.id === 'anthropic')!;
+    expect(active.active).toBe(true);
+    // key survives provider_set (same provider) — round-tripped from the earlier key_set
+    expect(active.key_configured).toBe(true);
+    expect(active.key_last4).toBe('1234');
+  });
+
+  it('switching to a different provider drops the previous provider key (M2 rule)', async () => {
+    await keySetHandler({ provider: 'anthropic', api_key: 'sk-ant-xxxx1111' }, {});
+    await providerSetHandler({ provider: 'anthropic' }, {});
+    await providerSetHandler({ provider: 'openai' }, {});
+
+    const status = textOf(await keyStatusHandler({}, {})) as { providers: Array<{ provider: string; configured: boolean }> };
+    expect(status.providers.find((p) => p.provider === 'openai')!.configured).toBe(false);
+    expect(status.providers.find((p) => p.provider === 'anthropic')!.configured).toBe(false);
+  });
+
+  it('rejects an unknown provider', async () => {
+    const res = await providerSetHandler({ provider: 'not-a-real-provider' }, {});
+    expect(res.isError).toBe(true);
+  });
+});
+
+describe('copilot_key_set / copilot_key_clear', () => {
+  it('key_clear on the active provider clears the key but keeps provider/model', async () => {
+    await keySetHandler({ provider: 'openai', api_key: 'sk-openai-999' }, {});
+    await providerSetHandler({ provider: 'openai', model: 'gpt-4o-mini' }, {});
+
+    const clearRes = await keyClearHandler({ provider: 'openai' }, {});
+    expect(textOf(clearRes)).toMatchObject({ ok: true, provider: 'openai', cleared: true });
+
+    const status = textOf(await keyStatusHandler({}, {})) as { providers: Array<{ provider: string; configured: boolean }> };
+    expect(status.providers.find((p) => p.provider === 'openai')!.configured).toBe(false);
+
+    const list = textOf(await providerListHandler({}, {})) as { active_provider: string };
+    expect(list.active_provider).toBe('openai'); // provider/model untouched by key_clear
+  });
+
+  it('key_clear on a provider with nothing configured is a no-op, not an error', async () => {
+    const res = await keyClearHandler({ provider: 'groq' }, {});
+    expect(textOf(res)).toMatchObject({ ok: true, provider: 'groq', cleared: false });
+    expect(res.isError).toBeFalsy();
+  });
+
+  it('key_set requires both provider and api_key', async () => {
+    expect((await keySetHandler({ provider: 'openai' }, {})).isError).toBe(true);
+    expect((await keySetHandler({ api_key: 'x' }, {})).isError).toBe(true);
+  });
+});
+
+describe('copilot_key_status', () => {
+  it('reports configured:false for every provider before any key is set', async () => {
+    const data = textOf(await keyStatusHandler({}, {})) as { providers: Array<{ configured: boolean }> };
+    expect(data.providers.every((p) => !p.configured)).toBe(true);
+  });
+});
+
+describe('key-safety canary — no handler ever returns the raw key', () => {
+  const RAW_KEY = 'sk-canary-do-not-leak-XYZQ';
+
+  it('scans every copilot_* result for the raw key substring', async () => {
+    await keySetHandler({ provider: 'anthropic', api_key: RAW_KEY }, {});
+    await providerSetHandler({ provider: 'anthropic' }, {});
+
+    const results = await Promise.all([
+      providerListHandler({}, {}),
+      providerSetHandler({ provider: 'anthropic' }, {}),
+      modelListHandler({ provider: 'anthropic' }, {}),
+      keyStatusHandler({}, {}),
+      healthHandler({}, {}),
+    ]);
+    for (const r of results) {
+      const text = r.content.map((c) => c.text).join('\n');
+      expect(text).not.toContain(RAW_KEY);
+    }
+  });
+});
+
+describe('copilot_model_list', () => {
+  it('is advisory and includes the configured + default model', async () => {
+    await providerSetHandler({ provider: 'anthropic', model: 'claude-sonnet-4-8' }, {});
+    const data = textOf(await modelListHandler({ provider: 'anthropic' }, {})) as {
+      known_models: string[];
+      configured_model: string;
+      advisory: boolean;
+    };
+    expect(data.advisory).toBe(true);
+    expect(data.configured_model).toBe('claude-sonnet-4-8');
+    expect(data.known_models).toContain('claude-sonnet-4-8');
+    expect(data.known_models).toContain('claude-opus-4-8'); // catalog default
+  });
+
+  it('rejects an unknown provider', async () => {
+    expect((await modelListHandler({ provider: 'nope' }, {})).isError).toBe(true);
+  });
+});
+
+describe('copilot_provider_test — preflight (no network)', () => {
+  it('fails clean with no_key when the provider needs a key and none is configured', async () => {
+    await providerSetHandler({ provider: 'anthropic' }, {});
+    const data = textOf(await providerTestHandler({}, {})) as { ok: boolean; reason?: string };
+    expect(data).toEqual({ ok: false, reason: 'no_key' });
+  });
+
+  it('does not call the client factory during the no_key preflight', async () => {
+    const factory = vi.fn();
+    __setClientFactory(factory as unknown as typeof factory);
+    await providerSetHandler({ provider: 'anthropic' }, {});
+    await providerTestHandler({}, {});
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it('reports ok:true on a mocked successful completion', async () => {
+    await keySetHandler({ provider: 'anthropic', api_key: 'sk-ant-good' }, {});
+    await providerSetHandler({ provider: 'anthropic' }, {});
+    __setClientFactory(() => ({
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      protocol: 'anthropic',
+      async complete() {
+        return { content: 'pong', toolCalls: [], stopReason: 'end_turn' as const };
+      },
+      async *stream() {},
+    } as unknown as LLMClient));
+
+    const data = textOf(await providerTestHandler({}, {})) as { ok: boolean; model?: string; latency_ms?: number };
+    expect(data.ok).toBe(true);
+    expect(data.model).toBe('claude-opus-4-8');
+    expect(typeof data.latency_ms).toBe('number');
+  });
+
+  it('maps an auth failure from the client to reason:auth_failed', async () => {
+    await keySetHandler({ provider: 'anthropic', api_key: 'sk-ant-bad' }, {});
+    await providerSetHandler({ provider: 'anthropic' }, {});
+    __setClientFactory(() => ({
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      protocol: 'anthropic',
+      async complete() {
+        const err = new Error('invalid api key') as Error & { kind: string };
+        err.kind = 'auth';
+        throw err;
+      },
+      async *stream() {},
+    } as unknown as LLMClient));
+
+    const data = textOf(await providerTestHandler({}, {})) as { ok: boolean; reason?: string };
+    expect(data.ok).toBe(false);
+    expect(data.reason).toBe('auth_failed');
+  });
+
+  it('mock provider needs no key and can be probed directly', async () => {
+    __setClientFactory(() => ({
+      provider: 'mock',
+      model: 'mock',
+      protocol: 'anthropic',
+      async complete() {
+        return { content: 'echo: ping', toolCalls: [], stopReason: 'end_turn' as const };
+      },
+      async *stream() {},
+    } as unknown as LLMClient));
+    const data = textOf(await providerTestHandler({ provider: 'mock' }, {})) as { ok: boolean };
+    expect(data.ok).toBe(true);
+  });
+});
+
+describe('copilot_health', () => {
+  beforeEach(() => setDefaultSender(undefined as never));
+  afterEach(() => setDefaultSender(undefined as never));
+
+  it('reports sidecar_ok=false and ue_connected=false before anything is wired up', async () => {
+    const data = textOf(await healthHandler({}, {})) as {
+      sidecar_ok: boolean;
+      ue_connected: boolean;
+      tools_available: number;
+      active_provider: string | null;
+    };
+    expect(data.sidecar_ok).toBe(false);
+    expect(data.ue_connected).toBe(false);
+    // tools_available reflects listRecordedCommands(), which is populated by
+    // src/tools/index.ts's module-scope recordToolSchema loop — not loaded by
+    // this test file in isolation, so only assert the field's shape here.
+    expect(typeof data.tools_available).toBe('number');
+    expect(data.tools_available).toBeGreaterThanOrEqual(0);
+    expect(data.active_provider).toBeNull();
+  });
+
+  it('reports sidecar_ok=true once chat routes are registered', async () => {
+    const fakeApp = { post: vi.fn(), get: vi.fn() };
+    registerChatRoutes(fakeApp as never);
+    const data = textOf(await healthHandler({}, {})) as { sidecar_ok: boolean };
+    expect(data.sidecar_ok).toBe(true);
+  });
+
+  it('reports ue_connected=true when the UE bridge answers', async () => {
+    const okSender: Sender = async () => ({ id: 't', ok: true, data: {} });
+    setDefaultSender(okSender);
+    const data = textOf(await healthHandler({}, {})) as { ue_connected: boolean };
+    expect(data.ue_connected).toBe(true);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/copilot/copilot-tools.ts
+++ b/mcp-tools/hayba-mcp/src/tools/copilot/copilot-tools.ts
@@ -1,0 +1,369 @@
+/**
+ * copilot_* MCP tools (Task 5) — config/introspection for the BYOK in-editor
+ * copilot, so an agent (or the C++ panel via `hayba_invoke`) can manage the
+ * copilot without guessing at HTTP routes or memorized provider ids.
+ *
+ * These tools read/write the SAME in-memory config store that
+ * `POST/GET /chat/config` (src/chat/chat-server.ts) uses — see the narrow
+ * accessors exported there (`getConfigEntry`/`setConfigEntry`/`clearConfigKey`/
+ * `maskKey`). No duplicated state.
+ *
+ * TODO(Task 6): `copilot_key_set` / `copilot_key_clear` currently write/clear
+ * the in-memory configStore. Task 6 swaps the storage target to the C++ DPAPI
+ * vault (via a localhost handshake) — the tool names, schemas, and the
+ * never-echo-the-key contract do not change when that lands.
+ *
+ * Key-safety invariant (tested — see copilot-tools.test.ts "canary" case): no
+ * handler in this file ever places a raw API key value into a ToolResult. Only
+ * `last4` (via `maskKey`) is ever returned.
+ */
+
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import type { ToolHandler, ToolResult } from '../types.js';
+import { listProviders, getProvider, type ProviderEntry } from '../../agents/providers.js';
+import { createLLMClient, type LLMClient, type LLMClientConfig } from '../../agents/llm-client.js';
+import {
+  getConfigEntry,
+  setConfigEntry,
+  clearConfigKey,
+  maskKey,
+  isChatRoutesRegistered,
+} from '../../chat/chat-server.js';
+import { listRecordedCommands } from '../schema-registry.js';
+import { executeCommand } from '../tool-executor.js';
+
+const PACK = 'copilot';
+
+function ok(data: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+}
+
+function fail(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+function sessionIdOf(args: Record<string, unknown>): string | undefined {
+  return typeof args.session_id === 'string' ? args.session_id : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Test seam — DI for the LLM client factory used by copilot_provider_test, so
+// the probe never touches a real network in tests.
+// ---------------------------------------------------------------------------
+
+type ClientFactory = (config: LLMClientConfig) => LLMClient;
+let clientFactory: ClientFactory = createLLMClient;
+
+/** Test hook: inject a fake client factory (e.g. one that fails auth deterministically). */
+export function __setClientFactory(factory: ClientFactory): void {
+  clientFactory = factory;
+}
+
+/** Test hook: restore the real factory. */
+export function __resetClientFactory(): void {
+  clientFactory = createLLMClient;
+}
+
+// ---------------------------------------------------------------------------
+// copilot_provider_list
+// ---------------------------------------------------------------------------
+
+export const providerListMeta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'checking which BYOK providers are known and which one is active, before configuring the copilot',
+  not_when: 'you already know the active provider and just need its model — use copilot_model_list',
+  pack: PACK,
+};
+
+export const providerListHandler: ToolHandler = async (args) => {
+  const sessionId = sessionIdOf(args);
+  const cfg = getConfigEntry(sessionId);
+  const providers = listProviders().map((p: ProviderEntry) => {
+    const isActive = cfg?.provider === p.id;
+    return {
+      id: p.id,
+      label: p.label,
+      protocol: p.protocol,
+      needs_key: p.needsKey,
+      key_hint: p.keyHint,
+      default_model: p.defaultModel || null,
+      base_url_default: p.baseURLDefault || null,
+      active: isActive,
+      key_configured: isActive ? Boolean(cfg?.apiKey) : false,
+      key_last4: isActive ? maskKey(cfg?.apiKey) : null,
+    };
+  });
+  return ok({ providers, active_provider: cfg?.provider ?? null });
+};
+
+// ---------------------------------------------------------------------------
+// copilot_provider_set
+// ---------------------------------------------------------------------------
+
+export const providerSetMeta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['mutates in-memory copilot config'],
+  when: 'switching the active BYOK provider/model/base URL for a copilot session',
+  not_when: 'you only need to change the API key — use copilot_key_set',
+  pack: PACK,
+};
+
+export const providerSetHandler: ToolHandler = async (args) => {
+  const provider = args.provider;
+  if (typeof provider !== 'string' || !provider) {
+    return fail('provider is required');
+  }
+  const entry = getProvider(provider);
+  if (!entry) {
+    return fail(`unknown provider: ${provider}`);
+  }
+  const sessionId = sessionIdOf(args);
+  const existing = getConfigEntry(sessionId);
+  const model = typeof args.model === 'string' ? args.model : undefined;
+  const baseURL = typeof args.base_url === 'string' ? args.base_url : undefined;
+  // Switching provider drops a stale key from a DIFFERENT provider (mirrors the
+  // /chat/config route's M2 rule): the key belongs to whichever provider was
+  // configured when it was set, not to the new one.
+  const keepKey = existing?.provider === provider ? existing?.apiKey : undefined;
+  setConfigEntry(sessionId, {
+    provider,
+    model,
+    baseURL,
+    apiKey: keepKey,
+  });
+  return ok({
+    ok: true,
+    provider,
+    model: model ?? entry.defaultModel ?? null,
+    base_url: baseURL ?? entry.baseURLDefault ?? null,
+    key_last4: maskKey(keepKey),
+  });
+};
+
+// ---------------------------------------------------------------------------
+// copilot_provider_test — needsKey preflight, then a minimal complete() probe.
+// ---------------------------------------------------------------------------
+
+export const providerTestMeta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['may perform one network call to the configured LLM provider'],
+  when: 'verifying a BYOK provider/key actually works before relying on it in a chat session',
+  not_when: 'just listing catalog/config state — use copilot_provider_list or copilot_key_status (no network)',
+  pack: PACK,
+};
+
+export const providerTestHandler: ToolHandler = async (args) => {
+  const sessionId = sessionIdOf(args);
+  const cfg = getConfigEntry(sessionId);
+  const provider = typeof args.provider === 'string' && args.provider ? args.provider : cfg?.provider;
+  if (!provider) {
+    return ok({ ok: false, reason: 'no_provider_configured' });
+  }
+  const entry = getProvider(provider);
+  if (!entry) {
+    return ok({ ok: false, reason: 'unknown_provider' });
+  }
+  const apiKey = provider === cfg?.provider ? cfg?.apiKey : undefined;
+
+  // Preflight: needsKey + no key configured => fail clean, no network call.
+  if (entry.needsKey && !apiKey) {
+    return ok({ ok: false, reason: 'no_key' });
+  }
+
+  const model = typeof args.model === 'string' ? args.model : cfg?.model;
+  const start = Date.now();
+  try {
+    const client = clientFactory({
+      provider,
+      model,
+      baseURL: cfg?.baseURL,
+      apiKey,
+    });
+    await client.complete({
+      system: 'You are a connectivity probe. Reply with a single word.',
+      messages: [{ role: 'user', content: 'ping' }],
+      maxTokens: 8,
+    });
+    return ok({ ok: true, latency_ms: Date.now() - start, model: client.model });
+  } catch (err) {
+    const kind = (err as { kind?: string })?.kind;
+    const reason = kind === 'auth' ? 'auth_failed' : kind === 'rate_limit' ? 'rate_limited' : kind === 'network' ? 'network_error' : 'api_error';
+    return ok({
+      ok: false,
+      reason,
+      latency_ms: Date.now() - start,
+      detail: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// copilot_model_list — advisory, static known-models per provider.
+// ---------------------------------------------------------------------------
+
+/**
+ * Advisory only: BYOK means the user may point any provider at any model id
+ * their key/endpoint supports (esp. `custom` and `openrouter`, whose catalogs
+ * rotate). This list is a convenience starting point, NOT a validated set.
+ */
+const KNOWN_MODELS: Record<string, string[]> = {
+  mock: ['mock'],
+  anthropic: ['claude-opus-4-8', 'claude-sonnet-4-8', 'claude-haiku-4-5'],
+  openai: ['gpt-4o', 'gpt-4o-mini', 'gpt-4.1'],
+  groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant'],
+  openrouter: [], // free-tier slugs rotate — no stable defaults; see providers.ts
+  ollama: ['qwen2.5-coder:7b-instruct', 'llama3.1:8b'],
+  lmstudio: ['local-model'],
+  custom: [],
+};
+
+export const modelListMeta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'picking a model id for a provider before calling copilot_provider_set',
+  not_when: 'you already have a model id in hand — this list is advisory, not a validator',
+  pack: PACK,
+};
+
+export const modelListHandler: ToolHandler = async (args) => {
+  const provider = args.provider;
+  if (typeof provider !== 'string' || !provider) {
+    return fail('provider is required');
+  }
+  const entry = getProvider(provider);
+  if (!entry) {
+    return fail(`unknown provider: ${provider}`);
+  }
+  const sessionId = sessionIdOf(args);
+  const cfg = getConfigEntry(sessionId);
+  const configuredModel = cfg?.provider === provider ? cfg?.model : undefined;
+  const known = KNOWN_MODELS[provider] ?? [];
+  const models = new Set(known);
+  if (configuredModel) models.add(configuredModel);
+  if (entry.defaultModel) models.add(entry.defaultModel);
+  return ok({
+    provider,
+    default_model: entry.defaultModel || null,
+    configured_model: configuredModel ?? null,
+    known_models: [...models],
+    advisory: true,
+    note: 'BYOK: any model id your key/endpoint supports may work, even if absent from this list.',
+  });
+};
+
+// ---------------------------------------------------------------------------
+// copilot_key_set / copilot_key_clear
+// ---------------------------------------------------------------------------
+
+export const keySetMeta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['writes an API key into the in-memory copilot config (TODO Task 6: DPAPI vault)'],
+  when: 'configuring the BYOK key for a provider before using the copilot',
+  not_when: 'switching providers without changing the key — use copilot_provider_set',
+  pack: PACK,
+};
+
+export const keySetHandler: ToolHandler = async (args) => {
+  const provider = args.provider;
+  const apiKey = args.api_key;
+  if (typeof provider !== 'string' || !provider) {
+    return fail('provider is required');
+  }
+  if (typeof apiKey !== 'string' || !apiKey) {
+    return fail('api_key is required');
+  }
+  if (!getProvider(provider)) {
+    return fail(`unknown provider: ${provider}`);
+  }
+  const sessionId = sessionIdOf(args);
+  const existing = getConfigEntry(sessionId);
+  setConfigEntry(sessionId, {
+    provider,
+    model: existing?.provider === provider ? existing?.model : undefined,
+    baseURL: existing?.provider === provider ? existing?.baseURL : undefined,
+    apiKey,
+  });
+  // NEVER echo the key — masked last-4 only.
+  return ok({ ok: true, provider, key_last4: maskKey(apiKey) });
+};
+
+export const keyClearMeta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['clears the stored API key for a provider (in-memory; TODO Task 6: DPAPI vault)'],
+  when: 'removing a stored BYOK key, e.g. before handing off a machine or rotating credentials',
+  not_when: 'never — this is destructive and plan-gated when Plan Mode is on',
+  pack: PACK,
+};
+
+export const keyClearHandler: ToolHandler = async (args) => {
+  const provider = args.provider;
+  if (typeof provider !== 'string' || !provider) {
+    return fail('provider is required');
+  }
+  const sessionId = sessionIdOf(args);
+  const existing = getConfigEntry(sessionId);
+  if (existing?.provider !== provider) {
+    // Nothing configured for this provider — clearing is a no-op, not an error.
+    return ok({ ok: true, provider, cleared: false });
+  }
+  clearConfigKey(sessionId);
+  return ok({ ok: true, provider, cleared: true });
+};
+
+// ---------------------------------------------------------------------------
+// copilot_key_status
+// ---------------------------------------------------------------------------
+
+export const keyStatusMeta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'checking whether a key is configured for each provider, without a network call',
+  not_when: 'verifying the key actually authenticates — use copilot_provider_test',
+  pack: PACK,
+};
+
+export const keyStatusHandler: ToolHandler = async (args) => {
+  const sessionId = sessionIdOf(args);
+  const cfg = getConfigEntry(sessionId);
+  const providers = listProviders().map((p) => {
+    const isActive = cfg?.provider === p.id;
+    const configured = isActive && Boolean(cfg?.apiKey);
+    return {
+      provider: p.id,
+      configured,
+      last4: configured ? maskKey(cfg?.apiKey) : undefined,
+    };
+  });
+  return ok({ providers });
+};
+
+// ---------------------------------------------------------------------------
+// copilot_health
+// ---------------------------------------------------------------------------
+
+export const healthMeta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'diagnosing whether the copilot sidecar/UE bridge/tool registry are up before troubleshooting a chat failure',
+  not_when: 'you just need provider/key state — use copilot_provider_list / copilot_key_status',
+  pack: PACK,
+};
+
+export const healthHandler: ToolHandler = async (args) => {
+  const sessionId = sessionIdOf(args);
+  const cfg = getConfigEntry(sessionId);
+  let ueConnected = false;
+  try {
+    await executeCommand('hayba_check_ue_status', {}, { timeout: 2000 });
+    ueConnected = true;
+  } catch {
+    ueConnected = false;
+  }
+  return ok({
+    sidecar_ok: isChatRoutesRegistered(),
+    ue_connected: ueConnected,
+    tools_available: listRecordedCommands().length,
+    active_provider: cfg?.provider ?? null,
+  });
+};

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -61,6 +61,16 @@ import { materialDisconnectHandler, meta as materialDisconnectMeta } from './mat
 import { materialValidateHandler, meta as materialValidateMeta } from './material/material-validate.js';
 import { worldGenerateHandler, meta as worldGenerateMeta } from './world/world-generate.js';
 import {
+  providerListHandler, providerListMeta,
+  providerSetHandler, providerSetMeta,
+  providerTestHandler, providerTestMeta,
+  modelListHandler, modelListMeta,
+  keySetHandler, keySetMeta,
+  keyClearHandler, keyClearMeta,
+  keyStatusHandler, keyStatusMeta,
+  healthHandler, healthMeta,
+} from './copilot/copilot-tools.js';
+import {
   textureGetInfoHandler, getInfoMeta as textureGetInfoMeta,
   textureSetCompressionHandler, setCompressionMeta as textureSetCompressionMeta,
   textureSetSettingsHandler, setSettingsMeta as textureSetSettingsMeta,
@@ -219,6 +229,7 @@ const dCoerceVec3 = z.preprocess((v) => {
  * are now generated automatically from this list.
  */
 const M = 'material'; // niche domain for the material toolset
+const PACK = 'copilot'; // niche domain for the BYOK copilot config/introspection toolset
 // Hand-written descriptors. Kept as a named const so the generated legacy list
 // can be de-duplicated against these names before splicing (see below).
 const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
@@ -897,6 +908,116 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
     // and src/tools/mesh/mesh-py-tools.ts for the catalog overlap/skip analysis.
     ...assetPyDescriptors.map((d) => toToolDescriptor(d)),
     ...meshPyDescriptors.map((d) => toToolDescriptor(d)),
+
+    // ── BYOK copilot config/introspection (Task 5) ────────────────────────────
+    // Pure-TS descriptors reading/writing the SAME in-memory config store the
+    // /chat/config sidecar routes use (src/chat/chat-server.ts). See
+    // src/tools/copilot/copilot-tools.ts for the vault TODO (Task 6).
+    {
+      name: 'copilot_provider_list',
+      description: 'List the BYOK provider catalog, flagging which provider is active and whether a key is configured for it (masked last-4 only).',
+      meta: providerListMeta,
+      handler: providerListHandler,
+      cost: 'low',
+      returns: '{providers:[{id,label,protocol,needs_key,key_hint,default_model,base_url_default,active,key_configured,key_last4}], active_provider}',
+      niche: PACK,
+      schema: {
+        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
+      },
+    },
+    {
+      name: 'copilot_provider_set',
+      description: 'Set the active BYOK provider (and optional model/base URL) for a copilot session.',
+      meta: providerSetMeta,
+      handler: providerSetHandler,
+      cost: 'low',
+      returns: '{ok, provider, model, base_url, key_last4}',
+      niche: PACK,
+      schema: {
+        provider: z.string().min(1).describe('Provider id from copilot_provider_list, e.g. "anthropic"'),
+        model: z.string().optional().describe('Override the provider default model'),
+        base_url: z.string().optional().describe('Override the provider default base URL (e.g. self-hosted OpenAI-compat endpoint)'),
+        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
+      },
+    },
+    {
+      name: 'copilot_provider_test',
+      description: 'Preflight-check a BYOK provider: fails clean with {ok:false, reason:"no_key"} (no network call) if a key is required but absent; otherwise runs a minimal completion probe and reports latency.',
+      meta: providerTestMeta,
+      handler: providerTestHandler,
+      cost: 'low',
+      returns: '{ok, latency_ms?, model?, reason?, detail?}',
+      niche: PACK,
+      schema: {
+        provider: z.string().optional().describe('Provider id to test; defaults to the configured active provider'),
+        model: z.string().optional().describe('Model id to test; defaults to the configured/default model'),
+        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
+      },
+    },
+    {
+      name: 'copilot_model_list',
+      description: 'List known model ids for a BYOK provider (advisory starting point only — BYOK users may use any id their key/endpoint supports).',
+      meta: modelListMeta,
+      handler: modelListHandler,
+      cost: 'low',
+      returns: '{provider, default_model, configured_model, known_models:[string], advisory:true, note}',
+      niche: PACK,
+      schema: {
+        provider: z.string().min(1).describe('Provider id from copilot_provider_list'),
+        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
+      },
+    },
+    {
+      name: 'copilot_key_set',
+      description: 'Set the BYOK API key for a provider. The key is NEVER echoed back or logged — the response contains only a masked last-4. Stored in-memory (TODO Task 6: swaps to the C++ DPAPI vault).',
+      meta: keySetMeta,
+      handler: keySetHandler,
+      cost: 'low',
+      returns: '{ok, provider, key_last4}',
+      niche: PACK,
+      schema: {
+        provider: z.string().min(1).describe('Provider id from copilot_provider_list'),
+        api_key: z.string().min(1).describe('The raw API key (never returned or logged)'),
+        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
+      },
+    },
+    {
+      name: 'copilot_key_clear',
+      description: 'Clear the stored BYOK API key for a provider. Destructive — plan-gated when Plan Mode is on.',
+      meta: keyClearMeta,
+      handler: keyClearHandler,
+      cost: 'low',
+      returns: '{ok, provider, cleared}',
+      niche: PACK,
+      schema: {
+        provider: z.string().min(1).describe('Provider id whose key should be cleared'),
+        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
+      },
+    },
+    {
+      name: 'copilot_key_status',
+      description: 'Report, per provider, whether a BYOK key is configured (masked last-4 only, no network call).',
+      meta: keyStatusMeta,
+      handler: keyStatusHandler,
+      cost: 'low',
+      returns: '{providers:[{provider,configured,last4?}]}',
+      niche: PACK,
+      schema: {
+        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
+      },
+    },
+    {
+      name: 'copilot_health',
+      description: 'Cheap health snapshot for the copilot stack: sidecar chat routes registered, UE bridge reachable, tool registry size, and the active provider.',
+      meta: healthMeta,
+      handler: healthHandler,
+      cost: 'low',
+      returns: '{sidecar_ok, ue_connected, tools_available, active_provider}',
+      niche: PACK,
+      schema: {
+        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
+      },
+    },
 ];
 
 // Single-source tool descriptor list = hand-written entries + the sidecar-

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -36,6 +36,7 @@ import { dagRecordHandler, dagRecordSchema } from '../dag/record.js';
 import { dagRebuildHandler, dagRebuildSchema } from '../dag/rebuild.js';
 import { journalTailHandler, journalTailSchema } from '../dag/journal-tail.js';
 import { setAssetDagSink } from '../asset-sources/shared.js';
+import { registerChatCapturedTools } from '../../chat/tool-dispatch.js';
 
 /** Tools registered by registerDeferredRouting itself — skip in shim re-register. */
 export const ALWAYS_ON_META = new Set<string>([
@@ -125,6 +126,10 @@ export async function registerDeferredRouting(
   captured: Map<string, CapturedTool>,
   cacheDir?: string,
 ): Promise<RoutingHandle> {
+  // Publish the captured-tool map to the chat dispatcher (Task 4) so the sidecar
+  // SSE copilot reaches TS-side handlers, not just UE-bridged commands.
+  registerChatCapturedTools(captured);
+
   const settings = readSettings();
   const effectiveCacheDir = cacheDir
     ?? process.env.HAYBA_TOOL_INDEX_DIR

--- a/mcp-tools/hayba-mcp/tests/agents/llm-client.test.ts
+++ b/mcp-tools/hayba-mcp/tests/agents/llm-client.test.ts
@@ -363,6 +363,129 @@ describe('mock provider', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Content-block transcript fidelity (tool_use + tool_result round-trip)
+// ---------------------------------------------------------------------------
+
+describe('content-block transcript', () => {
+  const TRANSCRIPT = {
+    system: 'sys',
+    tools: [TOOL],
+    messages: [
+      { role: 'user' as const, content: 'weather in Paris?' },
+      {
+        role: 'assistant' as const,
+        content: [
+          { type: 'text' as const, text: 'let me check' },
+          { type: 'tool_use' as const, id: 'tu_1', name: 'get_weather', input: { city: 'Paris' } },
+        ],
+      },
+      {
+        role: 'user' as const,
+        content: [
+          { type: 'tool_result' as const, tool_use_id: 'tu_1', content: '{"temp":20}' },
+        ],
+      },
+    ],
+  };
+
+  it('Anthropic builder passes tool_use + tool_result blocks through natively', async () => {
+    let captured: any;
+    const fake: AnthropicClientLike = {
+      messages: {
+        async create(params) {
+          captured = params;
+          return { content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' };
+        },
+        stream: () => iter([]),
+      },
+    };
+    const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake });
+    await client.complete(TRANSCRIPT);
+
+    const assistant = captured.messages[1];
+    expect(assistant.content).toContainEqual({
+      type: 'tool_use',
+      id: 'tu_1',
+      name: 'get_weather',
+      input: { city: 'Paris' },
+    });
+    const userResult = captured.messages[2];
+    expect(userResult.content).toContainEqual({
+      type: 'tool_result',
+      tool_use_id: 'tu_1',
+      content: '{"temp":20}',
+    });
+  });
+
+  it('OpenAI builder maps tool_use → tool_calls and tool_result → tool messages', async () => {
+    let captured: any;
+    const fake: OpenAIClientLike = {
+      chat: {
+        completions: {
+          async create(params) {
+            captured = params;
+            return { choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }] };
+          },
+        },
+      },
+    };
+    const client = createLLMClient({ provider: 'openai', apiKey: 'k' }, { openai: fake });
+    await client.complete(TRANSCRIPT);
+
+    // messages[0] is the system fold; assistant turn carries tool_calls.
+    const assistant = captured.messages.find((m: any) => m.role === 'assistant');
+    expect(assistant.content).toBe('let me check');
+    expect(assistant.tool_calls).toEqual([
+      { id: 'tu_1', type: 'function', function: { name: 'get_weather', arguments: '{"city":"Paris"}' } },
+    ]);
+    // tool_result becomes a standalone tool-role message with matching id.
+    const toolMsg = captured.messages.find((m: any) => m.role === 'tool');
+    expect(toolMsg).toEqual({ role: 'tool', tool_call_id: 'tu_1', content: '{"temp":20}' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AbortSignal threading
+// ---------------------------------------------------------------------------
+
+describe('signal threading', () => {
+  it('threads the signal into the Anthropic SDK request options', async () => {
+    const ac = new AbortController();
+    let opts: any;
+    const fake: AnthropicClientLike = {
+      messages: {
+        async create(_params, options) {
+          opts = options;
+          return { content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' };
+        },
+        stream: () => iter([]),
+      },
+    };
+    const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake });
+    await client.complete({ ...BASE, signal: ac.signal });
+    expect(opts?.signal).toBe(ac.signal);
+  });
+
+  it('threads the signal into the OpenAI SDK request options', async () => {
+    const ac = new AbortController();
+    let opts: any;
+    const fake: OpenAIClientLike = {
+      chat: {
+        completions: {
+          async create(_params, options) {
+            opts = options;
+            return { choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }] };
+          },
+        },
+      },
+    };
+    const client = createLLMClient({ provider: 'openai', apiKey: 'k' }, { openai: fake });
+    await client.complete({ ...BASE, signal: ac.signal });
+    expect(opts?.signal).toBe(ac.signal);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Config resolution
 // ---------------------------------------------------------------------------
 

--- a/mcp-tools/hayba-mcp/tests/agents/llm-client.test.ts
+++ b/mcp-tools/hayba-mcp/tests/agents/llm-client.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createLLMClient,
+  LLMError,
+  type AnthropicClientLike,
+  type OpenAIClientLike,
+  type LLMStreamEvent,
+  type LLMTool,
+} from '../../src/agents/llm-client.js';
+
+const TOOL: LLMTool = {
+  name: 'get_weather',
+  description: 'Get the weather',
+  input_schema: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] },
+};
+
+const BASE = { system: 'sys', messages: [{ role: 'user' as const, content: 'hi' }], tools: [TOOL] };
+
+async function drain(gen: AsyncGenerator<LLMStreamEvent>): Promise<LLMStreamEvent[]> {
+  const out: LLMStreamEvent[] = [];
+  for await (const ev of gen) out.push(ev);
+  return out;
+}
+
+/** Turn an array into an async iterable (fake stream). */
+async function* iter<T>(items: T[]): AsyncGenerator<T> {
+  for (const i of items) yield i;
+}
+
+// ---------------------------------------------------------------------------
+// Tool mapping
+// ---------------------------------------------------------------------------
+
+describe('tool mapping', () => {
+  it('maps tools to the Anthropic wire format', async () => {
+    let captured: any;
+    const fake: AnthropicClientLike = {
+      messages: {
+        async create(params) {
+          captured = params;
+          return { content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' };
+        },
+        stream: () => iter([]),
+      },
+    };
+    const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake });
+    await client.complete(BASE);
+    expect(captured.tools).toEqual([
+      { name: 'get_weather', description: 'Get the weather', input_schema: TOOL.input_schema },
+    ]);
+    expect(captured.model).toBe('claude-opus-4-8');
+  });
+
+  it('maps tools to the OpenAI function format', async () => {
+    let captured: any;
+    const fake: OpenAIClientLike = {
+      chat: {
+        completions: {
+          async create(params) {
+            captured = params;
+            return { choices: [{ message: { content: 'ok', tool_calls: [] }, finish_reason: 'stop' }] };
+          },
+        },
+      },
+    };
+    const client = createLLMClient({ provider: 'openai', apiKey: 'k' }, { openai: fake });
+    await client.complete(BASE);
+    expect(captured.tools).toEqual([
+      {
+        type: 'function',
+        function: { name: 'get_weather', description: 'Get the weather', parameters: TOOL.input_schema },
+      },
+    ]);
+    // system prompt folds into the first message for openai-compat
+    expect(captured.messages[0]).toEqual({ role: 'system', content: 'sys' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// complete() parsing
+// ---------------------------------------------------------------------------
+
+describe('complete() parsing', () => {
+  it('parses Anthropic tool_use blocks and stop_reason', async () => {
+    const fake: AnthropicClientLike = {
+      messages: {
+        async create() {
+          return {
+            content: [
+              { type: 'text', text: 'let me check' },
+              { type: 'tool_use', id: 'tu_1', name: 'get_weather', input: { city: 'Paris' } },
+            ],
+            stop_reason: 'tool_use',
+          };
+        },
+        stream: () => iter([]),
+      },
+    };
+    const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake });
+    const resp = await client.complete(BASE);
+    expect(resp.stopReason).toBe('tool_use');
+    expect(resp.content).toBe('let me check');
+    expect(resp.toolCalls).toEqual([{ id: 'tu_1', name: 'get_weather', input: { city: 'Paris' } }]);
+  });
+
+  it('parses Anthropic end_turn with no tools', async () => {
+    const fake: AnthropicClientLike = {
+      messages: {
+        async create() {
+          return { content: [{ type: 'text', text: 'hello' }], stop_reason: 'end_turn' };
+        },
+        stream: () => iter([]),
+      },
+    };
+    const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake });
+    const resp = await client.complete({ system: 's', messages: [{ role: 'user', content: 'x' }] });
+    expect(resp.stopReason).toBe('end_turn');
+    expect(resp.toolCalls).toEqual([]);
+  });
+
+  it('parses OpenAI tool_calls with JSON-string arguments', async () => {
+    const fake: OpenAIClientLike = {
+      chat: {
+        completions: {
+          async create() {
+            return {
+              choices: [
+                {
+                  message: {
+                    content: null,
+                    tool_calls: [
+                      { id: 'call_1', function: { name: 'get_weather', arguments: '{"city":"Paris"}' } },
+                    ],
+                  },
+                  finish_reason: 'tool_calls',
+                },
+              ],
+            };
+          },
+        },
+      },
+    };
+    const client = createLLMClient({ provider: 'groq', apiKey: 'k' }, { openai: fake });
+    const resp = await client.complete(BASE);
+    expect(resp.stopReason).toBe('tool_use');
+    expect(resp.content).toBeNull();
+    expect(resp.toolCalls).toEqual([{ id: 'call_1', name: 'get_weather', input: { city: 'Paris' } }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming accumulation == complete()
+// ---------------------------------------------------------------------------
+
+describe('stream() accumulation', () => {
+  it('Anthropic stream produces the same final response as complete()', async () => {
+    const events = [
+      { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'let me ' } },
+      { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'check' } },
+      { type: 'content_block_stop', index: 0 },
+      {
+        type: 'content_block_start',
+        index: 1,
+        content_block: { type: 'tool_use', id: 'tu_1', name: 'get_weather' },
+      },
+      { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{"city":' } },
+      { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '"Paris"}' } },
+      { type: 'content_block_stop', index: 1 },
+      { type: 'message_delta', delta: { stop_reason: 'tool_use' } },
+    ];
+    const fake: AnthropicClientLike = {
+      messages: {
+        async create() {
+          return {
+            content: [
+              { type: 'text', text: 'let me check' },
+              { type: 'tool_use', id: 'tu_1', name: 'get_weather', input: { city: 'Paris' } },
+            ],
+            stop_reason: 'tool_use',
+          };
+        },
+        stream: () => iter(events),
+      },
+    };
+    const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake });
+    const streamed = await drain(client.stream(BASE));
+
+    const deltas = streamed.filter((e) => e.type === 'text_delta').map((e) => (e as any).text);
+    expect(deltas.join('')).toBe('let me check');
+    const toolEvents = streamed.filter((e) => e.type === 'tool_call');
+    expect(toolEvents).toHaveLength(1);
+
+    const doneEv = streamed.at(-1);
+    expect(doneEv?.type).toBe('done');
+    const streamedResponse = (doneEv as any).response;
+    const completed = await client.complete(BASE);
+    expect(streamedResponse).toEqual(completed);
+  });
+
+  it('OpenAI stream accumulates delta fragments and matches complete()', async () => {
+    const chunks = [
+      { choices: [{ delta: { content: 'let me ' } }] },
+      { choices: [{ delta: { content: 'check' } }] },
+      {
+        choices: [
+          { delta: { tool_calls: [{ index: 0, id: 'call_1', function: { name: 'get_weather', arguments: '{"ci' } }] } },
+        ],
+      },
+      { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: 'ty":"Paris"}' } }] } }] },
+      { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+    ];
+    const fake: OpenAIClientLike = {
+      chat: {
+        completions: {
+          async create(params) {
+            if (params.stream) return iter(chunks) as unknown as Record<string, unknown>;
+            return {
+              choices: [
+                {
+                  message: {
+                    content: 'let me check',
+                    tool_calls: [
+                      { id: 'call_1', function: { name: 'get_weather', arguments: '{"city":"Paris"}' } },
+                    ],
+                  },
+                  finish_reason: 'tool_calls',
+                },
+              ],
+            };
+          },
+        },
+      },
+    };
+    const client = createLLMClient({ provider: 'openai', apiKey: 'k' }, { openai: fake });
+    const streamed = await drain(client.stream(BASE));
+    const doneEv = streamed.at(-1);
+    const streamedResponse = (doneEv as any).response;
+    const completed = await client.complete(BASE);
+    expect(streamedResponse).toEqual(completed);
+    expect(streamedResponse.toolCalls).toEqual([
+      { id: 'call_1', name: 'get_weather', input: { city: 'Paris' } },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+describe('error mapping', () => {
+  const cases: Array<[unknown, string]> = [
+    [{ status: 401, message: 'bad key' }, 'auth'],
+    [{ status: 429, message: 'slow down' }, 'rate_limit'],
+    [Object.assign(new Error('ECONNREFUSED'), {}), 'network'],
+  ];
+
+  for (const [thrown, kind] of cases) {
+    it(`maps to '${kind}' (anthropic)`, async () => {
+      const fake: AnthropicClientLike = {
+        messages: {
+          async create() {
+            throw thrown;
+          },
+          stream: () => iter([]),
+        },
+      };
+      const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake });
+      await expect(client.complete(BASE)).rejects.toMatchObject({ kind });
+    });
+
+    it(`maps to '${kind}' (openai)`, async () => {
+      const fake: OpenAIClientLike = {
+        chat: {
+          completions: {
+            async create() {
+              throw thrown;
+            },
+          },
+        },
+      };
+      const client = createLLMClient({ provider: 'openai', apiKey: 'k' }, { openai: fake });
+      await expect(client.complete(BASE)).rejects.toBeInstanceOf(LLMError);
+      await expect(client.complete(BASE)).rejects.toMatchObject({ kind });
+    });
+  }
+
+  it('maps streaming errors too', async () => {
+    const fake: OpenAIClientLike = {
+      chat: {
+        completions: {
+          async create() {
+            throw { status: 429, message: 'rate' };
+          },
+        },
+      },
+    };
+    const client = createLLMClient({ provider: 'openai', apiKey: 'k' }, { openai: fake });
+    await expect(drain(client.stream(BASE))).rejects.toMatchObject({ kind: 'rate_limit' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Key safety
+// ---------------------------------------------------------------------------
+
+describe('API key safety', () => {
+  const SECRET = 'sk-ant-super-secret-key-123';
+
+  it('never leaks the key in a thrown error message', async () => {
+    const fake: AnthropicClientLike = {
+      messages: {
+        async create() {
+          throw { status: 401, message: `auth failed for ${SECRET}` };
+        },
+        stream: () => iter([]),
+      },
+    };
+    const client = createLLMClient({ provider: 'anthropic', apiKey: SECRET }, { anthropic: fake });
+    try {
+      await client.complete(BASE);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LLMError);
+      expect((err as LLMError).message).not.toContain(SECRET);
+      expect((err as LLMError).message).toContain('***');
+    }
+  });
+
+  it('never emits the key in stream events', async () => {
+    const client = createLLMClient({ provider: 'mock' });
+    const events = await drain(client.stream({ system: 's', messages: [{ role: 'user', content: SECRET }] }));
+    const serialized = JSON.stringify(events);
+    // The mock echoes the user message, so the secret content itself may appear —
+    // what must never appear is the configured apiKey, which mock never receives.
+    expect(serialized).not.toContain('apiKey');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mock provider
+// ---------------------------------------------------------------------------
+
+describe('mock provider', () => {
+  it('completes deterministically offline (no SDK, no key)', async () => {
+    const client = createLLMClient({ provider: 'mock' });
+    const resp = await client.complete({ system: 's', messages: [{ role: 'user', content: 'ping' }] });
+    expect(resp).toEqual({ content: 'echo: ping', toolCalls: [], stopReason: 'end_turn' });
+  });
+
+  it('streams deltas that reconstruct the completed content', async () => {
+    const client = createLLMClient({ provider: 'mock' });
+    const params = { system: 's', messages: [{ role: 'user' as const, content: 'hello world' }] };
+    const events = await drain(client.stream(params));
+    const text = events
+      .filter((e) => e.type === 'text_delta')
+      .map((e) => (e as any).text)
+      .join('');
+    const done = events.at(-1) as any;
+    expect(text).toBe(done.response.content);
+    expect(done.response.content).toBe('echo: hello world');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config resolution
+// ---------------------------------------------------------------------------
+
+describe('config resolution', () => {
+  it('throws for an unknown provider', () => {
+    expect(() => createLLMClient({ provider: 'nope' })).toThrow(LLMError);
+  });
+
+  it('honors explicit model/baseURL over catalog defaults', async () => {
+    let captured: any;
+    const fake: OpenAIClientLike = {
+      chat: {
+        completions: {
+          async create(params) {
+            captured = params;
+            return { choices: [{ message: { content: 'x' }, finish_reason: 'stop' }] };
+          },
+        },
+      },
+    };
+    const client = createLLMClient(
+      { provider: 'openrouter', model: 'custom/model', apiKey: 'k' },
+      { openai: fake },
+    );
+    expect(client.model).toBe('custom/model');
+    await client.complete({ system: 's', messages: [{ role: 'user', content: 'x' }] });
+    expect(captured.model).toBe('custom/model');
+  });
+});

--- a/mcp-tools/hayba-mcp/tests/agents/providers.test.ts
+++ b/mcp-tools/hayba-mcp/tests/agents/providers.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { listProviders, getProvider, registerCustomProvider } from '../../src/agents/providers.js';
+
+const EXPECTED_IDS = ['mock', 'anthropic', 'openai', 'groq', 'openrouter', 'ollama', 'lmstudio', 'custom'];
+
+describe('providers catalog', () => {
+  it('exposes all 8 built-in providers', () => {
+    const ids = listProviders().map((p) => p.id);
+    for (const id of EXPECTED_IDS) {
+      expect(ids).toContain(id);
+    }
+    expect(ids.length).toBeGreaterThanOrEqual(EXPECTED_IDS.length);
+  });
+
+  it('classifies anthropic as the anthropic protocol', () => {
+    expect(getProvider('anthropic')?.protocol).toBe('anthropic');
+  });
+
+  it('classifies the openai-compat family as the openai protocol', () => {
+    for (const id of ['openai', 'groq', 'openrouter', 'ollama', 'lmstudio', 'custom']) {
+      expect(getProvider(id)?.protocol).toBe('openai');
+    }
+  });
+
+  it('flags mock/ollama/lmstudio as keyless', () => {
+    for (const id of ['mock', 'ollama', 'lmstudio']) {
+      expect(getProvider(id)?.needsKey).toBe(false);
+    }
+  });
+
+  it('flags anthropic/openai/groq/openrouter as needing a key', () => {
+    for (const id of ['anthropic', 'openai', 'groq', 'openrouter']) {
+      expect(getProvider(id)?.needsKey).toBe(true);
+    }
+  });
+
+  it('anthropic defaults to claude-opus-4-8', () => {
+    expect(getProvider('anthropic')?.defaultModel).toBe('claude-opus-4-8');
+  });
+
+  it('registers a custom provider and it appears in the list afterward', () => {
+    const before = listProviders().length;
+    const entry = registerCustomProvider('My Local vLLM', 'http://localhost:8080/v1', 'Bearer abc', 'llama-3-8b');
+
+    const after = listProviders();
+    expect(after.length).toBe(before + 1);
+
+    const found = getProvider(entry.id);
+    expect(found).toBeDefined();
+    expect(found?.baseURLDefault).toBe('http://localhost:8080/v1');
+    expect(found?.defaultModel).toBe('llama-3-8b');
+    expect(found?.needsKey).toBe(true);
+    expect(found?.protocol).toBe('openai');
+  });
+
+  it('registering with the same label again overwrites rather than duplicating', () => {
+    registerCustomProvider('Dup Provider', 'http://a', undefined, 'm1');
+    const countAfterFirst = listProviders().length;
+    registerCustomProvider('Dup Provider', 'http://b', undefined, 'm2');
+    const countAfterSecond = listProviders().length;
+    expect(countAfterSecond).toBe(countAfterFirst);
+    expect(getProvider('dup-provider')?.baseURLDefault).toBe('http://b');
+  });
+});

--- a/mcp-tools/hayba-mcp/tests/chat/chat-server.test.ts
+++ b/mcp-tools/hayba-mcp/tests/chat/chat-server.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import {
+  registerChatRoutes,
+  __resetChatState,
+  isLoopback,
+} from '../../src/chat/chat-server.js';
+import type { LLMClient, LLMStreamEvent } from '../../src/agents/llm-client.js';
+
+// A distinctive fake key we assert never leaks into any SSE frame or config read.
+const FAKE_KEY = 'sk-ant-LEAK-CANARY-000111222333';
+
+// ---------------------------------------------------------------------------
+// Scriptable fake LLM client
+// ---------------------------------------------------------------------------
+
+interface ScriptStep {
+  deltas?: string[];
+  slowMs?: number;
+  content: string | null;
+  toolCalls: Array<{ id: string; name: string; input: Record<string, unknown> }>;
+  stopReason: 'end_turn' | 'tool_use' | 'max_tokens';
+}
+
+function makeFakeClientFactory(script: ScriptStep[]): () => LLMClient {
+  let turn = 0;
+  return () =>
+    ({
+      provider: 'mock',
+      model: 'fake',
+      protocol: 'anthropic',
+      async complete() {
+        throw new Error('not used');
+      },
+      async *stream(): AsyncGenerator<LLMStreamEvent, void, unknown> {
+        const step = script[turn++] ?? {
+          content: null,
+          toolCalls: [],
+          stopReason: 'end_turn' as const,
+        };
+        for (const t of step.deltas ?? []) {
+          if (step.slowMs) await new Promise((r) => setTimeout(r, step.slowMs));
+          yield { type: 'text_delta', text: t };
+        }
+        yield {
+          type: 'done',
+          response: {
+            content: step.content,
+            toolCalls: step.toolCalls,
+            stopReason: step.stopReason,
+          },
+        };
+      },
+    }) as unknown as LLMClient;
+}
+
+// ---------------------------------------------------------------------------
+// SSE reader — parses `event:`/`data:`/`id:` frames from a fetch stream.
+// ---------------------------------------------------------------------------
+
+interface Frame {
+  id?: number;
+  event: string;
+  data: unknown;
+}
+
+async function readAllFrames(body: ReadableStream<Uint8Array>): Promise<Frame[]> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  const frames: Frame[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    buf = drain(buf, frames);
+  }
+  drain(buf + '\n\n', frames);
+  return frames;
+}
+
+function drain(buf: string, out: Frame[]): string {
+  let idx: number;
+  while ((idx = buf.indexOf('\n\n')) !== -1) {
+    const block = buf.slice(0, idx);
+    buf = buf.slice(idx + 2);
+    if (!block.trim() || block.startsWith(':')) continue; // heartbeat / blank
+    let event = 'message';
+    let dataStr = '';
+    let id: number | undefined;
+    for (const line of block.split('\n')) {
+      if (line.startsWith('event:')) event = line.slice(6).trim();
+      else if (line.startsWith('data:')) dataStr += line.slice(5).trim();
+      else if (line.startsWith('id:')) id = Number(line.slice(3).trim());
+    }
+    let data: unknown = dataStr;
+    try {
+      data = JSON.parse(dataStr);
+    } catch {
+      /* leave as string */
+    }
+    out.push({ id, event, data });
+  }
+  return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function startApp(opts: Parameters<typeof registerChatRoutes>[1]): {
+  server: Server;
+  url: string;
+} {
+  const app = express();
+  app.use(express.json());
+  registerChatRoutes(app, opts);
+  const server = app.listen(0);
+  const port = (server.address() as AddressInfo).port;
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+describe('sidecar SSE chat server', () => {
+  let server: Server;
+  let url: string;
+
+  beforeEach(() => __resetChatState());
+  afterEach(() => server?.close());
+
+  it('isLoopback recognises loopback addresses only', () => {
+    expect(isLoopback('127.0.0.1')).toBe(true);
+    expect(isLoopback('::1')).toBe(true);
+    expect(isLoopback('::ffff:127.0.0.1')).toBe(true);
+    expect(isLoopback('10.0.0.5')).toBe(false);
+    expect(isLoopback(undefined)).toBe(false);
+  });
+
+  it('streams ordered SSE frames: tool_call → tool_result → text_delta → done', async () => {
+    let dispatchCount = 0;
+    ({ server, url } = startApp({
+      createClient: makeFakeClientFactory([
+        {
+          content: null,
+          toolCalls: [{ id: 't1', name: 'get_thing', input: { q: 1 } }],
+          stopReason: 'tool_use',
+        },
+        { deltas: ['Hello ', 'world'], content: 'Hello world', toolCalls: [], stopReason: 'end_turn' },
+      ]) as never,
+      tools: [
+        { name: 'get_thing', description: 'read a thing', input_schema: { type: 'object', properties: {} } },
+      ],
+      dispatchTool: async () => {
+        dispatchCount++;
+        return { ok: true, value: 42 };
+      },
+    }));
+
+    const res = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 's1', prompt: 'hi', provider: 'mock' }),
+    });
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const frames = await readAllFrames(res.body!);
+    const events = frames.map((f) => f.event);
+
+    expect(events).toContain('tool_call');
+    expect(events).toContain('tool_result');
+    expect(events).toContain('text_delta');
+    expect(events[events.length - 1]).toBe('done');
+    // ordering: tool_call before tool_result before first text_delta
+    expect(events.indexOf('tool_call')).toBeLessThan(events.indexOf('tool_result'));
+    expect(events.indexOf('tool_result')).toBeLessThan(events.indexOf('text_delta'));
+
+    const done = frames.find((f) => f.event === 'done')!.data as {
+      reason: string;
+      assistant_text: string;
+      tool_trace: Array<{ name: string; result: unknown }>;
+    };
+    expect(done.reason).toBe('end_turn');
+    expect(done.assistant_text).toBe('Hello world');
+    expect(done.tool_trace[0].name).toBe('get_thing');
+    expect(done.tool_trace[0].result).toEqual({ ok: true, value: 42 });
+    expect(dispatchCount).toBe(1);
+
+    // seq ids are monotonic
+    const ids = frames.map((f) => f.id!).filter((n) => Number.isFinite(n));
+    for (let i = 1; i < ids.length; i++) expect(ids[i]).toBeGreaterThan(ids[i - 1]);
+  });
+
+  it('cancel mid-stream ends with done{cancelled:true, partial_text}', async () => {
+    ({ server, url } = startApp({
+      createClient: makeFakeClientFactory([
+        {
+          deltas: ['a', 'b', 'c', 'd', 'e'],
+          slowMs: 25,
+          content: 'abcde',
+          toolCalls: [],
+          stopReason: 'end_turn',
+        },
+      ]) as never,
+      dispatchTool: async () => ({}),
+    }));
+
+    const res = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'cx', prompt: 'go', provider: 'mock' }),
+    });
+
+    // Read in the background; fire cancel once some text has arrived.
+    const framesP = readAllFrames(res.body!);
+    await new Promise((r) => setTimeout(r, 40));
+    const cancelRes = await fetch(`${url}/chat/cancel`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'cx' }),
+    });
+    expect((await cancelRes.json()).cancelled).toBe(true);
+
+    const frames = await framesP;
+    const done = frames.find((f) => f.event === 'done')!.data as {
+      cancelled: boolean;
+      partial_text: string;
+    };
+    expect(done.cancelled).toBe(true);
+    expect(done.partial_text.length).toBeGreaterThan(0);
+    expect(done.partial_text.length).toBeLessThan('abcde'.length);
+  });
+
+  it('resume replays buffered frames without re-dispatching tools', async () => {
+    let dispatchCount = 0;
+    ({ server, url } = startApp({
+      createClient: makeFakeClientFactory([
+        {
+          content: null,
+          toolCalls: [{ id: 'r1', name: 'get_thing', input: {} }],
+          stopReason: 'tool_use',
+        },
+        { deltas: ['done'], content: 'done', toolCalls: [], stopReason: 'end_turn' },
+      ]) as never,
+      tools: [
+        { name: 'get_thing', description: 'read a thing', input_schema: { type: 'object', properties: {} } },
+      ],
+      dispatchTool: async () => {
+        dispatchCount++;
+        return { ok: true };
+      },
+    }));
+
+    // First turn: run to completion (frames buffer server-side).
+    const first = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'rs', prompt: 'x', provider: 'mock' }),
+    });
+    const firstFrames = await readAllFrames(first.body!);
+    expect(dispatchCount).toBe(1);
+    expect(firstFrames.at(-1)!.event).toBe('done');
+
+    // Reconnect with last_seq=0 → replay ALL buffered frames, no new dispatch.
+    const resume = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'rs', last_seq: 0 }),
+    });
+    const replayed = await readAllFrames(resume.body!);
+    expect(dispatchCount).toBe(1); // NOT re-dispatched
+    expect(replayed.map((f) => f.event)).toEqual(firstFrames.map((f) => f.event));
+  });
+
+  it('config: set → masked get; raw key never returned', async () => {
+    ({ server, url } = startApp({}));
+    const setRes = await fetch(`${url}/chat/config`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'cfg', provider: 'anthropic', api_key: FAKE_KEY }),
+    });
+    const setBody = await setRes.text();
+    expect(setBody).not.toContain(FAKE_KEY);
+    expect(JSON.parse(setBody).key_last4).toBe('2333');
+
+    const getRes = await fetch(`${url}/chat/config?session_id=cfg`);
+    const getBody = await getRes.text();
+    expect(getBody).not.toContain(FAKE_KEY);
+    const parsed = JSON.parse(getBody);
+    expect(parsed.provider).toBe('anthropic');
+    expect(parsed.key_last4).toBe('2333');
+  });
+
+  it('the API key never appears in any stream frame or log', async () => {
+    ({ server, url } = startApp({
+      createClient: makeFakeClientFactory([
+        { deltas: ['ok'], content: 'ok', toolCalls: [], stopReason: 'end_turn' },
+      ]) as never,
+      dispatchTool: async () => ({}),
+    }));
+    // Register the canary key for this session.
+    await fetch(`${url}/chat/config`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'sec', provider: 'mock', api_key: FAKE_KEY }),
+    });
+    const res = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'sec', prompt: 'hi' }),
+    });
+    const raw = await res.text();
+    expect(raw).not.toContain(FAKE_KEY);
+    expect(raw).not.toContain('LEAK-CANARY');
+  });
+});

--- a/mcp-tools/hayba-mcp/tests/chat/chat-server.test.ts
+++ b/mcp-tools/hayba-mcp/tests/chat/chat-server.test.ts
@@ -5,6 +5,8 @@ import type { Server } from 'node:http';
 import {
   registerChatRoutes,
   __resetChatState,
+  __sweepSessions,
+  __sessionCount,
   isLoopback,
 } from '../../src/chat/chat-server.js';
 import type { LLMClient, LLMStreamEvent } from '../../src/agents/llm-client.js';
@@ -288,6 +290,157 @@ describe('sidecar SSE chat server', () => {
     const parsed = JSON.parse(getBody);
     expect(parsed.provider).toBe('anthropic');
     expect(parsed.key_last4).toBe('2333');
+  });
+
+  it('I3: a concurrent second /chat/stream gets a real 409 (not mid-stream JSON)', async () => {
+    ({ server, url } = startApp({
+      createClient: makeFakeClientFactory([
+        { deltas: ['a', 'b', 'c'], slowMs: 50, content: 'abc', toolCalls: [], stopReason: 'end_turn' },
+      ]) as never,
+      dispatchTool: async () => ({}),
+    }));
+
+    const first = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'conc', prompt: 'go', provider: 'mock' }),
+    });
+    const firstP = readAllFrames(first.body!);
+    await new Promise((r) => setTimeout(r, 20)); // let the first turn start running
+
+    const second = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'conc', prompt: 'again', provider: 'mock' }),
+    });
+    expect(second.status).toBe(409);
+    expect(second.headers.get('content-type')).toContain('application/json');
+    const body = (await second.json()) as { error: string };
+    expect(body.error).toMatch(/in flight/);
+
+    await firstP; // drain the first stream
+  });
+
+  it('I2: resume past the eviction window emits an explicit resume_gap error', async () => {
+    ({ server, url } = startApp({
+      createClient: makeFakeClientFactory([
+        // 600 deltas overflow BUFFER_LIMIT (500) so the buffer head advances.
+        { deltas: Array(600).fill('.'), content: '.'.repeat(600), toolCalls: [], stopReason: 'end_turn' },
+      ]) as never,
+      dispatchTool: async () => ({}),
+    }));
+
+    const first = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'gap', prompt: 'x', provider: 'mock' }),
+    });
+    await readAllFrames(first.body!); // run to completion; early frames get evicted
+
+    const resume = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'gap', last_seq: 5 }), // predates buffer head
+    });
+    const frames = await readAllFrames(resume.body!);
+    const err = frames.find((f) => f.event === 'error')!.data as {
+      code: string;
+      oldest_available_seq: number;
+    };
+    expect(err.code).toBe('resume_gap');
+    expect(err.oldest_available_seq).toBeGreaterThan(6);
+  });
+
+  it('I1: idle session evicted by the TTL sweep; active controller aborted', async () => {
+    ({ server, url } = startApp({
+      createClient: makeFakeClientFactory([
+        { deltas: ['a', 'b', 'c', 'd'], slowMs: 60, content: 'abcd', toolCalls: [], stopReason: 'end_turn' },
+      ]) as never,
+      dispatchTool: async () => ({}),
+    }));
+
+    const res = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'idle', prompt: 'go', provider: 'mock' }),
+    });
+    const framesP = readAllFrames(res.body!);
+    await new Promise((r) => setTimeout(r, 20)); // turn is running
+    expect(__sessionCount()).toBe(1);
+
+    // Advance the virtual clock past the 30-min TTL and sweep → eviction aborts
+    // the in-flight controller and closes the client.
+    __sweepSessions(Date.now() + 31 * 60_000);
+    expect(__sessionCount()).toBe(0);
+
+    // The stream is force-closed by eviction (well before the ~240ms it would
+    // otherwise take), so the reader resolves promptly.
+    await framesP;
+  });
+
+  it('C1: /chat/approve requires a pending plan request, then binds the call', async () => {
+    let dispatchCount = 0;
+    ({ server, url } = startApp({
+      createClient: makeFakeClientFactory([
+        { content: null, toolCalls: [{ id: 'p1', name: 'actor_spawn', input: { id: 'A' } }], stopReason: 'tool_use' },
+        { content: null, toolCalls: [{ id: 'p2', name: 'actor_spawn', input: { id: 'A' } }], stopReason: 'tool_use' },
+        { deltas: ['ok'], content: 'ok', toolCalls: [], stopReason: 'end_turn' },
+      ]) as never,
+      tools: [
+        { name: 'actor_spawn', description: 'spawn', input_schema: { type: 'object', properties: {} } },
+      ],
+      dispatchTool: async () => {
+        dispatchCount++;
+        return { ok: true };
+      },
+    }));
+
+    // Approve with nothing pending → 409.
+    const early = await fetch(`${url}/chat/approve`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'pm' }),
+    });
+    expect(early.status).toBe(404); // session doesn't exist yet
+
+    // Turn 1: destructive tool under Plan Mode → plan_request pause, NO dispatch.
+    const turn1 = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'pm', prompt: 'spawn it', provider: 'mock' }),
+    });
+    const frames1 = await readAllFrames(turn1.body!);
+    const plan = frames1.find((f) => f.event === 'plan_request')!.data as { args_hash: string };
+    expect(plan.args_hash).toBeTruthy();
+    expect(dispatchCount).toBe(0);
+
+    // Approve binds to the paused call.
+    const approve = await fetch(`${url}/chat/approve`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'pm' }),
+    });
+    expect(approve.status).toBe(200);
+    expect((await approve.json()).approved).toBe(true);
+
+    // Approving again (already consumed) → 409, nothing pending.
+    const again = await fetch(`${url}/chat/approve`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'pm' }),
+    });
+    expect(again.status).toBe(409);
+
+    // Turn 2: resume dispatches the approved call exactly once → end_turn.
+    const turn2 = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: 'pm', prompt: 'spawn it', provider: 'mock' }),
+    });
+    const frames2 = await readAllFrames(turn2.body!);
+    const done = frames2.find((f) => f.event === 'done')!.data as { reason: string };
+    expect(done.reason).toBe('end_turn');
+    expect(dispatchCount).toBe(1);
   });
 
   it('the API key never appears in any stream frame or log', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.110.0",
         "@distube/ytdl-core": "^4.16.12",
         "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -109,6 +110,7 @@
         "js-yaml": "^4.1.1",
         "lru-cache": "^11.3.6",
         "minisearch": "^7.2.0",
+        "openai": "^6.45.0",
         "youtube-transcript-api": "^3.0.6",
         "zod": "^3.23.0"
       },
@@ -139,339 +141,12 @@
         "undici-types": "~7.16.0"
       }
     },
-    "mcp-tools/hayba-mcp/node_modules/@vitest/expect": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
-      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/@vitest/runner": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
-      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "3.2.6",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/@vitest/snapshot": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
-      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/@vitest/spy": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
-      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/@vitest/utils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
-      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "mcp-tools/hayba-mcp/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "mcp-tools/hayba-mcp/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "mcp-tools/hayba-mcp/node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "mcp-tools/hayba-mcp/node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
-    },
-    "mcp-tools/hayba-mcp/node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/vitest": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
-      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.6",
-        "@vitest/mocker": "3.2.6",
-        "@vitest/pretty-format": "^3.2.6",
-        "@vitest/runner": "3.2.6",
-        "@vitest/snapshot": "3.2.6",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.6",
-        "@vitest/ui": "3.2.6",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/debug": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "mcp-tools/hayba-mcp/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
-      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.2.6",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
     },
     "mcp-tools/linguistics": {
       "extraneous": true
@@ -491,6 +166,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
+      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2577,16 +2273,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/chai/node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3080,6 +2766,56 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
@@ -3208,6 +2944,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ast-v8-to-istanbul": {
       "version": "0.3.12",
@@ -3514,6 +3260,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3545,6 +3308,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -3810,6 +3583,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -5507,6 +5290,13 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.5.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
@@ -5997,6 +5787,36 @@
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6193,6 +6013,16 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7179,6 +7009,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
@@ -7904,6 +7744,232 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -8201,118 +8267,6 @@
         }
       }
     },
-    "packages/architecture/node_modules/@vitest/expect": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
-      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/architecture/node_modules/@vitest/runner": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
-      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "3.2.6",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/architecture/node_modules/@vitest/snapshot": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
-      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/architecture/node_modules/@vitest/spy": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
-      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/architecture/node_modules/@vitest/utils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
-      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/architecture/node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/architecture/node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/architecture/node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
     "packages/architecture/node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -8331,23 +8285,6 @@
         }
       }
     },
-    "packages/architecture/node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/architecture/node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/architecture/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8355,185 +8292,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/architecture/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/architecture/node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
-    "packages/architecture/node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "packages/architecture/node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "packages/architecture/node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "packages/architecture/node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/architecture/node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/architecture/node_modules/vitest": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
-      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.6",
-        "@vitest/mocker": "3.2.6",
-        "@vitest/pretty-format": "^3.2.6",
-        "@vitest/runner": "3.2.6",
-        "@vitest/snapshot": "3.2.6",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.6",
-        "@vitest/ui": "3.2.6",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/debug": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "packages/architecture/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
-      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.2.6",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
     },
     "packages/design-tokens": {
       "name": "@hayba/design-tokens",
@@ -8642,339 +8406,12 @@
         "undici-types": "~7.18.0"
       }
     },
-    "packages/linguistics/node_modules/@vitest/expect": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
-      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/linguistics/node_modules/@vitest/runner": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
-      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "3.2.6",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/linguistics/node_modules/@vitest/snapshot": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
-      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/linguistics/node_modules/@vitest/spy": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
-      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/linguistics/node_modules/@vitest/utils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
-      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/linguistics/node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/linguistics/node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/linguistics/node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "packages/linguistics/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "packages/linguistics/node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/linguistics/node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/linguistics/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/linguistics/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/linguistics/node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
-    "packages/linguistics/node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "packages/linguistics/node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "packages/linguistics/node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "packages/linguistics/node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/linguistics/node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/linguistics/node_modules/vitest": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
-      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.6",
-        "@vitest/mocker": "3.2.6",
-        "@vitest/pretty-format": "^3.2.6",
-        "@vitest/runner": "3.2.6",
-        "@vitest/snapshot": "3.2.6",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.6",
-        "@vitest/ui": "3.2.6",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/debug": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "packages/linguistics/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
-      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.2.6",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
     },
     "packages/pcgex": {
       "name": "@hayba/pcgex",
@@ -9019,339 +8456,12 @@
         "undici-types": "~7.18.0"
       }
     },
-    "packages/planet-physics/node_modules/@vitest/expect": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
-      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/planet-physics/node_modules/@vitest/runner": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
-      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "3.2.6",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/planet-physics/node_modules/@vitest/snapshot": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
-      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/planet-physics/node_modules/@vitest/spy": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
-      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/planet-physics/node_modules/@vitest/utils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
-      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/planet-physics/node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/planet-physics/node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/planet-physics/node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "packages/planet-physics/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "packages/planet-physics/node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/planet-physics/node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/planet-physics/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/planet-physics/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/planet-physics/node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
-    "packages/planet-physics/node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "packages/planet-physics/node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "packages/planet-physics/node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "packages/planet-physics/node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/planet-physics/node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/planet-physics/node_modules/vitest": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
-      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.6",
-        "@vitest/mocker": "3.2.6",
-        "@vitest/pretty-format": "^3.2.6",
-        "@vitest/runner": "3.2.6",
-        "@vitest/snapshot": "3.2.6",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.6",
-        "@vitest/ui": "3.2.6",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/debug": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "packages/planet-physics/node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
-      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.2.6",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/HaybaMCPToolkit.Build.cs
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/HaybaMCPToolkit.Build.cs
@@ -86,5 +86,13 @@ public class HaybaMCPToolkit : ModuleRules
         // MetaSound (gh#18) and Sequencer (gh#9) moved to optional satellite
         // plugins (HaybaMCPMetaSound, HaybaMCPSequencer) so the core loads when
         // those plugins are disabled.
+
+        // Windows DPAPI (CryptProtectData/CryptUnprotectData) for the BYOK API-key
+        // vault in HaybaMCPSettings.cpp. Win64-only, matching the plugin's pinning;
+        // guarded by #if PLATFORM_WINDOWS in the source.
+        if (Target.Platform == UnrealTargetPlatform.Win64)
+        {
+            PublicSystemLibraries.Add("Crypt32.lib");
+        }
     }
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
@@ -59,6 +59,18 @@ FString FHaybaMCPAgentClient::MakeSessionId()
 // ─────────────────────────────────────────────────────────────────────────────
 void FHaybaMCPAgentClient::SendPrompt(const FString& UserPrompt)
 {
+	// Re-entrancy guard: a second SendPrompt while a turn is in flight would
+	// start a second /chat/stream sharing this instance's ParseCursor +
+	// AccumulatedText (reset in StartStream), corrupting the live parse. The
+	// server 409s a concurrent turn, but self-guard so the UI can't garble it.
+	if (bStreaming)
+	{
+		FHaybaChatError Busy;
+		Busy.Error = TEXT("a chat turn is already in progress; cancel it or wait for done");
+		Busy.Kind = TEXT("busy");
+		OnError.Broadcast(Busy);
+		return;
+	}
 	if (SessionId.IsEmpty())
 	{
 		SessionId = MakeSessionId();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
@@ -126,12 +126,12 @@ void FHaybaMCPAgentClient::PostConfig(const FString& UserPrompt)
 	UE_LOG(LogHaybaAgentClient, Verbose, TEXT("POST /chat/config provider=%s (key %d bytes, not logged)"),
 		*Provider, ApiKey.Len());
 
-	TWeakPtr<FHaybaMCPAgentClient> WeakThis = AsShared();
+	TWeakPtr<FHaybaMCPAgentClient> WeakSelf = AsShared();
 	const FString CapturedPrompt = UserPrompt;
 	Request->OnProcessRequestComplete().BindLambda(
-		[WeakThis, CapturedPrompt](FHttpRequestPtr /*Req*/, FHttpResponsePtr Response, bool bConnected)
+		[WeakSelf, CapturedPrompt](FHttpRequestPtr /*Req*/, FHttpResponsePtr Response, bool bConnected)
 		{
-			TSharedPtr<FHaybaMCPAgentClient> Self = WeakThis.Pin();
+			TSharedPtr<FHaybaMCPAgentClient> Self = WeakSelf.Pin();
 			if (!Self.IsValid()) return;
 
 			if (!bConnected || !Response.IsValid())
@@ -183,15 +183,15 @@ void FHaybaMCPAgentClient::StartStream(const FString& UserPrompt)
 	Request->SetContentAsString(JsonToString(Body));
 	StreamRequest = Request;
 
-	TWeakPtr<FHaybaMCPAgentClient> WeakThis = AsShared();
+	TWeakPtr<FHaybaMCPAgentClient> WeakSelf = AsShared();
 
 	// Progressive body access: OnRequestProgress64 fires as bytes arrive. The
 	// response's GetContentAsString() returns the whole body received so far, so
 	// we track a parse cursor and pull out only newly-completed `\n\n` frames.
 	Request->OnRequestProgress64().BindLambda(
-		[WeakThis](FHttpRequestPtr Req, uint64 /*BytesSent*/, uint64 /*BytesReceived*/)
+		[WeakSelf](FHttpRequestPtr Req, uint64 /*BytesSent*/, uint64 /*BytesReceived*/)
 		{
-			TSharedPtr<FHaybaMCPAgentClient> Self = WeakThis.Pin();
+			TSharedPtr<FHaybaMCPAgentClient> Self = WeakSelf.Pin();
 			if (!Self.IsValid() || !Req.IsValid()) return;
 			FHttpResponsePtr Response = Req->GetResponse();
 			if (!Response.IsValid()) return;
@@ -199,9 +199,9 @@ void FHaybaMCPAgentClient::StartStream(const FString& UserPrompt)
 		});
 
 	Request->OnProcessRequestComplete().BindLambda(
-		[WeakThis](FHttpRequestPtr /*Req*/, FHttpResponsePtr Response, bool bConnected)
+		[WeakSelf](FHttpRequestPtr /*Req*/, FHttpResponsePtr Response, bool bConnected)
 		{
-			TSharedPtr<FHaybaMCPAgentClient> Self = WeakThis.Pin();
+			TSharedPtr<FHaybaMCPAgentClient> Self = WeakSelf.Pin();
 			if (!Self.IsValid()) return;
 			Self->bStreaming = false;
 
@@ -423,11 +423,11 @@ void FHaybaMCPAgentClient::PostApprove()
 	Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
 	Request->SetContentAsString(JsonToString(Body));
 
-	TWeakPtr<FHaybaMCPAgentClient> WeakThis = AsShared();
+	TWeakPtr<FHaybaMCPAgentClient> WeakSelf = AsShared();
 	Request->OnProcessRequestComplete().BindLambda(
-		[WeakThis](FHttpRequestPtr /*Req*/, FHttpResponsePtr Response, bool bConnected)
+		[WeakSelf](FHttpRequestPtr /*Req*/, FHttpResponsePtr Response, bool bConnected)
 		{
-			TSharedPtr<FHaybaMCPAgentClient> Self = WeakThis.Pin();
+			TSharedPtr<FHaybaMCPAgentClient> Self = WeakSelf.Pin();
 			if (!Self.IsValid()) return;
 
 			if (!bConnected || !Response.IsValid())

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
@@ -1,0 +1,435 @@
+#include "HaybaMCPAgentClient.h"
+#include "HaybaMCPSettings.h"
+#include "HttpModule.h"
+#include "Interfaces/IHttpResponse.h"
+#include "Json.h"
+#include "Misc/Guid.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogHaybaAgentClient, Log, All);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Small JSON helpers
+// ─────────────────────────────────────────────────────────────────────────────
+namespace
+{
+	/** Serialize a JSON object to a compact string. */
+	FString JsonToString(const TSharedRef<FJsonObject>& Root)
+	{
+		FString Out;
+		TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Out);
+		FJsonSerializer::Serialize(Root, Writer);
+		return Out;
+	}
+
+	/** Re-serialize a JSON value field back to its compact JSON string (for input/result). */
+	FString FieldAsJsonString(const TSharedPtr<FJsonObject>& Obj, const TCHAR* Field)
+	{
+		if (!Obj.IsValid()) return FString();
+		TSharedPtr<FJsonValue> Val = Obj->TryGetField(Field);
+		if (!Val.IsValid()) return FString();
+		if (Val->Type == EJson::String) return Val->AsString();
+		FString Out;
+		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+			TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Out);
+		FJsonSerializer::Serialize(Val.ToSharedRef(), TEXT(""), Writer);
+		return Out;
+	}
+}
+
+FHaybaMCPAgentClient::~FHaybaMCPAgentClient()
+{
+	// Best-effort: drop callbacks and cancel any in-flight request so a late HTTP
+	// tick cannot re-enter a destroyed client. (Callbacks also capture a weak ptr.)
+	if (StreamRequest.IsValid())
+	{
+		StreamRequest->OnRequestProgress64().Unbind();
+		StreamRequest->OnProcessRequestComplete().Unbind();
+		StreamRequest->CancelRequest();
+		StreamRequest.Reset();
+	}
+}
+
+FString FHaybaMCPAgentClient::MakeSessionId()
+{
+	return FString::Printf(TEXT("ue_%s"), *FGuid::NewGuid().ToString(EGuidFormats::Digits));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public entry
+// ─────────────────────────────────────────────────────────────────────────────
+void FHaybaMCPAgentClient::SendPrompt(const FString& UserPrompt)
+{
+	if (SessionId.IsEmpty())
+	{
+		SessionId = MakeSessionId();
+	}
+	bTerminalEmitted = false;
+
+	if (bConfigDone)
+	{
+		StartStream(UserPrompt);
+	}
+	else
+	{
+		PostConfig(UserPrompt);
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step 1 — POST /chat/config (key handoff, loopback only, never logged)
+// ─────────────────────────────────────────────────────────────────────────────
+void FHaybaMCPAgentClient::PostConfig(const FString& UserPrompt)
+{
+	const FHaybaMCPSettings& Settings = FHaybaMCPSettings::Get();
+	const FString Provider = Settings.SelectedProviderId;
+	const FHaybaProviderInfo* Info = FHaybaMCPSettings::FindProvider(Provider);
+
+	const FString Model   = (Info && Info->DefaultModel)   ? FString(Info->DefaultModel)   : Settings.Model;
+	const FString BaseURL = (Info && Info->BaseURLDefault) ? FString(Info->BaseURLDefault) : Settings.BaseURL;
+
+	// Key of record lives DPAPI-encrypted in the vault; fall back to the legacy
+	// shared accessor (which also routes through the vault).
+	FString ApiKey = FHaybaMCPSettings::GetProviderKey(Provider);
+	if (ApiKey.IsEmpty())
+	{
+		ApiKey = FHaybaMCPSettings::GetSharedApiKey();
+	}
+
+	TSharedRef<FJsonObject> Body = MakeShared<FJsonObject>();
+	Body->SetStringField(TEXT("session_id"), SessionId);
+	Body->SetStringField(TEXT("provider"), Provider);
+	Body->SetStringField(TEXT("model"), Model);
+	Body->SetStringField(TEXT("base_url"), BaseURL);
+	Body->SetStringField(TEXT("api_key"), ApiKey);   // loopback only — never logged
+
+	const FString ConfigUrl = Settings.SidecarURL / TEXT("chat/config");
+
+	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = FHttpModule::Get().CreateRequest();
+	Request->SetURL(ConfigUrl);
+	Request->SetVerb(TEXT("POST"));
+	Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+	Request->SetContentAsString(JsonToString(Body));
+
+	// NB: never log the body — it carries the raw key.
+	UE_LOG(LogHaybaAgentClient, Verbose, TEXT("POST /chat/config provider=%s (key %d bytes, not logged)"),
+		*Provider, ApiKey.Len());
+
+	TWeakPtr<FHaybaMCPAgentClient> WeakThis = AsShared();
+	const FString CapturedPrompt = UserPrompt;
+	Request->OnProcessRequestComplete().BindLambda(
+		[WeakThis, CapturedPrompt](FHttpRequestPtr /*Req*/, FHttpResponsePtr Response, bool bConnected)
+		{
+			TSharedPtr<FHaybaMCPAgentClient> Self = WeakThis.Pin();
+			if (!Self.IsValid()) return;
+
+			if (!bConnected || !Response.IsValid())
+			{
+				Self->OnError.Broadcast(FHaybaChatError{
+					TEXT("Could not reach the Hayba sidecar. Is it running?"), TEXT("transport") });
+				Self->EmitLocalDone(TEXT("error"), /*cancelled*/ false);
+				return;
+			}
+			const int32 Code = Response->GetResponseCode();
+			if (Code != 200)
+			{
+				Self->OnError.Broadcast(FHaybaChatError{
+					FString::Printf(TEXT("Sidecar /chat/config rejected the request (HTTP %d)."), Code),
+					TEXT("config") });
+				Self->EmitLocalDone(TEXT("error"), /*cancelled*/ false);
+				return;
+			}
+			Self->bConfigDone = true;
+			Self->StartStream(CapturedPrompt);
+		});
+
+	Request->ProcessRequest();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step 2 — POST /chat/stream and consume the SSE body incrementally
+// ─────────────────────────────────────────────────────────────────────────────
+void FHaybaMCPAgentClient::StartStream(const FString& UserPrompt)
+{
+	const FHaybaMCPSettings& Settings = FHaybaMCPSettings::Get();
+	const FString StreamUrl = Settings.SidecarURL / TEXT("chat/stream");
+
+	// Reset per-turn parse state.
+	ParseCursor = 0;
+	AccumulatedText.Empty();
+	bStreaming = true;
+
+	TSharedRef<FJsonObject> Body = MakeShared<FJsonObject>();
+	Body->SetStringField(TEXT("session_id"), SessionId);
+	Body->SetStringField(TEXT("prompt"), UserPrompt);
+	// provider/model/key already registered via /chat/config for this session.
+
+	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = FHttpModule::Get().CreateRequest();
+	Request->SetURL(StreamUrl);
+	Request->SetVerb(TEXT("POST"));
+	Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+	Request->SetHeader(TEXT("Accept"), TEXT("text/event-stream"));
+	Request->SetContentAsString(JsonToString(Body));
+	StreamRequest = Request;
+
+	TWeakPtr<FHaybaMCPAgentClient> WeakThis = AsShared();
+
+	// Progressive body access: OnRequestProgress64 fires as bytes arrive. The
+	// response's GetContentAsString() returns the whole body received so far, so
+	// we track a parse cursor and pull out only newly-completed `\n\n` frames.
+	Request->OnRequestProgress64().BindLambda(
+		[WeakThis](FHttpRequestPtr Req, uint64 /*BytesSent*/, uint64 /*BytesReceived*/)
+		{
+			TSharedPtr<FHaybaMCPAgentClient> Self = WeakThis.Pin();
+			if (!Self.IsValid() || !Req.IsValid()) return;
+			FHttpResponsePtr Response = Req->GetResponse();
+			if (!Response.IsValid()) return;
+			Self->ParseNewFrames(Response->GetContentAsString());
+		});
+
+	Request->OnProcessRequestComplete().BindLambda(
+		[WeakThis](FHttpRequestPtr /*Req*/, FHttpResponsePtr Response, bool bConnected)
+		{
+			TSharedPtr<FHaybaMCPAgentClient> Self = WeakThis.Pin();
+			if (!Self.IsValid()) return;
+			Self->bStreaming = false;
+
+			// Drain any frames that arrived between the last progress tick and
+			// completion (a small tail can land in one shot).
+			if (Response.IsValid())
+			{
+				Self->ParseNewFrames(Response->GetContentAsString());
+			}
+
+			// If the server already sent a `done` frame it drives the terminus;
+			// otherwise this was a transport drop / local cancel.
+			if (Self->bTerminalEmitted)
+			{
+				Self->StreamRequest.Reset();
+				return;
+			}
+			if (!bConnected || !Response.IsValid())
+			{
+				Self->OnError.Broadcast(FHaybaChatError{
+					TEXT("Chat stream disconnected before completion."), TEXT("transport") });
+				Self->EmitLocalDone(TEXT("error"), /*cancelled*/ false);
+			}
+			else
+			{
+				// Stream closed without an explicit done frame — synthesize one.
+				Self->EmitLocalDone(TEXT("end_turn"), /*cancelled*/ false);
+			}
+			Self->StreamRequest.Reset();
+		});
+
+	UE_LOG(LogHaybaAgentClient, Verbose, TEXT("POST /chat/stream session=%s"), *SessionId);
+	Request->ProcessRequest();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SSE frame extraction — buffers partial frames across progress callbacks.
+// ─────────────────────────────────────────────────────────────────────────────
+void FHaybaMCPAgentClient::ParseNewFrames(const FString& FullBody)
+{
+	// Frames are separated by a blank line ("\n\n"). Because FullBody is the whole
+	// accumulated body, we advance ParseCursor past each complete frame and leave
+	// any trailing partial frame unparsed until more bytes arrive.
+	while (true)
+	{
+		const int32 Boundary = FullBody.Find(
+			TEXT("\n\n"), ESearchCase::CaseSensitive, ESearchDir::FromStart, ParseCursor);
+		if (Boundary == INDEX_NONE)
+		{
+			break; // remainder is a partial frame; wait for more
+		}
+		const FString FrameBlock = FullBody.Mid(ParseCursor, Boundary - ParseCursor);
+		ParseCursor = Boundary + 2; // skip the "\n\n"
+		DispatchFrame(FrameBlock);
+	}
+}
+
+void FHaybaMCPAgentClient::DispatchFrame(const FString& FrameBlock)
+{
+	// A frame is a set of lines: `id:`, `event:`, one or more `data:`, and/or
+	// `:comment` (heartbeat) lines. Parse them per the SSE grammar.
+	TArray<FString> Lines;
+	FrameBlock.ParseIntoArray(Lines, TEXT("\n"), /*CullEmpty*/ false);
+
+	FString EventType;
+	FString DataStr;
+	bool bHasData = false;
+
+	for (FString Line : Lines)
+	{
+		Line.RemoveFromEnd(TEXT("\r")); // tolerate CRLF
+		if (Line.IsEmpty())
+		{
+			continue;
+		}
+		if (Line.StartsWith(TEXT(":")))
+		{
+			continue; // comment / heartbeat (`: ping`) — ignore
+		}
+		if (Line.StartsWith(TEXT("event:")))
+		{
+			EventType = Line.RightChop(6).TrimStartAndEnd();
+		}
+		else if (Line.StartsWith(TEXT("data:")))
+		{
+			FString Chunk = Line.RightChop(5);
+			Chunk.RemoveFromStart(TEXT(" ")); // SSE strips exactly one leading space
+			if (bHasData) DataStr += TEXT("\n"); // multi-line data joins with \n
+			DataStr += Chunk;
+			bHasData = true;
+		}
+		// `id:` (seq) is ignored client-side — we don't resume yet.
+	}
+
+	if (EventType.IsEmpty())
+	{
+		return; // heartbeat-only or malformed frame
+	}
+
+	// Log frame TYPE + size only — never the payload (may contain user content).
+	UE_LOG(LogHaybaAgentClient, Verbose, TEXT("SSE frame '%s' (%d bytes data)"),
+		*EventType, DataStr.Len());
+
+	// Parse the JSON data payload.
+	TSharedPtr<FJsonObject> Data;
+	if (bHasData && !DataStr.IsEmpty())
+	{
+		TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(DataStr);
+		FJsonSerializer::Deserialize(Reader, Data);
+	}
+
+	if (EventType == TEXT("text_delta") || EventType == TEXT("token"))
+	{
+		FString Text;
+		if (Data.IsValid()) Data->TryGetStringField(TEXT("text"), Text);
+		if (!Text.IsEmpty())
+		{
+			AccumulatedText += Text;
+			OnTextDelta.Broadcast(Text);
+		}
+	}
+	else if (EventType == TEXT("tool_call"))
+	{
+		FHaybaChatToolCall Call;
+		if (Data.IsValid())
+		{
+			Data->TryGetStringField(TEXT("id"), Call.Id);
+			Data->TryGetStringField(TEXT("name"), Call.Name);
+			Call.InputJson = FieldAsJsonString(Data, TEXT("input"));
+		}
+		OnToolCall.Broadcast(Call);
+	}
+	else if (EventType == TEXT("tool_result"))
+	{
+		FHaybaChatToolResult Result;
+		if (Data.IsValid())
+		{
+			Data->TryGetStringField(TEXT("id"), Result.Id);
+			Data->TryGetStringField(TEXT("name"), Result.Name);
+			Result.ResultJson = FieldAsJsonString(Data, TEXT("result"));
+			Data->TryGetBoolField(TEXT("isError"), Result.bIsError);
+		}
+		OnToolResult.Broadcast(Result);
+	}
+	else if (EventType == TEXT("plan_request"))
+	{
+		FHaybaChatPlanRequest Plan;
+		if (Data.IsValid())
+		{
+			Data->TryGetStringField(TEXT("id"), Plan.Id);
+			Data->TryGetStringField(TEXT("name"), Plan.Name);
+			Plan.InputJson = FieldAsJsonString(Data, TEXT("input"));
+			Data->TryGetStringField(TEXT("source"), Plan.Source);
+			Data->TryGetStringField(TEXT("hint"), Plan.Hint);
+			Data->TryGetStringField(TEXT("args_hash"), Plan.ArgsHash);
+		}
+		OnPlanRequest.Broadcast(Plan);
+	}
+	else if (EventType == TEXT("done"))
+	{
+		FHaybaChatDone Done;
+		if (Data.IsValid())
+		{
+			Data->TryGetStringField(TEXT("reason"), Done.Reason);
+			// Prefer assistant_text; fall back to partial_text.
+			if (!Data->TryGetStringField(TEXT("assistant_text"), Done.AssistantText))
+			{
+				Data->TryGetStringField(TEXT("partial_text"), Done.AssistantText);
+			}
+			Data->TryGetBoolField(TEXT("cancelled"), Done.bCancelled);
+		}
+		bTerminalEmitted = true;
+		OnDone.Broadcast(Done);
+	}
+	else if (EventType == TEXT("error"))
+	{
+		FHaybaChatError Err;
+		if (Data.IsValid())
+		{
+			Data->TryGetStringField(TEXT("error"), Err.Error);
+			Data->TryGetStringField(TEXT("kind"), Err.Kind);
+			// resume_gap uses `code` instead of `error`.
+			if (Err.Error.IsEmpty()) Data->TryGetStringField(TEXT("code"), Err.Error);
+		}
+		OnError.Broadcast(Err);
+	}
+	// Unknown event types are ignored (forward-compatible).
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step 3 — Cancel: abort server-side loop + local request, emit local done
+// ─────────────────────────────────────────────────────────────────────────────
+void FHaybaMCPAgentClient::Cancel()
+{
+	if (!bStreaming && !StreamRequest.IsValid())
+	{
+		return;
+	}
+
+	// Tell the sidecar to abort the server-side loop (fire-and-forget). Without
+	// this the turn keeps running server-side even after we drop the socket.
+	if (!SessionId.IsEmpty())
+	{
+		const FHaybaMCPSettings& Settings = FHaybaMCPSettings::Get();
+		TSharedRef<FJsonObject> Body = MakeShared<FJsonObject>();
+		Body->SetStringField(TEXT("session_id"), SessionId);
+
+		TSharedRef<IHttpRequest, ESPMode::ThreadSafe> CancelReq = FHttpModule::Get().CreateRequest();
+		CancelReq->SetURL(Settings.SidecarURL / TEXT("chat/cancel"));
+		CancelReq->SetVerb(TEXT("POST"));
+		CancelReq->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+		CancelReq->SetContentAsString(JsonToString(Body));
+		CancelReq->ProcessRequest(); // ignore response
+	}
+
+	// Cancel the local streaming request. This will trigger OnProcessRequestComplete
+	// with bConnected=false; bTerminalEmitted guards against a duplicate done.
+	if (StreamRequest.IsValid())
+	{
+		StreamRequest->OnRequestProgress64().Unbind();
+		StreamRequest->OnProcessRequestComplete().Unbind();
+		StreamRequest->CancelRequest();
+		StreamRequest.Reset();
+	}
+	bStreaming = false;
+
+	// Fire our own terminal done carrying the partial text streamed so far.
+	EmitLocalDone(TEXT("cancelled"), /*cancelled*/ true);
+}
+
+void FHaybaMCPAgentClient::EmitLocalDone(const FString& Reason, bool bCancelled)
+{
+	if (bTerminalEmitted)
+	{
+		return;
+	}
+	bTerminalEmitted = true;
+	FHaybaChatDone Done;
+	Done.Reason = Reason;
+	Done.AssistantText = AccumulatedText;
+	Done.bCancelled = bCancelled;
+	OnDone.Broadcast(Done);
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
@@ -392,6 +392,69 @@ void FHaybaMCPAgentClient::DispatchFrame(const FString& FrameBlock)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Plan-mode resume — POST /chat/approve, then re-issue /chat/stream (empty prompt)
+// ─────────────────────────────────────────────────────────────────────────────
+void FHaybaMCPAgentClient::ApproveAndResume()
+{
+	if (SessionId.IsEmpty())
+	{
+		OnError.Broadcast(FHaybaChatError{
+			TEXT("Cannot resume: no chat session is active."), TEXT("resume") });
+		return;
+	}
+	if (bStreaming)
+	{
+		// A turn is already running; nothing to approve/resume against.
+		return;
+	}
+	PostApprove();
+}
+
+void FHaybaMCPAgentClient::PostApprove()
+{
+	const FHaybaMCPSettings& Settings = FHaybaMCPSettings::Get();
+
+	TSharedRef<FJsonObject> Body = MakeShared<FJsonObject>();
+	Body->SetStringField(TEXT("session_id"), SessionId);
+
+	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> Request = FHttpModule::Get().CreateRequest();
+	Request->SetURL(Settings.SidecarURL / TEXT("chat/approve"));
+	Request->SetVerb(TEXT("POST"));
+	Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+	Request->SetContentAsString(JsonToString(Body));
+
+	TWeakPtr<FHaybaMCPAgentClient> WeakThis = AsShared();
+	Request->OnProcessRequestComplete().BindLambda(
+		[WeakThis](FHttpRequestPtr /*Req*/, FHttpResponsePtr Response, bool bConnected)
+		{
+			TSharedPtr<FHaybaMCPAgentClient> Self = WeakThis.Pin();
+			if (!Self.IsValid()) return;
+
+			if (!bConnected || !Response.IsValid())
+			{
+				Self->OnError.Broadcast(FHaybaChatError{
+					TEXT("Could not reach the Hayba sidecar to approve the plan."), TEXT("transport") });
+				return;
+			}
+			const int32 Code = Response->GetResponseCode();
+			if (Code != 200)
+			{
+				Self->OnError.Broadcast(FHaybaChatError{
+					FString::Printf(TEXT("Sidecar /chat/approve rejected the request (HTTP %d)."), Code),
+					TEXT("approve") });
+				return;
+			}
+			// Approval bound server-side; resume the paused turn. The stored
+			// transcript continues — an empty prompt just re-drives the loop.
+			Self->bTerminalEmitted = false;
+			Self->StartStream(FString());
+		});
+
+	UE_LOG(LogHaybaAgentClient, Verbose, TEXT("POST /chat/approve session=%s"), *SessionId);
+	Request->ProcessRequest();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Step 3 — Cancel: abort server-side loop + local request, emit local done
 // ─────────────────────────────────────────────────────────────────────────────
 void FHaybaMCPAgentClient::Cancel()

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.cpp
@@ -466,19 +466,7 @@ void FHaybaMCPAgentClient::Cancel()
 
 	// Tell the sidecar to abort the server-side loop (fire-and-forget). Without
 	// this the turn keeps running server-side even after we drop the socket.
-	if (!SessionId.IsEmpty())
-	{
-		const FHaybaMCPSettings& Settings = FHaybaMCPSettings::Get();
-		TSharedRef<FJsonObject> Body = MakeShared<FJsonObject>();
-		Body->SetStringField(TEXT("session_id"), SessionId);
-
-		TSharedRef<IHttpRequest, ESPMode::ThreadSafe> CancelReq = FHttpModule::Get().CreateRequest();
-		CancelReq->SetURL(Settings.SidecarURL / TEXT("chat/cancel"));
-		CancelReq->SetVerb(TEXT("POST"));
-		CancelReq->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
-		CancelReq->SetContentAsString(JsonToString(Body));
-		CancelReq->ProcessRequest(); // ignore response
-	}
+	PostCancel();
 
 	// Cancel the local streaming request. This will trigger OnProcessRequestComplete
 	// with bConnected=false; bTerminalEmitted guards against a duplicate done.
@@ -493,6 +481,36 @@ void FHaybaMCPAgentClient::Cancel()
 
 	// Fire our own terminal done carrying the partial text streamed so far.
 	EmitLocalDone(TEXT("cancelled"), /*cancelled*/ true);
+}
+
+// Fire-and-forget POST /chat/cancel with {session_id}. Shared by Cancel() (mid-
+// stream abort) and AbortServerTurn() (parked-turn abort on plan reject).
+void FHaybaMCPAgentClient::PostCancel()
+{
+	if (SessionId.IsEmpty())
+	{
+		return;
+	}
+
+	const FHaybaMCPSettings& Settings = FHaybaMCPSettings::Get();
+	TSharedRef<FJsonObject> Body = MakeShared<FJsonObject>();
+	Body->SetStringField(TEXT("session_id"), SessionId);
+
+	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> CancelReq = FHttpModule::Get().CreateRequest();
+	CancelReq->SetURL(Settings.SidecarURL / TEXT("chat/cancel"));
+	CancelReq->SetVerb(TEXT("POST"));
+	CancelReq->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+	CancelReq->SetContentAsString(JsonToString(Body));
+	CancelReq->ProcessRequest(); // ignore response
+}
+
+// Abort a parked server-side turn (plan reject). The plan_request stream has
+// already closed, so Cancel()'s early-return would skip the server notification.
+// This fires POST /chat/cancel independent of local stream state and emits no
+// local done (the UI already finalized the bubble as [rejected]).
+void FHaybaMCPAgentClient::AbortServerTurn()
+{
+	PostCancel();
 }
 
 void FHaybaMCPAgentClient::EmitLocalDone(const FString& Reason, bool bCancelled)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.h
@@ -116,6 +116,16 @@ public:
 	 */
 	void Cancel();
 
+	/**
+	 * Abort a PARKED server-side turn without touching local stream state. On a
+	 * plan reject the plan_request SSE stream has already closed (bStreaming is
+	 * false), so Cancel()'s early-return would skip the server notification and
+	 * leave the paused session parked. This fires POST /chat/cancel regardless of
+	 * local stream state and does NOT emit a local done (the UI already finalized
+	 * the bubble as [rejected]).
+	 */
+	void AbortServerTurn();
+
 	/** True while a stream request is in flight. */
 	bool IsStreaming() const { return bStreaming; }
 
@@ -134,6 +144,9 @@ private:
 	void PostConfig(const FString& UserPrompt);
 	void StartStream(const FString& UserPrompt);
 	void PostApprove();
+
+	/** Fire-and-forget POST /chat/cancel with {session_id} (no-op if no session). */
+	void PostCancel();
 
 	/** Parse any newly-completed `\n\n`-delimited frames out of the full body. */
 	void ParseNewFrames(const FString& FullBody);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.h
@@ -100,6 +100,16 @@ public:
 	void SendPrompt(const FString& UserPrompt);
 
 	/**
+	 * Plan-mode resume: after the user Approves a gated action in the Plan tab,
+	 * POST /chat/approve {session_id} (binds the paused call), then re-issue
+	 * /chat/stream with an EMPTY prompt so the stored server transcript continues
+	 * and the one approved call dispatches past the TS gate exactly once. NEVER
+	 * call this without an explicit human Approve — it is the resume half of the
+	 * plan_request handshake.
+	 */
+	void ApproveAndResume();
+
+	/**
 	 * Abort the in-flight stream: tells the sidecar to abort the server-side loop
 	 * (POST /chat/cancel), cancels the local HTTP request, and fires OnDone with
 	 * {cancelled:true, partial_text} = whatever text streamed so far.
@@ -123,6 +133,7 @@ public:
 private:
 	void PostConfig(const FString& UserPrompt);
 	void StartStream(const FString& UserPrompt);
+	void PostApprove();
 
 	/** Parse any newly-completed `\n\n`-delimited frames out of the full body. */
 	void ParseNewFrames(const FString& FullBody);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPAgentClient.h
@@ -1,0 +1,148 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "Interfaces/IHttpRequest.h"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FHaybaMCPAgentClient — Server-Sent-Events consumer for the BYOK copilot.
+//
+// Talks to the Node sidecar (SidecarURL, default http://localhost:7821) chat
+// surface defined in mcp-tools/hayba-mcp/src/chat/chat-server.ts:
+//
+//   1. POST /chat/config  (once per session) — pushes {provider, model,
+//      base_url, api_key} into the sidecar's in-memory config store. This is the
+//      KEY HANDOFF: the decrypted BYOK key travels over loopback to /chat/config
+//      and is never placed on the MCP command socket, never journaled, never
+//      logged. (Chosen over copilot_get_key — one egress, key never round-trips
+//      through the MCP tool layer.)
+//   2. POST /chat/stream  — starts the turn and returns a text/event-stream. We
+//      consume the body incrementally (OnRequestProgress64), parse complete
+//      `\n\n`-delimited SSE frames out of the growing buffer, and fan each frame
+//      out on a typed multicast delegate.
+//   3. POST /chat/cancel  — {session_id}: on Cancel() we abort the in-flight
+//      HTTP request locally (CancelRequest) AND tell the sidecar to abort the
+//      server-side loop, then fire OnDone{cancelled:true, partial_text}.
+//
+// SSE frame → delegate mapping (event names mirror chat-server.ts EXACTLY):
+//   text_delta   {text}                        -> OnTextDelta
+//   tool_call    {id,name,input}               -> OnToolCall
+//   tool_result  {id,name,result,isError?}     -> OnToolResult
+//   plan_request {id,name,input,source,hint?,args_hash} -> OnPlanRequest
+//   done         {reason,assistant_text,partial_text,cancelled,...} -> OnDone
+//   error        {error,kind?}                 -> OnError
+//   `: ping` heartbeat comment lines           -> ignored
+//
+// THREADING: FHttpModule dispatches OnRequestProgress64 / OnProcessRequestComplete
+// on the game thread (FHttpManager ticks there in-editor), so all delegates fire
+// on the game thread and are safe to touch Slate widgets directly.
+//
+// LIFETIME: create via MakeShared; callbacks capture a TWeakPtr so a destroyed
+// client cannot be re-entered by a late HTTP callback.
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct FHaybaChatToolCall
+{
+	FString Id;
+	FString Name;
+	FString InputJson;   // raw JSON of the tool input object
+};
+
+struct FHaybaChatToolResult
+{
+	FString Id;
+	FString Name;
+	FString ResultJson;  // raw JSON of the result value
+	bool bIsError = false;
+};
+
+struct FHaybaChatPlanRequest
+{
+	FString Id;
+	FString Name;
+	FString InputJson;
+	FString Source;
+	FString Hint;
+	FString ArgsHash;
+};
+
+struct FHaybaChatDone
+{
+	FString Reason;
+	FString AssistantText;
+	bool bCancelled = false;
+};
+
+struct FHaybaChatError
+{
+	FString Error;
+	FString Kind;
+};
+
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnHaybaChatTextDelta, const FString& /*Text*/);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnHaybaChatToolCall, const FHaybaChatToolCall&);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnHaybaChatToolResult, const FHaybaChatToolResult&);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnHaybaChatPlanRequest, const FHaybaChatPlanRequest&);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnHaybaChatDone, const FHaybaChatDone&);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnHaybaChatError, const FHaybaChatError&);
+
+class FHaybaMCPAgentClient : public TSharedFromThis<FHaybaMCPAgentClient>
+{
+public:
+	FHaybaMCPAgentClient() = default;
+	~FHaybaMCPAgentClient();
+
+	/**
+	 * Push provider/key config to the sidecar (once) then start a streaming turn
+	 * with the given user prompt. Provider/model/baseURL/key are resolved from
+	 * FHaybaMCPSettings (selected provider + DPAPI vault). Safe to call again for
+	 * a follow-up turn on the same session; the config push is skipped after the
+	 * first success.
+	 */
+	void SendPrompt(const FString& UserPrompt);
+
+	/**
+	 * Abort the in-flight stream: tells the sidecar to abort the server-side loop
+	 * (POST /chat/cancel), cancels the local HTTP request, and fires OnDone with
+	 * {cancelled:true, partial_text} = whatever text streamed so far.
+	 */
+	void Cancel();
+
+	/** True while a stream request is in flight. */
+	bool IsStreaming() const { return bStreaming; }
+
+	/** The session id used against the sidecar (stable for this client). */
+	const FString& GetSessionId() const { return SessionId; }
+
+	// Delegates — Task 8's panel subscribes to these. All fire on the game thread.
+	FOnHaybaChatTextDelta   OnTextDelta;
+	FOnHaybaChatToolCall    OnToolCall;
+	FOnHaybaChatToolResult  OnToolResult;
+	FOnHaybaChatPlanRequest OnPlanRequest;
+	FOnHaybaChatDone        OnDone;
+	FOnHaybaChatError       OnError;
+
+private:
+	void PostConfig(const FString& UserPrompt);
+	void StartStream(const FString& UserPrompt);
+
+	/** Parse any newly-completed `\n\n`-delimited frames out of the full body. */
+	void ParseNewFrames(const FString& FullBody);
+	/** Dispatch a single SSE frame block (the text between two `\n\n`). */
+	void DispatchFrame(const FString& FrameBlock);
+
+	/** Emit a synthetic local terminal done frame (used by Cancel / transport error). */
+	void EmitLocalDone(const FString& Reason, bool bCancelled);
+
+	FString MakeSessionId();
+
+	// State
+	FString SessionId;
+	TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> StreamRequest;
+	bool bConfigDone = false;
+	bool bStreaming = false;
+	bool bTerminalEmitted = false;   // guards against double done (local + server)
+
+	/** Index into the decoded stream body up to which frames have been parsed. */
+	int32 ParseCursor = 0;
+	/** Accumulated assistant text (for partial_text on local cancel). */
+	FString AccumulatedText;
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.cpp
@@ -125,6 +125,11 @@ SHaybaMCPChatPanel::~SHaybaMCPChatPanel()
         Module->OnPlanApproved.Remove(PlanApprovedSubscription);
         PlanApprovedSubscription.Reset();
     }
+    if (Module && PlanRejectedSubscription.IsValid())
+    {
+        Module->OnPlanRejected.Remove(PlanRejectedSubscription);
+        PlanRejectedSubscription.Reset();
+    }
     // Tear down the streaming client: clear our delegate bindings so a late HTTP
     // tick can't fan out into this destroyed panel, then cancel the stream. The
     // client itself captures a weak ptr, so the ordering is belt-and-braces.
@@ -343,8 +348,16 @@ TSharedRef<SWidget> SHaybaMCPChatPanel::BuildInput()
                 .VAlign(VAlign_Center).Padding(FMargin(4.f, 0.f))
                 [
                     SNew(STextBlock)
-                    .Text(LOCTEXT("InputHint",
-                        "Describe what you want to generate…  (⏎ to send · ⇧⏎ for newline)"))
+                    .Text_Lambda([this]()
+                    {
+                        // Reflect the parked-at-the-gate state so the disabled
+                        // input reads as intentional, not broken.
+                        if (bAwaitingPlanApproval)
+                            return LOCTEXT("InputHintAwaitApproval",
+                                "Action needs approval — Approve or Reject it in the Plan tab to continue.");
+                        return LOCTEXT("InputHint",
+                            "Describe what you want to generate…  (⏎ to send · ⇧⏎ for newline)");
+                    })
                     .ColorAndOpacity(FSlateColor(FLinearColor(0.50f, 0.52f, 0.60f)))
                     .OverflowPolicy(ETextOverflowPolicy::MiddleEllipsis)
                     .Visibility_Lambda([this]()
@@ -706,7 +719,13 @@ void SHaybaMCPChatPanel::StopGeneration()
 
 bool SHaybaMCPChatPanel::CanSend() const
 {
-    return !Session.bWaitingForAI;
+    // Blocked while the AI is streaming AND while a plan_request is parked at the
+    // approval gate. On plan_request the server emits a `done` frame (so
+    // bWaitingForAI is false), but sending a fresh prompt here would start a new
+    // /chat/stream that server-side replaces session.messages — orphaning the
+    // paused plan and losing transcript context. Stay disabled until the user
+    // Approves (resume) or Rejects (cancel) the pending plan.
+    return !Session.bWaitingForAI && !bAwaitingPlanApproval;
 }
 
 // ── New / recent ──────────────────────────────────────────────────────────
@@ -906,6 +925,15 @@ void SHaybaMCPChatPanel::EnsureAgentClient()
         PlanApprovedSubscription = Module->OnPlanApproved.AddSP(
             this, &SHaybaMCPChatPanel::HandlePlanApproved);
     }
+
+    // Watch for Plan-tab rejections so a paused turn is cancelled and this panel
+    // disarms — otherwise it stays armed and a later, unrelated Approve resumes
+    // the rejected turn. Also guarded by bAwaitingPlanApproval in the handler.
+    if (Module && !PlanRejectedSubscription.IsValid())
+    {
+        PlanRejectedSubscription = Module->OnPlanRejected.AddSP(
+            this, &SHaybaMCPChatPanel::HandlePlanRejected);
+    }
 }
 
 void SHaybaMCPChatPanel::StartAgentTurn(const FString& Prompt)
@@ -1084,6 +1112,24 @@ void SHaybaMCPChatPanel::HandlePlanApproved()
     AgentClient->ApproveAndResume();
 
     if (MainPanel) MainPanel->ShowPanel(EHaybaPanel::Chat);
+}
+
+void SHaybaMCPChatPanel::HandlePlanRejected()
+{
+    // Only act if WE are the panel waiting on a plan (avoids cancelling on stray
+    // rejections from an unrelated Plan-tab action). Disarm before cancelling.
+    if (!bAwaitingPlanApproval) return;
+    bAwaitingPlanApproval = false;
+
+    // Cancel the paused server-side turn so it can never be resumed, and mark the
+    // in-progress bubble as aborted. Re-enables the input (CanSend clears once
+    // bAwaitingPlanApproval + bWaitingForAI are both false).
+    if (AgentClient.IsValid()) AgentClient->Cancel();
+    Session.bWaitingForAI = false;
+    bIsStreaming = false;
+    FinalizeInProgressBubble(TEXT("[rejected]"));
+
+    Toast(LOCTEXT("PlanRejected", "Plan rejected — the paused action was cancelled."));
 }
 
 void SHaybaMCPChatPanel::HandleStreamDone(const FHaybaChatDone& Done)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.cpp
@@ -707,6 +707,9 @@ void SHaybaMCPChatPanel::StopGeneration()
     // Cancel the in-flight stream: aborts the server-side loop, cancels the local
     // HTTP request, and fires OnDone{cancelled} which finalizes the bubble.
     if (AgentClient.IsValid()) AgentClient->Cancel();
+    // Defensively disarm the plan gate too, in case Stop is pressed while parked
+    // at the approval gate (Cancel() above already notifies the server).
+    bAwaitingPlanApproval = false;
     // Belt-and-braces if there is no live client (shouldn't happen while
     // bIsStreaming): tag the partial reply and reset local flags.
     if (!AgentClient.IsValid())
@@ -1124,7 +1127,10 @@ void SHaybaMCPChatPanel::HandlePlanRejected()
     // Cancel the paused server-side turn so it can never be resumed, and mark the
     // in-progress bubble as aborted. Re-enables the input (CanSend clears once
     // bAwaitingPlanApproval + bWaitingForAI are both false).
-    if (AgentClient.IsValid()) AgentClient->Cancel();
+    // NOTE: use AbortServerTurn(), not Cancel(): on plan reject the plan_request
+    // SSE stream has already closed (bStreaming=false), so Cancel() would hit its
+    // early-return and never POST /chat/cancel, leaving the turn parked server-side.
+    if (AgentClient.IsValid()) AgentClient->AbortServerTurn();
     Session.bWaitingForAI = false;
     bIsStreaming = false;
     FinalizeInProgressBubble(TEXT("[rejected]"));

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.cpp
@@ -9,6 +9,8 @@
 #include "HaybaMCPModule.h"
 #include "HaybaMCPMainPanel.h"
 #include "HaybaMCPClaudeClient.h"
+#include "HaybaMCPAgentClient.h"
+#include "HaybaMCPPlanPanel.h"
 #include "HaybaMCPSettings.h"
 #include "HaybaMCPWizardPrompt.h"
 
@@ -107,6 +109,36 @@ void SHaybaMCPChatPanel::Construct(const FArguments& InArgs, FHaybaMCPModule* In
     ];
 
     RebuildChat();
+}
+
+SHaybaMCPChatPanel::~SHaybaMCPChatPanel()
+{
+    // Drop the legacy module tool-call subscription.
+    if (Module && ToolCallSubscription.IsValid())
+    {
+        Module->OnToolCallRecorded.Remove(ToolCallSubscription);
+        ToolCallSubscription.Reset();
+    }
+    // Drop the plan-approval subscription.
+    if (Module && PlanApprovedSubscription.IsValid())
+    {
+        Module->OnPlanApproved.Remove(PlanApprovedSubscription);
+        PlanApprovedSubscription.Reset();
+    }
+    // Tear down the streaming client: clear our delegate bindings so a late HTTP
+    // tick can't fan out into this destroyed panel, then cancel the stream. The
+    // client itself captures a weak ptr, so the ordering is belt-and-braces.
+    if (AgentClient.IsValid())
+    {
+        AgentClient->OnTextDelta.RemoveAll(this);
+        AgentClient->OnToolCall.RemoveAll(this);
+        AgentClient->OnToolResult.RemoveAll(this);
+        AgentClient->OnPlanRequest.RemoveAll(this);
+        AgentClient->OnDone.RemoveAll(this);
+        AgentClient->OnError.RemoveAll(this);
+        AgentClient->Cancel();
+        AgentClient.Reset();
+    }
 }
 
 // ── Toolbar (top-right new + recent) ──────────────────────────────────────
@@ -646,31 +678,30 @@ FReply SHaybaMCPChatPanel::OnSendCurrentInput()
     UnseenWhileScrolledUp = 0;
     ScrollToBottomIfPinned();
 
-    if (Session.Goal.IsEmpty()) InitializeSession(Text);
-    else SendToMCP(Text);
+    // First user message names the conversation (title dropdown / recents).
+    if (Session.Goal.IsEmpty()) Session.Goal = Text;
+
+    // Streaming agent path (Task 8). The legacy single-POST pipeline
+    // (InitializeSession / SendToMCP / OnClaudeResponse) is retained below but
+    // no longer wired — see the "Legacy send pipeline" section.
+    StartAgentTurn(Text);
 
     return FReply::Handled();
 }
 
 void SHaybaMCPChatPanel::StopGeneration()
 {
-    // Q16-a: cancel HTTP only. The underlying client doesn't yet expose an
-    // abort handle, so the minimum viable is to ignore the next response and
-    // tag the partial reply.
-    // TODO: wire FHaybaMCPClaudeClient::Cancel() once implemented.
-    bIsStreaming = false;
-    Session.bWaitingForAI = false;
-    if (Module && ToolCallSubscription.IsValid())
+    // Cancel the in-flight stream: aborts the server-side loop, cancels the local
+    // HTTP request, and fires OnDone{cancelled} which finalizes the bubble.
+    if (AgentClient.IsValid()) AgentClient->Cancel();
+    // Belt-and-braces if there is no live client (shouldn't happen while
+    // bIsStreaming): tag the partial reply and reset local flags.
+    if (!AgentClient.IsValid())
     {
-        Module->OnToolCallRecorded.Remove(ToolCallSubscription);
-        ToolCallSubscription.Reset();
+        bIsStreaming = false;
+        Session.bWaitingForAI = false;
+        FinalizeInProgressBubble(TEXT(""));
     }
-    if (Session.Messages.IsValidIndex(InProgressMessageIndex))
-    {
-        Session.Messages[InProgressMessageIndex].Text += TEXT("\n\n[stopped]");
-        InProgressMessageIndex = INDEX_NONE;
-    }
-    RebuildChat();
 }
 
 bool SHaybaMCPChatPanel::CanSend() const
@@ -683,6 +714,25 @@ bool SHaybaMCPChatPanel::CanSend() const
 FReply SHaybaMCPChatPanel::OnNewConversation()
 {
     // TODO: when persistence lands, save current Session to disk before reset.
+    // Abort any in-flight stream and drop the client so the next send opens a
+    // FRESH server session (new session_id, new transcript).
+    if (AgentClient.IsValid())
+    {
+        AgentClient->OnTextDelta.RemoveAll(this);
+        AgentClient->OnToolCall.RemoveAll(this);
+        AgentClient->OnToolResult.RemoveAll(this);
+        AgentClient->OnPlanRequest.RemoveAll(this);
+        AgentClient->OnDone.RemoveAll(this);
+        AgentClient->OnError.RemoveAll(this);
+        AgentClient->Cancel();
+        AgentClient.Reset();
+    }
+    bAwaitingPlanApproval = false;
+    bIsStreaming = false;
+    InProgressMessageIndex = INDEX_NONE;
+    InProgressTrace.Reset();
+    InProgressAssistantText.Reset();
+
     Session = FHaybaMCPWizardSession{};
     UnseenWhileScrolledUp = 0;
     RebuildChat();
@@ -829,7 +879,242 @@ FReply SHaybaMCPChatPanel::OnTestItFromMessage(int32 /*MessageIndex*/)
     return FReply::Handled();
 }
 
-// ── Existing send pipeline ────────────────────────────────────────────────
+// ── Streaming agent pipeline (Task 8) ─────────────────────────────────────
+
+void SHaybaMCPChatPanel::EnsureAgentClient()
+{
+    if (AgentClient.IsValid()) return;
+
+    // MUST be MakeShared — the client calls AsShared() internally and asserts if
+    // it was ever stack/heap-allocated outside a shared ref.
+    AgentClient = MakeShared<FHaybaMCPAgentClient>();
+
+    // Subscribe once; the client persists for the panel's lifetime so a
+    // multi-turn conversation reuses one server session. RemoveAll(this) in the
+    // destructor drops these. Handlers all fire on the game thread.
+    AgentClient->OnTextDelta.AddSP(this, &SHaybaMCPChatPanel::HandleTextDelta);
+    AgentClient->OnToolCall.AddSP(this, &SHaybaMCPChatPanel::HandleToolCall);
+    AgentClient->OnToolResult.AddSP(this, &SHaybaMCPChatPanel::HandleToolResult);
+    AgentClient->OnPlanRequest.AddSP(this, &SHaybaMCPChatPanel::HandlePlanRequest);
+    AgentClient->OnDone.AddSP(this, &SHaybaMCPChatPanel::HandleStreamDone);
+    AgentClient->OnError.AddSP(this, &SHaybaMCPChatPanel::HandleStreamError);
+
+    // Watch for Plan-tab approvals so a paused turn can resume. One-shot per
+    // pending plan (guarded by bAwaitingPlanApproval in the handler).
+    if (Module && !PlanApprovedSubscription.IsValid())
+    {
+        PlanApprovedSubscription = Module->OnPlanApproved.AddSP(
+            this, &SHaybaMCPChatPanel::HandlePlanApproved);
+    }
+}
+
+void SHaybaMCPChatPanel::StartAgentTurn(const FString& Prompt)
+{
+    if (!FHaybaMCPSettings::Get().HasApiKey())
+    {
+        AddSystemError(TEXT("No API key set — open Settings"), TEXT(""));
+        return;
+    }
+
+    EnsureAgentClient();
+
+    Session.bWaitingForAI = true;
+    bIsStreaming = true;
+    BeginInProgressBubble();
+
+    // Server owns the system prompt (see HaybaMCPWizardPrompt.h) — send only the
+    // user turn. Provider/model/key are resolved by the client from the vault
+    // and pushed to the sidecar via /chat/config on the first turn.
+    AgentClient->SendPrompt(Prompt);
+}
+
+void SHaybaMCPChatPanel::BeginInProgressBubble()
+{
+    InProgressTrace.Reset();
+    InProgressAssistantText.Reset();
+
+    FHaybaMCPChatMessage Placeholder;
+    Placeholder.bFromUser = false;
+    Placeholder.Text      = TEXT("…");
+    Session.Messages.Add(Placeholder);
+    InProgressMessageIndex = Session.Messages.Num() - 1;
+
+    RebuildChat();
+    ScrollToBottomIfPinned();
+}
+
+void SHaybaMCPChatPanel::RefreshInProgressBubble()
+{
+    if (!Session.Messages.IsValidIndex(InProgressMessageIndex)) return;
+
+    // Tool-step trace (if any) sits above the streaming answer so the user sees
+    // what the agent is doing, then the prose it produces.
+    FString Composed;
+    if (InProgressTrace.Num() > 0)
+    {
+        Composed = FString::Join(InProgressTrace, TEXT("\n"));
+    }
+    if (!InProgressAssistantText.IsEmpty())
+    {
+        if (!Composed.IsEmpty()) Composed += TEXT("\n\n");
+        Composed += InProgressAssistantText;
+    }
+    if (Composed.IsEmpty()) Composed = TEXT("…");
+
+    Session.Messages[InProgressMessageIndex].Text = Composed;
+    const bool bPinned = IsScrolledNearBottom();
+    RebuildChat();
+    if (bPinned) ScrollToBottomIfPinned();
+}
+
+void SHaybaMCPChatPanel::FinalizeInProgressBubble(const FString& FallbackText)
+{
+    if (!Session.Messages.IsValidIndex(InProgressMessageIndex))
+    {
+        InProgressMessageIndex = INDEX_NONE;
+        return;
+    }
+    // If nothing streamed (e.g. immediate error), drop or substitute the
+    // placeholder so we don't leave a lone "…" bubble.
+    const bool bEmpty = InProgressTrace.Num() == 0 && InProgressAssistantText.IsEmpty();
+    if (bEmpty)
+    {
+        if (FallbackText.IsEmpty())
+        {
+            Session.Messages.RemoveAt(InProgressMessageIndex);
+        }
+        else
+        {
+            Session.Messages[InProgressMessageIndex].Text = FallbackText;
+        }
+    }
+    else
+    {
+        RefreshInProgressBubble();
+        if (!FallbackText.IsEmpty() && Session.Messages.IsValidIndex(InProgressMessageIndex))
+        {
+            Session.Messages[InProgressMessageIndex].Text += FString::Printf(TEXT("\n\n%s"), *FallbackText);
+        }
+    }
+    InProgressMessageIndex = INDEX_NONE;
+    InProgressTrace.Reset();
+    InProgressAssistantText.Reset();
+    RebuildChat();
+}
+
+// ── Agent-client delegate handlers ────────────────────────────────────────
+
+void SHaybaMCPChatPanel::HandleTextDelta(const FString& Text)
+{
+    if (InProgressMessageIndex == INDEX_NONE) BeginInProgressBubble();
+    InProgressAssistantText += Text;
+    RefreshInProgressBubble();
+}
+
+void SHaybaMCPChatPanel::HandleToolCall(const FHaybaChatToolCall& Call)
+{
+    if (InProgressMessageIndex == INDEX_NONE) BeginInProgressBubble();
+    // Collapsible-step affordance: a compact one-liner per tool call. (Full
+    // arg/result inspection lives in the Tool Stream panel.)
+    InProgressTrace.Add(FString::Printf(TEXT("→ %s"),
+        Call.Name.IsEmpty() ? TEXT("tool") : *Call.Name));
+    RefreshInProgressBubble();
+}
+
+void SHaybaMCPChatPanel::HandleToolResult(const FHaybaChatToolResult& Result)
+{
+    if (InProgressMessageIndex == INDEX_NONE) BeginInProgressBubble();
+    const TCHAR* Glyph = Result.bIsError ? TEXT("✕") : TEXT("✓");
+    InProgressTrace.Add(FString::Printf(TEXT("  %s %s"),
+        Glyph, Result.Name.IsEmpty() ? TEXT("tool") : *Result.Name));
+    RefreshInProgressBubble();
+}
+
+void SHaybaMCPChatPanel::HandlePlanRequest(const FHaybaChatPlanRequest& Plan)
+{
+    // Surface the gated action in the Plan tab for EXPLICIT human approval.
+    // NEVER auto-approve. The paused turn stays parked server-side until the
+    // user clicks Approve (→ OnPlanApproved → HandlePlanApproved → resume).
+    bAwaitingPlanApproval = true;
+
+    if (InProgressMessageIndex != INDEX_NONE)
+    {
+        InProgressTrace.Add(FString::Printf(
+            TEXT("⏸ Needs approval: %s — see the Plan tab."),
+            Plan.Name.IsEmpty() ? TEXT("action") : *Plan.Name));
+        RefreshInProgressBubble();
+    }
+
+    if (Module)
+    {
+        if (TSharedPtr<SHaybaMCPPlanPanel> PP = Module->PlanPanel.Pin())
+        {
+            FHaybaPlanStep Step;
+            Step.Index       = 0;
+            Step.Title       = Plan.Name.IsEmpty() ? TEXT("Proposed action") : Plan.Name;
+            Step.Description = Plan.Hint.IsEmpty()
+                ? FString::Printf(TEXT("Input: %s"), *Plan.InputJson)
+                : Plan.Hint;
+            Step.Tool        = Plan.Name;
+            TArray<FHaybaPlanStep> Steps; Steps.Add(Step);
+            PP->LoadPlan(Steps, /*AwaitSeconds*/ 120);
+        }
+    }
+
+    // Route the user to the Plan tab so the Approve/Reject bar is in front of
+    // them. This does not approve anything.
+    if (MainPanel) MainPanel->ShowPanel(EHaybaPanel::Plan);
+
+    Toast(LOCTEXT("PlanPause", "Action needs approval — review it in the Plan tab."));
+}
+
+void SHaybaMCPChatPanel::HandlePlanApproved()
+{
+    // Only act if WE are the panel waiting on a plan (avoids resuming on stray
+    // approvals). One-shot: clear the flag before resuming.
+    if (!bAwaitingPlanApproval) return;
+    bAwaitingPlanApproval = false;
+
+    if (!AgentClient.IsValid()) return;
+
+    // Resume the paused turn into a fresh in-progress bubble.
+    Session.bWaitingForAI = true;
+    bIsStreaming = true;
+    BeginInProgressBubble();
+    AgentClient->ApproveAndResume();
+
+    if (MainPanel) MainPanel->ShowPanel(EHaybaPanel::Chat);
+}
+
+void SHaybaMCPChatPanel::HandleStreamDone(const FHaybaChatDone& Done)
+{
+    Session.bWaitingForAI = false;
+    bIsStreaming = false;
+
+    // Prefer streamed text; fall back to the server's assembled assistant_text
+    // (e.g. on a clean end with no incremental deltas).
+    if (InProgressAssistantText.IsEmpty() && !Done.AssistantText.IsEmpty())
+    {
+        InProgressAssistantText = Done.AssistantText;
+    }
+    const FString Tag = Done.bCancelled ? TEXT("[stopped]") : TEXT("");
+    FinalizeInProgressBubble(Tag);
+}
+
+void SHaybaMCPChatPanel::HandleStreamError(const FHaybaChatError& Error)
+{
+    Session.bWaitingForAI = false;
+    bIsStreaming = false;
+    // Keep any partial content, then surface the error inline.
+    FinalizeInProgressBubble(TEXT(""));
+    AddSystemError(Error.Error.IsEmpty() ? TEXT("Chat error") : Error.Error, TEXT(""));
+}
+
+// ── Legacy send pipeline (UNUSED — retained for least-risk fallback) ──────
+// The single-POST FHaybaMCPClaudeClient path below is no longer wired into the
+// send button; StartAgentTurn() replaced it. Kept compilable so the fallback
+// remains available and to avoid a wide deletion. See HaybaMCPWizardPrompt.h
+// for the system-prompt ownership decision.
 
 void SHaybaMCPChatPanel::InitializeSession(const FString& Goal)
 {

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.cpp
@@ -1149,8 +1149,8 @@ void SHaybaMCPChatPanel::HandleStreamDone(const FHaybaChatDone& Done)
     {
         InProgressAssistantText = Done.AssistantText;
     }
-    const FString Tag = Done.bCancelled ? TEXT("[stopped]") : TEXT("");
-    FinalizeInProgressBubble(Tag);
+    const FString DoneTag = Done.bCancelled ? TEXT("[stopped]") : TEXT("");
+    FinalizeInProgressBubble(DoneTag);
 }
 
 void SHaybaMCPChatPanel::HandleStreamError(const FHaybaChatError& Error)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.h
@@ -15,6 +15,14 @@ class SVerticalBox;
 class SHorizontalBox;
 class SButton;
 
+// Streaming agent client + its SSE payload structs (Task 7).
+class FHaybaMCPAgentClient;
+struct FHaybaChatToolCall;
+struct FHaybaChatToolResult;
+struct FHaybaChatPlanRequest;
+struct FHaybaChatDone;
+struct FHaybaChatError;
+
 /**
  * Single-purpose chat surface for API-key mode users. Integrated-mode users
  * never see this tab. Conversation, input, footer status — that's it.
@@ -29,6 +37,10 @@ public:
     SLATE_END_ARGS()
 
     void Construct(const FArguments& InArgs, FHaybaMCPModule* InModule);
+
+    // Unsubscribe delegates + cancel any in-flight stream so a late callback
+    // cannot touch freed Slate widgets.
+    virtual ~SHaybaMCPChatPanel() override;
 
 private:
     FHaybaMCPModule* Module = nullptr;
@@ -47,9 +59,32 @@ private:
     int32                                   UnseenWhileScrolledUp = 0;
 
     // In-flight tool-call trace state.
-    FDelegateHandle ToolCallSubscription;
+    FDelegateHandle ToolCallSubscription;   // legacy path (module recorder)
     int32           InProgressMessageIndex = INDEX_NONE;
-    TArray<FString> InProgressTrace;
+    TArray<FString> InProgressTrace;        // tool-step lines for the live bubble
+    FString         InProgressAssistantText;// streamed assistant deltas
+
+    // ── Streaming agent client (Task 7/8) ────────────────────────────────────
+    // Held via MakeShared (NEVER stack — AsShared asserts). One client per panel
+    // = one server session; reused across turns so the transcript continues.
+    TSharedPtr<FHaybaMCPAgentClient> AgentClient;
+    FDelegateHandle PlanApprovedSubscription;   // module OnPlanApproved
+    bool            bAwaitingPlanApproval = false;
+
+    void            EnsureAgentClient();
+    void            StartAgentTurn(const FString& Prompt);
+    void            BeginInProgressBubble();
+    void            RefreshInProgressBubble();
+    void            FinalizeInProgressBubble(const FString& FallbackText);
+
+    // Agent-client delegate handlers (all fire on the game thread).
+    void            HandleTextDelta(const FString& Text);
+    void            HandleToolCall(const FHaybaChatToolCall& Call);
+    void            HandleToolResult(const FHaybaChatToolResult& Result);
+    void            HandlePlanRequest(const FHaybaChatPlanRequest& Plan);
+    void            HandleStreamDone(const FHaybaChatDone& Done);
+    void            HandleStreamError(const FHaybaChatError& Error);
+    void            HandlePlanApproved();
 
     // ── Layout ─────────────────────────────────────────────────────────────
     TSharedRef<SWidget> BuildToolbar();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPChatPanel.h
@@ -69,6 +69,7 @@ private:
     // = one server session; reused across turns so the transcript continues.
     TSharedPtr<FHaybaMCPAgentClient> AgentClient;
     FDelegateHandle PlanApprovedSubscription;   // module OnPlanApproved
+    FDelegateHandle PlanRejectedSubscription;   // module OnPlanRejected
     bool            bAwaitingPlanApproval = false;
 
     void            EnsureAgentClient();
@@ -85,6 +86,7 @@ private:
     void            HandleStreamDone(const FHaybaChatDone& Done);
     void            HandleStreamError(const FHaybaChatError& Error);
     void            HandlePlanApproved();
+    void            HandlePlanRejected();
 
     // ── Layout ─────────────────────────────────────────────────────────────
     TSharedRef<SWidget> BuildToolbar();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
@@ -116,6 +116,11 @@ static bool IsDestructiveCommand(const FString& Cmd)
         TEXT("input_create_mapping"),
         // Memory
         TEXT("memory_clear"),
+        // Credential mutation — writing/clearing an API key is as consequential
+        // as memory_clear. (copilot_get_key is a read → NOT gated here; it is
+        // separately fail-closed on capability-token config below.)
+        TEXT("copilot_key_set"),
+        TEXT("copilot_key_clear"),
     };
     return DestructiveCommands.Contains(Cmd);
 }
@@ -752,10 +757,14 @@ FString FHaybaMCPCommandHandler::ProcessCommand(const FString& CommandJson)
     // The TS copilot tools (copilot_key_*) and the local chat sidecar reach the
     // DPAPI key vault (FHaybaMCPSettings) ONLY through these four commands. They
     // have already cleared the capability-token auth gate above, and the TCP
-    // listener is bound to 127.0.0.1 only (HaybaMCPTcpServer.cpp:51) so no key
-    // material ever leaves the local machine. copilot_get_key is the ONLY command
-    // that returns a plaintext key; nothing here is written to the journal or a
-    // UE_LOG (the generic dispatch logger only records cmd+id, never params).
+    // listener is bound to 127.0.0.1 only (HaybaMCPTcpServer.cpp:51). Key
+    // material stays on the local machine SO LONG AS the bind remains loopback
+    // AND — for copilot_get_key specifically — a capability token is configured:
+    // that command fails CLOSED (below) and refuses to return a decrypted key
+    // when auth is unconfigured, even though the rest of the surface fails open.
+    // copilot_get_key is the ONLY command that returns a plaintext key; nothing
+    // here is written to the journal or a UE_LOG (the generic dispatch logger
+    // only records cmd+id, never params).
     if (Cmd == TEXT("copilot_key_status"))
     {
         auto Emit = [](const FString& ProviderId) -> TSharedPtr<FJsonObject>
@@ -785,6 +794,15 @@ FString FHaybaMCPCommandHandler::ProcessCommand(const FString& CommandJson)
 
     if (Cmd == TEXT("copilot_get_key"))
     {
+        // FAIL CLOSED: this is the only command that returns a plaintext key.
+        // ValidateRequest fails OPEN when no capability token is configured
+        // (usability default), which would let any local process read the
+        // decrypted key unauthenticated. Refuse unless auth is actually
+        // configured — regardless of the global fail-open posture.
+        if (!FHaybaMCPSecurityManager::Get().IsAuthConfigured())
+        {
+            return MakeErrorResponse(Id, TEXT("copilot_get_key requires a configured capability token (set one in Hayba settings); refusing to return a decrypted key without authentication"));
+        }
         FString Provider;
         Params->TryGetStringField(TEXT("provider"), Provider);
         if (Provider.IsEmpty()) Provider = FHaybaMCPSettings::Get().SelectedProviderId;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
@@ -748,6 +748,85 @@ FString FHaybaMCPCommandHandler::ProcessCommand(const FString& CommandJson)
         return MakeOkResponse(Id, Data);
     }
 
+    // ── copilot_* BYOK key-vault proxy ──────────────────────────────────────
+    // The TS copilot tools (copilot_key_*) and the local chat sidecar reach the
+    // DPAPI key vault (FHaybaMCPSettings) ONLY through these four commands. They
+    // have already cleared the capability-token auth gate above, and the TCP
+    // listener is bound to 127.0.0.1 only (HaybaMCPTcpServer.cpp:51) so no key
+    // material ever leaves the local machine. copilot_get_key is the ONLY command
+    // that returns a plaintext key; nothing here is written to the journal or a
+    // UE_LOG (the generic dispatch logger only records cmd+id, never params).
+    if (Cmd == TEXT("copilot_key_status"))
+    {
+        auto Emit = [](const FString& ProviderId) -> TSharedPtr<FJsonObject>
+        {
+            auto O = MakeShared<FJsonObject>();
+            O->SetStringField(TEXT("provider"), ProviderId);
+            const FString Last4 = FHaybaMCPSettings::GetProviderKeyLast4(ProviderId);
+            O->SetBoolField(TEXT("configured"), !Last4.IsEmpty());
+            if (Last4.IsEmpty()) O->SetField(TEXT("last4"), MakeShared<FJsonValueNull>());
+            else                 O->SetStringField(TEXT("last4"), Last4);
+            return O;
+        };
+        FString Provider;
+        Params->TryGetStringField(TEXT("provider"), Provider);
+        if (!Provider.IsEmpty())
+        {
+            return MakeOkResponse(Id, Emit(Provider));
+        }
+        // No provider given → report the whole catalog.
+        auto Data = MakeShared<FJsonObject>();
+        TArray<TSharedPtr<FJsonValue>> Arr;
+        for (const FHaybaProviderInfo& P : FHaybaMCPSettings::GetProviderCatalog())
+            Arr.Add(MakeShared<FJsonValueObject>(Emit(FString(P.Id))));
+        Data->SetArrayField(TEXT("providers"), Arr);
+        return MakeOkResponse(Id, Data);
+    }
+
+    if (Cmd == TEXT("copilot_get_key"))
+    {
+        FString Provider;
+        Params->TryGetStringField(TEXT("provider"), Provider);
+        if (Provider.IsEmpty()) Provider = FHaybaMCPSettings::Get().SelectedProviderId;
+        const FString Key = FHaybaMCPSettings::GetProviderKey(Provider);
+        auto Data = MakeShared<FJsonObject>();
+        Data->SetStringField(TEXT("provider"), Provider);
+        Data->SetBoolField(TEXT("set"), !Key.IsEmpty());
+        if (Key.IsEmpty()) Data->SetField(TEXT("key"), MakeShared<FJsonValueNull>());
+        else               Data->SetStringField(TEXT("key"), Key);
+        return MakeOkResponse(Id, Data);
+    }
+
+    if (Cmd == TEXT("copilot_key_set"))
+    {
+        FString Provider, Key;
+        Params->TryGetStringField(TEXT("provider"), Provider);
+        Params->TryGetStringField(TEXT("api_key"), Key);
+        if (Provider.IsEmpty()) return MakeErrorResponse(Id, TEXT("copilot_key_set requires { provider, api_key }"));
+        if (Key.IsEmpty())      return MakeErrorResponse(Id, TEXT("copilot_key_set requires a non-empty api_key"));
+        FHaybaMCPSettings::SetProviderKey(Provider, Key);
+        auto Data = MakeShared<FJsonObject>();
+        Data->SetStringField(TEXT("provider"), Provider);
+        Data->SetBoolField(TEXT("ok"), true);
+        // Echo the masked last-4 only — never the raw key.
+        Data->SetStringField(TEXT("key_last4"), FHaybaMCPSettings::GetProviderKeyLast4(Provider));
+        return MakeOkResponse(Id, Data);
+    }
+
+    if (Cmd == TEXT("copilot_key_clear"))
+    {
+        FString Provider;
+        Params->TryGetStringField(TEXT("provider"), Provider);
+        if (Provider.IsEmpty()) return MakeErrorResponse(Id, TEXT("copilot_key_clear requires { provider }"));
+        const bool bHad = FHaybaMCPSettings::HasProviderKey(Provider);
+        FHaybaMCPSettings::ClearProviderKey(Provider);
+        auto Data = MakeShared<FJsonObject>();
+        Data->SetStringField(TEXT("provider"), Provider);
+        Data->SetBoolField(TEXT("ok"), true);
+        Data->SetBoolField(TEXT("cleared"), bHad);
+        return MakeOkResponse(Id, Data);
+    }
+
     auto* Found = CommandToHandler.Find(Cmd);
     if (!Found)
     {

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPPlanPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPPlanPanel.cpp
@@ -320,6 +320,9 @@ FReply SHaybaMCPPlanPanel::OnApprove()
     if (FHaybaMCPModule* M = FModuleManager::GetModulePtr<FHaybaMCPModule>("HaybaMCPToolkit"))
     {
         M->bPlanApproved = true;
+        // Notify the chat panel (and any observer) so a paused streaming turn
+        // can POST /chat/approve and resume. Broadcast AFTER the flag is set.
+        M->OnPlanApproved.Broadcast();
     }
     RebuildSteps();
     return FReply::Handled();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPPlanPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPPlanPanel.cpp
@@ -330,10 +330,14 @@ FReply SHaybaMCPPlanPanel::OnApprove()
 
 FReply SHaybaMCPPlanPanel::OnReject()
 {
-    // Make sure rejecting clears the approval flag in case it was somehow set.
+    // Make sure rejecting clears the approval flag in case it was somehow set,
+    // then notify the chat panel so it disarms and cancels the paused turn.
+    // Without this broadcast the chat panel would stay armed and a later,
+    // unrelated Approve would resume this rejected turn (wrong-context fan-out).
     if (FHaybaMCPModule* M = FModuleManager::GetModulePtr<FHaybaMCPModule>("HaybaMCPToolkit"))
     {
         M->bPlanApproved = false;
+        M->OnPlanRejected.Broadcast();
     }
     Clear();
     return FReply::Handled();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSecurityManager.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSecurityManager.cpp
@@ -112,6 +112,11 @@ bool FHaybaMCPSecurityManager::ValidateRequest(const TSharedPtr<FJsonObject>& Re
     return true;
 }
 
+bool FHaybaMCPSecurityManager::IsAuthConfigured() const
+{
+    return !FHaybaMCPSettings::Get().CapabilityToken.IsEmpty();
+}
+
 FString FHaybaMCPSecurityManager::HashParams(const TSharedPtr<FJsonObject>& Params)
 {
     if (!Params.IsValid())

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSecurityManager.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSecurityManager.h
@@ -24,6 +24,14 @@ public:
      */
     bool ValidateRequest(const TSharedPtr<FJsonObject>& Request, FString& OutReason) const;
 
+    /**
+     * True when a non-empty capability token is configured (auth is enforced).
+     * When false, ValidateRequest fails OPEN for usability — so credential-
+     * returning paths (copilot_get_key) must consult this and refuse rather
+     * than hand back a decrypted key with no authentication.
+     */
+    bool IsAuthConfigured() const;
+
     /** Append a journal entry to hayba-execution.log in project Saved dir. Thread-safe. */
     void Journal(const FHaybaJournalEntry& Entry);
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettings.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettings.cpp
@@ -3,7 +3,18 @@
 #include "Misc/ConfigCacheIni.h"
 #include "Misc/Paths.h"
 #include "Misc/FileHelper.h"
+#include "Misc/Base64.h"
 #include "HAL/FileManager.h"
+
+// File-local log category. Used only for redacted vault failures — the key
+// plaintext is NEVER passed to any UE_LOG call in this file.
+DEFINE_LOG_CATEGORY_STATIC(LogHaybaMCPVault, Log, All);
+
+#if PLATFORM_WINDOWS
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include <wincrypt.h>
+#include "Windows/HideWindowsPlatformTypes.h"
+#endif
 
 FHaybaMCPSettings& FHaybaMCPSettings::Get()
 {
@@ -11,17 +22,189 @@ FHaybaMCPSettings& FHaybaMCPSettings::Get()
     return Instance;
 }
 
+// ── Provider catalog mirror (see FHaybaProviderInfo doc / providers.ts) ──────
+const TArray<FHaybaProviderInfo>& FHaybaMCPSettings::GetProviderCatalog()
+{
+    // MIRROR of mcp-tools/hayba-mcp/src/agents/providers.ts. Keep in sync by
+    // hand — there is no codegen. Order matches the TS PROVIDERS array.
+    static const TArray<FHaybaProviderInfo> Catalog = {
+        { TEXT("mock"),       TEXT("Mock (offline, no key)"),        TEXT(""),                                 TEXT("mock"),                       false, TEXT("(no key)") },
+        { TEXT("anthropic"),  TEXT("Anthropic"),                     TEXT("https://api.anthropic.com"),        TEXT("claude-opus-4-8"),            true,  TEXT("sk-ant-...") },
+        { TEXT("openai"),     TEXT("OpenAI"),                        TEXT("https://api.openai.com/v1"),        TEXT("gpt-4o-mini"),                true,  TEXT("sk-...") },
+        { TEXT("groq"),       TEXT("Groq (free tier)"),              TEXT("https://api.groq.com/openai/v1"),   TEXT("llama-3.3-70b-versatile"),    true,  TEXT("gsk_...") },
+        { TEXT("openrouter"), TEXT("OpenRouter (free routes)"),      TEXT("https://openrouter.ai/api/v1"),     TEXT(""),                           true,  TEXT("sk-or-...") },
+        { TEXT("ollama"),     TEXT("Ollama (local)"),                TEXT("http://localhost:11434/v1"),        TEXT("qwen2.5-coder:7b-instruct"),  false, TEXT("(no key)") },
+        { TEXT("lmstudio"),   TEXT("LM Studio (local)"),             TEXT("http://localhost:1234/v1"),         TEXT("local-model"),                false, TEXT("(no key)") },
+        { TEXT("custom"),     TEXT("Custom OpenAI-compatible"),      TEXT(""),                                 TEXT(""),                           false, TEXT("optional") },
+    };
+    return Catalog;
+}
+
+const FHaybaProviderInfo* FHaybaMCPSettings::FindProvider(const FString& ProviderId)
+{
+    for (const FHaybaProviderInfo& P : GetProviderCatalog())
+    {
+        if (ProviderId.Equals(P.Id, ESearchCase::IgnoreCase)) return &P;
+    }
+    return nullptr;
+}
+
+// ── DPAPI encrypt/decrypt helpers ────────────────────────────────────────────
+namespace
+{
+    // Weak fallback obfuscation key for non-Windows platforms only. This is NOT
+    // cryptographic protection — it exists so the vault format round-trips on
+    // platforms without DPAPI. The plugin is Win64-pinned so this path is
+    // effectively dead in shipping.
+    const uint8 kFallbackXor[] = { 0x48, 0x61, 0x79, 0x62, 0x61, 0x4D, 0x43, 0x50 }; // "HaybaMCP"
+
+    // Encrypt plaintext -> opaque hex string. Empty in -> empty out.
+    bool EncryptToHex(const FString& Plain, FString& OutHex)
+    {
+        OutHex.Reset();
+        if (Plain.IsEmpty()) return true;
+
+        // UTF-8 encode the plaintext.
+        FTCHARToUTF8 Utf8(*Plain);
+        const int32 NumBytes = Utf8.Length();
+
+#if PLATFORM_WINDOWS
+        DATA_BLOB In;
+        In.cbData = (DWORD)NumBytes;
+        In.pbData = (BYTE*)(const ANSICHAR*)Utf8.Get(); // CryptProtectData does not modify input
+        DATA_BLOB Out;
+        Out.cbData = 0;
+        Out.pbData = nullptr;
+        if (!CryptProtectData(&In, L"HaybaMCP BYOK key", nullptr, nullptr, nullptr,
+                              CRYPTPROTECT_UI_FORBIDDEN, &Out))
+        {
+            return false;
+        }
+        OutHex = BytesToHex(Out.pbData, (int32)Out.cbData);
+        LocalFree(Out.pbData); // DATA_BLOB.pbData is owned by us, free with LocalFree
+        return true;
+#else
+        // Fallback: XOR + Base64 (NOT secure). Marked with an 'F:' prefix so
+        // decrypt can distinguish it from DPAPI hex.
+        TArray<uint8> Bytes;
+        Bytes.Append((const uint8*)(const ANSICHAR*)Utf8.Get(), NumBytes);
+        for (int32 i = 0; i < Bytes.Num(); ++i)
+            Bytes[i] ^= kFallbackXor[i % UE_ARRAY_COUNT(kFallbackXor)];
+        OutHex = TEXT("F:") + FBase64::Encode(Bytes);
+        return true;
+#endif
+    }
+
+    // Decrypt hex string -> plaintext. Empty in -> empty out.
+    bool DecryptFromHex(const FString& Stored, FString& OutPlain)
+    {
+        OutPlain.Reset();
+        if (Stored.IsEmpty()) return true;
+
+        if (Stored.StartsWith(TEXT("F:")))
+        {
+            // Fallback-obfuscated payload (written on a non-Windows host).
+            TArray<uint8> Bytes;
+            if (!FBase64::Decode(Stored.RightChop(2), Bytes)) return false;
+            for (int32 i = 0; i < Bytes.Num(); ++i)
+                Bytes[i] ^= kFallbackXor[i % UE_ARRAY_COUNT(kFallbackXor)];
+            auto Conv = StringCast<TCHAR>((const UTF8CHAR*)Bytes.GetData(), Bytes.Num());
+            OutPlain = FString(Conv.Length(), Conv.Get());
+            return true;
+        }
+
+#if PLATFORM_WINDOWS
+        TArray<uint8> Cipher;
+        Cipher.SetNumUninitialized(Stored.Len() / 2);
+        HexToBytes(Stored, Cipher.GetData());
+        DATA_BLOB In;
+        In.cbData = (DWORD)Cipher.Num();
+        In.pbData = Cipher.GetData();
+        DATA_BLOB Out;
+        Out.cbData = 0;
+        Out.pbData = nullptr;
+        if (!CryptUnprotectData(&In, nullptr, nullptr, nullptr, nullptr,
+                                CRYPTPROTECT_UI_FORBIDDEN, &Out))
+        {
+            return false;
+        }
+        {
+            auto Conv = StringCast<TCHAR>((const UTF8CHAR*)Out.pbData, (int32)Out.cbData);
+            OutPlain = FString(Conv.Length(), Conv.Get());
+        }
+        LocalFree(Out.pbData);
+        return true;
+#else
+        // Non-fallback ciphertext on a non-Windows host is undecryptable.
+        return false;
+#endif
+    }
+}
+
+void FHaybaMCPSettings::SetProviderKey(const FString& ProviderId, const FString& Plaintext)
+{
+    if (ProviderId.IsEmpty()) return;
+    if (Plaintext.IsEmpty())
+    {
+        ClearProviderKey(ProviderId);
+        return;
+    }
+    FString Hex;
+    if (!EncryptToHex(Plaintext, Hex))
+    {
+        // NEVER log the plaintext. Only the failure + provider id.
+        UE_LOG(LogHaybaMCPVault, Warning, TEXT("SetProviderKey: DPAPI encrypt failed for provider '%s' — key NOT stored."), *ProviderId);
+        return;
+    }
+    GConfig->SetString(VaultSection, *ProviderId, *Hex, GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FString FHaybaMCPSettings::GetProviderKey(const FString& ProviderId)
+{
+    if (ProviderId.IsEmpty()) return FString();
+    FString Hex;
+    if (!GConfig->GetString(VaultSection, *ProviderId, Hex, GEditorPerProjectIni) || Hex.IsEmpty())
+        return FString();
+    FString Plain;
+    if (!DecryptFromHex(Hex, Plain))
+    {
+        UE_LOG(LogHaybaMCPVault, Warning, TEXT("GetProviderKey: DPAPI decrypt failed for provider '%s' (wrong user/machine?)."), *ProviderId);
+        return FString();
+    }
+    return Plain;
+}
+
+void FHaybaMCPSettings::ClearProviderKey(const FString& ProviderId)
+{
+    if (ProviderId.IsEmpty()) return;
+    GConfig->RemoveKey(VaultSection, *ProviderId, GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FString FHaybaMCPSettings::GetProviderKeyLast4(const FString& ProviderId)
+{
+    const FString Plain = GetProviderKey(ProviderId);
+    if (Plain.IsEmpty()) return FString();
+    return (Plain.Len() <= 4) ? Plain : Plain.Right(4);
+}
+
+bool FHaybaMCPSettings::HasProviderKey(const FString& ProviderId)
+{
+    if (ProviderId.IsEmpty()) return false;
+    FString Hex;
+    return GConfig->GetString(VaultSection, *ProviderId, Hex, GEditorPerProjectIni) && !Hex.IsEmpty();
+}
+
 FString FHaybaMCPSettings::GetSharedApiKey()
 {
-    FString Key;
-    GConfig->GetString(SharedSection, KeyApiKey, Key, GEditorPerProjectIni);
-    return Key;
+    // Route the legacy single-key path through the vault under the selected provider.
+    return GetProviderKey(Get().SelectedProviderId);
 }
 
 void FHaybaMCPSettings::SetSharedApiKey(const FString& Key)
 {
-    GConfig->SetString(SharedSection, KeyApiKey, *Key, GEditorPerProjectIni);
-    GConfig->Flush(false, GEditorPerProjectIni);
+    SetProviderKey(Get().SelectedProviderId, Key);
 }
 
 void FHaybaMCPSettings::Load()
@@ -41,7 +224,36 @@ void FHaybaMCPSettings::Load()
         bEnableContinuousCapture = DevSettings->bEnableContinuousCapture;
     }
 
-    GConfig->GetString(Section, KeyApiKey,     ApiKey,      GEditorPerProjectIni);
+    GConfig->GetString(Section, TEXT("SelectedProviderId"), SelectedProviderId, GEditorPerProjectIni);
+    if (SelectedProviderId.IsEmpty()) SelectedProviderId = TEXT("anthropic");
+
+    // One-time migration: earlier builds stored the LLM key in PLAINTEXT under
+    // [HaybaShared] ApiKey. If that legacy value exists and the vault has no key
+    // for the selected provider yet, re-encrypt it into the DPAPI vault and wipe
+    // the plaintext so it never lingers on disk.
+    {
+        FString LegacyPlain;
+        if (GConfig->GetString(SharedSection, KeyApiKey, LegacyPlain, GEditorPerProjectIni) && !LegacyPlain.IsEmpty())
+        {
+            if (!HasProviderKey(SelectedProviderId))
+                SetProviderKey(SelectedProviderId, LegacyPlain);
+            GConfig->RemoveKey(SharedSection, KeyApiKey, GEditorPerProjectIni);
+            GConfig->Flush(false, GEditorPerProjectIni);
+        }
+    }
+    // Legacy plaintext key under [HaybaMCPToolkit] ApiKey is likewise removed
+    // (never decrypted into a variable that could be logged). Do NOT read it back.
+    {
+        FString LegacyPlain2;
+        if (GConfig->GetString(Section, KeyApiKey, LegacyPlain2, GEditorPerProjectIni) && !LegacyPlain2.IsEmpty())
+        {
+            if (!HasProviderKey(SelectedProviderId))
+                SetProviderKey(SelectedProviderId, LegacyPlain2);
+            GConfig->RemoveKey(Section, KeyApiKey, GEditorPerProjectIni);
+            GConfig->Flush(false, GEditorPerProjectIni);
+        }
+    }
+
     GConfig->GetString(Section, KeyBaseURL,    BaseURL,     GEditorPerProjectIni);
     GConfig->GetString(Section, KeyModel,      Model,       GEditorPerProjectIni);
     GConfig->GetString(Section, KeyOutputPath, OutputPath,  GEditorPerProjectIni);
@@ -92,7 +304,9 @@ void FHaybaMCPSettings::Load()
 
 void FHaybaMCPSettings::Save() const
 {
-    GConfig->SetString(Section, KeyApiKey,     *ApiKey,      GEditorPerProjectIni);
+    // NOTE: the LLM API key is NOT written here — it lives DPAPI-encrypted in the
+    // vault ([HaybaProviderKeys]) via SetProviderKey. Never persist it plaintext.
+    GConfig->SetString(Section, TEXT("SelectedProviderId"), *SelectedProviderId, GEditorPerProjectIni);
     GConfig->SetString(Section, KeyBaseURL,    *BaseURL,     GEditorPerProjectIni);
     GConfig->SetString(Section, KeyModel,      *Model,       GEditorPerProjectIni);
     GConfig->SetString(Section, KeyOutputPath, *OutputPath,  GEditorPerProjectIni);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettings.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettings.h
@@ -8,15 +8,41 @@ enum class EHaybaMCPOperationMode : uint8
     ApiKey
 };
 
+// ── BYOK provider catalog mirror ────────────────────────────────────────────
+// MIRROR of mcp-tools/hayba-mcp/src/agents/providers.ts (Task 1 catalog).
+// There is NO build-time codegen linking the two — this is a DOCUMENTED MANUAL
+// MIRROR. If you add/edit/remove a provider in providers.ts you MUST make the
+// same change in the GetProviderCatalog() array in HaybaMCPSettings.cpp, and
+// vice-versa. Fields map 1:1 to ProviderEntry (id/label/baseURLDefault/
+// defaultModel/needsKey/keyHint); `protocol` is not needed C++-side.
+struct FHaybaProviderInfo
+{
+    const TCHAR* Id;
+    const TCHAR* Label;
+    const TCHAR* BaseURLDefault;
+    const TCHAR* DefaultModel;
+    bool         bNeedsKey;
+    const TCHAR* KeyHint;
+};
+
 class FHaybaMCPSettings
 {
 public:
     static FHaybaMCPSettings& Get();
 
-    // Claude API settings
+    // Claude / LLM API settings.
+    // ApiKey is a transient in-memory scratch value only (e.g. the Settings panel
+    // stages a freshly-typed key here before handing it to the vault). It is NOT
+    // loaded from or persisted to disk — the key of record lives DPAPI-encrypted
+    // in the vault via Get/SetProviderKey. Treat as sensitive: never log/journal.
     FString ApiKey;
     FString BaseURL = TEXT("https://api.anthropic.com/v1/messages");
     FString Model = TEXT("claude-opus-4-6-20251101");
+
+    // BYOK — id of the currently-selected provider (matches a catalog entry id).
+    // The vault stores one encrypted key per provider id; this picks which one
+    // the chat client / GetSharedApiKey resolves.
+    FString SelectedProviderId = TEXT("anthropic");
 
     // PCGEx output
     FString OutputPath = TEXT("/Game/Hayba/Generated");
@@ -76,8 +102,27 @@ public:
     // MCP server watches this file and rebuilds its disabled set from it.
     void WriteDisabledToolsFile() const;
 
+    // Legacy single-key accessors. Retained for the in-editor chat client;
+    // now route through the DPAPI vault under the currently-selected provider id.
     static FString GetSharedApiKey();
     static void SetSharedApiKey(const FString& Key);
+
+    // ── DPAPI-encrypted BYOK key vault ──────────────────────────────────────
+    // Keys are stored as DPAPI ciphertext (hex) in GEditorPerProjectIni under
+    // [HaybaProviderKeys], keyed by provider id — never plaintext. Decrypted on
+    // demand. On Windows this uses CryptProtectData/CryptUnprotectData (per-user,
+    // per-machine). DPAPI is Windows-only; other platforms fall back to a weak
+    // XOR+Base64 obfuscation (NOT secure) — documented limitation matching the
+    // plugin's Win64 pinning.
+    static void    SetProviderKey(const FString& ProviderId, const FString& Plaintext);
+    static FString GetProviderKey(const FString& ProviderId);   // -> plaintext ("" if none / decrypt fail)
+    static void    ClearProviderKey(const FString& ProviderId);
+    static FString GetProviderKeyLast4(const FString& ProviderId); // masked, safe to display/log
+    static bool    HasProviderKey(const FString& ProviderId);
+
+    // Catalog mirror of providers.ts. See FHaybaProviderInfo doc above.
+    static const TArray<FHaybaProviderInfo>& GetProviderCatalog();
+    static const FHaybaProviderInfo* FindProvider(const FString& ProviderId);
 
     void Load();
     void Save() const;
@@ -88,6 +133,8 @@ public:
 private:
     static constexpr const TCHAR* Section       = TEXT("HaybaMCPToolkit");
     static constexpr const TCHAR* SharedSection = TEXT("HaybaShared");
+    // Ciphertext (DPAPI hex) lives here, one entry per provider id.
+    static constexpr const TCHAR* VaultSection  = TEXT("HaybaProviderKeys");
     static constexpr const TCHAR* KeyApiKey     = TEXT("ApiKey");
     static constexpr const TCHAR* KeyBaseURL    = TEXT("BaseURL");
     static constexpr const TCHAR* KeyModel      = TEXT("Model");

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettingsPanel.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettingsPanel.cpp
@@ -11,6 +11,7 @@
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SCheckBox.h"
 #include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Input/SComboBox.h"
 #include "Styling/AppStyle.h"
 
 void SHaybaMCPSettingsPanel::Construct(const FArguments& InArgs)
@@ -34,9 +35,50 @@ void SHaybaMCPSettingsPanel::Construct(const FArguments& InArgs)
     SAssignNew(LlmBaseUrlBox,  SEditableTextBox)
         .Text(FText::FromString(S.BaseURL))
         .OnTextChanged_Lambda(OnDirty);
+    // Key box starts EMPTY — we never populate it with the stored secret. The
+    // last-4 status label (RefreshKeyStatus) is the only readback. Typing here
+    // marks the key as edited so OnSave writes the new value through the vault.
     SAssignNew(LlmApiKeyBox,   SEditableTextBox)
-        .Text(FText::FromString(FHaybaMCPSettings::GetSharedApiKey())).IsPassword(true)
-        .OnTextChanged_Lambda(OnDirty);
+        .IsPassword(true)
+        .HintText(NSLOCTEXT("Hayba", "S.Backend.KeyHint", "enter to replace stored key"))
+        .OnTextChanged_Lambda([this](const FText&){ bKeyEdited = true; MarkDirty(); });
+
+    // Provider dropdown — options mirror the catalog (providers.ts).
+    ProviderOptions.Reset();
+    for (const FHaybaProviderInfo& P : FHaybaMCPSettings::GetProviderCatalog())
+    {
+        TSharedPtr<FString> Opt = MakeShared<FString>(FString(P.Id));
+        ProviderOptions.Add(Opt);
+        if (S.SelectedProviderId.Equals(P.Id, ESearchCase::IgnoreCase))
+            SelectedProvider = Opt;
+    }
+    if (!SelectedProvider.IsValid() && ProviderOptions.Num() > 0)
+        SelectedProvider = ProviderOptions[0];
+
+    auto MakeProviderLabel = [](TSharedPtr<FString> Id) -> FText
+    {
+        const FHaybaProviderInfo* Info = Id.IsValid() ? FHaybaMCPSettings::FindProvider(*Id) : nullptr;
+        return FText::FromString(Info ? FString(Info->Label) : (Id.IsValid() ? *Id : FString()));
+    };
+
+    SAssignNew(ProviderCombo, SComboBox<TSharedPtr<FString>>)
+        .OptionsSource(&ProviderOptions)
+        .InitiallySelectedItem(SelectedProvider)
+        .OnGenerateWidget_Lambda([MakeProviderLabel](TSharedPtr<FString> Id)
+        {
+            return SNew(STextBlock).Text(MakeProviderLabel(Id));
+        })
+        .OnSelectionChanged(this, &SHaybaMCPSettingsPanel::OnProviderChanged)
+        [
+            SNew(STextBlock)
+            .Text_Lambda([this, MakeProviderLabel]()
+            {
+                return MakeProviderLabel(SelectedProvider);
+            })
+        ];
+
+    SAssignNew(KeyStatusText, STextBlock)
+        .TextStyle(&FAppStyle::Get().GetWidgetStyle<FTextBlockStyle>("SmallText"));
     SAssignNew(RateLimitBox,   SEditableTextBox)
         .Text(FText::AsNumber(S.RateLimitPerMinute))
         .OnTextChanged_Lambda(OnDirty);
@@ -155,6 +197,14 @@ void SHaybaMCPSettingsPanel::Construct(const FArguments& InArgs)
                             SNew(SVerticalBox)
                             + SVerticalBox::Slot().AutoHeight().Padding(0.f, 2.f)
                             [ BuildLabeledRow(
+                                NSLOCTEXT("Hayba", "S.Backend.Provider", "Provider"),
+                                NSLOCTEXT("Hayba", "S.Backend.Provider.TT",
+                                    "Pick your LLM provider. Selecting one auto-fills the Base URL, "
+                                    "default Model, and key hint below. Local providers "
+                                    "(Ollama, LM Studio) and Mock need no API key."),
+                                ProviderCombo.ToSharedRef()) ]
+                            + SVerticalBox::Slot().AutoHeight().Padding(0.f, 2.f)
+                            [ BuildLabeledRow(
                                 NSLOCTEXT("Hayba", "S.Backend.Url",  "Base URL"),
                                 FText::GetEmpty(),
                                 LlmBaseUrlBox.ToSharedRef()) ]
@@ -166,8 +216,16 @@ void SHaybaMCPSettingsPanel::Construct(const FArguments& InArgs)
                             + SVerticalBox::Slot().AutoHeight().Padding(0.f, 2.f)
                             [ BuildLabeledRow(
                                 NSLOCTEXT("Hayba", "S.Backend.Key",  "API Key"),
-                                FText::GetEmpty(),
+                                NSLOCTEXT("Hayba", "S.Backend.Key.TT",
+                                    "Stored encrypted at rest via Windows DPAPI (per-user, per-machine); "
+                                    "never written to disk in plaintext and never shown here in full. "
+                                    "Leave blank to keep the existing key; type to replace it."),
                                 LlmApiKeyBox.ToSharedRef()) ]
+                            + SVerticalBox::Slot().AutoHeight().Padding(0.f, 2.f)
+                            [ BuildLabeledRow(
+                                FText::GetEmpty(),
+                                FText::GetEmpty(),
+                                KeyStatusText.ToSharedRef()) ]
                             + SVerticalBox::Slot().AutoHeight().Padding(0.f, 2.f)
                             [ BuildToggle(
                                 NSLOCTEXT("Hayba", "S.CodeMode", "Code Mode (meta-tools)"),
@@ -328,6 +386,14 @@ void SHaybaMCPSettingsPanel::Construct(const FArguments& InArgs)
             ]
         ]
     ];
+
+    // Initialize the key box enabled/hint state + status label for the provider
+    // restored from settings. Do NOT overwrite the user's saved Base URL / Model
+    // on first paint — only the dropdown interaction does that.
+    ApplyProviderDefaults(
+        SelectedProvider.IsValid() ? FHaybaMCPSettings::FindProvider(*SelectedProvider) : nullptr,
+        /*bOverwriteUrlModel=*/false);
+    RefreshKeyStatus();
 }
 
 TSharedRef<SWidget> SHaybaMCPSettingsPanel::BuildSection(const FText& Heading, const FText& Tooltip, const TSharedRef<SWidget>& Body)
@@ -417,10 +483,21 @@ FReply SHaybaMCPSettingsPanel::OnSave()
     if (SidecarUrlBox.IsValid()) S.SidecarURL      = SidecarUrlBox->GetText().ToString();
     if (LlmModelBox.IsValid())   S.Model           = LlmModelBox->GetText().ToString();
     if (LlmBaseUrlBox.IsValid()) S.BaseURL         = LlmBaseUrlBox->GetText().ToString();
-    if (LlmApiKeyBox.IsValid())
+
+    // Persist the selected provider before writing the key so the vault stores
+    // it under the right id.
+    if (SelectedProvider.IsValid()) S.SelectedProviderId = *SelectedProvider;
+
+    // Only touch the vault when the user actually typed a new key this session.
+    // An empty-but-untouched box must NOT wipe the stored key.
+    if (bKeyEdited && LlmApiKeyBox.IsValid())
     {
-        S.ApiKey = LlmApiKeyBox->GetText().ToString();
-        FHaybaMCPSettings::SetSharedApiKey(S.ApiKey);
+        const FString Typed = LlmApiKeyBox->GetText().ToString();
+        FHaybaMCPSettings::SetProviderKey(S.SelectedProviderId, Typed); // empty -> clears
+        // Do not keep the plaintext around: clear the input and the scratch field.
+        S.ApiKey.Empty();
+        LlmApiKeyBox->SetText(FText::GetEmpty());
+        bKeyEdited = false;
     }
     if (RateLimitBox.IsValid())
     {
@@ -433,9 +510,68 @@ FReply SHaybaMCPSettingsPanel::OnSave()
         if (T.IsNumeric()) S.ToolCacheTTLSeconds = FCString::Atof(*T);
     }
     S.Save();
+    RefreshKeyStatus();
     bIsDirty = false;
     Invalidate(EInvalidateWidgetReason::Paint);
     return FReply::Handled();
+}
+
+void SHaybaMCPSettingsPanel::OnProviderChanged(TSharedPtr<FString> NewId, ESelectInfo::Type)
+{
+    if (!NewId.IsValid()) return;
+    SelectedProvider = NewId;
+    const FHaybaProviderInfo* Info = FHaybaMCPSettings::FindProvider(*NewId);
+    // Overwrite the Base URL / Model fields with this provider's defaults so the
+    // panel always shows a coherent config for the picked provider.
+    ApplyProviderDefaults(Info, /*bOverwriteUrlModel=*/true);
+    RefreshKeyStatus();
+    MarkDirty();
+}
+
+void SHaybaMCPSettingsPanel::ApplyProviderDefaults(const FHaybaProviderInfo* Info, bool bOverwriteUrlModel)
+{
+    if (!Info) return;
+    if (bOverwriteUrlModel)
+    {
+        if (LlmBaseUrlBox.IsValid()) LlmBaseUrlBox->SetText(FText::FromString(FString(Info->BaseURLDefault)));
+        if (LlmModelBox.IsValid())   LlmModelBox->SetText(FText::FromString(FString(Info->DefaultModel)));
+    }
+    if (LlmApiKeyBox.IsValid())
+    {
+        // Keyless providers: disable the key box; keyed providers: use the hint.
+        LlmApiKeyBox->SetEnabled(Info->bNeedsKey);
+        LlmApiKeyBox->SetHintText(Info->bNeedsKey
+            ? FText::FromString(FString(Info->KeyHint))
+            : NSLOCTEXT("Hayba", "S.Backend.KeylessHint", "no key required"));
+    }
+}
+
+void SHaybaMCPSettingsPanel::RefreshKeyStatus()
+{
+    if (!KeyStatusText.IsValid()) return;
+    const FString Id = SelectedProvider.IsValid() ? *SelectedProvider : FString();
+    const FHaybaProviderInfo* Info = FHaybaMCPSettings::FindProvider(Id);
+
+    if (Info && !Info->bNeedsKey)
+    {
+        KeyStatusText->SetText(NSLOCTEXT("Hayba", "S.Key.Keyless",
+            "Keyless provider — no API key needed."));
+        KeyStatusText->SetColorAndOpacity(FSlateColor(FLinearColor(0.45f, 0.8f, 0.5f))); // green
+        return;
+    }
+
+    // NEVER display the full key — last-4 only.
+    const FString Last4 = FHaybaMCPSettings::GetProviderKeyLast4(Id);
+    if (Last4.IsEmpty())
+    {
+        KeyStatusText->SetText(NSLOCTEXT("Hayba", "S.Key.None", "No key stored for this provider."));
+        KeyStatusText->SetColorAndOpacity(FSlateColor(FLinearColor(0.85f, 0.55f, 0.35f))); // amber
+    }
+    else
+    {
+        KeyStatusText->SetText(FText::FromString(FString::Printf(TEXT("Stored (DPAPI): ••••%s"), *Last4)));
+        KeyStatusText->SetColorAndOpacity(FSlateColor(FLinearColor(0.65f, 0.65f, 0.7f))); // muted
+    }
 }
 
 FReply SHaybaMCPSettingsPanel::OnRedoSetup()

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettingsPanel.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettingsPanel.h
@@ -4,7 +4,10 @@
 #include "Input/Reply.h"
 
 class SEditableTextBox;
+class STextBlock;
 class SHaybaMCPMainPanel;
+struct FHaybaProviderInfo;
+template <typename T> class SComboBox;
 
 class SHaybaMCPSettingsPanel : public SCompoundWidget
 {
@@ -26,6 +29,19 @@ private:
     TSharedPtr<SEditableTextBox> LlmApiKeyBox;
     TSharedPtr<SEditableTextBox> RateLimitBox;
     TSharedPtr<SEditableTextBox> CacheTtlBox;
+
+    // ── BYOK provider dropdown ──────────────────────────────────────────────
+    // Options are pointers into the static catalog (FHaybaMCPSettings::GetProviderCatalog()).
+    TArray<TSharedPtr<FString>>              ProviderOptions;   // provider ids, for the combo
+    TSharedPtr<FString>                      SelectedProvider;  // current combo selection
+    TSharedPtr<SComboBox<TSharedPtr<FString>>> ProviderCombo;
+    TSharedPtr<STextBlock>                   KeyStatusText;     // "Stored: ••••1234" / keyless badge
+    // Whether the user typed a new key this session (only then do we write the vault).
+    bool bKeyEdited = false;
+
+    void OnProviderChanged(TSharedPtr<FString> NewId, ESelectInfo::Type);
+    void ApplyProviderDefaults(const FHaybaProviderInfo* Info, bool bOverwriteUrlModel);
+    void RefreshKeyStatus();
 
     // Dirty tracking — Save button only enables when something has changed.
     bool bIsDirty = false;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPWizardPrompt.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPWizardPrompt.h
@@ -1,6 +1,40 @@
 #pragma once
 #include "CoreMinimal.h"
 
+// ─────────────────────────────────────────────────────────────────────────────
+// System-prompt ownership (Task 8 decision)
+//
+// The STREAMING chat path (SHaybaMCPChatPanel → FHaybaMCPAgentClient → sidecar
+// /chat/stream) lets the SERVER own the system prompt: the Task-3/4 agent loop
+// injects a system role describing the full tool surface, plan-mode gate, and
+// output contract. The panel sends ONLY user turns — it never ships a system
+// prompt over /chat/stream. This keeps the tool-surface description versioned
+// with the sidecar (which actually dispatches the tools) instead of drifting in
+// C++ string literals.
+//
+// GetHaybaMCPAgentSystemPrompt() below is a concise fallback describing the
+// agentic surface, kept for reference / any future path that must self-supply a
+// prompt. GetHaybaMCPWizardSystemPrompt() (graph-only JSON contract) is retained
+// solely for the LEGACY single-POST FHaybaMCPClaudeClient path, which is no
+// longer wired into the panel but still compiles.
+// ─────────────────────────────────────────────────────────────────────────────
+inline FString GetHaybaMCPAgentSystemPrompt()
+{
+	return TEXT(
+		"You are the Hayba copilot embedded in the Unreal Editor. You have a live "
+		"MCP tool surface for inspecting and mutating the open level and its "
+		"assets: spawning/deleting actors, editing properties, creating and "
+		"executing PCG graphs, importing meshes, and validating results.\n\n"
+		"Work agentically: call tools to observe the scene before acting, then act, "
+		"then verify. Narrate what you are doing in short prose between tool calls.\n\n"
+		"Plan Mode: when it is ON, destructive tools (spawn / delete / set_property "
+		"and similar) are gated. Do not attempt to bypass the gate — propose the "
+		"action; the human approves it in the Plan tab before it runs.\n\n"
+		"Prefer the smallest correct change, validate naming/placement, and report "
+		"the concrete result (asset paths, actor names, counts)."
+	);
+}
+
 inline FString GetHaybaMCPWizardSystemPrompt()
 {
 	return TEXT(

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPModule.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPModule.h
@@ -85,8 +85,23 @@ public:
     // The chat panel subscribes while a plan_request is pending so it can POST
     // /chat/approve and resume the paused streaming turn. Explicit human action
     // only — never auto-fired.
+    //
+    // INVARIANT: these are parameterless multicasts that assume exactly ONE chat
+    // panel is ever awaiting approval at a time (the plugin has a single chat
+    // surface). Because the broadcast carries no session/plan token, every
+    // subscriber that is armed (bAwaitingPlanApproval) treats the event as its
+    // own — the receiving handler re-validates bAwaitingPlanApproval to ignore
+    // strays. If a second concurrent chat surface is ever added, these must
+    // carry a session/plan id so the right panel resumes/aborts.
     DECLARE_MULTICAST_DELEGATE(FOnPlanApproved);
     FOnPlanApproved OnPlanApproved;
+
+    // Fires on the GameThread when the user clicks Reject in the Plan panel.
+    // Mirrors FOnPlanApproved (same single-awaiting-subscriber invariant above):
+    // the awaiting chat panel clears its armed state and cancels the paused turn
+    // so a later, unrelated Approve can't resume the rejected turn.
+    DECLARE_MULTICAST_DELEGATE(FOnPlanRejected);
+    FOnPlanRejected OnPlanRejected;
 
 private:
     mutable FCriticalSection ToolCallHistoryLock;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPModule.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPModule.h
@@ -81,6 +81,13 @@ public:
     DECLARE_MULTICAST_DELEGATE_OneParam(FOnToolCallRecorded, const FHaybaToolCallRecord&);
     FOnToolCallRecorded OnToolCallRecorded;
 
+    // Fires on the GameThread when the user clicks Approve in the Plan panel.
+    // The chat panel subscribes while a plan_request is pending so it can POST
+    // /chat/approve and resume the paused streaming turn. Explicit human action
+    // only — never auto-fired.
+    DECLARE_MULTICAST_DELEGATE(FOnPlanApproved);
+    FOnPlanApproved OnPlanApproved;
+
 private:
     mutable FCriticalSection ToolCallHistoryLock;
     TArray<FHaybaToolCallRecord> ToolCallHistory;


### PR DESCRIPTION
Revives the in-editor AI copilot as a **BYOK** (bring-your-own-key) agent: users paste their own provider key, and an agentic tool-calling loop drives the ~160-tool MCP catalog from a streaming chat panel — a local-first, vendor-neutral in-editor agent. 18 commits, subagent-driven with per-task spec+quality review and a final rebuild + live verification.

## Architecture — fat-server / thin-client
The agent loop runs in the Node MCP server (where the tool catalog, dispatch, PLUMB validator, journaling, and Plan-Mode gate already live, and it stays off the UE game thread). The C++ Slate panel is a thin SSE client. The old in-tree panel was a single no-tools POST; the real tool-calling shape was recovered from git history (`ac46d40`) and rebuilt server-side.

## TS (fully unit-tested — 766 vitest, tsc clean)
- **`providers.ts`** — 8-provider BYOK catalog (anthropic, openai, groq, openrouter, ollama, lmstudio, custom, mock); protocol classification; stale defaults corrected.
- **`llm-client.ts`** — restored + streaming + tool-calling across Anthropic (`tool_use`/`input_json_delta`) and OpenAI-compat (`tool_calls` fragment accumulation) with one normalized event type; typed error mapping; **key redaction at a single seam**; abort threading; proper `tool_use`/`tool_result` content blocks.
- **`agent-loop.ts`** — registry-derived tool catalog (archetype/disabled filtered), multi-step loop, **Plan-Mode-gated** (TS predicate + C++ `plan_mode_required`), abortable, call-bound approval.
- **`chat-server.ts`** — SSE `/chat/stream` + `/chat/cancel` + `/chat/approve` + `/chat/config`; **call-bound one-shot approval** (`{name,argsHash}`); session TTL/LRU eviction; resume-gap error; loopback-only; key never framed/logged.
- **`copilot-*` tools** — provider/model/key config + health, masked introspection.

## C++ [needs-rebuild → now rebuild-verified]
- **DPAPI key vault** — per-provider `CryptProtectData`; plaintext migrated out of the ini; provider dropdown mirrors the catalog; `copilot_get_key` **fail-closed** without a capability token; key mutators plan-gated.
- **`FHaybaMCPAgentClient`** — SSE consumer (partial-frame buffering), working `Cancel()`, `/chat/config` key push, `AbortServerTurn()` on reject.
- **Panel wiring** — streaming bubbles, collapsible tool steps, Plan-tab approve/reject handoff, Stop; correct Slate weak-lifetime teardown; legacy client kept compilable.

## Verification (live, UE 5.7, template project)
- ✅ All 8 C++ commits **compile** (fix: two `TSharedFromThis` shadow renames, C4458).
- ✅ Battery: **41 PASS** — full tool surface intact, no regression.
- ✅ **Copilot pipeline 7/7**: `/chat/config → /chat/stream` → agent loop → real dispatch → live `actor_list` → `tool_result(WorldSettings)` → `done`; **no api_key in any frame**.
- ✅ **Vault live**: `copilot_get_key` refused without a token; `copilot_key_status` masked.

## Pending (human): panel-UI smoke — provider key + eyes on the Slate panel (stream/tool-trace/Plan-tab approve+reject/Stop). Session disk-persistence for the recent-chats menu deferred (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamed in-editor chat experience with tool execution, session resume, cancel, and approval/rejection flows.
  * Added provider selection and per-provider key management in settings, with masked key status and provider defaults.
  * Added new copilot tools for provider status, testing, health, and key lifecycle actions.

* **Bug Fixes**
  * Improved key handling so secrets are masked and no longer shown in plaintext.
  * Added safer approval handling for destructive actions and paused plan requests.

* **Documentation**
  * Added a planning document outlining the rollout and safety requirements for the chat panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
