### PR TITLE
fix(mcp): heavy-op resilience — no phantom crashes on slow editor ops

### DIFF
--- a/docs/HANDOFF-mcp-agent-ergonomics-postmortem.md
+++ b/docs/HANDOFF-mcp-agent-ergonomics-postmortem.md
@@ -109,6 +109,16 @@ These would replace the bespoke python and eliminate most P1 guessing.
 
 ---
 
+## P0b — Stale queued commands REPLAY on reconnect and pin the game thread (added 2026-07-05)
+
+**Symptom:** after an editor relaunch, the plugin processed `python_run (id: req_4)` that the agent never sent this session — it triggered an Interchange import of a multi-LOD Nanite glTF (`.scratch/ph-assets/pine_tree_01`, 60s+ Nanite build per LOD, 6.7GB memory estimates), pinning the game thread for minutes. Every in-flight agent request then times out, which is indistinguishable from an editor wedge — the agent kill-relooped the editor twice blaming its own graph edits before spotting `LogHaybaMCPCmd: Processing command: python_run (id: req_4)` + `LogInterchangeEngine` in the log.
+
+**Root cause to investigate:** the TS server (or sidecar) apparently re-sends unacknowledged/queued requests when a client (re)connects — including expensive asset-import commands from a long-dead session. Low request id (req_4) right after reconnect is the tell.
+
+**Fix:** (a) do NOT replay queued commands across a TCP reconnect — drop the queue when the editor connection is lost (the editor that would have serviced them is gone; results are undeliverable anyway); (b) tag every command with a session/connection id and have the plugin reject mismatched ones; (c) log a loud one-liner when a command older than N minutes executes. Acceptance: relaunch editor mid-session → no unexpected `Processing command` entries before the next fresh agent request.
+
+**Agent-side lesson (recorded in memory):** on suspected wedge, ALWAYS `tail` the editor log for `LogHaybaMCPCmd: Processing command` before blaming the in-flight script — frame number not advancing + a foreign req id = queued-command replay, not a graph bug.
+
 ## Smaller notes
 
 - **Nativize errors are cryptic.** `Cannot nativize 'NoneType' as 'RequestedLOD'` should ideally surface the expected Python type/constructor up front. Low priority; P1 introspection mostly addresses this.

