### PR TITLE
fix(ui): register generated widget GUIDs

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPUIHandlerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPUIHandlerTest.cpp
@@ -1,0 +1,59 @@
+#include "Misc/AutomationTest.h"
+
+#if WITH_EDITOR
+#include "EditorAssetLibrary.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "WidgetBlueprint.h"
+#include "handlers/HaybaMCPUIHandler.h"
+#endif
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaMCPUIWidgetGuidTest,
+    "Hayba.MCP.UI.WidgetGuidRegistration",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaMCPUIWidgetGuidTest::RunTest(const FString& Parameters)
+{
+#if WITH_EDITOR
+    const FString AssetName = FString::Printf(TEXT("WBP_WidgetGuid_%s"), *FGuid::NewGuid().ToString(EGuidFormats::Digits));
+    const FString PackagePath = TEXT("/Game/HaybaMCPAutomation");
+    const FString AssetPath = FString::Printf(TEXT("%s/%s"), *PackagePath, *AssetName);
+
+    FHaybaMCPUIHandler Handler;
+
+    TSharedPtr<FJsonObject> CreateParams = MakeShared<FJsonObject>();
+    CreateParams->SetStringField(TEXT("path"), PackagePath);
+    CreateParams->SetStringField(TEXT("name"), AssetName);
+    CreateParams->SetStringField(TEXT("parent_class"), TEXT("UserWidget"));
+    const FHaybaHandlerResult CreateResult = Handler.Handle(TEXT("ui_create_widget"), CreateParams);
+    TestTrue(TEXT("ui_create_widget succeeds"), CreateResult.bOk);
+
+    FString ObjectPath;
+    if (CreateResult.bOk && CreateResult.Data.IsValid())
+    {
+        CreateResult.Data->TryGetStringField(TEXT("path"), ObjectPath);
+    }
+
+    TSharedPtr<FJsonObject> AddParams = MakeShared<FJsonObject>();
+    AddParams->SetStringField(TEXT("widget_blueprint_path"), ObjectPath);
+    AddParams->SetStringField(TEXT("child_class"), TEXT("Button"));
+    AddParams->SetStringField(TEXT("name"), TEXT("TestButton"));
+    const FHaybaHandlerResult AddResult = Handler.Handle(TEXT("ui_add_element"), AddParams);
+    TestTrue(TEXT("ui_add_element succeeds"), AddResult.bOk);
+
+    UWidgetBlueprint* WidgetBlueprint = LoadObject<UWidgetBlueprint>(nullptr, *ObjectPath);
+    if (TestNotNull(TEXT("created widget blueprint loads"), WidgetBlueprint))
+    {
+        const FGuid* RootGuid = WidgetBlueprint->WidgetVariableNameToGuidMap.Find(TEXT("RootCanvas"));
+        const FGuid* ButtonGuid = WidgetBlueprint->WidgetVariableNameToGuidMap.Find(TEXT("TestButton"));
+        TestTrue(TEXT("root widget has a valid variable GUID"), RootGuid && RootGuid->IsValid());
+        TestTrue(TEXT("added widget has a valid variable GUID"), ButtonGuid && ButtonGuid->IsValid());
+
+        FKismetEditorUtilities::CompileBlueprint(WidgetBlueprint);
+        TestEqual(TEXT("widget blueprint compiles successfully"), WidgetBlueprint->Status, BS_UpToDate);
+    }
+
+    TestTrue(TEXT("temporary widget blueprint is deleted"), UEditorAssetLibrary::DeleteAsset(AssetPath));
+#endif
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -53,6 +53,20 @@ TArray<FString> FHaybaMCPUIHandler::GetCommands() const
 
 namespace
 {
+    void RegisterWidgetVariable(UWidgetBlueprint* WidgetBlueprint, UWidget* Widget)
+    {
+        if (!WidgetBlueprint || !Widget)
+        {
+            return;
+        }
+
+        const FName WidgetName = Widget->GetFName();
+        if (!WidgetBlueprint->WidgetVariableNameToGuidMap.Contains(WidgetName))
+        {
+            WidgetBlueprint->OnVariableAdded(WidgetName);
+        }
+    }
+
     UClass* ResolveWidgetClass(const FString& Name)
     {
         // Try common UMG widget classes by short name first.
@@ -266,6 +280,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::Handle(const FString& Cmd, const TShared
         {
             UCanvasPanel* Root = WBP->WidgetTree->ConstructWidget<UCanvasPanel>(UCanvasPanel::StaticClass(), TEXT("RootCanvas"));
             WBP->WidgetTree->RootWidget = Root;
+            RegisterWidgetVariable(WBP, Root);
             FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
         }
 
@@ -323,6 +338,11 @@ FHaybaHandlerResult FHaybaMCPUIHandler::Handle(const FString& Cmd, const TShared
         UPanelSlot* NewSlot = Parent->AddChild(NewChild);
         if (!NewSlot)
             return FHaybaHandlerResult::Err(TEXT("ui_add_element: AddChild rejected (panel may be full or incompatible)"));
+
+        // Widget blueprints track every designer widget by a stable GUID. ConstructWidget
+        // does not update that map, and compiling a partially populated map triggers an
+        // ensure in UMGEditor (and leaves references vulnerable to rename breakage).
+        RegisterWidgetVariable(WBP, NewChild);
 
         const TSharedPtr<FJsonObject>* SlotProps = nullptr;
         if (P->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid())


### PR DESCRIPTION
## Summary
- register the default root widget with UWidgetBlueprint's variable GUID map
- register widgets added through ui_add_element before structural compilation
- add an editor automation regression covering creation, GUID validity, and compilation

## Validation
- UE 5.8 BuildPlugin (Win64): passed
- Hayba.MCP.UI.WidgetGuidRegistration: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI widget creation so newly created root and child widgets receive valid identifiers immediately.
  * Ensured widget registrations remain available before blueprint compilation and saving.

* **Tests**
  * Added automated editor coverage verifying widget identifier registration and successful blueprint compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->