### PR TITLE
feat(ui): agent-callable UMG Widget Blueprint tools

### DIFF
--- a/HANDOFF-umg-authoring.md
+++ b/HANDOFF-umg-authoring.md
@@ -1,0 +1,117 @@
+# Handoff: Enable UMG (Widget Blueprint) authoring through the Hayba MCP
+
+**Author of handoff:** Claude (Aphrosia session), 2026-07-19
+**Audience:** the next Claude/dev working in `D:\Hackathons\hayba`
+**One-line goal:** make `ui_create_widget` / `ui_add_element` / `ui_query` **agent-callable** so an agent can build & edit UMG Widget Blueprints in a live UE editor via the MCP — instead of hand-writing UMG in C++.
+
+---
+
+## ✅ DONE (2026-07-19) — native-TS route
+
+The TS wrappers now exist. `list_tool_categories` will report the `ui` domain with
+`callable_count: 3` after reconnect. What was added (all in `mcp-tools/hayba-mcp`):
+
+- `src/tools/ui/ui-create-widget.ts`, `ui-add-element.ts`, `ui-query.ts` — Zod
+  schemas + handlers calling `executeCommand('ui_*', args)` (mirrors `material_*`).
+- `src/tools/index.ts` — 3 `ToolDescriptor` entries in `HANDWRITTEN_STANDARD_DESCRIPTORS`
+  (`niche: UI`), the `UI` niche const, and an `inferDir('ui_') → 'ui'` pack entry.
+- `src/tools/niche-briefing.ts` — a `ui` first-touch briefing.
+- `src/tools/ui/ui-tools.test.ts` — 7 passing tests (registration + dispatch + param names).
+- Built to `dist/`; typecheck + `lint:legacy-wrappers` green. **Legacy route NOT used**
+  — the `ui` domain is a modern `IHaybaMCPHandler`, absent from the C++ legacy dispatch
+  table, so the native-TS route was correct (confirmed: lint stays green with no sidecar edits).
+
+### ⚠️ Param-name corrections (the `.cpp` is the source of truth; this doc was wrong)
+
+The wrappers follow `HaybaMCPUIHandler.cpp`, which differs from the contracts below:
+
+| command          | doc said                 | actual C++ reads              |
+|------------------|--------------------------|-------------------------------|
+| `ui_add_element` | `properties`             | **`slot_props`**              |
+| `ui_query`       | `widget_blueprint_path`  | **`path`**                    |
+| `ui_create_widget` | `parent_class` required | **optional** (defaults `UserWidget`) |
+
+Returns also differ from the doc: `ui_add_element` → `{widget_blueprint_path, parent,
+name, class, slot_class}`; `ui_query` → `{path, parent_class, root:{name,class,slot,children}}`.
+
+### Known gap (not blocking, worth a follow-up)
+
+The C++ handler `MarkBlueprintAsStructurallyModified` + `MarkPackageDirty` but does **not**
+compile or save. The "Compile after edits" gotcha below overstates what the handler does —
+after `ui_add_element` you likely still need an explicit save (`asset_save`) for the BP to
+survive an editor restart, and a BP compile before use.
+
+---
+
+## Why this matters (motivating case)
+
+In the Aphrosia project I built a start screen by constructing the UMG tree in **C++** (`UStartScreenWidget::BuildTree`, `WidgetTree->ConstructWidget<...>()`). It works, but two things bit us and both are symptoms of "no visual UMG authoring":
+
+1. **Fonts render as `UFontFace` preview tiles** ("BASIC LATIN / A / 0000–007F" boxes) because `FSlateFontInfo(UFontFace*, size)` does **not** render a raw Font Face — Slate needs a composite **`UFont`** asset (or a Font Face assigned through the UMG designer, which wraps it correctly). In a Widget Blueprint you just pick the font and it works.
+2. The whole start screen is binary-invisible: a `.uasset` Widget Blueprint would be designer-editable; C++ is not.
+
+If the MCP could author Widget Blueprints, agents would use Unreal's real UMG pipeline (designer-compatible, font picker works, artists can tweak).
+
+## Current state (verified this session)
+
+- **UE plugin handler is COMPLETE.** File:
+  `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.{h,cpp}`
+  - `FHaybaMCPUIHandler : IHaybaMCPHandler`, `GetDomain() == "ui"`.
+  - `GetCommands()` → `ui_create_widget`, `ui_add_element`, `ui_query`.
+  - Real implementation: `UWidgetBlueprintFactory` to create the BP, `WidgetTree->ConstructWidget`, panel-slot handling (Canvas/Horizontal/Vertical), reflection-based property setting, `FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified` + compile, asset registry notify. A `ResolveWidgetClass` map already supports Button/TextBlock/Image/CanvasPanel/HorizontalBox/VerticalBox/Overlay/ScrollBox/Border/GridPanel/UniformGridPanel/SizeBox/Spacer/CheckBox/EditableTextBox/ProgressBar/Slider, plus full class-path lookup.
+- **MCP/TS wrapper is MISSING.** `list_tool_categories` reports the `ui` domain with `callable_count: 0` and all three under `unavailable`. The legend: *"unavailable = plugin supports it but no agent wrapper exists yet (calling it errors)."*
+- `src/legacy-commands/sidecar.json` has **no `ui_*` entries** (grep returns nothing).
+
+## Command contracts (read from `HaybaMCPUIHandler.cpp` — source of truth)
+
+- **`ui_create_widget`** → creates a Widget Blueprint asset.
+  - `path` (string, required): content package dir, e.g. `/Game/Aphrosia/UI`.
+  - `name` (string, required): asset name, e.g. `WBP_StartScreen`.
+  - `parent_class` (string, required): must derive from `UserWidget`. Accepts a class path
+    like `/Script/Aphrosia.StartScreenWidget` or `/Script/UMG.UserWidget`.
+  - Returns: `{ path, parent_class }` (created asset path + resolved parent).
+- **`ui_add_element`** → adds a widget to an existing BP's tree.
+  - `widget_blueprint_path` (string, required).
+  - `child_class` (string, required): short name (e.g. `Button`, `TextBlock`, `EditableTextBox`) or full class path.
+  - `parent_widget_name` (string, optional): name of an existing **panel** widget to parent under; defaults to the root panel (errors if root isn't a panel and none given).
+  - `name` (string, optional): name for the new widget.
+  - `properties` (object, optional): slot props `x,y,w,h,fill,padding` are handled explicitly for canvas/box slots; any other key falls through to reflection (`FProperty::ImportText_Direct`) on the widget or its slot.
+  - Returns: created widget `{ class, slot{...} }`.
+- **`ui_query`** → returns the widget tree of a BP (per-widget `class` + `slot`).
+
+## What to build (TS side) — recommended route
+
+Make the three commands **natively callable** (matches how `material_*`, `actor_*` are exposed), so they work both directly and via `hayba_invoke(..., via:"ts")`.
+
+1. **Add a `ui` tool module** under `src/tools/ui/` (mirror an existing domain, e.g. `src/tools/material/`):
+   - Zod schemas for the three param contracts above.
+   - Each tool calls the UE bridge the same way other tools do — grep an existing tool for the `executeCommand('<name>', args)` / `dispatch('<name>', ...)` helper and reuse it (the invariant doc in `sidecar.json` says wrappers live under `src/tools/**`).
+   - Register the tools in the pack that the core/domain loader reads (see how `material` tools get into the `core` pack; `hayba_pack_load('core')` already lists `material_*`).
+2. **Register in the catalog** so `list_tool_categories` moves them from `unavailable` → `callable`. See `src/catalog.ts` (+ `catalog.test.ts`) for how the callable/unavailable split is computed.
+3. `npm run build` (emits `dist/`), then the user restarts Claude Code / reconnects the `hayba` MCP.
+
+### Alternate/quick route (legacy allowlist)
+
+If the ui handler is reachable through `HaybaMCPLegacyHandler`'s dispatch table, you can instead add three `sidecar.json` entries with `agent_callable: true` and `has_ts_wrapper: false`, which exposes them via `hayba_invoke(name, via:"ue_legacy")`. **But** `sidecar.json`'s own `_doc` + `scripts/check-legacy-wrappers.ts` enforce invariants: *every dispatch-table command in the `.cpp` must have a sidecar entry; `has_ts_wrapper` must match whether a `src/tools/**` call exists.* Confirm whether the `ui` domain is in the legacy dispatch table before taking this route — it's a **modern `IHaybaMCPHandler`**, so it may not be, in which case the native-TS route above is correct. Run `npm run lint:legacy-wrappers` after any sidecar edit.
+
+## Verification
+
+1. Rebuild MCP + reconnect. `list_tool_categories` → `ui` domain `callable_count: 3`.
+2. With a live editor:
+   ```
+   ui_create_widget { path:"/Game/Aphrosia/UI", name:"WBP_Test", parent_class:"/Script/UMG.UserWidget" }
+   ui_add_element  { widget_blueprint_path:"/Game/Aphrosia/UI/WBP_Test", child_class:"CanvasPanel", name:"Root" }
+   ui_add_element  { widget_blueprint_path:"/Game/Aphrosia/UI/WBP_Test", child_class:"TextBlock", parent_widget_name:"Root", name:"Title", properties:{ x:40, y:40 } }
+   ui_query        { widget_blueprint_path:"/Game/Aphrosia/UI/WBP_Test" }
+   ```
+   Expect the BP to appear in the Content Browser with a Canvas + TextBlock.
+
+## Immediate payoff for Aphrosia (once callable)
+
+Create `WBP_StartScreen` with `parent_class = /Script/Aphrosia.StartScreenWidget` (the existing C++ base keeps the auth logic + animations), then set fonts/brushes in the BP so the **font renders correctly** (fixes the UFontFace tile bug) and artists can tweak layout visually. Point `AMainMenuPlayerController` at the BP class instead of the raw C++ class.
+
+## Gotchas
+- **Fonts:** if you keep any code-set fonts, use a `UFont` composite asset, not a `UFontFace` — `FSlateFontInfo(UFontFace*, size)` shows the preview tile. The UMG designer path avoids this.
+- **Compile after edits:** `ui_add_element` should mark the BP structurally modified and compile (the handler already does this) — verify the asset is saved (`asset_save` / `EditorLoadingAndSavingUtils`) so it survives editor restart.
+- **Plugin lives via junction:** `D:\Projects\aphrosia\Plugins\HaybaMCPToolkit` and `.../geoforge/Plugins/HaybaMCPToolkit` are junctions to `D:\Hackathons\hayba\unreal\HaybaMCPToolkit` — editing the plugin here affects all of them.
+- **Engine 5.8**, BuildId 55116800. `hayba_check_ue_status` must show `connected:true` before any `ui_*` call.

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -59,6 +59,9 @@ import { materialSetMaterialPropertyHandler, meta as materialSetMaterialProperty
 import { materialCompileHandler, meta as materialCompileMeta } from './material/material-compile.js';
 import { materialDisconnectHandler, meta as materialDisconnectMeta } from './material/material-disconnect.js';
 import { materialValidateHandler, meta as materialValidateMeta } from './material/material-validate.js';
+import { uiCreateWidgetHandler, meta as uiCreateWidgetMeta } from './ui/ui-create-widget.js';
+import { uiAddElementHandler, meta as uiAddElementMeta } from './ui/ui-add-element.js';
+import { uiQueryHandler, meta as uiQueryMeta } from './ui/ui-query.js';
 import { worldGenerateHandler, meta as worldGenerateMeta } from './world/world-generate.js';
 import {
   providerListHandler, providerListMeta,
@@ -238,6 +241,7 @@ const dCoerceVec3 = z.preprocess((v) => {
  * are now generated automatically from this list.
  */
 const M = 'material'; // niche domain for the material toolset
+const UI = 'ui'; // niche domain for the UMG / Widget Blueprint toolset
 const PACK = 'copilot'; // niche domain for the BYOK copilot config/introspection toolset
 // Hand-written descriptors. Kept as a named const so the generated legacy list
 // can be de-duplicated against these names before splicing (see below).
@@ -672,6 +676,55 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
         to_input: z.string().optional().describe('Input pin name on the target node (defaults to first input)'),
         to_input_index: z.number().int().nonnegative().optional().describe('Zero-based input pin index (alternative to to_input)'),
         to_property: z.string().optional().describe('Material output property name to disconnect (e.g. base_color, normal)'),
+      },
+    },
+
+    // ── UMG / Widget Blueprint domain ─────────────────────────────────────────
+    // Native TS wrappers over the modern FHaybaMCPUIHandler (GetDomain()=="ui").
+    // Param names mirror HaybaMCPUIHandler.cpp exactly (the source of truth):
+    // ui_add_element takes slot_props (not "properties"); ui_query takes path
+    // (not widget_blueprint_path).
+    {
+      name: 'ui_create_widget',
+      description: 'Create a new UMG Widget Blueprint asset (designer-editable UI). Seeds a root CanvasPanel. Use the real UMG pipeline instead of hand-building the tree in C++.',
+      meta: uiCreateWidgetMeta,
+      handler: uiCreateWidgetHandler,
+      cost: 'medium',
+      returns: '{path, name, parent_class, root?}',
+      niche: UI,
+      schema: {
+        path: z.string().min(1).describe('UE content package directory, e.g. "/Game/Aphrosia/UI"'),
+        name: z.string().min(1).describe('Asset name, e.g. "WBP_StartScreen"'),
+        parent_class: z.string().optional().describe('Parent class (must descend from UserWidget); class path or short name. Defaults to UserWidget.'),
+      },
+    },
+    {
+      name: 'ui_add_element',
+      description: 'Add a widget (Button/TextBlock/Image/panel/…) to an existing Widget Blueprint tree, optionally under a named panel, with slot layout props. Marks the BP structurally modified + dirty.',
+      meta: uiAddElementMeta,
+      handler: uiAddElementHandler,
+      cost: 'medium',
+      returns: '{widget_blueprint_path, parent, name, class, slot_class}',
+      niche: UI,
+      schema: {
+        widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+        child_class: z.string().min(1).describe('Widget class — short name (Button, TextBlock, CanvasPanel, HorizontalBox, …) or full class path'),
+        parent_widget_name: z.string().optional().describe('Name of an existing PANEL widget to parent under; defaults to the root panel'),
+        name: z.string().optional().describe('Name for the new widget (auto-generated if omitted)'),
+        slot_props: z.record(z.union([z.number(), z.string(), z.boolean()])).optional()
+          .describe('Slot layout props: x/y/w/h (canvas), fill/padding (box); other keys set on the slot by reflection'),
+      },
+    },
+    {
+      name: 'ui_query',
+      description: 'Return the widget tree of a Widget Blueprint — per-widget name, class, slot (offsets/fill/padding) and nested children.',
+      meta: uiQueryMeta,
+      handler: uiQueryHandler,
+      cost: 'low',
+      returns: '{path, parent_class, root:{name, class, slot, children:[…]}}',
+      niche: UI,
+      schema: {
+        path: z.string().min(1).describe('Full path of the Widget Blueprint to inspect'),
       },
     },
 
@@ -1168,12 +1221,17 @@ export async function registerTools(server: McpServer, session: SessionManagerSt
 /**
  * Infer the pack-source directory for a tool name by matching against the
  * known top-level dirs under src/tools/. Root-level tools return null.
+ *
+ * Exported so the deferred-routing regression tests can assert a domain's
+ * tools group under the expected pack (the "hidden until searched" surface —
+ * deriveDomainPacks buckets by this dir, and ToolIndex indexes by it).
  */
-function inferDir(name: string): string | null {
+export function inferDir(name: string): string | null {
   if (name.startsWith('actor_'))          return 'actor';
   if (name.startsWith('scene_'))          return 'scene';
   if (name.startsWith('editor_'))         return 'editor';
   if (name.startsWith('material_'))       return 'material';
+  if (name.startsWith('ui_'))             return 'ui';
   if (name.startsWith('hayba_fab_'))      return 'fab';
   if (name.startsWith('hayba_polyhaven_'))return 'asset-sources';
   if (name.startsWith('hayba_ambientcg_'))return 'asset-sources';

--- a/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
+++ b/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
@@ -33,6 +33,26 @@ INSTANCE LAYER
   material_set_param           Set a scalar, vector (rgba), or texture parameter on a material instance
   material_apply               Apply a material (or instance) to an actor in the level
 `.trim(),
+
+  ui: `
+UMG / WIDGET BLUEPRINT TOOLSET (3 tools) — first-touch briefing
+================================================================
+Author designer-editable UI the real UMG way (font picker works, artists can
+tweak) instead of hand-building the tree in C++. Param names mirror the C++
+handler exactly.
+
+  ui_create_widget   Create a Widget Blueprint asset (seeds a root CanvasPanel).
+                     path + name (+ optional parent_class descending from UserWidget).
+  ui_add_element     Add a widget to an existing BP tree. widget_blueprint_path +
+                     child_class (Button/TextBlock/Image/CanvasPanel/…), optional
+                     parent_widget_name (a panel), name, and slot_props
+                     (x/y/w/h for canvas, fill/padding for boxes).
+  ui_query           Read back the widget tree: per-widget name/class/slot/children.
+
+Tip: pass parent_class="/Script/<Module>.<CppWidget>" to keep C++ logic while
+setting fonts/brushes visually in the BP — this fixes the UFontFace preview-tile
+bug (Slate needs a composite UFont, or a font assigned through the designer).
+`.trim(),
 };
 
 /**

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-add-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-add-element.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'adding a widget (Button/TextBlock/Image/panels/…) to an existing Widget Blueprint tree',
+  not_when: 'creating the Widget Blueprint itself (use ui_create_widget first)',
+};
+
+// slot_props keys x/y/w/h (canvas offsets), fill/padding (box slots) are handled
+// explicitly by the C++ handler; any other key falls through to reflection on the
+// slot object. Values are primitives (number/string/bool) — see HaybaMCPUIHandler.cpp.
+export const schema = z.object({
+  widget_blueprint_path: z
+    .string()
+    .min(1)
+    .describe('Full path of the target Widget Blueprint, e.g. "/Game/Aphrosia/UI/WBP_StartScreen"'),
+  child_class: z
+    .string()
+    .min(1)
+    .describe(
+      'Widget class to add — short name (Button, TextBlock, Image, CanvasPanel, HorizontalBox, VerticalBox, Overlay, ScrollBox, Border, GridPanel, UniformGridPanel, SizeBox, Spacer, CheckBox, EditableTextBox, ProgressBar, Slider) or a full class path.',
+    ),
+  parent_widget_name: z
+    .string()
+    .optional()
+    .describe('Name of an existing PANEL widget to parent under. Defaults to the root panel; errors if the root is not a panel and none is given.'),
+  name: z.string().optional().describe('Name for the new widget (auto-generated if omitted).'),
+  slot_props: z
+    .record(z.union([z.number(), z.string(), z.boolean()]))
+    .optional()
+    .describe(
+      'Slot layout props. Canvas slot: x, y, w, h (offsets). Box slot: fill, padding. Any other key is set on the slot by reflection.',
+    ),
+});
+
+export const uiAddElementHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_add_element', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-create-widget.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-create-widget.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['creates_asset'],
+  when: 'creating a new UMG Widget Blueprint asset (designer-editable UI) in the project',
+  not_when: 'adding a widget to an EXISTING Widget Blueprint (use ui_add_element)',
+};
+
+export const schema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe('UE content package directory for the new Widget Blueprint, e.g. "/Game/Aphrosia/UI"'),
+  name: z.string().min(1).describe('Asset name for the new Widget Blueprint, e.g. "WBP_StartScreen"'),
+  parent_class: z
+    .string()
+    .optional()
+    .describe(
+      'Parent class the widget derives from — MUST descend from UserWidget. A class path like "/Script/Aphrosia.StartScreenWidget" or "/Script/UMG.UserWidget", or a short name. Defaults to UserWidget.',
+    ),
+});
+
+export const uiCreateWidgetHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_create_widget', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'inspecting the widget tree of an existing Widget Blueprint (per-widget class + slot + children)',
+  not_when: 'you are mutating the tree (use ui_add_element)',
+};
+
+export const schema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe('Full path of the Widget Blueprint to inspect, e.g. "/Game/Aphrosia/UI/WBP_StartScreen"'),
+});
+
+export const uiQueryHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_query', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-tools.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-tools.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { InMemoryToolExecutor, setDefaultSender } from '../tool-executor.js';
+import { inferDir } from '../index.js';
+import { deriveDomainPacks } from '../routing/pack-discovery.js';
+import { uiCreateWidgetHandler } from './ui-create-widget.js';
+import { uiAddElementHandler } from './ui-add-element.js';
+import { uiQueryHandler } from './ui-query.js';
+
+const UI_TOOLS = ['ui_create_widget', 'ui_add_element', 'ui_query'] as const;
+
+/**
+ * Smoke test for the three UMG / Widget Blueprint wrapper tools:
+ * - ui_create_widget
+ * - ui_add_element
+ * - ui_query
+ *
+ * Asserts each wrapper is (1) declared as a descriptor consumed by the
+ * registerTool/recordToolSchema loops so it is registered + schema-recorded
+ * (→ callable via hayba_invoke and surfaced by list_tool_categories), (2) wired
+ * to executeCommand with the correct command name, and (3) forwards the exact
+ * param names the C++ handler reads (HaybaMCPUIHandler.cpp is the source of
+ * truth: ui_add_element→slot_props, ui_query→path).
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexSrc = readFileSync(join(__dirname, '..', 'index.ts'), 'utf-8');
+
+const REGISTRAR_LOOP = /for\s*\(\s*const\s+d\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*registerTool\(/;
+const SCHEMA_LOOP = /for\s*\(\s*const\s+d\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*recordToolSchema\(/;
+function isToolRegistered(name: string): boolean {
+  const descriptor = new RegExp(`name:\\s*['"]${name}['"]`);
+  return descriptor.test(indexSrc) && REGISTRAR_LOOP.test(indexSrc);
+}
+function isSchemaRecorded(name: string): boolean {
+  const descriptor = new RegExp(`name:\\s*['"]${name}['"]`);
+  return descriptor.test(indexSrc) && SCHEMA_LOOP.test(indexSrc);
+}
+
+/** Text of the first content block of a ToolResult. */
+function textOf(r: { content: Array<{ type: string; text: string }> }): string {
+  return r.content[0].text;
+}
+
+describe('UMG / Widget Blueprint wrappers', () => {
+  describe('ui_create_widget', () => {
+    it('is registered + schema-recorded via the descriptor loops', () => {
+      expect(isToolRegistered('ui_create_widget')).toBe(true);
+      expect(isSchemaRecorded('ui_create_widget')).toBe(true);
+    });
+
+    it('dispatches ui_create_widget with path/name/parent_class', async () => {
+      const exec = new InMemoryToolExecutor().on('ui_create_widget', (p) => {
+        expect(p).toMatchObject({ path: '/Game/UI', name: 'WBP_Test', parent_class: '/Script/UMG.UserWidget' });
+        return { ok: true, data: { path: '/Game/UI/WBP_Test.WBP_Test', name: 'WBP_Test' } };
+      });
+      setDefaultSender(exec.send);
+      const r = await uiCreateWidgetHandler(
+        { path: '/Game/UI', name: 'WBP_Test', parent_class: '/Script/UMG.UserWidget' },
+        undefined as never,
+      );
+      expect(r.isError).toBeFalsy();
+      expect(textOf(r)).toContain('WBP_Test');
+    });
+
+    it('rejects missing required fields', async () => {
+      const r = await uiCreateWidgetHandler({ path: '/Game/UI' }, undefined as never);
+      expect(r.isError).toBe(true);
+      expect(textOf(r)).toMatch(/Validation error/);
+    });
+  });
+
+  describe('ui_add_element', () => {
+    it('is registered + schema-recorded via the descriptor loops', () => {
+      expect(isToolRegistered('ui_add_element')).toBe(true);
+      expect(isSchemaRecorded('ui_add_element')).toBe(true);
+    });
+
+    it('forwards slot_props verbatim (matches the C++ param name)', async () => {
+      const exec = new InMemoryToolExecutor().on('ui_add_element', (p) => {
+        expect(p).toMatchObject({
+          widget_blueprint_path: '/Game/UI/WBP_Test',
+          child_class: 'TextBlock',
+          parent_widget_name: 'Root',
+          slot_props: { x: 40, y: 40 },
+        });
+        return { ok: true, data: { name: 'TextBlock_0', class: 'TextBlock' } };
+      });
+      setDefaultSender(exec.send);
+      const r = await uiAddElementHandler(
+        {
+          widget_blueprint_path: '/Game/UI/WBP_Test',
+          child_class: 'TextBlock',
+          parent_widget_name: 'Root',
+          slot_props: { x: 40, y: 40 },
+        },
+        undefined as never,
+      );
+      expect(r.isError).toBeFalsy();
+      expect(textOf(r)).toContain('TextBlock');
+    });
+  });
+
+  // In deferred routing (the default "hidden until searched" mode) tools are
+  // captured, indexed for hayba_search_tools, and bucketed into a domain pack by
+  // inferDir. This proves the ui_* tools land in their own loadable 'ui' pack.
+  describe('deferred routing / pack discovery', () => {
+    it('groups every ui_* tool under the "ui" dir', () => {
+      for (const name of UI_TOOLS) {
+        expect(inferDir(name), name).toBe('ui');
+      }
+    });
+
+    it('derives a loadable "ui" domain pack containing all three tools', () => {
+      const toolDirs = new Map<string, string | null>(UI_TOOLS.map((n) => [n, inferDir(n)]));
+      const packs = deriveDomainPacks(toolDirs, new Map());
+      const ui = packs.find((p) => p.name === 'ui');
+      expect(ui).toBeDefined();
+      expect(ui!.kind).toBe('domain');
+      expect(ui!.tools.sort()).toEqual([...UI_TOOLS].sort());
+    });
+  });
+
+  describe('ui_query', () => {
+    it('is registered + schema-recorded via the descriptor loops', () => {
+      expect(isToolRegistered('ui_query')).toBe(true);
+      expect(isSchemaRecorded('ui_query')).toBe(true);
+    });
+
+    it('dispatches ui_query with path (not widget_blueprint_path)', async () => {
+      const exec = new InMemoryToolExecutor().on('ui_query', (p) => {
+        expect(p).toEqual({ path: '/Game/UI/WBP_Test' });
+        return { ok: true, data: { path: '/Game/UI/WBP_Test', root: { class: 'CanvasPanel' } } };
+      });
+      setDefaultSender(exec.send);
+      const r = await uiQueryHandler(
+        { path: '/Game/UI/WBP_Test' },
+        undefined as never,
+      );
+      expect(r.isError).toBeFalsy();
+      expect(textOf(r)).toContain('CanvasPanel');
+    });
+  });
+});


### PR DESCRIPTION
## What

Makes the three UMG commands **agent-callable** via the MCP so an agent can author & edit Widget Blueprints in a live UE editor instead of hand-building the tree in C++. The `ui` domain moves from `callable_count: 0` → `3` in `list_tool_categories`.

- `ui_create_widget` — create a Widget Blueprint asset (seeds a root CanvasPanel)
- `ui_add_element` — add a widget to an existing BP tree, under a named panel, with slot props
- `ui_query` — read back the widget tree (per-widget name/class/slot/children)

## How

Native-TS wrappers over the modern `FHaybaMCPUIHandler` (the plugin handler already existed; only the agent wrapper was missing).

- `src/tools/ui/{ui-create-widget,ui-add-element,ui-query}.ts` — Zod schema + handler calling `executeCommand('ui_*')`, mirroring the `material_*` wrappers.
- `src/tools/index.ts` — three `ToolDescriptor` entries (`niche: ui`), the `UI` const, and `inferDir('ui_') → 'ui'`. Registering the descriptors records their schemas (→ callable + `hayba_invoke via:"ts"`) and, under the default **deferred routing**, captures + indexes them for `hayba_search_tools` and buckets them into a loadable **`ui` domain pack** (`hayba_pack_load('ui')`) — the hidden-until-searched surface.
- `src/tools/niche-briefing.ts` — a `ui` first-touch briefing.
- `src/tools/ui/ui-tools.test.ts` — 9 tests: registration + schema-record + dispatch + exact param names + pack-discovery.

### Route note
Native-TS, **not** the legacy sidecar allowlist — the `ui` domain is a modern `IHaybaMCPHandler`, absent from the C++ legacy dispatch table. `lint:legacy-wrappers` stays green with zero sidecar edits.

### ⚠️ Param names follow `HaybaMCPUIHandler.cpp` (source of truth), which differs from the handoff doc
| command | doc said | actual C++ |
|---|---|---|
| `ui_add_element` | `properties` | **`slot_props`** |
| `ui_query` | `widget_blueprint_path` | **`path`** |
| `ui_create_widget` | `parent_class` required | **optional** (defaults `UserWidget`) |

### Known gap (follow-up, not blocking)
The C++ handler marks the BP structurally-modified + dirty but does **not** compile or save — after `ui_add_element` an explicit `asset_save` (+ BP compile) is likely still needed for edits to survive an editor restart.

## Verification
- `npm run typecheck` — clean (also runs as pre-commit hook)
- `npm run lint:legacy-wrappers` — OK, no violations
- `npx vitest run` — **955 passed / 113 files**, incl. the 9 new UI tests
- `npm run build:server` — emits `dist/tools/ui/*.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools for creating UMG Widget Blueprints, adding elements, and querying widget contents.
  * Added automatic discovery and routing for the new UI toolset.
  * Added contextual guidance for using UMG/Widget Blueprint tools.
* **Bug Fixes**
  * Improved validation and error reporting for invalid UI tool inputs.
* **Tests**
  * Added coverage confirming tool registration, parameter handling, routing, and successful results.
* **Documentation**
  * Added a handoff guide covering setup, usage, verification, and practical considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->