--- a/docs/HANDOFF-mcp-worldswitch-crash-guardrail.md
+++ b/docs/HANDOFF-mcp-worldswitch-crash-guardrail.md
@@ -1,0 +1,84 @@
+# Handoff — python_run world-switch crash: add a guardrail (+ optional safe path)
+
+**Author:** Claude (Fable 5), sessions 4df015f5/3c601b17 — Plumb PCG system on `template.uproject`.
+**Audience:** the next Claude working on `HaybaMCPToolkit` / `hayba-mcp`.
+**Date:** 2026-07-05
+**Companions:** `HANDOFF-mcp-agent-ergonomics-postmortem.md` (P2 "known-crasher guardrail" — this is a concrete new entry for that list, with a confirmed repro and crash signature), `HANDOFF-mcp-pcg-graph-parameters-tool.md`.
+
+## The crash (confirmed repro, user-visible editor death)
+
+Calling a **world-switching** function from `python_run` kills the editor:
+
+```python
+unreal.EditorLoadingAndSavingUtils.new_blank_map(False)   # ← this call
+```
+
+Sequence observed:
+1. The call first raises a **native access violation** during script execution — the plugin's SEH guard (`ExecPythonGuarded`, `HaybaMCPPythonHandler.cpp:35`) catches it and reports "native access violation … re-acquire handles fresh". Editor still alive at this point.
+2. On a subsequent tick the engine asserts and the editor dies:
+   ```
+   Assertion failed: CurrentGWorld == EditorContext.World()
+   [Engine\Source\Editor\UnrealEd\Private\EditorEngine.cpp] [Line: 1745]
+   ```
+
+**Root cause:** `python_run` executes on the game thread **mid-tick from the TCP server's tick delegate** (`FHaybaMCPTcpServer::DrainPendingCommands` → `FHaybaMCPPythonHandler::Run`). A map load/create tears down the current `UWorld` and swaps `GWorld` **underneath the in-flight tick whose context still references the old world**. The SEH guard can swallow the first AV, but nothing can reconcile `GWorld` vs `EditorContext.World()` afterwards — the 1745 assert is unavoidable. This is not a bug in the python script; it is a structural "never do this from this execution context."
+
+Same family (previously observed, now explained by the same mechanism): the `level_create` hayba command crashing the editor (twice, earlier sessions).
+
+## Fix 1 (required): block world-switching calls in python_run
+
+Add a pre-execution guard in `HaybaMCPPythonHandler` (or a python-side prelude injected before the user script) that rejects scripts containing world-switching calls, with a clear error naming the alternative:
+
+- Deny-list (substring match on the script is fine as a first pass):
+  - `EditorLoadingAndSavingUtils.new_blank_map`
+  - `EditorLoadingAndSavingUtils.new_map_from_template`
+  - `EditorLoadingAndSavingUtils.load_map`
+  - `EditorLevelLibrary.new_level` / `.load_level` (deprecated aliases)
+  - `LevelEditorSubsystem.new_level` / `.load_level`
+- Error message should say: *"World-switching calls crash the editor when run from the MCP tick (GWorld/EditorContext desync, EditorEngine.cpp:1745). Use the `editor_open_map` command instead (see Fix 2), or ask the user to switch maps in the editor UI."*
+- Also remove/guard the existing `level_create` legacy command the same way (known crasher).
+
+This mirrors the P2 "known-crash guardrail" item in the ergonomics handoff; treat this as its first concrete implementation with a repro.
+
+## Fix 2 (recommended): provide a SAFE map-switch command
+
+The agent has a legitimate need to open/create maps. The safe pattern is to **defer the world switch out of the command tick**:
+
+- New command `editor_open_map { path?: string, template?: string, save_current?: bool }`.
+- Implementation: from the handler, **do not** call the load synchronously. Schedule it for the next engine tick *outside* the TCP drain, e.g.:
+  ```cpp
+  // in the handler: capture params, then
+  GEditor->GetTimerManager()->SetTimerForNextTick([Params]() {
+      FEditorFileUtils::LoadMap(Params.Path, /*LoadAsTemplate*/false, /*bShowProgress*/true);
+      // or UEditorLoadingAndSavingUtils::NewBlankMap / NewMapFromTemplate for create-cases
+  });
+  ```
+  and return `{scheduled:true}` immediately. The agent then polls `hayba_check_ue_status` / a `current_map` query until the world name changes.
+- Include `current_map` in the response of `hayba_check_ue_status` (cheap, helps the agent confirm the switch landed).
+
+## Related save-blocker worth a helper (optional, low effort)
+
+The reason the agent reached for `new_blank_map` at all: an **untitled level created from the OpenWorld template cannot be saved** — `save_map` fails with
+`Can't save ...: Illegal reference to private object: 'StaticMesh /Temp/Untitled_1_InstanceOf_.../HVLDTOB47BH89LD9IMV2MQ.StaticMesh_HLOD0_Instancing_0' referenced by 'LandscapeMeshProxyComponent_0'` (template HLOD/Landscape junk holding `/Temp` refs). Also note `save_map` can pop a **modal "Message" dialog** on such warnings, which blocks the game thread and looks like a wedge to the MCP (the agent had to close it via `WM_CLOSE`).
+
+Two cheap improvements:
+1. A `level_save { path }` command that (a) pre-strips actors whose class is Landscape*/`HLOD` when the current map is an unsaved `/Temp` template map (or at least reports the illegal-ref failure as structured data instead of a modal), and (b) runs the save with `FEditorFileUtils::PromptToCheckoutLevels` suppressed / silent flags so no modal can block the thread.
+2. In the TS layer, surface save warnings in the command result rather than relying on the editor's modal.
+
+## Addendum (2026-07-06): world-partition untitled levels also crash USER-INITIATED saves
+
+After scripted `save_map` attempts on an OpenWorld-template untitled level (illegal HLOD refs → failed SaveAs, modal dismissed via WM_CLOSE, partial Landscape/HLOD actor deletion), the USER clicking Save in the UI crashed the editor:
+`Assertion failed: !GetWorldPartition() || !GetWorldPartition()->IsInitialized() [WorldPartitionSubsystem.cpp:507]` (Slate → LevelEditor → SaveAs path).
+Takeaway for `level_save`: never run the strip-and-SaveAs dance on a world-partitioned /Temp level — it leaves the WP subsystem inconsistent and the *next* save (even the user's) asserts.
+**Project-side mitigation now in place** (template.uproject): `EditorStartupMap=/Game/Plumb/L_PlumbWork` — a clean non-WP Basic-template level committed as an asset, so sessions never start in the hostile OpenWorld untitled world. The MCP-side `level_save`/`editor_open_map` work should treat "current world is an unsaved WP template" as an error state with a clear message, not something to muscle through.
+
+## Acceptance criteria
+- `python_run` with `new_blank_map(...)` in the script returns a structured error (editor stays alive, no assert) naming the safe alternative.
+- `editor_open_map` switches maps without the EditorEngine.cpp:1745 assert (verify: switch, then run a trivial `python_run` — no AV, no crash on next ticks).
+- `level_save` (if built) saves an untitled OpenWorld-template level containing PCG actors without a blocking modal, or returns the illegal-ref list as data.
+
+## Key files
+- `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPythonHandler.cpp` — deny-list guard (Fix 1); `ExecPythonGuarded` at :35, `Run` at :288.
+- `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPTcpServer.cpp` — `DrainPendingCommands` (:171), where the mid-tick context comes from.
+- New handler for `editor_open_map` / `level_save` — alongside `HaybaMCPEditorHandler.cpp`.
+- `mcp-tools/hayba-mcp/src/tools/` — TS wrappers + registration in `tools/index.ts`.

--- a/mcp-tools/hayba-mcp/src/tcp-client.test.ts
+++ b/mcp-tools/hayba-mcp/src/tcp-client.test.ts
@@ -4,8 +4,48 @@ import {
   connectWithBackoff,
   resolveTargetPort,
   ensureConnected,
+  awaitEditorResponsive,
   _resetClientForTesting,
 } from './tcp-client.js';
+
+describe('awaitEditorResponsive', () => {
+  const noDelay = async () => {};
+
+  it('returns true immediately when the first probe answers', async () => {
+    let probes = 0;
+    const ok = await awaitEditorResponsive({
+      probeFn: async () => { probes++; return true; },
+      delayFn: noDelay,
+    });
+    expect(ok).toBe(true);
+    expect(probes).toBe(1);
+  });
+
+  it('polls until the port becomes responsive', async () => {
+    let probes = 0;
+    const ok = await awaitEditorResponsive({
+      probeFn: async () => { probes++; return probes >= 3; },
+      delayFn: noDelay,
+      intervalMs: 1,
+      timeoutMs: 10_000,
+      now: () => 0, // never exhaust the budget
+    });
+    expect(ok).toBe(true);
+    expect(probes).toBe(3);
+  });
+
+  it('returns false when the budget expires before the port answers', async () => {
+    let t = 0;
+    const ok = await awaitEditorResponsive({
+      probeFn: async () => false,
+      delayFn: noDelay,
+      intervalMs: 1,
+      timeoutMs: 5,
+      now: () => (t += 10), // jump past the deadline after the first probe
+    });
+    expect(ok).toBe(false);
+  });
+});
 
 // ── Existing baseline tests ───────────────────────────────────────────────────
 

--- a/mcp-tools/hayba-mcp/src/tcp-client.ts
+++ b/mcp-tools/hayba-mcp/src/tcp-client.ts
@@ -256,6 +256,58 @@ export async function ensureConnected(
   return c;
 }
 
+export interface AwaitResponsiveOpts {
+  /** Total budget to wait for the port to become responsive (default 30 s). */
+  timeoutMs?: number;
+  /** Delay between probes (default 1 s). */
+  intervalMs?: number;
+  /** Per-probe send timeout (default 2 s) — a lightweight `ping`. */
+  probeTimeoutMs?: number;
+  /** Injected connect+ping for tests. Returns true if the port answered. */
+  probeFn?: () => Promise<boolean>;
+  /** Delay function — defaults to real setTimeout-based promise. */
+  delayFn?: DelayFn;
+  /** Clock — defaults to Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Pre-flight gate for heavy ops: poll the plugin TCP port with a lightweight
+ * `ping` until it answers or the budget expires. Returns true once the editor
+ * is responsive, false if it never settled within `timeoutMs`.
+ *
+ * This is an OPT-IN utility — scripts/tools call it to wait for a busy editor
+ * to settle before firing another heavy op into a closed port. It is NOT wired
+ * into executeCommand's default path.
+ */
+export async function awaitEditorResponsive(opts: AwaitResponsiveOpts = {}): Promise<boolean> {
+  const {
+    timeoutMs = 30_000,
+    intervalMs = 1_000,
+    probeTimeoutMs = 2_000,
+    delayFn = defaultDelay,
+    now = Date.now,
+  } = opts;
+
+  const probeFn = opts.probeFn ?? (async () => {
+    try {
+      const c = await ensureConnected();
+      const resp = await c.send('ping', {}, probeTimeoutMs);
+      return resp.ok;
+    } catch {
+      return false;
+    }
+  });
+
+  const deadline = now() + timeoutMs;
+  // Always probe at least once, even for a zero/negative budget.
+  for (;;) {
+    if (await probeFn()) return true;
+    if (now() >= deadline) return false;
+    await delayFn(intervalMs);
+  }
+}
+
 /** Reset the module-level singleton — for testing only. */
 export function _resetClientForTesting(): void {
   client = null;

--- a/mcp-tools/hayba-mcp/src/tools/heavy-op-probe.ts
+++ b/mcp-tools/hayba-mcp/src/tools/heavy-op-probe.ts
@@ -1,0 +1,30 @@
+import { execFile } from 'node:child_process';
+
+/**
+ * Best-effort "is the UnrealEditor process alive?" probe, mirroring the signal
+ * used by hayba_check_ue_status so a heavy-op transport failure can be
+ * described accurately as "editor busy" (process up) vs "editor gone" (process
+ * down). Cross-platform, short timeout, never throws — resolves null when the
+ * detection itself is unavailable.
+ *
+ * Kept dependency-light (child_process only) so the executor can lazy-import it
+ * without dragging in the TCP client / sidecar.
+ */
+export function probeEditorProcess(): Promise<boolean | null> {
+  const isWin = process.platform === 'win32';
+  const cmd = isWin ? 'tasklist' : 'pgrep';
+  const args = isWin
+    ? ['/FI', 'IMAGENAME eq UnrealEditor.exe', '/NH']
+    : ['-f', 'UnrealEditor'];
+  return new Promise((resolve) => {
+    try {
+      execFile(cmd, args, { timeout: 2000, windowsHide: true }, (err, stdout) => {
+        if (err && (err as NodeJS.ErrnoException).code === 'ENOENT') return resolve(null);
+        const out = (stdout || '').toLowerCase();
+        resolve(isWin ? out.includes('unrealeditor.exe') : out.trim().length > 0);
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}

--- a/mcp-tools/hayba-mcp/src/tools/heavy-ops.ts
+++ b/mcp-tools/hayba-mcp/src/tools/heavy-ops.ts
@@ -1,0 +1,54 @@
+/**
+ * Heavy-operation registry.
+ *
+ * These UE commands run synchronously on the editor game thread and can block
+ * it for tens of seconds (gigabyte gltf imports, world-partition level saves,
+ * full PCG generates, landscape imports, asset re-index). While one is in
+ * flight the plugin's TCP listener stops accepting connections, so a naive
+ * tool call either hangs with no signal or hits ECONNREFUSED and reads as a
+ * crash. The executor treats commands in this set specially:
+ *   - a dedicated, generous "heavy" timeout tier (not the normal cost tier), and
+ *   - NEVER auto-retrying on transport failure (retrying a busy editor
+ *     compounds the stall, and these ops are effectively non-idempotent).
+ *
+ * The set is extensible at runtime via {@link addHeavyOp} so new blocking
+ * commands (or aliases) can be registered without editing this file.
+ */
+
+/** Dedicated timeout for heavy ops (ms). Generous because a large import /
+ *  world-partition save legitimately runs for minutes on the game thread. */
+export const HEAVY_OP_TIMEOUT_MS = 300_000;
+
+const HEAVY_OPS = new Set<string>([
+  // Asset import — a large gltf/fbx import blocks the game thread for the
+  // whole cook/import, and re-running would create duplicate assets.
+  'asset_import',
+  // Landscape import (both the C++ handler name and the alias used by callers).
+  'landscape_import',
+  'import_landscape',
+  // Level save — world-partition saves serialise every dirty actor on the
+  // game thread and hold the port for tens of seconds.
+  'level_save',
+  'save_current_level',
+  // PCG generate — a full graph execution on a large volume stalls the editor.
+  'pcg_execute_graph',
+  'hayba_execute_pcg_graph',
+  // Asset re-index — a full asset-registry rescan / embedding rebuild.
+  'hayba_asset_reindex',
+  'asset_reindex',
+]);
+
+/** Register an additional command as a heavy (game-thread-blocking) op. */
+export function addHeavyOp(cmd: string): void {
+  HEAVY_OPS.add(cmd);
+}
+
+/** True when `cmd` is known to block the UE game thread. */
+export function isHeavyOp(cmd: string): boolean {
+  return HEAVY_OPS.has(cmd);
+}
+
+/** Snapshot of the current heavy-op set (for diagnostics / tests). */
+export function listHeavyOps(): string[] {
+  return [...HEAVY_OPS].sort();
+}

--- a/mcp-tools/hayba-mcp/src/tools/heavy-ops.ts
+++ b/mcp-tools/hayba-mcp/src/tools/heavy-ops.ts
@@ -43,6 +43,12 @@ export function addHeavyOp(cmd: string): void {
   HEAVY_OPS.add(cmd);
 }
 
+/** Unregister a runtime-added heavy op. Returns true if it was present.
+ *  (Built-in defaults can be removed too; primarily for test isolation.) */
+export function removeHeavyOp(cmd: string): boolean {
+  return HEAVY_OPS.delete(cmd);
+}
+
 /** True when `cmd` is known to block the UE game thread. */
 export function isHeavyOp(cmd: string): boolean {
   return HEAVY_OPS.has(cmd);

--- a/mcp-tools/hayba-mcp/src/tools/tool-executor.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-executor.test.ts
@@ -200,6 +200,58 @@ describe('executeCommand — idempotency / retry gating', () => {
   });
 });
 
+import { HEAVY_OP_TIMEOUT_MS, addHeavyOp, isHeavyOp, listHeavyOps } from './heavy-ops.js';
+
+describe('heavy-ops registry', () => {
+  it('recognises the known game-thread-blocking commands', () => {
+    for (const cmd of ['asset_import', 'landscape_import', 'level_save', 'pcg_execute_graph', 'hayba_asset_reindex']) {
+      expect(isHeavyOp(cmd)).toBe(true);
+    }
+    expect(isHeavyOp('actor_list')).toBe(false);
+  });
+
+  it('is extensible at runtime via addHeavyOp', () => {
+    expect(isHeavyOp('my_custom_blocking_op')).toBe(false);
+    addHeavyOp('my_custom_blocking_op');
+    expect(isHeavyOp('my_custom_blocking_op')).toBe(true);
+    expect(listHeavyOps()).toContain('my_custom_blocking_op');
+  });
+});
+
+describe('executeCommand — heavy ops', () => {
+  it('gets the dedicated heavy timeout (300s), not the cost tier', async () => {
+    const seen: number[] = [];
+    const spy: Sender = async (_c, _p, t) => { seen.push(t); return { id: 't', ok: true, data: {} }; };
+    await executeCommand('level_save', {}, { sender: spy });
+    expect(seen[0]).toBe(HEAVY_OP_TIMEOUT_MS);
+    expect(seen[0]).toBe(300_000);
+  });
+
+  it('does NOT retry on transport failure — sender called exactly once', async () => {
+    let calls = 0;
+    const sender: Sender = async () => { calls++; throw new Error('ECONNREFUSED'); };
+    await expect(executeCommand('pcg_execute_graph', {}, { sender }))
+      .rejects.toMatchObject({ name: 'UeToolError', code: 'editor_busy' });
+    expect(calls).toBe(1);
+  });
+
+  it('produces a structured "editor busy" error on transport failure', async () => {
+    const sender: Sender = async () => { throw new Error('socket hang up'); };
+    try {
+      await executeCommand('asset_import', {}, { sender });
+      throw new Error('should have thrown');
+    } catch (e: unknown) {
+      const u = e as InstanceType<typeof UeToolError>;
+      expect(u.code).toBe('editor_busy');
+      expect(u.message).toContain('block the UE game thread');
+      expect(u.message).toContain('socket hang up');
+      const payload = u.uePayload as { cmd: string; heavy: boolean };
+      expect(payload.heavy).toBe(true);
+      expect(payload.cmd).toBe('asset_import');
+    }
+  });
+});
+
 import { InMemoryToolExecutor } from './tool-executor.js';
 
 describe('InMemoryToolExecutor', () => {

--- a/mcp-tools/hayba-mcp/src/tools/tool-executor.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-executor.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { UeToolError, costToTimeoutMs, executeCommand, NON_IDEMPOTENT, type Sender } from './tool-executor.js';
+import { HEAVY_OP_TIMEOUT_MS, addHeavyOp, isHeavyOp, listHeavyOps, removeHeavyOp } from './heavy-ops.js';
+
+// Keep the "editor busy" tests hermetic: the real probe shells out to
+// tasklist/pgrep via the dynamic import in makeEditorBusyError. Mock it so unit
+// tests never spawn a subprocess (matches the "unit tests don't shell out" bar).
+vi.mock('./heavy-op-probe.js', () => ({ probeEditorProcess: async () => null }));
 import type { TcpResponse } from '../tcp-client.js';
 import { registerToolMeta, resetToolMetaRegistry } from './tool-meta-registry.js';
 
@@ -200,8 +206,6 @@ describe('executeCommand — idempotency / retry gating', () => {
   });
 });
 
-import { HEAVY_OP_TIMEOUT_MS, addHeavyOp, isHeavyOp, listHeavyOps } from './heavy-ops.js';
-
 describe('heavy-ops registry', () => {
   it('recognises the known game-thread-blocking commands', () => {
     for (const cmd of ['asset_import', 'landscape_import', 'level_save', 'pcg_execute_graph', 'hayba_asset_reindex']) {
@@ -215,6 +219,8 @@ describe('heavy-ops registry', () => {
     addHeavyOp('my_custom_blocking_op');
     expect(isHeavyOp('my_custom_blocking_op')).toBe(true);
     expect(listHeavyOps()).toContain('my_custom_blocking_op');
+    // Don't leak this runtime registration into other suites.
+    removeHeavyOp('my_custom_blocking_op');
   });
 });
 

--- a/mcp-tools/hayba-mcp/src/tools/tool-executor.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-executor.ts
@@ -1,13 +1,15 @@
 import type { HaybaToolCost } from './hayba-tool-meta.js';
 import type { TcpResponse } from '../tcp-client.js';
 import { getToolMeta } from './tool-meta-registry.js';
+import { isHeavyOp, HEAVY_OP_TIMEOUT_MS } from './heavy-ops.js';
 
 export type UeToolErrorCode =
   | 'transport'
   | 'timeout'
   | 'plan_gate'
   | 'tool_disabled'
-  | 'ue_error';
+  | 'ue_error'
+  | 'editor_busy';
 
 export class UeToolError extends Error {
   readonly code: UeToolErrorCode;
@@ -145,6 +147,51 @@ export function costToTimeoutMs(cost: HaybaToolCost | undefined): number {
   return COST_TIMEOUTS_MS.medium;
 }
 
+/**
+ * Resolve the effective timeout for a command. Heavy, game-thread-blocking ops
+ * (imports, level saves, PCG generate, asset re-index) get a dedicated,
+ * generous `heavy` tier instead of their cost tier, so they don't pre-time-out
+ * while UE is still legitimately working.
+ */
+export function resolveTimeoutMs(cmd: string): number {
+  if (isHeavyOp(cmd)) return HEAVY_OP_TIMEOUT_MS;
+  return costToTimeoutMs(getToolMeta(cmd)?.cost);
+}
+
+/**
+ * Build the structured, actionable error thrown when a heavy op fails at the
+ * transport layer (connection refused / reset / timeout). A heavy op that
+ * drops the connection almost always means "editor is busy finishing the
+ * operation on the game thread", NOT "editor crashed" — so the message steers
+ * the caller to re-check status rather than assume a crash. When a live status
+ * probe is reachable its process-up/down signal is folded in for accuracy.
+ */
+async function makeEditorBusyError(cmd: string, cause: unknown): Promise<UeToolError> {
+  const causeMsg = (cause as Error)?.message ?? String(cause);
+  let processHint =
+    'Re-check the editor with hayba_check_ue_status before retrying — do NOT auto-retry this op.';
+  try {
+    // Lazy import so this module stays unit-testable without the process probe.
+    const { probeEditorProcess } = await import('./heavy-op-probe.js');
+    const running = await probeEditorProcess();
+    if (running === true) {
+      processHint =
+        'The UnrealEditor process is still running — it is almost certainly busy finishing this operation on the game thread (not crashed). Wait for it to settle, then re-check hayba_check_ue_status. Do NOT auto-retry.';
+    } else if (running === false) {
+      processHint =
+        'No UnrealEditor process was detected — the editor may have exited/crashed during this operation. Verify with hayba_check_ue_status before retrying.';
+    }
+  } catch {
+    // Probe unavailable — fall back to the generic hint.
+  }
+  return new UeToolError(
+    `Heavy operation "${cmd}" failed at the transport layer (${causeMsg}). ` +
+      `Heavy ops block the UE game thread and stop the plugin TCP port from accepting ` +
+      `connections while they run. ${processHint}`,
+    { code: 'editor_busy', uePayload: { cmd, cause: causeMsg, heavy: true } },
+  );
+}
+
 export type Sender = (
   cmd: string,
   params: Record<string, unknown>,
@@ -171,7 +218,8 @@ export async function executeCommand<T = Record<string, unknown>>(
 ): Promise<T> {
   const sender = opts.sender ?? DEFAULT_SENDER;
   if (!sender) throw new UeToolError('No sender configured', { code: 'transport' });
-  const timeout = opts.timeout ?? costToTimeoutMs(getToolMeta(cmd)?.cost);
+  const heavy = isHeavyOp(cmd);
+  const timeout = opts.timeout ?? resolveTimeoutMs(cmd);
 
   const attemptOnce = async (): Promise<TcpResponse> => sender(cmd, params, timeout);
 
@@ -179,6 +227,13 @@ export async function executeCommand<T = Record<string, unknown>>(
   try {
     resp = await attemptOnce();
   } catch (firstErr) {
+    // Heavy ops NEVER retry: they block the game thread and are effectively
+    // non-idempotent, so re-firing into a busy editor compounds the stall.
+    // Throw a structured "editor busy" error steering the caller to re-check
+    // status rather than assume a crash.
+    if (heavy) {
+      throw await makeEditorBusyError(cmd, firstErr);
+    }
     // Transport-level failure. Only retry when the command is idempotent:
     // non-idempotent ops (spawn, delete, create, …) must not execute twice.
     if (NON_IDEMPOTENT.has(cmd)) {

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
@@ -113,8 +113,9 @@ bool FPlumbWallPlannerUnitTest::RunTest(const FString& Parameters)
         const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(CorrIn, { RoomB }, P);
         TestEqual(TEXT("f4b: one yielded socket"), Plan.Sockets.Num(), 1);
         if (Plan.Sockets.Num() == 1) TestTrue(TEXT("f4b: corridor does not own"), !Plan.Sockets[0].bOwned);
-        // near cap loses the 150 opening: 2200 - 150
-        TestEqual(TEXT("f4b: cap retiled around the opening"), CoveredLength(Plan), 2200.0 - 150.0, 1.0);
+        // socketed mouth insets by WallThickness(30): sides 770x2 + caps 300x2 = 2140; minus 150 opening
+        TestEqual(TEXT("f4b: inset cap retiled around the opening"), CoveredLength(Plan), 2140.0 - 150.0, 1.0);
+        TestEqual(TEXT("f4b: floor loop follows inset footprint"), Plan.FloorLoop.Num(), 4);
     }
 
     // ---- Fixture 5: split-level Z (Q12) — corridor floor at 60 meets room floor at 0

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
@@ -53,7 +53,7 @@ bool FPlumbWallPlannerUnitTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("f1: exactly ONE socket"), Plan.Sockets.Num(), 1);
         if (Plan.Sockets.Num() == 1)
         {
-            TestEqual(TEXT("f1: socket on north wall y=600"), Plan.Sockets[0].Center.Y, 600.0, 1.0);
+            TestEqual(TEXT("f1: frame centered on the gap (wall+thickness/2)"), Plan.Sockets[0].Center.Y, 615.0, 1.0);
             TestEqual(TEXT("f1: centered on the mouth x=1500"), Plan.Sockets[0].Center.X, 1500.0, 1.0);
             TestTrue (TEXT("f1: room owns"), Plan.Sockets[0].bOwned);
             TestEqual(TEXT("f1: opening is type-sized 150, not span-sized"), Plan.Sockets[0].Width, 150.0, 0.1);
@@ -97,7 +97,7 @@ bool FPlumbWallPlannerUnitTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("f3: one socket"), Plan.Sockets.Num(), 1);
         if (Plan.Sockets.Num() == 1)
         {
-            TestEqual(TEXT("f3: on east wall x=600"), Plan.Sockets[0].Center.X, 600.0, 1.0);
+            TestEqual(TEXT("f3: frame centered on the gap x=615"), Plan.Sockets[0].Center.X, 615.0, 1.0);
             TestEqual(TEXT("f3: at the mouth y=300"), Plan.Sockets[0].Center.Y, 300.0, 1.0);
         }
         TestEqual(TEXT("f3: coverage"), CoveredLength(Plan), 2400.0 - 150.0, 0.5);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
@@ -62,11 +62,18 @@ bool FPlumbWallPlannerUnitTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("f1: coverage = perimeter - opening"), CoveredLength(Plan), 2400.0 - 150.0, 0.5);
         TestEqual(TEXT("f1: no rejects"), Plan.Rejects.Num(), 0);
         // over-door band: a fill patch from opening top (220) to ceiling (300) over the 150 span
-        TestTrue (TEXT("f1: over-door fill exists"), Plan.Fills.Num() >= 1);
-        if (Plan.Fills.Num() >= 1)
+        TestTrue (TEXT("f1: over-door bands exist"), Plan.Fills.Num() >= 2);
+        if (Plan.Fills.Num() >= 2)
         {
-            TestEqual(TEXT("f1: fill starts at opening top"), Plan.Fills[0].Z0, 220.0, 0.1);
-            TestEqual(TEXT("f1: fill ends at ceiling"),      Plan.Fills[0].Z1, 300.0, 0.1);
+            double Lo = 1e9, Hi = -1e9; bool bCrownTops = false;
+            for (const FPlumbFillPlan& F : Plan.Fills)
+            {
+                Lo = FMath::Min(Lo, F.Z0); Hi = FMath::Max(Hi, F.Z1);
+                if (F.BandIndex == 2 && FMath::IsNearlyEqual(F.Z1, 300.0, 0.1)) bCrownTops = true;
+            }
+            TestEqual(TEXT("f1: bands start at opening top"), Lo, 220.0, 0.1);
+            TestEqual(TEXT("f1: bands reach the ceiling"),    Hi, 300.0, 0.1);
+            TestTrue (TEXT("f1: crown band tops out at ceiling"), bCrownTops);
         }
     }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
@@ -1,0 +1,148 @@
+// Regression fixtures = the exact broken scenes of 2026-07-05 (spec §4.1).
+// The audit invariant from the live sessions is the acceptance test:
+//   every wall run covered lo..hi, exactly one socket interval per junction, zero gaps/overlaps.
+#include "Misc/AutomationTest.h"
+#include "pcg/PlumbWallPlanner.h"
+
+namespace
+{
+    using namespace PlumbWallPlanner;
+
+    FPlumbStructure Room(const TCHAR* Id, const FVector& Min, const FVector& Max, double FloorZ = 0.0)
+    {
+        FPlumbStructure S;
+        S.Id = FName(Id); S.Kind = EPlumbStructureKind::Room; S.bClosed = true; S.FloorZ = FloorZ;
+        S.Points = { FVector(Min.X,Min.Y,FloorZ), FVector(Max.X,Min.Y,FloorZ),
+                     FVector(Max.X,Max.Y,FloorZ), FVector(Min.X,Max.Y,FloorZ) };
+        return S;
+    }
+
+    FPlumbStructure Corridor(const TCHAR* Id, std::initializer_list<FVector> Pts, double FloorZ = 0.0)
+    {
+        FPlumbStructure S;
+        S.Id = FName(Id); S.Kind = EPlumbStructureKind::Corridor; S.bClosed = false; S.FloorZ = FloorZ;
+        for (const FVector& P : Pts) S.Points.Add(FVector(P.X, P.Y, FloorZ));
+        return S;
+    }
+
+    // The live-session interval audit, as code: segments + socket widths must tile each run exactly.
+    double CoveredLength(const FPlumbWallPlan& Plan)
+    {
+        double L = 0.0;
+        for (const FPlumbSegmentPlan& S : Plan.Segments) L += FVector::Dist2D(S.A, S.B);
+        return L;
+    }
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FPlumbWallPlannerUnitTest,
+    "Plumb.WallPlanner",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FPlumbWallPlannerUnitTest::RunTest(const FString& Parameters)
+{
+    FPlumbPlanParams P; // defaults: opening 150x220, thickness 30, corner 30deg
+
+    // ---- Fixture 1: Demo_RoomB_Plain + Demo_Corridor_L (the "whole north wall became doorframes" bug)
+    {
+        const FPlumbStructure RoomB = Room(TEXT("RoomB"), FVector(1200,0,0), FVector(1800,600,0));
+        const FPlumbStructure CorrL = Corridor(TEXT("CorrL"), { FVector(1500,600,0), FVector(1500,1200,0), FVector(2100,1200,0) });
+
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(RoomB, { CorrL }, P);
+
+        TestEqual(TEXT("f1: exactly ONE socket"), Plan.Sockets.Num(), 1);
+        if (Plan.Sockets.Num() == 1)
+        {
+            TestEqual(TEXT("f1: socket on north wall y=600"), Plan.Sockets[0].Center.Y, 600.0, 1.0);
+            TestEqual(TEXT("f1: centered on the mouth x=1500"), Plan.Sockets[0].Center.X, 1500.0, 1.0);
+            TestTrue (TEXT("f1: room owns"), Plan.Sockets[0].bOwned);
+            TestEqual(TEXT("f1: opening is type-sized 150, not span-sized"), Plan.Sockets[0].Width, 150.0, 0.1);
+        }
+        // audit: perimeter 2400, one 150 opening -> segments cover 2250, no gaps
+        TestEqual(TEXT("f1: coverage = perimeter - opening"), CoveredLength(Plan), 2400.0 - 150.0, 0.5);
+        TestEqual(TEXT("f1: no rejects"), Plan.Rejects.Num(), 0);
+    }
+
+    // ---- Fixture 2: symmetric derivation (Q1) — corridor's own plan lands the identical socket
+    {
+        const FPlumbStructure RoomB = Room(TEXT("RoomB"), FVector(1200,0,0), FVector(1800,600,0));
+        const FPlumbStructure CorrL = Corridor(TEXT("CorrL"), { FVector(1500,600,0), FVector(1500,1200,0), FVector(2100,1200,0) });
+
+        const FPlumbWallPlan RoomPlan = PlumbWallPlanner::Plan(RoomB, { CorrL }, P);
+        const FPlumbWallPlan CorrPlan = PlumbWallPlanner::Plan(CorrL, { RoomB }, P);
+
+        TestEqual(TEXT("f2: corridor sees the same single junction"), CorrPlan.Sockets.Num(), 1);
+        if (RoomPlan.Sockets.Num() == 1 && CorrPlan.Sockets.Num() == 1)
+        {
+            TestEqual(TEXT("f2: identical center X"), CorrPlan.Sockets[0].Center.X, RoomPlan.Sockets[0].Center.X, 0.01);
+            TestEqual(TEXT("f2: identical center Y"), CorrPlan.Sockets[0].Center.Y, RoomPlan.Sockets[0].Center.Y, 0.01);
+            TestEqual(TEXT("f2: identical Z0"),       CorrPlan.Sockets[0].Z0,       RoomPlan.Sockets[0].Z0,       0.01);
+            TestTrue (TEXT("f2: corridor does NOT own (yields)"), !CorrPlan.Sockets[0].bOwned);
+        }
+    }
+
+    // ---- Fixture 3: Demo_RoomA + straight corridor (east-wall junction; the gap/overshoot bug)
+    {
+        const FPlumbStructure RoomA  = Room(TEXT("RoomA"), FVector(0,0,0), FVector(600,600,0));
+        const FPlumbStructure CorrAB = Corridor(TEXT("CorrAB"), { FVector(600,300,0), FVector(1400,300,0) });
+
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(RoomA, { CorrAB }, P);
+        TestEqual(TEXT("f3: one socket"), Plan.Sockets.Num(), 1);
+        if (Plan.Sockets.Num() == 1)
+        {
+            TestEqual(TEXT("f3: on east wall x=600"), Plan.Sockets[0].Center.X, 600.0, 1.0);
+            TestEqual(TEXT("f3: at the mouth y=300"), Plan.Sockets[0].Center.Y, 300.0, 1.0);
+        }
+        TestEqual(TEXT("f3: coverage"), CoveredLength(Plan), 2400.0 - 150.0, 0.5);
+    }
+
+    // ---- Fixture 4: cap coverage (the "caps produce no bays" bug) — corridor alone, no neighbors
+    {
+        const FPlumbStructure CorrAB = Corridor(TEXT("CorrAB"), { FVector(600,300,0), FVector(1400,300,0) });
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(CorrAB, {}, P);
+        TestEqual(TEXT("f4: open centerline plans its own runs w/o sockets"), Plan.Sockets.Num(), 0);
+        TestTrue (TEXT("f4: guaranteed coverage (segments exist)"), CoveredLength(Plan) > 0.0);
+    }
+
+    // ---- Fixture 5: split-level Z (Q12) — corridor floor at 60 meets room floor at 0
+    // (delta must leave the 220 opening under the 300 shared ceiling: 60+220=280 < 300;
+    //  a delta of 90 correctly REJECTS with the ceiling reason — that's fixture 6's territory)
+    {
+        const FPlumbStructure RoomA  = Room(TEXT("RoomA"), FVector(0,0,0), FVector(600,600,0), /*FloorZ*/0.0);
+        const FPlumbStructure CorrHi = Corridor(TEXT("CorrHi"), { FVector(600,300,0), FVector(1400,300,0) }, /*FloorZ*/60.0);
+
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(RoomA, { CorrHi }, P);
+        TestEqual(TEXT("f5: one socket"), Plan.Sockets.Num(), 1);
+        if (Plan.Sockets.Num() == 1)
+        {
+            TestEqual(TEXT("f5: walk level = max floor = 60"), Plan.Sockets[0].Z0, 60.0, 0.01);
+            TestEqual(TEXT("f5: room-side floor delta = 60 (stairs hook)"), Plan.Sockets[0].FloorDeltaSelf, 60.0, 0.01);
+        }
+    }
+
+    // ---- Fixture 6: ceiling reject (Q12 validation + Q13 reason)
+    {
+        FPlumbStructure RoomA = Room(TEXT("RoomA"), FVector(0,0,0), FVector(600,600,0));
+        FPlumbStructure CorrLo = Corridor(TEXT("CorrLo"), { FVector(600,300,0), FVector(1400,300,0) });
+        CorrLo.WallHeight = 150.0; // opening 220 cannot fit under a 150 ceiling
+
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(RoomA, { CorrLo }, P);
+        TestEqual(TEXT("f6: no socket"), Plan.Sockets.Num(), 0);
+        TestEqual(TEXT("f6: one reject"), Plan.Rejects.Num(), 1);
+        if (Plan.Rejects.Num() == 1)
+        {
+            TestTrue(TEXT("f6: human reason mentions ceiling"), Plan.Rejects[0].Reason.Contains(TEXT("ceiling")));
+        }
+        TestEqual(TEXT("f6: wall fully intact"), CoveredLength(Plan), 2400.0, 0.5);
+    }
+
+    // ---- Fixture 7: identity self-exclusion is structural — planning with yourself in Others is a no-op
+    {
+        const FPlumbStructure RoomA = Room(TEXT("RoomA"), FVector(0,0,0), FVector(600,600,0));
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(RoomA, { RoomA }, P);
+        TestEqual(TEXT("f7: no self-sockets"), Plan.Sockets.Num(), 0);
+        TestEqual(TEXT("f7: full coverage"), CoveredLength(Plan), 2400.0, 0.5);
+    }
+
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
@@ -96,12 +96,25 @@ bool FPlumbWallPlannerUnitTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("f3: coverage"), CoveredLength(Plan), 2400.0 - 150.0, 0.5);
     }
 
-    // ---- Fixture 4: cap coverage (the "caps produce no bays" bug) — corridor alone, no neighbors
+    // ---- Fixture 4: corridor = offset TUNNEL loop (Q2) — two sides + two caps, full coverage
     {
         const FPlumbStructure CorrAB = Corridor(TEXT("CorrAB"), { FVector(600,300,0), FVector(1400,300,0) });
         const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(CorrAB, {}, P);
-        TestEqual(TEXT("f4: open centerline plans its own runs w/o sockets"), Plan.Sockets.Num(), 0);
-        TestTrue (TEXT("f4: guaranteed coverage (segments exist)"), CoveredLength(Plan) > 0.0);
+        TestEqual(TEXT("f4: no sockets alone"), Plan.Sockets.Num(), 0);
+        // tunnel loop: 2 sides (800) + 2 caps (300) = 2200
+        TestEqual(TEXT("f4: tunnel loop coverage 2200"), CoveredLength(Plan), 2200.0, 1.0);
+        TestEqual(TEXT("f4: four wall runs (L, far cap, R, near cap)"), Plan.Segments.Num(), 4);
+    }
+
+    // ---- Fixture 4b: junction — corridor yields the span ON ITS NEAR CAP (retiled around it)
+    {
+        const FPlumbStructure RoomB = Room(TEXT("RoomB"), FVector(1200,0,0), FVector(1800,600,0));
+        const FPlumbStructure CorrIn = Corridor(TEXT("CorrIn"), { FVector(1800,300,0), FVector(2600,300,0) });
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(CorrIn, { RoomB }, P);
+        TestEqual(TEXT("f4b: one yielded socket"), Plan.Sockets.Num(), 1);
+        if (Plan.Sockets.Num() == 1) TestTrue(TEXT("f4b: corridor does not own"), !Plan.Sockets[0].bOwned);
+        // near cap loses the 150 opening: 2200 - 150
+        TestEqual(TEXT("f4b: cap retiled around the opening"), CoveredLength(Plan), 2200.0 - 150.0, 1.0);
     }
 
     // ---- Fixture 5: split-level Z (Q12) — corridor floor at 60 meets room floor at 0

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
@@ -144,5 +144,84 @@ bool FPlumbWallPlannerUnitTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("f7: full coverage"), CoveredLength(Plan), 2400.0, 0.5);
     }
 
+    // ---- Fixture 8: typed sockets — Arch offered both sides -> clean bond, Arch dims win
+    {
+        FPlumbSocketTypeDecl Arch;
+        Arch.Contract.Name = FName(TEXT("Arch"));
+        Arch.Contract.Provides = { TEXT("Entrance.Arch") };
+        Arch.Contract.Requires.All = { TEXT("Entrance.Arch") };
+        Arch.OpeningWidth = 180.0; Arch.OpeningHeight = 240.0; Arch.TransitionRadius = 80.0;
+
+        FPlumbStructure RoomA  = Room(TEXT("RoomA"), FVector(0,0,0), FVector(600,600,0));
+        FPlumbStructure CorrAB = Corridor(TEXT("CorrAB"), { FVector(600,300,0), FVector(1400,300,0) });
+        RoomA.SocketTypes  = { Arch };
+        CorrAB.SocketTypes = { Arch };
+
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(RoomA, { CorrAB }, P);
+        TestEqual(TEXT("f8: one socket"), Plan.Sockets.Num(), 1);
+        if (Plan.Sockets.Num() == 1)
+        {
+            TestEqual(TEXT("f8: Arch chosen"), Plan.Sockets[0].TypeName, FName(TEXT("Arch")));
+            TestEqual(TEXT("f8: Arch width 180"), Plan.Sockets[0].Width, 180.0, 0.1);
+            TestEqual(TEXT("f8: transition radius carried"), Plan.Sockets[0].TransitionRadius, 80.0, 0.1);
+            TestTrue (TEXT("f8: clean, not relaxed"), !Plan.Sockets[0].bRelaxedBond);
+        }
+    }
+
+    // ---- Fixture 9: incompatible non-relaxable types -> reject with missing-tag reason (the moat)
+    {
+        FPlumbSocketTypeDecl Vault;   // vault door demands a vault entrance back, non-negotiable
+        Vault.Contract.Name = FName(TEXT("Vault"));
+        Vault.Contract.Provides = { TEXT("Entrance.Vault") };
+        Vault.Contract.Requires.All = { TEXT("Entrance.Vault") };
+        Vault.Contract.bRelaxable = false;
+        FPlumbSocketTypeDecl Rough;
+        Rough.Contract.Name = FName(TEXT("Rough"));
+        Rough.Contract.Provides = { TEXT("Entrance.Rough") };
+        Rough.Contract.bRelaxable = false;
+
+        FPlumbStructure RoomA  = Room(TEXT("RoomA"), FVector(0,0,0), FVector(600,600,0));
+        FPlumbStructure CorrAB = Corridor(TEXT("CorrAB"), { FVector(600,300,0), FVector(1400,300,0) });
+        RoomA.SocketTypes  = { Vault };
+        CorrAB.SocketTypes = { Rough };
+
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(RoomA, { CorrAB }, P);
+        TestEqual(TEXT("f9: no socket"), Plan.Sockets.Num(), 0);
+        TestEqual(TEXT("f9: one reject"), Plan.Rejects.Num(), 1);
+        if (Plan.Rejects.Num() == 1)
+        {
+            TestTrue(TEXT("f9: reason names the missing tag"), Plan.Rejects[0].Reason.Contains(TEXT("Entrance.Vault")));
+        }
+        TestEqual(TEXT("f9: wall stays sealed at full coverage"), CoveredLength(Plan), 2400.0, 0.5);
+    }
+
+    // ---- Fixture 10: cost-min picks the compatible pair among mixed candidates
+    {
+        FPlumbSocketTypeDecl Vault; // won't match
+        Vault.Contract.Name = FName(TEXT("Vault"));
+        Vault.Contract.Provides = { TEXT("Entrance.Vault") };
+        Vault.Contract.Requires.All = { TEXT("Entrance.Vault") };
+        Vault.Contract.bRelaxable = false;
+        FPlumbSocketTypeDecl Arch;  // will match cleanly
+        Arch.Contract.Name = FName(TEXT("Arch"));
+        Arch.Contract.Provides = { TEXT("Entrance.Arch") };
+        Arch.Contract.Requires.All = { TEXT("Entrance.Arch") };
+        Arch.OpeningWidth = 200.0;
+
+        FPlumbStructure RoomA  = Room(TEXT("RoomA"), FVector(0,0,0), FVector(600,600,0));
+        FPlumbStructure CorrAB = Corridor(TEXT("CorrAB"), { FVector(600,300,0), FVector(1400,300,0) });
+        RoomA.SocketTypes  = { Vault, Arch };  // vault preferred by order, but incompatible
+        CorrAB.SocketTypes = { Arch };
+
+        const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(RoomA, { CorrAB }, P);
+        TestEqual(TEXT("f10: one socket"), Plan.Sockets.Num(), 1);
+        if (Plan.Sockets.Num() == 1)
+        {
+            TestEqual(TEXT("f10: solver picked Arch over incompatible Vault"), Plan.Sockets[0].TypeName, FName(TEXT("Arch")));
+            TestEqual(TEXT("f10: Arch dims used (200)"), Plan.Sockets[0].Width, 200.0, 0.1);
+        }
+        TestEqual(TEXT("f10: coverage = perimeter - 200"), CoveredLength(Plan), 2400.0 - 200.0, 0.5);
+    }
+
     return true;
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/PlumbWallPlannerTest.cpp
@@ -61,6 +61,13 @@ bool FPlumbWallPlannerUnitTest::RunTest(const FString& Parameters)
         // audit: perimeter 2400, one 150 opening -> segments cover 2250, no gaps
         TestEqual(TEXT("f1: coverage = perimeter - opening"), CoveredLength(Plan), 2400.0 - 150.0, 0.5);
         TestEqual(TEXT("f1: no rejects"), Plan.Rejects.Num(), 0);
+        // over-door band: a fill patch from opening top (220) to ceiling (300) over the 150 span
+        TestTrue (TEXT("f1: over-door fill exists"), Plan.Fills.Num() >= 1);
+        if (Plan.Fills.Num() >= 1)
+        {
+            TestEqual(TEXT("f1: fill starts at opening top"), Plan.Fills[0].Z0, 220.0, 0.1);
+            TestEqual(TEXT("f1: fill ends at ceiling"),      Plan.Fills[0].Z1, 300.0, 0.1);
+        }
     }
 
     // ---- Fixture 2: symmetric derivation (Q1) — corridor's own plan lands the identical socket
@@ -114,7 +121,9 @@ bool FPlumbWallPlannerUnitTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("f4b: one yielded socket"), Plan.Sockets.Num(), 1);
         if (Plan.Sockets.Num() == 1) TestTrue(TEXT("f4b: corridor does not own"), !Plan.Sockets[0].bOwned);
         // socketed mouth insets by WallThickness(30): sides 770x2 + caps 300x2 = 2140; minus 150 opening
-        TestEqual(TEXT("f4b: inset cap retiled around the opening"), CoveredLength(Plan), 2140.0 - 150.0, 1.0);
+        // cap flanks (75x2) are now FILL patches, not grammar segments
+        TestEqual(TEXT("f4b: grammar coverage = sides + far cap"), CoveredLength(Plan), 770.0*2 + 300.0, 1.0);
+        TestTrue (TEXT("f4b: cap flanks became fills"), Plan.Fills.Num() >= 2);
         TestEqual(TEXT("f4b: floor loop follows inset footprint"), Plan.FloorLoop.Num(), 4);
     }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
@@ -19,6 +19,7 @@ namespace PCGWallPlanPins
 	static const FName Sockets(TEXT("Sockets"));
 	static const FName Rejects(TEXT("Rejects"));
 	static const FName FloorLoop(TEXT("FloorLoop"));
+	static const FName Fills(TEXT("FillPoints"));
 }
 
 #if WITH_EDITOR
@@ -47,6 +48,7 @@ TArray<FPCGPinProperties> UPCGWallPlanSettings::OutputPinProperties() const
 	Pins.Emplace(PCGWallPlanPins::Sockets, EPCGDataType::Point);
 	Pins.Emplace(PCGWallPlanPins::Rejects, EPCGDataType::Point);
 	Pins.Emplace(PCGWallPlanPins::FloorLoop, EPCGDataType::Spline);
+	Pins.Emplace(PCGWallPlanPins::Fills, EPCGDataType::Point);
 	return Pins;
 }
 
@@ -163,6 +165,34 @@ bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
 			FPCGTaggedData& OutT = Context->OutputData.TaggedData.Emplace_GetRef();
 			OutT.Data = LoopData;
 			OutT.Pin = PCGWallPlanPins::FloorLoop;
+		}
+
+		// -- FillPoints: guaranteed-coverage patches (small remainders, over-door bands) --
+		if (Plan.Fills.Num() > 0)
+		{
+			UPCGPointData* PD = FPCGContext::NewObject_AnyThread<UPCGPointData>(Context);
+			UPCGMetadata* MD = PD->MutableMetadata();
+			FPCGMetadataAttribute<double>* AW  = MD->CreateAttribute<double>(TEXT("Width"), 0.0, false, true);
+			FPCGMetadataAttribute<double>* AZ0 = MD->CreateAttribute<double>(TEXT("Z0"), 0.0, false, true);
+			FPCGMetadataAttribute<double>* AZ1 = MD->CreateAttribute<double>(TEXT("Z1"), 0.0, false, true);
+			TArray<FPCGPoint>& Pts = PD->GetMutablePoints();
+			Pts.SetNum(Plan.Fills.Num());
+			for (int32 i = 0; i < Plan.Fills.Num(); ++i)
+			{
+				const FPlumbFillPlan& F = Plan.Fills[i];
+				FPCGPoint& Pt = Pts[i];
+				const FQuat Rot = FRotationMatrix::MakeFromXY(F.Tangent, F.Normal).ToQuat().GetNormalized();
+				Pt.Transform = FTransform(Rot, F.Center);
+				Pt.BoundsMin = FVector(-F.Width * 0.5, -1.0, 0.0);
+				Pt.BoundsMax = FVector( F.Width * 0.5,  1.0, F.Z1 - F.Z0);
+				Pt.MetadataEntry = MD->AddEntry();
+				AW->SetValue(Pt.MetadataEntry, F.Width);
+				AZ0->SetValue(Pt.MetadataEntry, F.Z0);
+				AZ1->SetValue(Pt.MetadataEntry, F.Z1);
+			}
+			FPCGTaggedData& OutT = Context->OutputData.TaggedData.Emplace_GetRef();
+			OutT.Data = PD;
+			OutT.Pin = PCGWallPlanPins::Fills;
 		}
 
 		// -- Sockets / Rejects as point data --

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
@@ -173,6 +173,7 @@ bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
 			UPCGPointData* PD = FPCGContext::NewObject_AnyThread<UPCGPointData>(Context);
 			UPCGMetadata* MD = PD->MutableMetadata();
 			FPCGMetadataAttribute<double>* AW  = MD->CreateAttribute<double>(TEXT("Width"), 0.0, false, true);
+			FPCGMetadataAttribute<FString>* AG = MD->CreateAttribute<FString>(TEXT("FillGrammar"), FString(), false, true);
 			FPCGMetadataAttribute<double>* AZ0 = MD->CreateAttribute<double>(TEXT("Z0"), 0.0, false, true);
 			FPCGMetadataAttribute<double>* AZ1 = MD->CreateAttribute<double>(TEXT("Z1"), 0.0, false, true);
 			TArray<FPCGPoint>& Pts = PD->GetMutablePoints();
@@ -183,10 +184,14 @@ bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
 				FPCGPoint& Pt = Pts[i];
 				const FQuat Rot = FRotationMatrix::MakeFromXY(F.Tangent, F.Normal).ToQuat().GetNormalized();
 				Pt.Transform = FTransform(Rot, F.Center);
-				Pt.BoundsMin = FVector(-F.Width * 0.5, -1.0, 0.0);
-				Pt.BoundsMax = FVector( F.Width * 0.5,  1.0, F.Z1 - F.Z0);
+				// Asymmetric Y-bounds [0,+1]: staging's center-justify then tucks the module
+				// 0.5 toward the interior — the SAME convention as every SubdivideSpline wall
+				// module (measured: all planes sit at drawn-line + 0.5*inward).
+				Pt.BoundsMin = FVector(-F.Width * 0.5, 0.0, 0.0);
+				Pt.BoundsMax = FVector( F.Width * 0.5, 1.0, F.Z1 - F.Z0);
 				Pt.MetadataEntry = MD->AddEntry();
 				AW->SetValue(Pt.MetadataEntry, F.Width);
+				AG->SetValue(Pt.MetadataEntry, F.Grammar);
 				AZ0->SetValue(Pt.MetadataEntry, F.Z0);
 				AZ1->SetValue(Pt.MetadataEntry, F.Z1);
 			}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
@@ -18,6 +18,7 @@ namespace PCGWallPlanPins
 	static const FName Segments(TEXT("WallSegments"));
 	static const FName Sockets(TEXT("Sockets"));
 	static const FName Rejects(TEXT("Rejects"));
+	static const FName FloorLoop(TEXT("FloorLoop"));
 }
 
 #if WITH_EDITOR
@@ -45,6 +46,7 @@ TArray<FPCGPinProperties> UPCGWallPlanSettings::OutputPinProperties() const
 	Pins.Emplace(PCGWallPlanPins::Segments, EPCGDataType::Spline);
 	Pins.Emplace(PCGWallPlanPins::Sockets, EPCGDataType::Point);
 	Pins.Emplace(PCGWallPlanPins::Rejects, EPCGDataType::Point);
+	Pins.Emplace(PCGWallPlanPins::FloorLoop, EPCGDataType::Spline);
 	return Pins;
 }
 
@@ -145,6 +147,22 @@ bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
 			FPCGTaggedData& Out = Context->OutputData.TaggedData.Emplace_GetRef();
 			Out.Data = SegData;
 			Out.Pin = PCGWallPlanPins::Segments;
+		}
+
+		// -- FloorLoop: one closed linear spline (rooms: drawn loop; corridors: tunnel footprint) --
+		if (Plan.FloorLoop.Num() >= 3)
+		{
+			UPCGSplineData* LoopData = FPCGContext::NewObject_AnyThread<UPCGSplineData>(Context);
+			TArray<FSplinePoint> Pts;
+			for (int32 i = 0; i < Plan.FloorLoop.Num(); ++i)
+			{
+				FSplinePoint SP((float)i, Plan.FloorLoop[i]); SP.Type = ESplinePointType::Linear;
+				Pts.Add(SP);
+			}
+			LoopData->Initialize(Pts, /*bClosed*/true, FTransform::Identity);
+			FPCGTaggedData& OutT = Context->OutputData.TaggedData.Emplace_GetRef();
+			OutT.Data = LoopData;
+			OutT.Pin = PCGWallPlanPins::FloorLoop;
 		}
 
 		// -- Sockets / Rejects as point data --

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
@@ -186,8 +186,10 @@ bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
 			{
 				const FPlumbSocketPlan& S = Plan.Sockets[i];
 				FPCGPoint& Pt = Pts[i];
-				const FMatrix Rot(S.Tangent, S.Normal, FVector::UpVector, FVector::ZeroVector);
-				Pt.Transform = FTransform(Rot.ToQuat(), S.Center);
+				// MakeFromXY re-orthonormalizes and stays right-handed even when Normal = -Y
+				// (a raw FMatrix basis can be mirrored -> non-normalized quat -> PCG asserts).
+				const FQuat Rot = FRotationMatrix::MakeFromXY(S.Tangent, S.Normal).ToQuat().GetNormalized();
+				Pt.Transform = FTransform(Rot, S.Center);
 				Pt.BoundsMin = FVector(-S.Width * 0.5, -Settings->WallThickness * 0.5, 0.0);
 				Pt.BoundsMax = FVector( S.Width * 0.5,  Settings->WallThickness * 0.5, S.Z1 - S.Z0);
 				Pt.MetadataEntry = MD->AddEntry();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
@@ -173,7 +173,7 @@ bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
 			UPCGPointData* PD = FPCGContext::NewObject_AnyThread<UPCGPointData>(Context);
 			UPCGMetadata* MD = PD->MutableMetadata();
 			FPCGMetadataAttribute<double>* AW  = MD->CreateAttribute<double>(TEXT("Width"), 0.0, false, true);
-			FPCGMetadataAttribute<FString>* AG = MD->CreateAttribute<FString>(TEXT("FillGrammar"), FString(), false, true);
+			FPCGMetadataAttribute<int64>* AG = MD->CreateAttribute<int64>(TEXT("FillIndex"), 0, false, true);
 			FPCGMetadataAttribute<double>* AZ0 = MD->CreateAttribute<double>(TEXT("Z0"), 0.0, false, true);
 			FPCGMetadataAttribute<double>* AZ1 = MD->CreateAttribute<double>(TEXT("Z1"), 0.0, false, true);
 			TArray<FPCGPoint>& Pts = PD->GetMutablePoints();
@@ -191,7 +191,7 @@ bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
 				Pt.BoundsMax = FVector( F.Width * 0.5, 1.0, F.Z1 - F.Z0);
 				Pt.MetadataEntry = MD->AddEntry();
 				AW->SetValue(Pt.MetadataEntry, F.Width);
-				AG->SetValue(Pt.MetadataEntry, F.Grammar);
+				AG->SetValue(Pt.MetadataEntry, (int64)F.BandIndex);
 				AZ0->SetValue(Pt.MetadataEntry, F.Z0);
 				AZ1->SetValue(Pt.MetadataEntry, F.Z1);
 			}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
