### PR TITLE
fix(mcp): block world-switching python_run calls (editor-crash guardrail)

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/guards/known-crashers.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/guards/known-crashers.test.ts
@@ -16,4 +16,22 @@ describe('known-crashers', () => {
   it('returns null for safe scripts', () => {
     expect(scanPythonForCrashers('print(unreal.EditorLevelLibrary.get_all_level_actors())')).toBeNull();
   });
+
+  it('flags world-switching calls (EditorEngine.cpp:1745 crash class)', () => {
+    for (const script of [
+      'unreal.EditorLoadingAndSavingUtils.new_blank_map(False)',
+      'unreal.EditorLoadingAndSavingUtils.new_map_from_template(t, False)',
+      'unreal.EditorLoadingAndSavingUtils.load_map("/Game/Maps/L1")',
+      'unreal.LevelEditorSubsystem().new_level("/Game/Maps/New")',
+      'unreal.EditorLevelLibrary.load_level("/Game/Maps/L1")',
+    ]) {
+      const hit = scanPythonForCrashers(script);
+      expect(hit, script).not.toBeNull();
+      expect(crashGuardMessage(hit!)).toMatch(/editor UI|editor_open_map/);
+    }
+  });
+
+  it('does not flag a script that merely reads level actors (no world switch)', () => {
+    expect(scanPythonForCrashers('actors = unreal.EditorActorSubsystem().get_all_level_actors()')).toBeNull();
+  });
 });

--- a/mcp-tools/hayba-mcp/src/tools/guards/known-crashers.ts
+++ b/mcp-tools/hayba-mcp/src/tools/guards/known-crashers.ts
@@ -23,6 +23,26 @@ const PYTHON_CRASHERS: CrashGuardHit[] = [
     reason: 'build_scale3d crashes the editor and does not update bounds',
     alternative: 'use GeometryScript append_box/transform_mesh + copy_mesh_to_static_mesh',
   },
+  // World-switching from python_run kills the editor: python_run runs on the
+  // game thread mid-tick (TCP drain), and a map load/create tears down the
+  // current UWorld / swaps GWorld under the in-flight tick → the engine asserts
+  // `CurrentGWorld == EditorContext.World()` (EditorEngine.cpp:1745). The SEH
+  // guard catches the first access violation but cannot reconcile the desync, so
+  // the assert on a later tick is unavoidable. Confirmed repro (2026-07-05
+  // HANDOFF-mcp-worldswitch-crash-guardrail). Structural — never do this here.
+  ...([
+    'new_blank_map',
+    'new_map_from_template',
+    'load_map',
+    'new_level',
+    'load_level',
+  ].map((p): CrashGuardHit => ({
+    pattern: p,
+    reason:
+      `world-switching from python_run ('${p}') tears down GWorld mid-tick and crashes the editor with the EditorEngine.cpp:1745 assert (GWorld/EditorContext desync); the SEH guard cannot recover it`,
+    alternative:
+      'switch or create maps from the editor UI (or a deferred editor_open_map command that schedules the load outside the command tick) — never load/create a map from python_run',
+  }))),
 ];
 
 /**


### PR DESCRIPTION
Implements Fix 1 from `docs/HANDOFF-mcp-worldswitch-crash-guardrail.md` — a confirmed, user-visible editor-death.

**The crash:** a map load/create from `python_run` (`new_blank_map`, `new_map_from_template`, `load_map`, `new_level`, `load_level`) runs on the game thread *mid-tick* (TCP drain), tearing down the current `UWorld` / swapping `GWorld` under the in-flight tick → the engine asserts `CurrentGWorld == EditorContext.World()` (`EditorEngine.cpp:1745`) and the editor dies. The SEH guard catches the first access violation but cannot reconcile the desync, so the later-tick assert is unavoidable. Structural — not a script bug.

**Fix (this PR, TS, no rebuild):** add the five world-switching call patterns to the `scanPythonForCrashers` deny-list that `python_run` already enforces. World-switch scripts are now refused **before reaching UE**, with guidance to switch maps from the editor UI (or a future deferred `editor_open_map`). New tests cover each pattern + a negative case (reading level actors is not flagged). Full suite 693 green, tsc clean, lint green.

**Follow-ups (not in this PR — need a rebuild / are larger):**
- Fix 2: a safe `editor_open_map` command that defers the load to `SetTimerForNextTick` (outside the command tick) + `current_map` in status. [C++]
- Fix 2b: same guard on the `level_create` legacy command (already plan-gated). [C++ defense-in-depth]
- Fix 3: a `level_save` helper for the untitled-OpenWorld-template save failure. [C++, optional]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash detection for editor commands that switch or load worlds during script execution.
  * These actions are now flagged with clearer guidance to use the editor UI or handle map changes outside the current command.
  * Added coverage to ensure safe read-only editor scripts are not incorrectly flagged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->