### PR TITLE
test(mcp): fix pre-existing flaky/env-dependent tool-hooks test

### DIFF
--- a/mcp-tools/hayba-mcp/src/validator/__tests__/tool-hooks.test.ts
+++ b/mcp-tools/hayba-mcp/src/validator/__tests__/tool-hooks.test.ts
@@ -8,6 +8,18 @@ import { setConfigPath } from '../config.js';
 import { rulesById } from '../rules.js';
 import { makeValidatedPythonRunHandler } from '../../tools/python-run-validator-wrap.js';
 
+// The `allow_unsafe` case delegates to the REAL pythonRunHandler, which calls
+// tcp-client's ensureConnected(). Without a mock this test's behavior depends on
+// whether a live UE editor is listening on 52342 (and now waits up to the raised
+// `high`-cost timeout when it isn't), making it hang/time out. Mock tcp-client so
+// the delegation resolves fast and deterministically in any environment; the
+// pre-flight-rejection tests never reach send(), so this only affects the
+// allow_unsafe path. Only ensureConnected is overridden — everything else real.
+vi.mock('../../tcp-client.js', async (orig) => ({
+  ...(await orig<typeof import('../../tcp-client.js')>()),
+  ensureConnected: async () => ({ send: async () => ({ id: 'mock', ok: true, data: { stdout: '', stderr: '' } }) }),
+}));
+
 let tmpDir: string;
 
 beforeEach(() => {


### PR DESCRIPTION
**Pre-existing** deterministic failure on `main` (not introduced by the copilot or Wave 3 branches — verified by reproducing on `main` directly).

`tool-hooks.test.ts > honours allow_unsafe and does not reject in pre-flight` delegates to the real `pythonRunHandler`, which calls `ensureConnected()`. Its outcome therefore depended on whether a live UE editor was listening on 52342 — and when none was, it waited up to the (recently raised) `high`-cost executor timeout, blowing vitest's 5s limit.

Fix: `vi.mock('../../tcp-client.js')` overriding **only** `ensureConnected` (everything else via `importActual`), so the `allow_unsafe` delegation resolves fast and deterministically in any environment. The pre-flight-rejection tests never reach `send()`, so they're unaffected.

Full suite: **691/691 green**, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)