@@ -1,0 +1,240 @@
+#include "pcg/PCGWallPlan.h"
+
+#include "PCGContext.h"
+#include "PCGPin.h"
+#include "PCGCommon.h"
+#include "Data/PCGSplineData.h"
+#include "Data/PCGPointData.h"
+#include "Metadata/PCGMetadata.h"
+#include "pcg/PlumbWallPlanner.h"
+
+#include UE_INLINE_GENERATED_CPP_BY_NAME(PCGWallPlan)
+
+#define LOCTEXT_NAMESPACE "PCGWallPlan"
+
+namespace PCGWallPlanPins
+{
+	static const FName Others(TEXT("Others"));
+	static const FName Segments(TEXT("WallSegments"));
+	static const FName Sockets(TEXT("Sockets"));
+	static const FName Rejects(TEXT("Rejects"));
+}
+
+#if WITH_EDITOR
+FText UPCGWallPlanSettings::GetDefaultNodeTitle() const
+{
+	return LOCTEXT("Title", "Plumb | Wall Plan");
+}
+FText UPCGWallPlanSettings::GetNodeTooltipText() const
+{
+	return LOCTEXT("Tooltip", "Resolves wall topology against neighboring structures: exact junction sockets (one per shared span, solver-typed), retiled wall segments with guaranteed coverage, and explained rejects. Realization stays downstream.");
+}
+#endif
+
+TArray<FPCGPinProperties> UPCGWallPlanSettings::InputPinProperties() const
+{
+	TArray<FPCGPinProperties> Pins;
+	Pins.Emplace(PCGPinConstants::DefaultInputLabel, EPCGDataType::Spline);
+	Pins.Emplace(PCGWallPlanPins::Others, EPCGDataType::Spline);
+	return Pins;
+}
+
+TArray<FPCGPinProperties> UPCGWallPlanSettings::OutputPinProperties() const
+{
+	TArray<FPCGPinProperties> Pins;
+	Pins.Emplace(PCGWallPlanPins::Segments, EPCGDataType::Spline);
+	Pins.Emplace(PCGWallPlanPins::Sockets, EPCGDataType::Point);
+	Pins.Emplace(PCGWallPlanPins::Rejects, EPCGDataType::Point);
+	return Pins;
+}
+
+FPCGElementPtr UPCGWallPlanSettings::CreateElement() const
+{
+	return MakeShared<FPCGWallPlanElement>();
+}
+
+namespace
+{
+	// Spline data -> planner structure. Identity = source actor name when known (deterministic
+	// across both structures' cooks), else the data UID. Kind falls out of closure:
+	// closed = room, open = corridor — the product's own rule.
+	bool ToStructure(const UPCGSplineData* Spline, const UPCGWallPlanSettings* S, FPlumbStructure& Out)
+	{
+		if (!Spline) return false;
+		const FPCGSplineStruct& SS = Spline->SplineStruct;
+		const int32 N = SS.GetNumberOfPoints();
+		if (N < 2) return false;
+
+		Out.bClosed = SS.IsClosedLoop();
+		Out.Kind = Out.bClosed ? EPlumbStructureKind::Room : EPlumbStructureKind::Corridor;
+		Out.WallHeight = S->WallHeight;
+		Out.CorridorWidth = S->CorridorWidth;
+
+		if (const AActor* Src = Spline->TargetActor.Get())
+		{
+			Out.Id = Src->GetFName();
+		}
+		else
+		{
+			Out.Id = FName(*FString::Printf(TEXT("pcgdata_%u"), Spline->GetUniqueID()));
+		}
+
+		Out.Points.Reset(N);
+		double MinZ = TNumericLimits<double>::Max();
+		for (int32 i = 0; i < N; ++i)
+		{
+			const FVector P = SS.GetLocationAtSplineInputKey((float)i, ESplineCoordinateSpace::World);
+			Out.Points.Add(P);
+			MinZ = FMath::Min(MinZ, P.Z);
+		}
+		Out.FloorZ = MinZ;
+		return true;
+	}
+}
+
+bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(FPCGWallPlanElement::Execute);
+	check(Context);
+	const UPCGWallPlanSettings* Settings = Context->GetInputSettings<UPCGWallPlanSettings>();
+	check(Settings);
+
+	FPlumbPlanParams P;
+	P.CornerAngleDeg = Settings->CornerAngleDeg;
+	P.MinOverlap     = Settings->MinOverlap;
+	P.WallThickness  = Settings->WallThickness;
+	P.CoincidenceTol = FMath::Max(Settings->WallThickness, 26.0);
+	P.OpeningWidth   = Settings->DefaultOpeningWidth;
+	P.OpeningHeight  = Settings->DefaultOpeningHeight;
+
+	// Gather neighbors once.
+	TArray<FPlumbStructure> Others;
+	for (const FPCGTaggedData& In : Context->InputData.GetInputsByPin(PCGWallPlanPins::Others))
+	{
+		FPlumbStructure O;
+		if (ToStructure(Cast<UPCGSplineData>(In.Data), Settings, O))
+		{
+			Others.Add(MoveTemp(O));
+		}
+	}
+
+	for (const FPCGTaggedData& In : Context->InputData.GetInputsByPin(PCGPinConstants::DefaultInputLabel))
+	{
+		const UPCGSplineData* SelfSpline = Cast<UPCGSplineData>(In.Data);
+		FPlumbStructure Self;
+		if (!ToStructure(SelfSpline, Settings, Self))
+		{
+			continue;
+		}
+
+		const FPlumbWallPlan Plan = PlumbWallPlanner::Plan(Self, Others, P);
+
+		// -- WallSegments: one open 2-point linear spline per segment --
+		for (const FPlumbSegmentPlan& Seg : Plan.Segments)
+		{
+			UPCGSplineData* SegData = FPCGContext::NewObject_AnyThread<UPCGSplineData>(Context);
+			TArray<FSplinePoint> Pts;
+			FSplinePoint PA(0.f, Seg.A); PA.Type = ESplinePointType::Linear;
+			FSplinePoint PB(1.f, Seg.B); PB.Type = ESplinePointType::Linear;
+			Pts.Add(PA); Pts.Add(PB);
+			SegData->Initialize(Pts, /*bClosed*/false, FTransform::Identity);
+			if (UPCGMetadata* MD = SegData->MutableMetadata())
+			{
+				MD->CreateAttribute<double>(TEXT("Z0"), Seg.Z0, false, true);
+				MD->CreateAttribute<double>(TEXT("Z1"), Seg.Z1, false, true);
+			}
+			FPCGTaggedData& Out = Context->OutputData.TaggedData.Emplace_GetRef();
+			Out.Data = SegData;
+			Out.Pin = PCGWallPlanPins::Segments;
+		}
+
+		// -- Sockets / Rejects as point data --
+		auto EmitPoints = [&](FName Pin, int32 Num, TFunctionRef<void(int32, FPCGPoint&, UPCGMetadata*)> Fill)
+		{
+			if (Num == 0) return;
+			UPCGPointData* PD = FPCGContext::NewObject_AnyThread<UPCGPointData>(Context);
+			UPCGMetadata* MD = PD->MutableMetadata();
+			TArray<FPCGPoint>& Pts = PD->GetMutablePoints();
+			Pts.SetNum(Num);
+			for (int32 i = 0; i < Num; ++i)
+			{
+				Pts[i].MetadataEntry = MD->AddEntry();
+				Fill(i, Pts[i], MD);
+			}
+			FPCGTaggedData& Out = Context->OutputData.TaggedData.Emplace_GetRef();
+			Out.Data = PD;
+			Out.Pin = Pin;
+		};
+
+		// Socket attributes: everything realization needs (Q9 — nothing modular-specific).
+		{
+			UPCGPointData* PD = FPCGContext::NewObject_AnyThread<UPCGPointData>(Context);
+			UPCGMetadata* MD = PD->MutableMetadata();
+			FPCGMetadataAttribute<FName>*   AType   = MD->CreateAttribute<FName>(TEXT("SocketType"), NAME_None, false, true);
+			FPCGMetadataAttribute<double>*  AWidth  = MD->CreateAttribute<double>(TEXT("Width"), 0.0, false, true);
+			FPCGMetadataAttribute<double>*  AZ0     = MD->CreateAttribute<double>(TEXT("Z0"), 0.0, false, true);
+			FPCGMetadataAttribute<double>*  AZ1     = MD->CreateAttribute<double>(TEXT("Z1"), 0.0, false, true);
+			FPCGMetadataAttribute<double>*  ADelta  = MD->CreateAttribute<double>(TEXT("FloorDelta"), 0.0, false, true);
+			FPCGMetadataAttribute<double>*  ATrans  = MD->CreateAttribute<double>(TEXT("TransitionRadius"), 0.0, false, true);
+			FPCGMetadataAttribute<bool>*    AOwned  = MD->CreateAttribute<bool>(TEXT("Owned"), false, false, true);
+			FPCGMetadataAttribute<bool>*    ARelax  = MD->CreateAttribute<bool>(TEXT("Relaxed"), false, false, true);
+			FPCGMetadataAttribute<FName>*   AOther  = MD->CreateAttribute<FName>(TEXT("OtherId"), NAME_None, false, true);
+
+			TArray<FPCGPoint>& Pts = PD->GetMutablePoints();
+			Pts.SetNum(Plan.Sockets.Num());
+			for (int32 i = 0; i < Plan.Sockets.Num(); ++i)
+			{
+				const FPlumbSocketPlan& S = Plan.Sockets[i];
+				FPCGPoint& Pt = Pts[i];
+				const FMatrix Rot(S.Tangent, S.Normal, FVector::UpVector, FVector::ZeroVector);
+				Pt.Transform = FTransform(Rot.ToQuat(), S.Center);
+				Pt.BoundsMin = FVector(-S.Width * 0.5, -Settings->WallThickness * 0.5, 0.0);
+				Pt.BoundsMax = FVector( S.Width * 0.5,  Settings->WallThickness * 0.5, S.Z1 - S.Z0);
+				Pt.MetadataEntry = MD->AddEntry();
+				AType->SetValue(Pt.MetadataEntry, S.TypeName);
+				AWidth->SetValue(Pt.MetadataEntry, S.Width);
+				AZ0->SetValue(Pt.MetadataEntry, S.Z0);
+				AZ1->SetValue(Pt.MetadataEntry, S.Z1);
+				ADelta->SetValue(Pt.MetadataEntry, S.FloorDeltaSelf);
+				ATrans->SetValue(Pt.MetadataEntry, S.TransitionRadius);
+				AOwned->SetValue(Pt.MetadataEntry, S.bOwned);
+				ARelax->SetValue(Pt.MetadataEntry, S.bRelaxedBond);
+				AOther->SetValue(Pt.MetadataEntry, S.OtherId);
+			}
+			if (Pts.Num() > 0)
+			{
+				FPCGTaggedData& Out = Context->OutputData.TaggedData.Emplace_GetRef();
+				Out.Data = PD;
+				Out.Pin = PCGWallPlanPins::Sockets;
+			}
+		}
+
+		// Rejects: position + human reason (Q13 overlay source).
+		{
+			UPCGPointData* PD = FPCGContext::NewObject_AnyThread<UPCGPointData>(Context);
+			UPCGMetadata* MD = PD->MutableMetadata();
+			FPCGMetadataAttribute<FString>* AReason = MD->CreateAttribute<FString>(TEXT("Reason"), FString(), false, true);
+			FPCGMetadataAttribute<FName>*   AOther  = MD->CreateAttribute<FName>(TEXT("OtherId"), NAME_None, false, true);
+			TArray<FPCGPoint>& Pts = PD->GetMutablePoints();
+			Pts.SetNum(Plan.Rejects.Num());
+			for (int32 i = 0; i < Plan.Rejects.Num(); ++i)
+			{
+				FPCGPoint& Pt = Pts[i];
+				Pt.Transform = FTransform(Plan.Rejects[i].At);
+				Pt.MetadataEntry = MD->AddEntry();
+				AReason->SetValue(Pt.MetadataEntry, Plan.Rejects[i].Reason);
+				AOther->SetValue(Pt.MetadataEntry, Plan.Rejects[i].OtherId);
+			}
+			if (Pts.Num() > 0)
+			{
+				FPCGTaggedData& Out = Context->OutputData.TaggedData.Emplace_GetRef();
+				Out.Data = PD;
+				Out.Pin = PCGWallPlanPins::Rejects;
+			}
+		}
+	}
+
+	return true;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
@@ -167,31 +167,32 @@ bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
 			OutT.Pin = PCGWallPlanPins::FloorLoop;
 		}
 
-		// -- FillPoints: guaranteed-coverage patches (small remainders, over-door bands) --
+		// -- FillPoints: guaranteed-coverage band patches, spawn-ready (AssetPath + exact
+		// stretch-fit scale + the kit's inward-tuck). One spawner realizes them; no staging.
 		if (Plan.Fills.Num() > 0)
 		{
 			UPCGPointData* PD = FPCGContext::NewObject_AnyThread<UPCGPointData>(Context);
 			UPCGMetadata* MD = PD->MutableMetadata();
-			FPCGMetadataAttribute<double>* AW  = MD->CreateAttribute<double>(TEXT("Width"), 0.0, false, true);
-			FPCGMetadataAttribute<int64>* AG = MD->CreateAttribute<int64>(TEXT("FillIndex"), 0, false, true);
+			FPCGMetadataAttribute<FSoftObjectPath>* AP = MD->CreateAttribute<FSoftObjectPath>(TEXT("AssetPath"), FSoftObjectPath(), false, true);
 			FPCGMetadataAttribute<double>* AZ0 = MD->CreateAttribute<double>(TEXT("Z0"), 0.0, false, true);
 			FPCGMetadataAttribute<double>* AZ1 = MD->CreateAttribute<double>(TEXT("Z1"), 0.0, false, true);
 			TArray<FPCGPoint>& Pts = PD->GetMutablePoints();
 			Pts.SetNum(Plan.Fills.Num());
+			const double Native = FMath::Max(1.0, Settings->FillMeshNativeSize);
 			for (int32 i = 0; i < Plan.Fills.Num(); ++i)
 			{
 				const FPlumbFillPlan& F = Plan.Fills[i];
 				FPCGPoint& Pt = Pts[i];
 				const FQuat Rot = FRotationMatrix::MakeFromXY(F.Tangent, F.Normal).ToQuat().GetNormalized();
-				Pt.Transform = FTransform(Rot, F.Center);
-				// Asymmetric Y-bounds [0,+1]: staging's center-justify then tucks the module
-				// 0.5 toward the interior — the SAME convention as every SubdivideSpline wall
-				// module (measured: all planes sit at drawn-line + 0.5*inward).
-				Pt.BoundsMin = FVector(-F.Width * 0.5, 0.0, 0.0);
-				Pt.BoundsMax = FVector( F.Width * 0.5, 1.0, F.Z1 - F.Z0);
+				const double H = F.Z1 - F.Z0;
+				FVector Pos = F.Center + F.Normal * Settings->FillInwardTuck; // match wall-module plane
+				Pos.Z = (F.Z0 + F.Z1) * 0.5;                                   // quad pivot = center
+				Pt.Transform = FTransform(Rot, Pos, FVector(F.Width / Native, 1.0, H / Native));
+				Pt.BoundsMin = FVector(-Native * 0.5, -1.0, -Native * 0.5);
+				Pt.BoundsMax = FVector( Native * 0.5,  1.0,  Native * 0.5);
 				Pt.MetadataEntry = MD->AddEntry();
-				AW->SetValue(Pt.MetadataEntry, F.Width);
-				AG->SetValue(Pt.MetadataEntry, (int64)F.BandIndex);
+				const int32 Band = FMath::Clamp(F.BandIndex, 0, Settings->FillBandMeshes.Num() - 1);
+				AP->SetValue(Pt.MetadataEntry, Settings->FillBandMeshes.IsValidIndex(Band) ? Settings->FillBandMeshes[Band] : FSoftObjectPath());
 				AZ0->SetValue(Pt.MetadataEntry, F.Z0);
 				AZ1->SetValue(Pt.MetadataEntry, F.Z1);
 			}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
@@ -104,6 +104,7 @@ bool FPCGWallPlanElement::ExecuteInternal(FPCGContext* Context) const
 	P.CoincidenceTol = FMath::Max(Settings->WallThickness, 26.0);
 	P.OpeningWidth   = Settings->DefaultOpeningWidth;
 	P.OpeningHeight  = Settings->DefaultOpeningHeight;
+	P.bFlipWallFacing = Settings->bFlipWallFacing;
 
 	// Gather neighbors once.
 	TArray<FPlumbStructure> Others;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/pcg/PCGWallPlan.cpp
@@ -70,24 +70,22 @@ namespace
 		Out.WallHeight = S->WallHeight;
 		Out.CorridorWidth = S->CorridorWidth;
 
-		if (const AActor* Src = Spline->TargetActor.Get())
-		{
-			Out.Id = Src->GetFName();
-		}
-		else
-		{
-			Out.Id = FName(*FString::Printf(TEXT("pcgdata_%u"), Spline->GetUniqueID()));
-		}
-
 		Out.Points.Reset(N);
 		double MinZ = TNumericLimits<double>::Max();
+		uint64 Hash = 1469598103934665603ull; // FNV-1a over quantized points: GEOMETRIC identity.
 		for (int32 i = 0; i < N; ++i)
 		{
 			const FVector P = SS.GetLocationAtSplineInputKey((float)i, ESplineCoordinateSpace::World);
 			Out.Points.Add(P);
 			MinZ = FMath::Min(MinZ, P.Z);
+			const int64 Q[3] = { (int64)FMath::RoundToDouble(P.X), (int64)FMath::RoundToDouble(P.Y), (int64)FMath::RoundToDouble(P.Z) };
+			for (int64 V : Q) { Hash ^= (uint64)V; Hash *= 1099511628211ull; }
 		}
 		Out.FloorZ = MinZ;
+
+		// Identity: the same drawn spline seen through ANY pin/data path hashes identically —
+		// self-exclusion cannot depend on TargetActor being populated (it isn't, in parse mode).
+		Out.Id = FName(*FString::Printf(TEXT("geo_%016llx"), Hash));
 		return true;
 	}
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGWallPlan.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGWallPlan.h
@@ -1,0 +1,62 @@
+// Plumb | Wall Plan — thin PCG wrapper over FPlumbWallPlanner (the pure resolution core).
+// Decides sockets/segments; realization stays in graphs (spec 2026-07-05, grill Q7:
+// pins-only inputs => cacheable, multithread-safe pure math).
+
+#pragma once
+
+#include "PCGSettings.h"
+#include "PCGWallPlan.generated.h"
+
+UCLASS(BlueprintType, ClassGroup = (Procedural))
+class UPCGWallPlanSettings : public UPCGSettings
+{
+	GENERATED_BODY()
+
+public:
+#if WITH_EDITOR
+	virtual FName GetDefaultNodeName() const override { return FName(TEXT("WallPlan")); }
+	virtual FText GetDefaultNodeTitle() const override;
+	virtual FText GetNodeTooltipText() const override;
+	virtual EPCGSettingsType GetType() const override { return EPCGSettingsType::Spatial; }
+#endif
+
+	/** Corner angle (deg): bends sharper than this split the wall into separate straight runs. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Plan, meta = (ClampMin = "1", ClampMax = "89"))
+	double CornerAngleDeg = 30.0;
+
+	/** Minimum shared span (cm) for a junction to produce a socket. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Plan, meta = (ClampMin = "10"))
+	double MinOverlap = 150.0;
+
+	/** Wall thickness (cm) — also the mouth-coincidence tolerance base. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Plan, meta = (ClampMin = "1"))
+	double WallThickness = 30.0;
+
+	/** Corridor width (cm) for open splines (v1 uniform; per-actor override later). */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Plan, meta = (ClampMin = "50"))
+	double CorridorWidth = 300.0;
+
+	/** Wall height (cm). */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Plan, meta = (ClampMin = "50"))
+	double WallHeight = 300.0;
+
+	/** Default entrance opening (cm) when no DA_SocketType is declared. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Sockets, meta = (ClampMin = "50"))
+	double DefaultOpeningWidth = 150.0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Sockets, meta = (ClampMin = "50"))
+	double DefaultOpeningHeight = 220.0;
+
+protected:
+	virtual TArray<FPCGPinProperties> InputPinProperties() const override;
+	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;
+	virtual FPCGElementPtr CreateElement() const override;
+};
+
+class FPCGWallPlanElement : public IPCGElement
+{
+protected:
+	virtual bool ExecuteInternal(FPCGContext* InContext) const override;
+	// Pure function of pin data + settings (Q7): cacheable.
+	virtual bool IsCacheable(const UPCGSettings*) const override { return true; }
+};

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGWallPlan.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGWallPlan.h
@@ -47,6 +47,10 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Sockets, meta = (ClampMin = "50"))
 	double DefaultOpeningHeight = 220.0;
 
+	/** Author knob: reverse wall winding (inner <-> outer faces). Composable per master/graph. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Plan)
+	bool bFlipWallFacing = false;
+
 protected:
 	virtual TArray<FPCGPinProperties> InputPinProperties() const override;
 	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGWallPlan.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PCGWallPlan.h
@@ -51,6 +51,21 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Plan)
 	bool bFlipWallFacing = false;
 
+	/** Band meshes for fill patches (0=base, 1=field, 2=crown). Swap per-graph for other styles. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Fills)
+	TArray<FSoftObjectPath> FillBandMeshes = {
+		FSoftObjectPath(TEXT("/Game/Plumb/Mesh/SM_GB_BaseQ.SM_GB_BaseQ")),
+		FSoftObjectPath(TEXT("/Game/Plumb/Mesh/SM_GB_FieldQ.SM_GB_FieldQ")),
+		FSoftObjectPath(TEXT("/Game/Plumb/Mesh/SM_GB_CrownQ.SM_GB_CrownQ")) };
+
+	/** Fill band meshes' native size (cm) used for exact stretch-fit scaling. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Fills, meta = (ClampMin = "1"))
+	double FillMeshNativeSize = 50.0;
+
+	/** Wall modules render this far inside the drawn line (the kit convention); fills match it. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Fills)
+	double FillInwardTuck = 0.5;
+
 protected:
 	virtual TArray<FPCGPinProperties> InputPinProperties() const override;
 	virtual TArray<FPCGPinProperties> OutputPinProperties() const override;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
@@ -1,0 +1,304 @@
+// Plumb | Wall Plan — the pure resolution core (spec: 2026-07-05-plumb-pcg-vs-native-split-decision).
+// Realization stays in PCG graphs; THIS decides. Everything here is a deterministic pure function
+// of drawing splines + params (grill Q1: symmetric derivation — both structures independently
+// compute bit-identical sockets). Arc-length parameterized (Q6). Explicit Z intervals (Q12).
+// UObject-free; unit-tested headless before any PCG node wraps it.
+#pragma once
+
+#include "CoreMinimal.h"
+
+// ---------- inputs ----------
+
+enum class EPlumbStructureKind : uint8 { Room, Corridor };
+
+struct FPlumbStructure
+{
+    FName                Id;                 // actor name — the deterministic identity (Q8 tie-break)
+    EPlumbStructureKind  Kind = EPlumbStructureKind::Room;
+    TArray<FVector>      Points;             // drawing-spline control points, WORLD space (linear runs)
+    bool                 bClosed = true;     // rooms closed, corridors open
+    double               FloorZ = 0.0;       // Points[i].Z of the drawing plane
+    double               WallHeight = 300.0;
+    double               CorridorWidth = 300.0; // corridors only (Q10: rides with the corridor's data)
+};
+
+struct FPlumbPlanParams
+{
+    double MinOverlap     = 150.0;  // Q10 default: narrowest socket type's width
+    double CornerAngleDeg = 30.0;   // Q2: the corner-angle slider
+    double WallThickness  = 30.0;
+    double OpeningWidth   = 150.0;  // v1 stand-in for DA_SocketType dims (Q4: type-sized)
+    double OpeningHeight  = 220.0;
+    double CoincidenceTol = 26.0;   // how close a mouth must sit to a wall to count (>= thickness)
+};
+
+// ---------- outputs ----------
+
+// A straight wall run (post corner-split) minus socket spans: what the bay grammar tiles.
+struct FPlumbSegmentPlan
+{
+    FVector A = FVector::ZeroVector; // world start
+    FVector B = FVector::ZeroVector; // world end
+    double  Z0 = 0.0, Z1 = 300.0;    // explicit vertical interval (Q12 — never inferred downstream)
+};
+
+struct FPlumbSocketPlan
+{
+    FName    OtherId;                 // who we connect to
+    FVector  Center = FVector::ZeroVector; // world, at Z0 (walk level)
+    FVector  Tangent = FVector::XAxisVector;  // along the wall
+    FVector  Normal  = FVector::YAxisVector;  // out of the wall, toward the neighbor
+    double   Width = 0.0;             // opening width (type-sized, Q4)
+    double   Z0 = 0.0, Z1 = 0.0;      // walk level = max(floorA, floorB) .. +OpeningHeight (Q12)
+    double   FloorDeltaSelf = 0.0;    // Z0 - own floor (stairs hook, Q12)
+    bool     bOwned = false;          // Q8: this side realizes the entrance assembly; other side yields
+};
+
+struct FPlumbRejectPlan
+{
+    FName   OtherId;
+    FVector At = FVector::ZeroVector;
+    FString Reason;                   // human unsat text (Q13 overlay)
+};
+
+struct FPlumbWallPlan
+{
+    TArray<FPlumbSegmentPlan> Segments;
+    TArray<FPlumbSocketPlan>  Sockets;
+    TArray<FPlumbRejectPlan>  Rejects;
+};
+
+// ---------- core ----------
+
+namespace PlumbWallPlanner
+{
+    // -- polyline helpers (2-D in XY; Z carried separately) --
+
+    struct FRun // one straight wall run with its arc range
+    {
+        FVector A, B;
+        double  Len = 0.0;
+    };
+
+    // Split a structure's wall polyline into straight runs at corners sharper than CornerAngleDeg (Q2).
+    inline TArray<FRun> SplitRuns(const FPlumbStructure& S, double CornerAngleDeg)
+    {
+        TArray<FRun> Runs;
+        const int32 N = S.Points.Num();
+        if (N < 2) return Runs;
+        const double CosThresh = FMath::Cos(FMath::DegreesToRadians(CornerAngleDeg));
+
+        const int32 EdgeCount = S.bClosed ? N : N - 1;
+        int32 RunStart = 0;
+        for (int32 e = 0; e < EdgeCount; ++e)
+        {
+            const FVector P0 = S.Points[e % N], P1 = S.Points[(e + 1) % N];
+            const FVector D0 = (P1 - P0).GetSafeNormal2D();
+            const int32 eNext = (e + 1) % EdgeCount;
+            const FVector Q0 = S.Points[eNext % N], Q1 = S.Points[(eNext + 1) % N];
+            const FVector D1 = (Q1 - Q0).GetSafeNormal2D();
+            const bool bCornerAfter = (FVector::DotProduct(D0, D1) < CosThresh) || (!S.bClosed && e == EdgeCount - 1);
+            if (bCornerAfter)
+            {
+                FRun R; R.A = S.Points[RunStart % N]; R.B = P1; R.Len = FVector::Dist2D(R.A, R.B);
+                if (R.Len > KINDA_SMALL_NUMBER) Runs.Add(R);
+                RunStart = (e + 1) % N;
+            }
+        }
+        // closed loop with no corner at wrap: merge is unnecessary for our fixtures (square rooms
+        // always corner at every vertex); open polylines already flushed the last run above.
+        return Runs;
+    }
+
+    // Project P onto run AB (2-D). Returns param t in [0,1] and squared distance.
+    inline double ProjectOnRun(const FRun& R, const FVector& P, double& OutT)
+    {
+        const FVector AB = R.B - R.A;
+        const double  L2 = AB.SizeSquared2D();
+        OutT = (L2 <= KINDA_SMALL_NUMBER) ? 0.0 : FMath::Clamp(FVector::DotProduct((P - R.A), AB) / L2, 0.0, 1.0);
+        const FVector C = R.A + AB * OutT;
+        return FVector::DistSquared2D(C, P);
+    }
+
+    // -- the canonical socket derivation (Q1): pure function of the two structures --
+    // v1 detector: corridor-mouth — an OPEN structure's endpoint sitting on another structure's wall.
+    // (Pair-agnostic interval framework; collinear room|room shared-wall detector is the next fixture.)
+
+    struct FMouth { FVector At; FVector Dir; };  // endpoint + inward direction of the corridor
+
+    inline TArray<FMouth> Mouths(const FPlumbStructure& S)
+    {
+        TArray<FMouth> M;
+        if (S.bClosed || S.Points.Num() < 2) return M;
+        M.Add({ S.Points[0],                (S.Points[1] - S.Points[0]).GetSafeNormal2D() });
+        M.Add({ S.Points.Last(),            (S.Points[S.Points.Num() - 2] - S.Points.Last()).GetSafeNormal2D() });
+        return M;
+    }
+
+    // Try to derive the socket between Wall-owner `W` and open structure `C` at one mouth.
+    // Returns true and fills Out on geometric success; Reason set on a *near-miss* reject.
+    inline bool DeriveMouthSocket(const FPlumbStructure& W, const FPlumbStructure& C, const FMouth& M,
+                                  const FPlumbPlanParams& P, FPlumbSocketPlan& Out, FString& Reason)
+    {
+        const TArray<FRun> Runs = SplitRuns(W, P.CornerAngleDeg);
+        double BestD2 = TNumericLimits<double>::Max(); int32 BestRun = INDEX_NONE; double BestT = 0.0;
+        for (int32 i = 0; i < Runs.Num(); ++i)
+        {
+            double T; const double D2 = ProjectOnRun(Runs[i], M.At, T);
+            if (D2 < BestD2) { BestD2 = D2; BestRun = i; BestT = T; }
+        }
+        if (BestRun == INDEX_NONE) return false;
+        const double Dist = FMath::Sqrt(BestD2);
+        if (Dist > P.CoincidenceTol)
+        {
+            return false; // not touching at all — silent (no reject spam for distant structures)
+        }
+        const FRun& R = Runs[BestRun];
+
+        // Span on the wall: mouth center ± corridorWidth/2, clamped to the run (arc space of the run).
+        const double SAtRun   = BestT * R.Len;
+        const double HalfMouth = C.CorridorWidth * 0.5;
+        const double Span0 = FMath::Max(0.0, SAtRun - HalfMouth);
+        const double Span1 = FMath::Min(R.Len, SAtRun + HalfMouth);
+        const double SpanLen = Span1 - Span0;
+        if (SpanLen < P.MinOverlap)
+        {
+            Reason = FString::Printf(TEXT("shared span %.0fcm < min overlap %.0fcm"), SpanLen, P.MinOverlap);
+            return false;
+        }
+        if (P.OpeningWidth > SpanLen)
+        {
+            Reason = FString::Printf(TEXT("opening %.0fcm wider than shared wall %.0fcm"), P.OpeningWidth, SpanLen);
+            return false;
+        }
+
+        // Z algebra (Q12): walk level = max of floors; must fit under both ceilings.
+        const double Z0 = FMath::Max(W.FloorZ, C.FloorZ);
+        const double Z1 = Z0 + P.OpeningHeight;
+        const double SharedCeil = FMath::Min(W.FloorZ + W.WallHeight, C.FloorZ + C.WallHeight);
+        if (Z1 > SharedCeil)
+        {
+            Reason = FString::Printf(TEXT("opening top %.0f exceeds shared ceiling %.0f"), Z1, SharedCeil);
+            return false;
+        }
+
+        const double SCenter = (Span0 + Span1) * 0.5;   // opening centered on the span (Q4)
+        const FVector Tan = (R.B - R.A).GetSafeNormal2D();
+        Out.OtherId = C.Id;
+        Out.Center  = R.A + Tan * SCenter; Out.Center.Z = Z0;
+        Out.Tangent = Tan;
+        Out.Normal  = -M.Dir;              // out of the wall, toward the corridor
+        Out.Width   = P.OpeningWidth;
+        Out.Z0 = Z0; Out.Z1 = Z1;
+        return true;
+    }
+
+    // Q8 ownership: room > corridor > lexicographic name.
+    inline bool Owns(const FPlumbStructure& Self, const FPlumbStructure& Other)
+    {
+        if (Self.Kind != Other.Kind) return Self.Kind == EPlumbStructureKind::Room;
+        return Self.Id.LexicalLess(Other.Id);
+    }
+
+    // -- retile (Q11 audit invariant: full coverage, zero gaps/overlaps) --
+    inline void RetileRun(const FRun& R, double Z0, double Z1,
+                          TArray<TPair<double,double>> SocketSpans /*run-arc space, sorted*/,
+                          TArray<FPlumbSegmentPlan>& OutSegments)
+    {
+        SocketSpans.Sort([](const TPair<double,double>& X, const TPair<double,double>& Y){ return X.Key < Y.Key; });
+        const FVector Tan = (R.B - R.A).GetSafeNormal2D();
+        double Cursor = 0.0;
+        auto Emit = [&](double S0, double S1)
+        {
+            if (S1 - S0 <= KINDA_SMALL_NUMBER) return;
+            FPlumbSegmentPlan Seg;
+            Seg.A = R.A + Tan * S0; Seg.B = R.A + Tan * S1;
+            Seg.Z0 = Z0; Seg.Z1 = Z1;
+            OutSegments.Add(Seg);
+        };
+        for (const auto& Sp : SocketSpans)
+        {
+            Emit(Cursor, FMath::Max(Cursor, Sp.Key));
+            Cursor = FMath::Max(Cursor, Sp.Value);
+        }
+        Emit(Cursor, R.Len);
+    }
+
+    // -- the entry point --
+    inline FPlumbWallPlan Plan(const FPlumbStructure& Self, TArrayView<const FPlumbStructure> Others,
+                               const FPlumbPlanParams& P)
+    {
+        FPlumbWallPlan Out;
+        const TArray<FRun> Runs = SplitRuns(Self, P.CornerAngleDeg);
+
+        // Collect sockets ON MY WALLS (I am the wall-owner in DeriveMouthSocket terms):
+        // any open Other whose mouth touches my wall. Symmetric: the Other, planning itself,
+        // derives the identical socket via the same function with roles known from geometry.
+        struct FPerRun { TArray<TPair<double,double>> Spans; };
+        TArray<FPerRun> PerRun; PerRun.SetNum(Runs.Num());
+
+        auto RegisterSocket = [&](const FPlumbSocketPlan& S)
+        {
+            // locate the run + arc interval this socket occupies on my wall
+            for (int32 i = 0; i < Runs.Num(); ++i)
+            {
+                double T; const double D2 = ProjectOnRun(Runs[i], S.Center, T);
+                if (D2 < FMath::Square(P.CoincidenceTol))
+                {
+                    const double SC = T * Runs[i].Len;
+                    PerRun[i].Spans.Emplace(SC - S.Width * 0.5, SC + S.Width * 0.5);
+                    return;
+                }
+            }
+        };
+
+        for (const FPlumbStructure& O : Others)
+        {
+            if (O.Id == Self.Id) continue; // identity self-exclusion — structural, not a flag (Q1)
+
+            // Case 1: Other is open and its mouth lands on MY wall.
+            if (!O.bClosed)
+            {
+                for (const FMouth& M : Mouths(O))
+                {
+                    FPlumbSocketPlan S; FString Why;
+                    if (DeriveMouthSocket(Self, O, M, P, S, Why))
+                    {
+                        S.bOwned = Owns(Self, O);
+                        S.FloorDeltaSelf = S.Z0 - Self.FloorZ;
+                        Out.Sockets.Add(S);
+                        RegisterSocket(S);
+                    }
+                    else if (!Why.IsEmpty())
+                    {
+                        Out.Rejects.Add({ O.Id, M.At, Why });
+                    }
+                }
+            }
+            // Case 2: I am open and MY mouth lands on Other's wall — my cap yields the same span.
+            if (!Self.bClosed)
+            {
+                for (const FMouth& M : Mouths(Self))
+                {
+                    FPlumbSocketPlan S; FString Why;
+                    if (DeriveMouthSocket(O, Self, M, P, S, Why)) // derived on THEIR wall — identical both sides
+                    {
+                        S.OtherId = O.Id;
+                        S.bOwned  = Owns(Self, O);
+                        S.FloorDeltaSelf = S.Z0 - Self.FloorZ;
+                        S.Normal = M.Dir; // from my cap, opening faces along my inward dir
+                        Out.Sockets.Add(S);
+                        RegisterSocket(S); // registers only if the span lies on one of MY runs (the cap)
+                    }
+                }
+            }
+        }
+
+        // Retile every run around its sockets (guaranteed coverage — kills empty walls & the cap bug).
+        for (int32 i = 0; i < Runs.Num(); ++i)
+        {
+            RetileRun(Runs[i], Self.FloorZ, Self.FloorZ + Self.WallHeight, PerRun[i].Spans, Out.Segments);
+        }
+        return Out;
+    }
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
@@ -83,6 +83,7 @@ struct FPlumbWallPlan
     TArray<FPlumbSegmentPlan> Segments;
     TArray<FPlumbSocketPlan>  Sockets;
     TArray<FPlumbRejectPlan>  Rejects;
+    TArray<FVector>           FloorLoop; // closed loop for floor/ceiling realization (rooms: drawn; corridors: tunnel loop)
 };
 
 // ---------- core ----------
@@ -140,11 +141,25 @@ namespace PlumbWallPlanner
     // -- corridor offsetting (Q2 absorption): a corridor's WALLS are the mitered offset LOOP
     //    around its centerline (left side + far cap + right side + near cap), not the centerline.
     //    Pure + deterministic => both sides of a junction still derive identical geometry.
-    inline TArray<FVector> CorridorWallLoop(const FPlumbStructure& S)
+    // InsetStart/InsetEnd: pull the corridor's ends back along the centerline (the user's
+    // wall-thickness model — the gap between the two structures' inner faces IS the wall volume;
+    // the entrance frame spans it). Applied only at socketed mouths.
+    inline TArray<FVector> CorridorWallLoop(const FPlumbStructure& SIn, double InsetStart = 0.0, double InsetEnd = 0.0)
     {
         TArray<FVector> Loop;
+        FPlumbStructure S = SIn;
         const int32 N = S.Points.Num();
         if (S.bClosed || N < 2) return Loop;
+        if (InsetStart > 0.0)
+        {
+            const FVector D = (S.Points[1] - S.Points[0]).GetSafeNormal2D();
+            S.Points[0] += D * InsetStart;
+        }
+        if (InsetEnd > 0.0)
+        {
+            const FVector D = (S.Points[N-2] - S.Points[N-1]).GetSafeNormal2D();
+            S.Points[N-1] += D * InsetEnd;
+        }
         const double H = S.CorridorWidth * 0.5;
 
         // Offset one side of the polyline with LINE_PLANE-style mitered corners.
@@ -360,8 +375,43 @@ namespace PlumbWallPlanner
                                const FPlumbPlanParams& P)
     {
         FPlumbWallPlan Out;
-        // Q2: corridors plan their offset tunnel loop (side walls + caps); rooms plan the drawn loop.
-        const FPlumbStructure SelfWalls = EffectiveWalls(Self, P.bFlipWallFacing);
+
+        // Pass 1 (open self): resolve MY mouth sockets first — a socketed mouth insets that cap by
+        // WallThickness (the user's thickness model: the gap between the two structures' inner
+        // faces IS the wall volume; the entrance frame spans it).
+        double InsetStart = 0.0, InsetEnd = 0.0;
+        TArray<FPlumbSocketPlan> MouthSockets;
+        if (!Self.bClosed)
+        {
+            const TArray<FMouth> Ms = Mouths(Self);
+            for (const FPlumbStructure& O : Others)
+            {
+                if (O.Id == Self.Id) continue;
+                for (int32 mi = 0; mi < Ms.Num(); ++mi)
+                {
+                    FPlumbSocketPlan S; FString Why;
+                    if (DeriveMouthSocket(O, Self, Ms[mi], P, S, Why))
+                    {
+                        S.OtherId = O.Id;
+                        S.bOwned  = Owns(Self, O);
+                        S.FloorDeltaSelf = S.Z0 - Self.FloorZ;
+                        S.Normal = Ms[mi].Dir;
+                        MouthSockets.Add(S);
+                        if (mi == 0) InsetStart = P.WallThickness; else InsetEnd = P.WallThickness;
+                    }
+                }
+            }
+        }
+        Out.Sockets.Append(MouthSockets);
+
+        // Q2: corridors plan their offset tunnel loop (with socketed mouths inset); rooms plan the drawn loop.
+        FPlumbStructure SelfWalls = Self;
+        if (!Self.bClosed)
+        {
+            SelfWalls.Points = CorridorWallLoop(Self, InsetStart, InsetEnd);
+            SelfWalls.bClosed = true;
+        }
+        if (P.bFlipWallFacing) Algo::Reverse(SelfWalls.Points);
         const TArray<FRun> Runs = SplitRuns(SelfWalls, P.CornerAngleDeg);
 
         // Collect sockets ON MY WALLS (I am the wall-owner in DeriveMouthSocket terms):
@@ -372,11 +422,14 @@ namespace PlumbWallPlanner
 
         auto RegisterSocket = [&](const FPlumbSocketPlan& S)
         {
-            // locate the run + arc interval this socket occupies on my wall
+            // locate the run + arc interval this socket occupies on my wall.
+            // Tolerance includes WallThickness: an inset cap sits Thickness away from the
+            // socket center (which lies on the OTHER structure's inner face).
+            const double Tol2 = FMath::Square(P.CoincidenceTol + P.WallThickness);
             for (int32 i = 0; i < Runs.Num(); ++i)
             {
                 double T; const double D2 = ProjectOnRun(Runs[i], S.Center, T);
-                if (D2 < FMath::Square(P.CoincidenceTol))
+                if (D2 < Tol2)
                 {
                     const double SC = T * Runs[i].Len;
                     PerRun[i].Spans.Emplace(SC - S.Width * 0.5, SC + S.Width * 0.5);
@@ -384,6 +437,7 @@ namespace PlumbWallPlanner
                 }
             }
         };
+        for (const FPlumbSocketPlan& S : MouthSockets) RegisterSocket(S);
 
         for (const FPlumbStructure& O : Others)
         {
@@ -408,23 +462,7 @@ namespace PlumbWallPlanner
                     }
                 }
             }
-            // Case 2: I am open and MY mouth lands on Other's wall — my cap yields the same span.
-            if (!Self.bClosed)
-            {
-                for (const FMouth& M : Mouths(Self))
-                {
-                    FPlumbSocketPlan S; FString Why;
-                    if (DeriveMouthSocket(O, Self, M, P, S, Why)) // derived on THEIR wall — identical both sides
-                    {
-                        S.OtherId = O.Id;
-                        S.bOwned  = Owns(Self, O);
-                        S.FloorDeltaSelf = S.Z0 - Self.FloorZ;
-                        S.Normal = M.Dir; // from my cap, opening faces along my inward dir
-                        Out.Sockets.Add(S);
-                        RegisterSocket(S); // registers only if the span lies on one of MY runs (the cap)
-                    }
-                }
-            }
+            // (Case 2 — my own mouths — was resolved in pass 1 above, before the loop was built.)
         }
 
         // Retile every run around its sockets (guaranteed coverage — kills empty walls & the cap bug).
@@ -432,6 +470,7 @@ namespace PlumbWallPlanner
         {
             RetileRun(Runs[i], Self.FloorZ, Self.FloorZ + Self.WallHeight, PerRun[i].Spans, Out.Segments);
         }
+        Out.FloorLoop = SelfWalls.Points; // floor/ceiling follow the wall footprint (incl. cap insets)
         return Out;
     }
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
@@ -135,6 +135,52 @@ namespace PlumbWallPlanner
         return FVector::DistSquared2D(C, P);
     }
 
+    // -- corridor offsetting (Q2 absorption): a corridor's WALLS are the mitered offset LOOP
+    //    around its centerline (left side + far cap + right side + near cap), not the centerline.
+    //    Pure + deterministic => both sides of a junction still derive identical geometry.
+    inline TArray<FVector> CorridorWallLoop(const FPlumbStructure& S)
+    {
+        TArray<FVector> Loop;
+        const int32 N = S.Points.Num();
+        if (S.bClosed || N < 2) return Loop;
+        const double H = S.CorridorWidth * 0.5;
+
+        // Offset one side of the polyline with LINE_PLANE-style mitered corners.
+        auto OffsetSide = [&](double Sign, TArray<FVector>& Out)
+        {
+            for (int32 i = 0; i < N; ++i)
+            {
+                const FVector DirIn  = (i > 0)     ? (S.Points[i] - S.Points[i-1]).GetSafeNormal2D() : (S.Points[1] - S.Points[0]).GetSafeNormal2D();
+                const FVector DirOut = (i < N - 1) ? (S.Points[i+1] - S.Points[i]).GetSafeNormal2D() : DirIn;
+                const FVector NIn (-DirIn.Y * Sign,  DirIn.X * Sign, 0.0);
+                const FVector NOut(-DirOut.Y * Sign, DirOut.X * Sign, 0.0);
+                FVector MiterN = (NIn + NOut).GetSafeNormal2D();
+                if (MiterN.IsNearlyZero()) MiterN = NIn;
+                const double Cos = FVector::DotProduct(MiterN, NIn);
+                const double Scale = (FMath::Abs(Cos) > 0.1) ? (1.0 / Cos) : 1.0; // miter length
+                FVector P = S.Points[i] + MiterN * (H * Scale);
+                P.Z = S.Points[i].Z;
+                Out.Add(P);
+            }
+        };
+        TArray<FVector> Left, Right;
+        OffsetSide(+1.0, Left);
+        OffsetSide(-1.0, Right);
+        Loop.Append(Left);                                   // start-cap end .. far-cap end (left side)
+        for (int32 i = Right.Num() - 1; i >= 0; --i) Loop.Add(Right[i]); // far cap + right side back
+        return Loop; // closed implicitly: last->first edge = the near (mouth) cap
+    }
+
+    // Wall geometry a structure exposes: rooms = drawn loop; corridors = offset tunnel loop.
+    inline FPlumbStructure EffectiveWalls(const FPlumbStructure& S)
+    {
+        if (S.bClosed) return S;
+        FPlumbStructure W = S;
+        W.Points = CorridorWallLoop(S);
+        W.bClosed = true; // the tunnel loop is closed (caps included)
+        return W;
+    }
+
     // -- the canonical socket derivation (Q1): pure function of the two structures --
     // v1 detector: corridor-mouth — an OPEN structure's endpoint sitting on another structure's wall.
     // (Pair-agnostic interval framework; collinear room|room shared-wall detector is the next fixture.)
@@ -217,7 +263,7 @@ namespace PlumbWallPlanner
     inline bool DeriveMouthSocket(const FPlumbStructure& W, const FPlumbStructure& C, const FMouth& M,
                                   const FPlumbPlanParams& P, FPlumbSocketPlan& Out, FString& Reason)
     {
-        const TArray<FRun> Runs = SplitRuns(W, P.CornerAngleDeg);
+        const TArray<FRun> Runs = SplitRuns(EffectiveWalls(W), P.CornerAngleDeg);
         double BestD2 = TNumericLimits<double>::Max(); int32 BestRun = INDEX_NONE; double BestT = 0.0;
         for (int32 i = 0; i < Runs.Num(); ++i)
         {
@@ -306,7 +352,9 @@ namespace PlumbWallPlanner
                                const FPlumbPlanParams& P)
     {
         FPlumbWallPlan Out;
-        const TArray<FRun> Runs = SplitRuns(Self, P.CornerAngleDeg);
+        // Q2: corridors plan their offset tunnel loop (side walls + caps); rooms plan the drawn loop.
+        const FPlumbStructure SelfWalls = EffectiveWalls(Self);
+        const TArray<FRun> Runs = SplitRuns(SelfWalls, P.CornerAngleDeg);
 
         // Collect sockets ON MY WALLS (I am the wall-owner in DeriveMouthSocket terms):
         // any open Other whose mouth touches my wall. Symmetric: the Other, planning itself,

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
@@ -6,10 +6,21 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "pcg/HaybaSocketSolver.h"
 
 // ---------- inputs ----------
 
 enum class EPlumbStructureKind : uint8 { Room, Corridor };
+
+// A socket TYPE a structure offers at junctions (Q3: authored as DA_SocketType, converted
+// to this plain decl before Plan). Compatibility = the SP-1 tag contract; dims = type-sized (Q4).
+struct FPlumbSocketTypeDecl
+{
+    FHaybaSocketContract Contract;          // Name + Provides/Requires/bRelaxable (dotted tags)
+    double OpeningWidth    = 150.0;
+    double OpeningHeight   = 220.0;
+    double TransitionRadius = 0.0;          // Q9b: noisy-surface flatten falloff (0 = flat modular)
+};
 
 struct FPlumbStructure
 {
@@ -20,6 +31,7 @@ struct FPlumbStructure
     double               FloorZ = 0.0;       // Points[i].Z of the drawing plane
     double               WallHeight = 300.0;
     double               CorridorWidth = 300.0; // corridors only (Q10: rides with the corridor's data)
+    TArray<FPlumbSocketTypeDecl> SocketTypes;   // Q3: declared kinds; empty => params default type
 };
 
 struct FPlumbPlanParams
@@ -52,6 +64,9 @@ struct FPlumbSocketPlan
     double   Z0 = 0.0, Z1 = 0.0;      // walk level = max(floorA, floorB) .. +OpeningHeight (Q12)
     double   FloorDeltaSelf = 0.0;    // Z0 - own floor (stairs hook, Q12)
     bool     bOwned = false;          // Q8: this side realizes the entrance assembly; other side yields
+    FName    TypeName;                // winning DA_SocketType (drives the entrance kit)
+    double   TransitionRadius = 0.0;  // Q9b flatten falloff, from the winning type
+    bool     bRelaxedBond = false;    // solver committed by relaxing a requirement (yellow)
 };
 
 struct FPlumbRejectPlan
@@ -135,6 +150,68 @@ namespace PlumbWallPlanner
         return M;
     }
 
+    // -- socket-type resolution (Q3): SP-1 cost-min over the two sides' declared types --
+    struct FTypeChoice
+    {
+        bool    bOk = false;
+        bool    bRelaxed = false;
+        FName   TypeName;              // the WALL side's winning type (owner-facing kit)
+        double  Width = 0.0, Height = 0.0, Transition = 0.0;
+        FString Reason;                // unsat text when !bOk
+    };
+
+    inline FPlumbSocketTypeDecl DefaultType(const FPlumbPlanParams& P)
+    {
+        FPlumbSocketTypeDecl D;
+        D.Contract.Name = FName(TEXT("Default"));
+        D.Contract.Provides = { TEXT("Entrance") };
+        D.Contract.Requires.All = {};              // permissive: connects to anything
+        D.OpeningWidth  = P.OpeningWidth;
+        D.OpeningHeight = P.OpeningHeight;
+        return D;
+    }
+
+    // Pick the min-cost (wallType, otherType) pair that also FITS (width<=span, height<=headroom).
+    // Deterministic: candidates scanned in declared order; strict improvement wins (stable tie-break).
+    inline FTypeChoice SolveSocketType(const FPlumbStructure& Wall, const FPlumbStructure& Other,
+                                       double SpanLen, double Headroom, const FPlumbPlanParams& P)
+    {
+        TArray<FPlumbSocketTypeDecl> A = Wall.SocketTypes;  if (A.Num() == 0) A.Add(DefaultType(P));
+        TArray<FPlumbSocketTypeDecl> B = Other.SocketTypes; if (B.Num() == 0) B.Add(DefaultType(P));
+
+        FTypeChoice Best; double BestCost = HaybaSocketSolver::HardPenalty; FString FirstReason;
+        for (const FPlumbSocketTypeDecl& TA : A)
+        {
+            for (const FPlumbSocketTypeDecl& TB : B)
+            {
+                if (TA.OpeningWidth > SpanLen || TA.OpeningHeight > Headroom)
+                {
+                    if (FirstReason.IsEmpty())
+                        FirstReason = FString::Printf(TEXT("%s does not fit: w %.0f vs span %.0f, h %.0f vs headroom %.0f under shared ceiling"),
+                            *TA.Contract.Name.ToString(), TA.OpeningWidth, SpanLen, TA.OpeningHeight, Headroom);
+                    continue;
+                }
+                const FHaybaBondOutcome O = HaybaSocketSolver::SolveBond(TA.Contract, { TB.Contract });
+                if (O.bOk && O.Cost < BestCost)
+                {
+                    BestCost = O.Cost;
+                    Best.bOk = true; Best.bRelaxed = O.bRelaxed;
+                    Best.TypeName = TA.Contract.Name;
+                    Best.Width = TA.OpeningWidth; Best.Height = TA.OpeningHeight; Best.Transition = TA.TransitionRadius;
+                    if (BestCost <= 0.0) return Best; // clean bond: cannot improve
+                }
+                else if (!O.bOk && FirstReason.IsEmpty())
+                {
+                    FirstReason = FString::Printf(TEXT("%s vs %s: missing [%s]"),
+                        *TA.Contract.Name.ToString(), *TB.Contract.Name.ToString(),
+                        *FString::Join(O.MissingRequired, TEXT(", ")));
+                }
+            }
+        }
+        if (!Best.bOk) Best.Reason = FirstReason.IsEmpty() ? TEXT("no compatible socket types") : FirstReason;
+        return Best;
+    }
+
     // Try to derive the socket between Wall-owner `W` and open structure `C` at one mouth.
     // Returns true and fills Out on geometric success; Reason set on a *near-miss* reject.
     inline bool DeriveMouthSocket(const FPlumbStructure& W, const FPlumbStructure& C, const FMouth& M,
@@ -166,19 +243,16 @@ namespace PlumbWallPlanner
             Reason = FString::Printf(TEXT("shared span %.0fcm < min overlap %.0fcm"), SpanLen, P.MinOverlap);
             return false;
         }
-        if (P.OpeningWidth > SpanLen)
-        {
-            Reason = FString::Printf(TEXT("opening %.0fcm wider than shared wall %.0fcm"), P.OpeningWidth, SpanLen);
-            return false;
-        }
-
-        // Z algebra (Q12): walk level = max of floors; must fit under both ceilings.
+        // Z algebra (Q12): walk level = max of floors; headroom = shared ceiling above it.
         const double Z0 = FMath::Max(W.FloorZ, C.FloorZ);
-        const double Z1 = Z0 + P.OpeningHeight;
         const double SharedCeil = FMath::Min(W.FloorZ + W.WallHeight, C.FloorZ + C.WallHeight);
-        if (Z1 > SharedCeil)
+        const double Headroom = SharedCeil - Z0;
+
+        // Q3: the solver picks the entrance kind (dims come from the winning type).
+        const FTypeChoice Choice = SolveSocketType(W, C, SpanLen, Headroom, P);
+        if (!Choice.bOk)
         {
-            Reason = FString::Printf(TEXT("opening top %.0f exceeds shared ceiling %.0f"), Z1, SharedCeil);
+            Reason = Choice.Reason;
             return false;
         }
 
@@ -188,8 +262,11 @@ namespace PlumbWallPlanner
         Out.Center  = R.A + Tan * SCenter; Out.Center.Z = Z0;
         Out.Tangent = Tan;
         Out.Normal  = -M.Dir;              // out of the wall, toward the corridor
-        Out.Width   = P.OpeningWidth;
-        Out.Z0 = Z0; Out.Z1 = Z1;
+        Out.Width   = Choice.Width;
+        Out.Z0 = Z0; Out.Z1 = Z0 + Choice.Height;
+        Out.TypeName = Choice.TypeName;
+        Out.TransitionRadius = Choice.Transition;
+        Out.bRelaxedBond = Choice.bRelaxed;
         return true;
     }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
@@ -7,6 +7,7 @@
 
 #include "CoreMinimal.h"
 #include "pcg/HaybaSocketSolver.h"
+#include "Algo/Reverse.h"
 
 // ---------- inputs ----------
 
@@ -42,6 +43,7 @@ struct FPlumbPlanParams
     double OpeningWidth   = 150.0;  // v1 stand-in for DA_SocketType dims (Q4: type-sized)
     double OpeningHeight  = 220.0;
     double CoincidenceTol = 26.0;   // how close a mouth must sit to a wall to count (>= thickness)
+    bool   bFlipWallFacing = false; // author knob: reverse wall winding (inner<->outer faces)
 };
 
 // ---------- outputs ----------
@@ -166,18 +168,24 @@ namespace PlumbWallPlanner
         TArray<FVector> Left, Right;
         OffsetSide(+1.0, Left);
         OffsetSide(-1.0, Right);
-        Loop.Append(Left);                                   // start-cap end .. far-cap end (left side)
-        for (int32 i = Right.Num() - 1; i >= 0; --i) Loop.Add(Right[i]); // far cap + right side back
+        // Winding: modules face LEFT of travel (rooms: CCW loop => inner faces). For the tunnel
+        // interior to be faced, traverse right side forward, then left side back.
+        Loop.Append(Right);
+        for (int32 i = Left.Num() - 1; i >= 0; --i) Loop.Add(Left[i]);
         return Loop; // closed implicitly: last->first edge = the near (mouth) cap
     }
 
     // Wall geometry a structure exposes: rooms = drawn loop; corridors = offset tunnel loop.
-    inline FPlumbStructure EffectiveWalls(const FPlumbStructure& S)
+    // bFlip reverses winding (inner<->outer faces) — the author's facing knob, uniform for both kinds.
+    inline FPlumbStructure EffectiveWalls(const FPlumbStructure& S, bool bFlip = false)
     {
-        if (S.bClosed) return S;
         FPlumbStructure W = S;
-        W.Points = CorridorWallLoop(S);
-        W.bClosed = true; // the tunnel loop is closed (caps included)
+        if (!S.bClosed)
+        {
+            W.Points = CorridorWallLoop(S);
+            W.bClosed = true; // the tunnel loop is closed (caps included)
+        }
+        if (bFlip) Algo::Reverse(W.Points);
         return W;
     }
 
@@ -263,7 +271,7 @@ namespace PlumbWallPlanner
     inline bool DeriveMouthSocket(const FPlumbStructure& W, const FPlumbStructure& C, const FMouth& M,
                                   const FPlumbPlanParams& P, FPlumbSocketPlan& Out, FString& Reason)
     {
-        const TArray<FRun> Runs = SplitRuns(EffectiveWalls(W), P.CornerAngleDeg);
+        const TArray<FRun> Runs = SplitRuns(EffectiveWalls(W, P.bFlipWallFacing), P.CornerAngleDeg);
         double BestD2 = TNumericLimits<double>::Max(); int32 BestRun = INDEX_NONE; double BestT = 0.0;
         for (int32 i = 0; i < Runs.Num(); ++i)
         {
@@ -353,7 +361,7 @@ namespace PlumbWallPlanner
     {
         FPlumbWallPlan Out;
         // Q2: corridors plan their offset tunnel loop (side walls + caps); rooms plan the drawn loop.
-        const FPlumbStructure SelfWalls = EffectiveWalls(Self);
+        const FPlumbStructure SelfWalls = EffectiveWalls(Self, P.bFlipWallFacing);
         const TArray<FRun> Runs = SplitRuns(SelfWalls, P.CornerAngleDeg);
 
         // Collect sockets ON MY WALLS (I am the wall-owner in DeriveMouthSocket terms):

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
@@ -342,6 +342,10 @@ namespace PlumbWallPlanner
         const FVector Tan = (R.B - R.A).GetSafeNormal2D();
         Out.OtherId = C.Id;
         Out.Center  = R.A + Tan * SCenter; Out.Center.Z = Z0;
+        // Center the frame ON THE THICKNESS GAP, not the wall plane: half a thickness along the
+        // mouth direction (wall plane -> corridor face). Both sides derive from the same mouth,
+        // so symmetry holds; the assembly (depth == thickness) then spans face-to-face exactly.
+        Out.Center += FVector(M.Dir.X, M.Dir.Y, 0.0) * (P.WallThickness * 0.5);
         Out.Tangent = Tan;
         Out.Normal  = -M.Dir;              // out of the wall, toward the corridor
         Out.Width   = Choice.Width;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
@@ -44,6 +44,7 @@ struct FPlumbPlanParams
     double OpeningHeight  = 220.0;
     double CoincidenceTol = 26.0;   // how close a mouth must sit to a wall to count (>= thickness)
     bool   bFlipWallFacing = false; // author knob: reverse wall winding (inner<->outer faces)
+    double MinGrammarLen  = 160.0;  // below this, a remainder realizes as a FILL patch, not the grammar
 };
 
 // ---------- outputs ----------
@@ -71,6 +72,17 @@ struct FPlumbSocketPlan
     bool     bRelaxedBond = false;    // solver committed by relaxing a requirement (yellow)
 };
 
+// A guaranteed-coverage patch: one stretched grammar module over an area the bay grammar
+// can't tile (sub-minimum remainders, over-opening bands). Realized like a socket point.
+struct FPlumbFillPlan
+{
+    FVector Center = FVector::ZeroVector; // world, at Z0
+    FVector Tangent = FVector::XAxisVector;
+    FVector Normal  = FVector::YAxisVector;
+    double  Width = 0.0;
+    double  Z0 = 0.0, Z1 = 0.0;
+};
+
 struct FPlumbRejectPlan
 {
     FName   OtherId;
@@ -82,6 +94,7 @@ struct FPlumbWallPlan
 {
     TArray<FPlumbSegmentPlan> Segments;
     TArray<FPlumbSocketPlan>  Sockets;
+    TArray<FPlumbFillPlan>    Fills;   // guaranteed-coverage patches (small remainders, over-door bands)
     TArray<FPlumbRejectPlan>  Rejects;
     TArray<FVector>           FloorLoop; // closed loop for floor/ceiling realization (rooms: drawn; corridors: tunnel loop)
 };
@@ -347,27 +360,48 @@ namespace PlumbWallPlanner
     }
 
     // -- retile (Q11 audit invariant: full coverage, zero gaps/overlaps) --
+    // Guaranteed coverage, literally: remainders too small for the bay grammar, and the
+    // wall band ABOVE each opening (socket Z1 .. ceiling), are emitted as FILL patches —
+    // single stretched grammar modules — so no wall area is ever silently dropped.
     inline void RetileRun(const FRun& R, double Z0, double Z1,
-                          TArray<TPair<double,double>> SocketSpans /*run-arc space, sorted*/,
-                          TArray<FPlumbSegmentPlan>& OutSegments)
+                          TArray<TTuple<double,double,double>> SocketSpans /*S0,S1,openTopZ; run-arc space*/,
+                          double MinGrammarLen,
+                          TArray<FPlumbSegmentPlan>& OutSegments,
+                          TArray<FPlumbFillPlan>& OutFills)
     {
-        SocketSpans.Sort([](const TPair<double,double>& X, const TPair<double,double>& Y){ return X.Key < Y.Key; });
+        SocketSpans.Sort([](const TTuple<double,double,double>& X, const TTuple<double,double,double>& Y){ return X.Get<0>() < Y.Get<0>(); });
         const FVector Tan = (R.B - R.A).GetSafeNormal2D();
+        const FVector Nrm(-Tan.Y, Tan.X, 0.0); // left of travel = the faced side
         double Cursor = 0.0;
-        auto Emit = [&](double S0, double S1)
+        auto Emit = [&](double S0, double S1, double SegZ0, double SegZ1)
         {
-            if (S1 - S0 <= KINDA_SMALL_NUMBER) return;
-            FPlumbSegmentPlan Seg;
-            Seg.A = R.A + Tan * S0; Seg.B = R.A + Tan * S1;
-            Seg.Z0 = Z0; Seg.Z1 = Z1;
-            OutSegments.Add(Seg);
+            const double Len = S1 - S0;
+            if (Len <= KINDA_SMALL_NUMBER || SegZ1 - SegZ0 <= KINDA_SMALL_NUMBER) return;
+            if (Len < MinGrammarLen || SegZ1 - SegZ0 < (Z1 - Z0) - KINDA_SMALL_NUMBER)
+            {
+                // too small for the grammar, or a partial-height band -> fill patch
+                FPlumbFillPlan F;
+                F.Center = R.A + Tan * ((S0 + S1) * 0.5); F.Center.Z = SegZ0;
+                F.Tangent = Tan; F.Normal = Nrm;
+                F.Width = Len; F.Z0 = SegZ0; F.Z1 = SegZ1;
+                OutFills.Add(F);
+            }
+            else
+            {
+                FPlumbSegmentPlan Seg;
+                Seg.A = R.A + Tan * S0; Seg.B = R.A + Tan * S1;
+                Seg.Z0 = SegZ0; Seg.Z1 = SegZ1;
+                OutSegments.Add(Seg);
+            }
         };
         for (const auto& Sp : SocketSpans)
         {
-            Emit(Cursor, FMath::Max(Cursor, Sp.Key));
-            Cursor = FMath::Max(Cursor, Sp.Value);
+            Emit(Cursor, FMath::Max(Cursor, Sp.Get<0>()), Z0, Z1);
+            // over-opening band: opening top .. ceiling, same span (follows the grammar as a fill)
+            Emit(FMath::Max(Cursor, Sp.Get<0>()), Sp.Get<1>(), Sp.Get<2>(), Z1);
+            Cursor = FMath::Max(Cursor, Sp.Get<1>());
         }
-        Emit(Cursor, R.Len);
+        Emit(Cursor, R.Len, Z0, Z1);
     }
 
     // -- the entry point --
@@ -417,7 +451,7 @@ namespace PlumbWallPlanner
         // Collect sockets ON MY WALLS (I am the wall-owner in DeriveMouthSocket terms):
         // any open Other whose mouth touches my wall. Symmetric: the Other, planning itself,
         // derives the identical socket via the same function with roles known from geometry.
-        struct FPerRun { TArray<TPair<double,double>> Spans; };
+        struct FPerRun { TArray<TTuple<double,double,double>> Spans; }; // S0,S1,openTopZ
         TArray<FPerRun> PerRun; PerRun.SetNum(Runs.Num());
 
         auto RegisterSocket = [&](const FPlumbSocketPlan& S)
@@ -432,7 +466,7 @@ namespace PlumbWallPlanner
                 if (D2 < Tol2)
                 {
                     const double SC = T * Runs[i].Len;
-                    PerRun[i].Spans.Emplace(SC - S.Width * 0.5, SC + S.Width * 0.5);
+                    PerRun[i].Spans.Emplace(SC - S.Width * 0.5, SC + S.Width * 0.5, S.Z1);
                     return;
                 }
             }
@@ -468,7 +502,7 @@ namespace PlumbWallPlanner
         // Retile every run around its sockets (guaranteed coverage — kills empty walls & the cap bug).
         for (int32 i = 0; i < Runs.Num(); ++i)
         {
-            RetileRun(Runs[i], Self.FloorZ, Self.FloorZ + Self.WallHeight, PerRun[i].Spans, Out.Segments);
+            RetileRun(Runs[i], Self.FloorZ, Self.FloorZ + Self.WallHeight, PerRun[i].Spans, P.MinGrammarLen, Out.Segments, Out.Fills);
         }
         Out.FloorLoop = SelfWalls.Points; // floor/ceiling follow the wall footprint (incl. cap insets)
         return Out;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
@@ -81,6 +81,7 @@ struct FPlumbFillPlan
     FVector Normal  = FVector::YAxisVector;
     double  Width = 0.0;
     double  Z0 = 0.0, Z1 = 0.0;
+    FString Grammar;                      // Z-grammar for the band, chosen by height (crown-aligned)
 };
 
 struct FPlumbRejectPlan
@@ -383,11 +384,17 @@ namespace PlumbWallPlanner
             if (Len <= KINDA_SMALL_NUMBER || SegZ1 - SegZ0 <= KINDA_SMALL_NUMBER) return;
             if (Len < MinGrammarLen || SegZ1 - SegZ0 < (Z1 - Z0) - KINDA_SMALL_NUMBER)
             {
-                // too small for the grammar, or a partial-height band -> fill patch
+                // too small for the grammar, or a partial-height band -> fill patch.
+                // The fill still FOLLOWS the wall grammar: its Z-grammar is chosen by height so
+                // the crown band runs continuously (user: "pink thing at the top").
                 FPlumbFillPlan F;
                 F.Center = R.A + Tan * ((S0 + S1) * 0.5); F.Center.Z = SegZ0;
                 F.Tangent = Tan; F.Normal = Nrm;
                 F.Width = Len; F.Z0 = SegZ0; F.Z1 = SegZ1;
+                const double H = SegZ1 - SegZ0;
+                F.Grammar = (SegZ0 <= Z0 + KINDA_SMALL_NUMBER && H >= (Z1 - Z0) - KINDA_SMALL_NUMBER)
+                    ? TEXT("[base,field,crown]")
+                    : (H >= 100.0 ? TEXT("[field,crown]") : TEXT("[crown]"));
                 OutFills.Add(F);
             }
             else

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/pcg/PlumbWallPlanner.h
@@ -81,7 +81,7 @@ struct FPlumbFillPlan
     FVector Normal  = FVector::YAxisVector;
     double  Width = 0.0;
     double  Z0 = 0.0, Z1 = 0.0;
-    FString Grammar;                      // Z-grammar for the band, chosen by height (crown-aligned)
+    int32   BandIndex = 1;                // kit entry: 0=base, 1=field, 2=crown (stretch-fit per band)
 };
 
 struct FPlumbRejectPlan
@@ -384,18 +384,24 @@ namespace PlumbWallPlanner
             if (Len <= KINDA_SMALL_NUMBER || SegZ1 - SegZ0 <= KINDA_SMALL_NUMBER) return;
             if (Len < MinGrammarLen || SegZ1 - SegZ0 < (Z1 - Z0) - KINDA_SMALL_NUMBER)
             {
-                // too small for the grammar, or a partial-height band -> fill patch.
-                // The fill still FOLLOWS the wall grammar: its Z-grammar is chosen by height so
-                // the crown band runs continuously (user: "pink thing at the top").
-                FPlumbFillPlan F;
-                F.Center = R.A + Tan * ((S0 + S1) * 0.5); F.Center.Z = SegZ0;
-                F.Tangent = Tan; F.Normal = Nrm;
-                F.Width = Len; F.Z0 = SegZ0; F.Z1 = SegZ1;
-                const double H = SegZ1 - SegZ0;
-                F.Grammar = (SegZ0 <= Z0 + KINDA_SMALL_NUMBER && H >= (Z1 - Z0) - KINDA_SMALL_NUMBER)
-                    ? TEXT("[base,field,crown]")
-                    : (H >= 100.0 ? TEXT("[field,crown]") : TEXT("[crown]"));
-                OutFills.Add(F);
+                // too small for the grammar, or a partial-height band -> fill patches that still
+                // FOLLOW the wall grammar: the planner splits the area into exact base/field/crown
+                // bands (PCGEx flex can only grow, so band sizing is decided HERE) and each band
+                // stretch-fits its kit module. Crown always tops out at the ceiling (the pink line).
+                auto Band = [&](double B0, double B1, int32 Idx)
+                {
+                    if (B1 - B0 <= KINDA_SMALL_NUMBER) return;
+                    FPlumbFillPlan F;
+                    F.Center = R.A + Tan * ((S0 + S1) * 0.5); F.Center.Z = B0;
+                    F.Tangent = Tan; F.Normal = Nrm;
+                    F.Width = Len; F.Z0 = B0; F.Z1 = B1; F.BandIndex = Idx;
+                    OutFills.Add(F);
+                };
+                const bool bFull = SegZ0 <= Z0 + KINDA_SMALL_NUMBER && SegZ1 - SegZ0 >= (Z1 - Z0) - KINDA_SMALL_NUMBER;
+                const double CrownZ0 = FMath::Max(SegZ0, SegZ1 - 50.0);
+                if (bFull) Band(SegZ0, FMath::Min(SegZ0 + 50.0, CrownZ0), 0);          // base
+                Band(bFull ? SegZ0 + 50.0 : SegZ0, CrownZ0, 1);                        // field
+                Band(CrownZ0, SegZ1, 2);                                               // crown
             }
             else
             {


### PR DESCRIPTION
A synchronous UE editor op (asset/landscape import, world-partition level save, PCG generate, asset reindex) blocks the game thread for tens of seconds, during which the plugin's TCP port stops accepting connections. A naive tool call then either hangs with no signal or hits ECONNREFUSED and reads as a **crash** — and the client may auto-retry, compounding the stall. This burned real hours during scene setup.

**Fix (TS transport layer, no rebuild):**
- **Heavy-op registry** (`heavy-ops.ts`) — the known game-thread-blocking commands; extensible at runtime via `addHeavyOp`/`removeHeavyOp`.
- **Dedicated 300s timeout** for heavy ops instead of their cost tier (a real gigabyte import / WP save legitimately runs minutes). Explicit `opts.timeout` still wins.
- **Never auto-retry** a heavy op — the short-circuit fires before the idempotency branch, so the sender is called exactly once regardless of `NON_IDEMPOTENT`.
- **Structured `editor_busy` error** (new additive `UeToolErrorCode`) on heavy-op transport failure: says the editor is likely busy finishing the op (not crashed), folds in a live process-up/down probe, and points to `hayba_check_ue_status`.
- **Opt-in `awaitEditorResponsive(...)`** helper (injectable) to let callers wait for the port to settle — NOT wired into the default path.

**Verification:** 31 executor/registry/tcp tests (no-retry call-count, 300s tier, error shape, responsive-probe) — all pass, and the editor-busy tests are isolated from the real `tasklist`/`pgrep` probe. tsc clean (excl. 3 pre-existing `node:sqlite` errors on main), lint green. Independently reviewed; the one review finding (test shelling out) fixed in 8068d2f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a PCG wall-planning node that generates wall segments, floor loops, sockets, fill areas, and rejection details from spline layouts.
  * Added support for deterministic wall planning, corridor connections, socket compatibility, vertical tiling, and full-coverage fill patches.
  * Added editor responsiveness checks and process detection for more reliable command execution.
  * Added dedicated handling and clearer errors for long-running editor operations.

* **Bug Fixes**
  * Documented safeguards for stale command replay and unsafe world-switching operations.

* **Tests**
  * Added regression coverage for wall planning, socket selection, coverage, rejection behavior, and editor responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->