### PR TITLE
UMG toolset overhaul + UI validation engine

### DIFF
--- a/HANDOFF-umg-authoring.md
+++ b/HANDOFF-umg-authoring.md
@@ -1,0 +1,117 @@
+# Handoff: Enable UMG (Widget Blueprint) authoring through the Hayba MCP
+
+**Author of handoff:** Claude (Aphrosia session), 2026-07-19
+**Audience:** the next Claude/dev working in `D:\Hackathons\hayba`
+**One-line goal:** make `ui_create_widget` / `ui_add_element` / `ui_query` **agent-callable** so an agent can build & edit UMG Widget Blueprints in a live UE editor via the MCP — instead of hand-writing UMG in C++.
+
+---
+
+## ✅ DONE (2026-07-19) — native-TS route
+
+The TS wrappers now exist. `list_tool_categories` will report the `ui` domain with
+`callable_count: 3` after reconnect. What was added (all in `mcp-tools/hayba-mcp`):
+
+- `src/tools/ui/ui-create-widget.ts`, `ui-add-element.ts`, `ui-query.ts` — Zod
+  schemas + handlers calling `executeCommand('ui_*', args)` (mirrors `material_*`).
+- `src/tools/index.ts` — 3 `ToolDescriptor` entries in `HANDWRITTEN_STANDARD_DESCRIPTORS`
+  (`niche: UI`), the `UI` niche const, and an `inferDir('ui_') → 'ui'` pack entry.
+- `src/tools/niche-briefing.ts` — a `ui` first-touch briefing.
+- `src/tools/ui/ui-tools.test.ts` — 7 passing tests (registration + dispatch + param names).
+- Built to `dist/`; typecheck + `lint:legacy-wrappers` green. **Legacy route NOT used**
+  — the `ui` domain is a modern `IHaybaMCPHandler`, absent from the C++ legacy dispatch
+  table, so the native-TS route was correct (confirmed: lint stays green with no sidecar edits).
+
+### ⚠️ Param-name corrections (the `.cpp` is the source of truth; this doc was wrong)
+
+The wrappers follow `HaybaMCPUIHandler.cpp`, which differs from the contracts below:
+
+| command          | doc said                 | actual C++ reads              |
+|------------------|--------------------------|-------------------------------|
+| `ui_add_element` | `properties`             | **`slot_props`**              |
+| `ui_query`       | `widget_blueprint_path`  | **`path`**                    |
+| `ui_create_widget` | `parent_class` required | **optional** (defaults `UserWidget`) |
+
+Returns also differ from the doc: `ui_add_element` → `{widget_blueprint_path, parent,
+name, class, slot_class}`; `ui_query` → `{path, parent_class, root:{name,class,slot,children}}`.
+
+### Known gap (not blocking, worth a follow-up)
+
+The C++ handler `MarkBlueprintAsStructurallyModified` + `MarkPackageDirty` but does **not**
+compile or save. The "Compile after edits" gotcha below overstates what the handler does —
+after `ui_add_element` you likely still need an explicit save (`asset_save`) for the BP to
+survive an editor restart, and a BP compile before use.
+
+---
+
+## Why this matters (motivating case)
+
+In the Aphrosia project I built a start screen by constructing the UMG tree in **C++** (`UStartScreenWidget::BuildTree`, `WidgetTree->ConstructWidget<...>()`). It works, but two things bit us and both are symptoms of "no visual UMG authoring":
+
+1. **Fonts render as `UFontFace` preview tiles** ("BASIC LATIN / A / 0000–007F" boxes) because `FSlateFontInfo(UFontFace*, size)` does **not** render a raw Font Face — Slate needs a composite **`UFont`** asset (or a Font Face assigned through the UMG designer, which wraps it correctly). In a Widget Blueprint you just pick the font and it works.
+2. The whole start screen is binary-invisible: a `.uasset` Widget Blueprint would be designer-editable; C++ is not.
+
+If the MCP could author Widget Blueprints, agents would use Unreal's real UMG pipeline (designer-compatible, font picker works, artists can tweak).
+
+## Current state (verified this session)
+
+- **UE plugin handler is COMPLETE.** File:
+  `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.{h,cpp}`
+  - `FHaybaMCPUIHandler : IHaybaMCPHandler`, `GetDomain() == "ui"`.
+  - `GetCommands()` → `ui_create_widget`, `ui_add_element`, `ui_query`.
+  - Real implementation: `UWidgetBlueprintFactory` to create the BP, `WidgetTree->ConstructWidget`, panel-slot handling (Canvas/Horizontal/Vertical), reflection-based property setting, `FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified` + compile, asset registry notify. A `ResolveWidgetClass` map already supports Button/TextBlock/Image/CanvasPanel/HorizontalBox/VerticalBox/Overlay/ScrollBox/Border/GridPanel/UniformGridPanel/SizeBox/Spacer/CheckBox/EditableTextBox/ProgressBar/Slider, plus full class-path lookup.
+- **MCP/TS wrapper is MISSING.** `list_tool_categories` reports the `ui` domain with `callable_count: 0` and all three under `unavailable`. The legend: *"unavailable = plugin supports it but no agent wrapper exists yet (calling it errors)."*
+- `src/legacy-commands/sidecar.json` has **no `ui_*` entries** (grep returns nothing).
+
+## Command contracts (read from `HaybaMCPUIHandler.cpp` — source of truth)
+
+- **`ui_create_widget`** → creates a Widget Blueprint asset.
+  - `path` (string, required): content package dir, e.g. `/Game/Aphrosia/UI`.
+  - `name` (string, required): asset name, e.g. `WBP_StartScreen`.
+  - `parent_class` (string, required): must derive from `UserWidget`. Accepts a class path
+    like `/Script/Aphrosia.StartScreenWidget` or `/Script/UMG.UserWidget`.
+  - Returns: `{ path, parent_class }` (created asset path + resolved parent).
+- **`ui_add_element`** → adds a widget to an existing BP's tree.
+  - `widget_blueprint_path` (string, required).
+  - `child_class` (string, required): short name (e.g. `Button`, `TextBlock`, `EditableTextBox`) or full class path.
+  - `parent_widget_name` (string, optional): name of an existing **panel** widget to parent under; defaults to the root panel (errors if root isn't a panel and none given).
+  - `name` (string, optional): name for the new widget.
+  - `properties` (object, optional): slot props `x,y,w,h,fill,padding` are handled explicitly for canvas/box slots; any other key falls through to reflection (`FProperty::ImportText_Direct`) on the widget or its slot.
+  - Returns: created widget `{ class, slot{...} }`.
+- **`ui_query`** → returns the widget tree of a BP (per-widget `class` + `slot`).
+
+## What to build (TS side) — recommended route
+
+Make the three commands **natively callable** (matches how `material_*`, `actor_*` are exposed), so they work both directly and via `hayba_invoke(..., via:"ts")`.
+
+1. **Add a `ui` tool module** under `src/tools/ui/` (mirror an existing domain, e.g. `src/tools/material/`):
+   - Zod schemas for the three param contracts above.
+   - Each tool calls the UE bridge the same way other tools do — grep an existing tool for the `executeCommand('<name>', args)` / `dispatch('<name>', ...)` helper and reuse it (the invariant doc in `sidecar.json` says wrappers live under `src/tools/**`).
+   - Register the tools in the pack that the core/domain loader reads (see how `material` tools get into the `core` pack; `hayba_pack_load('core')` already lists `material_*`).
+2. **Register in the catalog** so `list_tool_categories` moves them from `unavailable` → `callable`. See `src/catalog.ts` (+ `catalog.test.ts`) for how the callable/unavailable split is computed.
+3. `npm run build` (emits `dist/`), then the user restarts Claude Code / reconnects the `hayba` MCP.
+
+### Alternate/quick route (legacy allowlist)
+
+If the ui handler is reachable through `HaybaMCPLegacyHandler`'s dispatch table, you can instead add three `sidecar.json` entries with `agent_callable: true` and `has_ts_wrapper: false`, which exposes them via `hayba_invoke(name, via:"ue_legacy")`. **But** `sidecar.json`'s own `_doc` + `scripts/check-legacy-wrappers.ts` enforce invariants: *every dispatch-table command in the `.cpp` must have a sidecar entry; `has_ts_wrapper` must match whether a `src/tools/**` call exists.* Confirm whether the `ui` domain is in the legacy dispatch table before taking this route — it's a **modern `IHaybaMCPHandler`**, so it may not be, in which case the native-TS route above is correct. Run `npm run lint:legacy-wrappers` after any sidecar edit.
+
+## Verification
+
+1. Rebuild MCP + reconnect. `list_tool_categories` → `ui` domain `callable_count: 3`.
+2. With a live editor:
+   ```
+   ui_create_widget { path:"/Game/Aphrosia/UI", name:"WBP_Test", parent_class:"/Script/UMG.UserWidget" }
+   ui_add_element  { widget_blueprint_path:"/Game/Aphrosia/UI/WBP_Test", child_class:"CanvasPanel", name:"Root" }
+   ui_add_element  { widget_blueprint_path:"/Game/Aphrosia/UI/WBP_Test", child_class:"TextBlock", parent_widget_name:"Root", name:"Title", properties:{ x:40, y:40 } }
+   ui_query        { widget_blueprint_path:"/Game/Aphrosia/UI/WBP_Test" }
+   ```
+   Expect the BP to appear in the Content Browser with a Canvas + TextBlock.
+
+## Immediate payoff for Aphrosia (once callable)
+
+Create `WBP_StartScreen` with `parent_class = /Script/Aphrosia.StartScreenWidget` (the existing C++ base keeps the auth logic + animations), then set fonts/brushes in the BP so the **font renders correctly** (fixes the UFontFace tile bug) and artists can tweak layout visually. Point `AMainMenuPlayerController` at the BP class instead of the raw C++ class.
+
+## Gotchas
+- **Fonts:** if you keep any code-set fonts, use a `UFont` composite asset, not a `UFontFace` — `FSlateFontInfo(UFontFace*, size)` shows the preview tile. The UMG designer path avoids this.
+- **Compile after edits:** `ui_add_element` should mark the BP structurally modified and compile (the handler already does this) — verify the asset is saved (`asset_save` / `EditorLoadingAndSavingUtils`) so it survives editor restart.
+- **Plugin lives via junction:** `D:\Projects\aphrosia\Plugins\HaybaMCPToolkit` and `.../geoforge/Plugins/HaybaMCPToolkit` are junctions to `D:\Hackathons\hayba\unreal\HaybaMCPToolkit` — editing the plugin here affects all of them.
+- **Engine 5.8**, BuildId 55116800. `hayba_check_ue_status` must show `connected:true` before any `ui_*` call.

--- a/docs/HANDOFF-mcp-pcg-graph-parameters-tool.md
+++ b/docs/HANDOFF-mcp-pcg-graph-parameters-tool.md
@@ -1,0 +1,78 @@
+# Handoff — Add an MCP tool to author PCG graph user-parameters
+
+**Author:** Claude (Opus 4.8), session 4df015f5 — building the Plumb composable spline-room system.
+**Audience:** the next Claude implementing a new `HaybaMCPToolkit` command.
+**Date:** 2026-06-29
+
+## Why this tool is needed
+
+The Plumb composability keystone is "swap one style config → the whole room restyles, zero graph edits." The canonical UE way to do that is **PCG graph user-parameters** (exposed on the graph) driven by **`PCGGraphInstance`** style assets that override those parameters. From a script-driven agent (me, via `python_run`) I can:
+
+- **SET** existing graph-parameter values — `unreal.PCGGraphParametersHelpers.set_object_parameter(...)` etc. ✅
+- **READ** them, and create the `PCGUserParameterGetSettings` node to consume them in-graph. ✅
+- **ADD** a new user-parameter to a graph — ❌ **NOT POSSIBLE from Python.**
+
+### Root cause (verified this session)
+- A PCG graph's `user_parameters` is an `FInstancedPropertyBag` (Python: `unreal.InstancedPropertyBag`). Its Python surface is only `get/set_editor_property`, `import_text`, `export_text`, `assign`, `copy` — **no add-property method.**
+- The property *definitions* live in a dynamically-generated transient `UPropertyBag` struct (`export_text()` returns `(Value=/Engine/Transient.PropertyBag_<hash>())`). Defining a new property is done by C++ `FInstancedPropertyBag::AddProperty(...)`, which is **not bound to Python/Blueprint**.
+- `StructUtilsFunctionLibrary` and `BlueprintInstancedStructLibrary` only expose equality/validity helpers — no add-property.
+- The Python enum `unreal.PropertyBagPropertyType` lists only **scalar** types (`BOOL, BYTE, DOUBLE, FLOAT, INT32, INT64, NAME, STRING, TEXT, U_INT32, U_INT64`) — **no `Object`/`SoftObject`/`Struct`/`Class`/`Enum`**, so even a value-only path can't represent a kit (`PCGExMeshCollection*`) parameter.
+
+Result: the agent must ask a human to add parameters in the editor Details panel — a collaboration break the user explicitly wants removed. Hence this tool.
+
+## What to build
+
+A toolkit command (handler), e.g. **`pcg_graph_add_parameter`**, callable over the MCP, that adds (and optionally sets the default of) a user-parameter on a `UPCGGraph`. C++ has full access to `FInstancedPropertyBag::AddProperty` and `FPropertyBagPropertyDesc`, including object/struct/class types.
+
+### Proposed signature
+```
+pcg_graph_add_parameter({
+  graph: "/Game/Plumb/Graphs/Sub/SG_WallFacade",   // package path of the UPCGGraph
+  name:  "WallKit",                                  // parameter name
+  type:  "Object",                                   // Bool|Byte|Int32|Int64|Float|Double|Name|String|Text|Enum|Struct|Object|SoftObject|Class|SoftClass
+  valueClass: "/Script/PCGExtendedToolkit.PCGExMeshCollection", // for Object/Class/SoftObject/SoftClass/Struct/Enum: the type's class/struct/enum path
+  container: "None",                                 // optional: None|Array|Set
+  defaultValue: "/Game/Plumb/Kits/Kit_WallBay",      // optional: asset path (object types) or literal (scalars)
+  overwrite: false                                    // if the name exists: error vs replace
+})
+```
+Return: `{ ok, added: bool, name, type, paramCount }`.
+
+A companion **`pcg_graph_list_parameters`** (name/type/default per param) is cheap and very useful for the agent to verify and to drive `set_*_parameter` afterward.
+
+### Implementation sketch (C++)
+1. Load the graph: `UPCGGraph* Graph = LoadObject<UPCGGraph>(...)`.
+2. Get the mutable bag. PCG exposes the user-parameter bag via `Graph->GetMutableUserParametersStruct()` (or the equivalent accessor on the version installed here — grep `UserParameters` in the PCG plugin). It is an `FInstancedPropertyBag`.
+3. Build an `FPropertyBagPropertyDesc Desc(FName(name), EPropertyBagPropertyType::Object, ValueTypeObjectPtr)`:
+   - Map the `type` string → `EPropertyBagPropertyType`.
+   - For `Object`/`Class`/`SoftObject`/`SoftClass`: resolve `valueClass` to a `UClass*` and pass as the desc's value-type-object.
+   - For `Struct`: resolve to `UScriptStruct*`. For `Enum`: `UEnum*`.
+   - For `container`: set `Desc.ContainerTypes` accordingly.
+4. `Bag.AddProperties({ Desc })` (or `AddProperty`). If `overwrite` and the name exists, `RemoveProperty` first.
+5. Optionally set the default value (`Bag.SetValueObject(name, LoadObject(defaultValue))` etc.).
+6. `Graph->Modify(); Graph->MarkPackageDirty();` and notify so the editor + any open graph UI refresh (a `PostEditChange` / the PCG-specific "user parameters changed" delegate). Save is the caller's choice.
+
+Watch the installed PCG version's exact accessor names — `GetMutableUserParametersStruct`, the change-notification delegate, and whether `AddProperties` migrates existing instanced values (it should preserve them).
+
+### Optional stretch — `pcg_graph_bind_parameter`
+Wiring a parameter to a node property is doable from Python today (create `PCGUserParameterGetSettings`, point it at the param, wire its output into the target node's override pin), but it's fiddly and pin-name-sensitive. A convenience command `pcg_graph_bind_parameter({graph, paramName, targetNodeId, targetProperty})` that does the get-node + override wiring would complete the round-trip. Lower priority than the add.
+
+## Downstream payoff (what unblocks)
+
+With `pcg_graph_add_parameter`, the agent can author the real config-swap end-to-end with no human editor step:
+1. Add `WallKit`/`PillarKit`/`DoorKit` Object params to `SG_WallFacade`.
+2. Bind each `CollectionToModuleInfos.asset_collection` to its param.
+3. Create `PCGGraphInstance` style assets (`Style_Stone`, `Style_Brick`) overriding the three kit params via `PCGGraphParametersHelpers.set_object_parameter`.
+4. A beginner picks a graph instance on their spline → whole room restyles, zero graph edits. (The ONEiRA promise.)
+
+Today's interim workaround (works, but heavier): **style = a duplicated master variant** (`M_Room`, `M_Room_Plain`, …); the beginner selects the master via the component's graph. Verified: `PCGComponent.set_graph(master)` recooks and resolves each master's `subgraph_override` correctly. The downside is one master + one wall-subgraph per style instead of one parameterized graph + lightweight instances — exactly what this tool removes.
+
+## Acceptance criteria
+- `pcg_graph_add_parameter` adds an Object-typed param to `SG_WallFacade`; `pcg_graph_list_parameters` then shows it; the param appears in the editor Details → User Parameters.
+- `PCGGraphParametersHelpers.set_object_parameter` can set it, and a `PCGGraphInstance` of the graph can override it.
+- Cooking a component on the graph with the param bound to a CMI's `asset_collection` spawns meshes from the param's kit (swap the override value → different meshes, verified by ISM mesh names).
+
+## Key files
+- `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/` — add a `HaybaMCPPCGHandler.cpp` (or extend an existing handler) registering `pcg_graph_add_parameter` / `pcg_graph_list_parameters`.
+- `mcp-tools/hayba-mcp/src/tools/` — add the TS tool wrapper + register in `tools/index.ts`.
+- PCG plugin source (installed): grep `GetMutableUserParametersStruct` / `FInstancedPropertyBag` / `EPropertyBagPropertyType` for the exact API on this engine version.

--- a/docs/HANDOFF-tailscale-srv-dev-01.md
+++ b/docs/HANDOFF-tailscale-srv-dev-01.md
@@ -1,0 +1,112 @@
+# HANDOFF — Connecting to srv-dev-01 over Tailscale
+
+Status as of 2026-07-14. Everything in the "Verified" table below was tested live from
+`DESKTOP-OQAM6E3`. The SSH login user is **not** yet confirmed — see Open questions.
+
+## What Tailscale actually is
+
+Tailscale builds a private network (a "tailnet") across your machines, wherever they
+physically sit. Each machine runs a daemon, authenticates to a coordination server with
+your identity, and gets a stable IP in the `100.64.0.0/10` range. That IP belongs to the
+machine, not to its location — it does not change when the machine moves between the
+office LAN, a coffee shop, or a datacenter.
+
+Traffic between two machines is a WireGuard tunnel, encrypted end to end. The
+coordination server hands out public keys and helps the two peers find each other; it
+does not see the plaintext. There is no port forwarding, no VPN concentrator, and
+nothing exposed to the public internet.
+
+Two peers connect one of two ways:
+
+- **Direct** — they punch through NAT and talk peer to peer. Fast, low latency.
+- **DERP relay** — if NAT traversal fails, traffic is relayed through a Tailscale relay
+  server. Still end-to-end encrypted, but slower.
+
+You can see which path is in use. Our `tailscale ping` to srv-dev-01 returned a DERP
+response first (`via DERP(tor)`, 46ms) and then upgraded to direct (`via
+10.0.0.227:41641`, 86ms). That upgrade is normal and automatic — Tailscale starts on the
+relay so the connection works immediately, then negotiates a direct path in the
+background.
+
+## This tailnet
+
+| Field | Value |
+|---|---|
+| Tailnet | `zejbadr@gmail.com` |
+| MagicDNS suffix | `tail599939.ts.net` |
+| This machine | `DESKTOP-OQAM6E3` → `100.65.61.110` |
+| Other desktop | `DESKTOP-89Q6FFV` → `100.122.74.37` (online) |
+| **srv-dev-01** | **`100.98.219.8`** (Linux, online) |
+
+`srv-dev-01` is the box the self-hosted infra targets: Docker + Supabase behind a Caddy
+gateway, fronted by a Cloudflare Tunnel. See `infra/README.md`.
+
+## Verified
+
+| Check | Result |
+|---|---|
+| `tailscale ping 100.98.219.8` | pong, direct path established |
+| TCP 22 on `100.98.219.8` (Tailscale) | open |
+| TCP 22 on `10.0.0.227` (LAN) | open |
+| `known_hosts` | already contains `srv-dev-01` and `10.0.0.227` — this machine has connected before |
+
+## The name collision — read this before debugging anything
+
+`srv-dev-01` resolves to **two different addresses** on this machine depending on who
+answers first:
+
+- Your **hosts file** maps it to `100.98.219.8` (the Tailscale IP).
+- Your **local DNS** also answers `srv-dev-01` as `10.0.0.227` (the LAN IP).
+
+Same physical box, two routes to it. This is fine until you are off the home network, at
+which point the LAN address silently stops working and the failure looks like "the server
+is down" rather than "the name resolved to the wrong address."
+
+Pin the address explicitly rather than trusting name resolution. Use the Tailscale IP:
+it is correct on the LAN *and* off it.
+
+## How to connect
+
+There is currently **no `Host srv-dev-01` block** in `~/.ssh/config`, which is why no user
+or key is remembered. Once the login user is confirmed, add:
+
+```sshconfig
+Host srv-dev-01
+    Hostname 100.98.219.8
+    User <CONFIRM — see below>
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+Then `ssh srv-dev-01` works from anywhere the tailnet is up.
+
+Prerequisite: Tailscale must be running and authenticated on this machine. Check with
+`tailscale status` — `BackendState` should be `Running` (it is, right now). If it is not,
+`tailscale up` and complete the browser login.
+
+## Open questions
+
+1. **What is the SSH user?** Not recorded anywhere in the repo or in `~/.ssh/config`. The
+   `supabase_admin` in `infra/backup.sh:6` is the *Postgres* role, not an SSH login — do
+   not confuse the two. `root` was the working assumption but the test was interrupted
+   and **never completed**, so it is unconfirmed.
+2. **Which key does the server trust?** Available locally: `~/.ssh/id_ed25519` and
+   `~/.ssh/zajalist.pem`. Untested against this host.
+
+Resolve #1 and #2 by running the probe below; the first line it prints tells you both.
+
+```bash
+ssh -o BatchMode=yes -o ConnectTimeout=10 -i ~/.ssh/id_ed25519 \
+    root@100.98.219.8 'echo "CONNECTED as $(whoami)@$(hostname)"'
+```
+
+`BatchMode=yes` means it fails fast instead of hanging on a password prompt — if key auth
+is not set up for that user, you get `Permission denied (publickey)` immediately rather
+than a stuck terminal.
+
+## Why Tailscale rather than exposing SSH
+
+srv-dev-01's SSH port is reachable on the tailnet and on the LAN, not from the public
+internet. The Cloudflare Tunnel (`infra/cloudflared.yml`) is what publishes the *API*
+to the world at `api.hayba.app`; it does not publish SSH. Keeping admin access on the
+tailnet means there is no public SSH surface to brute-force, and no firewall rule to
+maintain — access is governed by tailnet membership.

--- a/docs/HANDOFF-umg-validation.md
+++ b/docs/HANDOFF-umg-validation.md
@@ -38,24 +38,33 @@ Do not move rules into C++.
 | `reparent` discarded slot layout, no index | and orphaned the widget entirely if the new panel refused it |
 | descriptor text claimed `FScopedTransaction` | deliberately removed in c071a59; several `returns:` strings named fields that did not exist |
 
-## New commands (C++) — **needs a plugin rebuild**
+## New commands (C++)
 
 `ui_build_tree`, `ui_set_variable`, `ui_list_widget_blueprints`,
-`ui_layout_snapshot`, `ui_measure_text`, plus `ui_mutate_tree` operations
-`move` / `rename` / `duplicate`, and `ui_query` filters
-(`name_pattern` / `class_filter` / `flatten`).
+`ui_layout_snapshot`, `ui_measure_text`, `ui_report_findings`, plus
+`ui_mutate_tree` operations `move` / `rename` / `duplicate`, and `ui_query`
+filters (`name_pattern` / `class_filter` / `flatten`).
 
 New files: `handlers/HaybaMCPUILayout.{h,cpp}`.
 
-**The C++ has not been compiled** — no engine build ran in this session. Build
-the plugin before trusting any of it. Things to check first if it does not
-compile:
+### UE 5.8 API notes (learned the hard way — the first build failed on all of these)
 
-- `UWidget::IsFocusable()` and `UWidget::SetCategoryName` availability on 5.8
-- `UUserWidget::TakeWidget()` on an editor-world instance in
-  `HaybaUILayout::ComputeGeometry` (it deliberately never uses a PIE world —
-  see `[[haybamcp-pie-transaction-leak]]`)
-- `FBlueprintTags::ParentClassPath` include path
+- **There is no `UWidget`-level focus API.** `Button`, `CheckBox` and `ComboBox`
+  each declare their own `IsFocusable` / `bIsFocusable`. The snapshot resolves it
+  reflectively over both spellings, with text-entry widgets treated as
+  inherently focusable, so one path covers every widget class.
+- **`FJsonObject::Values` keys are a storage type, not `FString`.** Anything
+  taking `const FString&` needs an explicit conversion.
+- **`DesignTimeSize` lives on the `UUserWidget` CDO**, not on `UWidgetBlueprint`
+  — and it only holds a real screen size when `DesignSizeMode` is `Custom` /
+  `CustomOnScreen`. Otherwise it keeps a `(100,100)` placeholder, which would
+  make every widget look off-canvas and fire the safe-area rules everywhere.
+- **`UMultiLineEditableTextBox` has no `GetWidgetStyle()`** — only
+  `UEditableTextBox` does; multi-line exposes `WidgetStyle` directly.
+- `TSharedPtr::Get()` already returns the pointer (`&Cached.Get()` does not
+  compile).
+- `ComputeGeometry` deliberately never outers to a PIE world — see
+  `[[haybamcp-pie-transaction-leak]]`.
 
 ## Verification status (2026-07-26, after a live run)
 
@@ -103,6 +112,40 @@ rules have been run against it).
 
 The probe blueprint currently contains the corrupt duplicate; clean it after
 the rebuild.
+
+## Still to do
+
+1. **Rebuild the plugin** for the two fixes listed above, then re-run the loop
+   and confirm the Validation panel actually populates.
+
+2. **Strictness control in the editor.** Strictness is fully wired through MCP
+   (`validator_strictness`) and persists to `.scratch/validator-config.json`.
+   The panel has no control for it yet.
+
+   Correction to an earlier assumption in this doc: `SHaybaMCPValidationPanel`
+   does **not** read that config file, or any file. It is push-only —
+   `AddIssue` / `Clear`, fed by post-dispatch hooks in the command handler
+   (`PushPhysicsResultsToPanel` and friends). The comment in
+   `HaybaMCPMainPanel.cpp` claiming findings persist to
+   `validator-history.jsonl` describes the MCP side, not the panel. This is why
+   `ui_report_findings` had to exist at all, and why a strictness dropdown needs
+   its own read/write path to the config rather than just a widget.
+
+3. **Grow the ruleset.** 32 rules ship. Adding one means appending an entry to
+   `src/validator/ui/rules.ts` — the runner, the settings surface and the
+   strictness gate all read that array. Gaps worth filling: focus-navigation
+   graph reachability, per-widget clipping behaviour, ListView entry-class
+   checks, animation-track validation, input-action binding coverage.
+
+4. **Calibrate against more real screens.** Two rules already needed demoting
+   after one live run (`ui_canvas_child_top_left_anchored` fired on 7 of 8
+   widgets; `ui_empty_panel` double-reported empty Buttons). Expect more of
+   this — a rule that is correct in principle can still be useless in practice
+   if it fires on everything.
+
+5. **Not built:** `ui_bind_event` (widget delegate → blueprint event graph) and
+   widget-animation authoring. Both need Kismet graph / MovieScene work that was
+   out of scope here.
 
 ## Rule catalogue shape
 

--- a/docs/HANDOFF-umg-validation.md
+++ b/docs/HANDOFF-umg-validation.md
@@ -1,0 +1,109 @@
+# Handoff: UMG toolset overhaul + UI validation engine
+
+**Date:** 2026-07-26
+**Branch:** `feat/umg-validation-engine`
+
+## What this changed
+
+Two things: the UMG authoring tools got fixed and extended, and a UI validation
+engine was added on top of real Slate measurement.
+
+### Architecture decision worth keeping
+
+**UE measures, MCP judges.** The plugin gained exactly two new read commands
+(`ui_layout_snapshot`, `ui_measure_text`) that do the one job only the engine
+can do — a real Slate prepass plus font metrics. Every rule that interprets
+those numbers lives in TypeScript (`src/validator/ui/`), so:
+
+- rules are unit-tested without an editor (54 tests, all green),
+- new rules ship without a plugin rebuild,
+- strictness and per-category config are plain JSON both sides read.
+
+Do not move rules into C++.
+
+## Bugs found and fixed (all were silent)
+
+| What | Symptom |
+|---|---|
+| `ui_search_widgets` never sent `path` | every call failed `ui_query: missing path` |
+| `ui_set_slot_layout` sent `slot_layout` | no handler revision read that key — every call failed "no properties provided" |
+| `HaybaReflection::SetProp` rejected JSON objects for struct properties | `ui_set_brush` and `ui_set_text_style` could not set a brush or a font at all |
+| `ui_set_text_style` sent `Typeface: {FontName}` | matched no property; the field is `TypefaceFontName` |
+| `ui_set_brush` sent `Brush` to Borders | Borders expose theirs as `Background` |
+| slot props counted as succeeded unconditionally | success counts included keys the slot never accepted |
+| padding only applied when non-zero | padding could never be cleared |
+| `preserve_properties` on replace | parsed, then never used |
+| `remove` purged only the named widget's GUID | descendants left phantom entries in `WidgetVariableNameToGuidMap` |
+| `replace` reused a name the old widget still held | UE silently uniquified to `Name_1`, breaking bindings |
+| `reparent` discarded slot layout, no index | and orphaned the widget entirely if the new panel refused it |
+| descriptor text claimed `FScopedTransaction` | deliberately removed in c071a59; several `returns:` strings named fields that did not exist |
+
+## New commands (C++) — **needs a plugin rebuild**
+
+`ui_build_tree`, `ui_set_variable`, `ui_list_widget_blueprints`,
+`ui_layout_snapshot`, `ui_measure_text`, plus `ui_mutate_tree` operations
+`move` / `rename` / `duplicate`, and `ui_query` filters
+(`name_pattern` / `class_filter` / `flatten`).
+
+New files: `handlers/HaybaMCPUILayout.{h,cpp}`.
+
+**The C++ has not been compiled** — no engine build ran in this session. Build
+the plugin before trusting any of it. Things to check first if it does not
+compile:
+
+- `UWidget::IsFocusable()` and `UWidget::SetCategoryName` availability on 5.8
+- `UUserWidget::TakeWidget()` on an editor-world instance in
+  `HaybaUILayout::ComputeGeometry` (it deliberately never uses a PIE world —
+  see `[[haybamcp-pie-transaction-leak]]`)
+- `FBlueprintTags::ParentClassPath` include path
+
+## Verification status
+
+- TypeScript: `npm run typecheck` clean, `npm run lint:legacy-wrappers` clean,
+  1011/1012 tests pass. The single failure is `landscape-import.test.ts`, which
+  fails on a clean tree too (pre-existing, unrelated).
+- C++: **not compiled, not run.**
+- Live editor: **nothing has been exercised against a running UE.**
+
+## Still to do
+
+1. **Rebuild the plugin** and run the loop end to end against a real blueprint:
+   `ui_build_tree` → `ui_compile_widget` → `ui_validate` → `ui_save_widget`.
+2. **Editor settings panel**: strictness is fully wired through MCP
+   (`validator_strictness`) and persists to `.scratch/validator-config.json`,
+   which is the same file `HaybaMCPValidationPanel` already reads for the rule
+   disable list. The panel does **not** yet have a strictness control — that
+   is a per-category dropdown over the existing config, and is the one piece of
+   the "configurable in settings" ask that was not built.
+3. **Calibrate the measurement path.** The character-count hints are only as
+   good as `ui_layout_snapshot`'s `available_width`. Once the plugin builds,
+   check a known label against the designer and confirm the numbers agree
+   before leaning on them.
+4. **Grow the ruleset.** 32 rules ship. Adding one means appending an entry to
+   `src/validator/ui/rules.ts` — the runner, the settings surface and the
+   strictness gate all read that array, so nothing else needs touching. Gaps
+   worth filling: focus-navigation graph reachability, per-widget clipping
+   behaviour, ListView entry-class checks, animation-track validation, and
+   input-action binding coverage.
+5. **Not built:** `ui_bind_event` (widget delegate → blueprint event graph) and
+   widget-animation authoring. Both need Kismet graph / MovieScene work that
+   was out of scope here.
+
+## Rule catalogue shape
+
+```
+src/validator/ui/
+  types.ts        snapshot + rule types
+  thresholds.ts   platform presets (pc/console/handheld/mobile) + strictness
+                  tuning, every number cited to its source
+  rules.ts        the 32 rules
+  index.ts        runner: strictness gate, disable list, skip accounting
+```
+
+`resolveThresholds` scales pixel numbers to the blueprint's design height, so a
+720p-authored screen is judged with 720p numbers.
+
+**Reporting contract:** a rule that needs geometry and has none is reported in
+`rules_skipped_no_layout`, never counted as a pass. Same principle as the
+per-key `unknown_slot_props` reporting on the authoring side — the whole point
+of this pass was that silence was being read as success.

--- a/docs/HANDOFF-umg-validation.md
+++ b/docs/HANDOFF-umg-validation.md
@@ -57,37 +57,52 @@ compile:
   see `[[haybamcp-pie-transaction-leak]]`)
 - `FBlueprintTags::ParentClassPath` include path
 
-## Verification status
+## Verification status (2026-07-26, after a live run)
 
-- TypeScript: `npm run typecheck` clean, `npm run lint:legacy-wrappers` clean,
-  1011/1012 tests pass. The single failure is `landscape-import.test.ts`, which
-  fails on a clean tree too (pre-existing, unrelated).
-- C++: **not compiled, not run.**
-- Live editor: **nothing has been exercised against a running UE.**
+The plugin **compiles and links** against UE 5.8, and the core loop has been
+exercised against a running editor.
 
-## Still to do
+Verified live, on `/Game/ReelAssets/UI/WBP_ValidatorProbe`:
 
-1. **Rebuild the plugin** and run the loop end to end against a real blueprint:
-   `ui_build_tree` → `ui_compile_widget` → `ui_validate` → `ui_save_widget`.
-2. **Editor settings panel**: strictness is fully wired through MCP
-   (`validator_strictness`) and persists to `.scratch/validator-config.json`,
-   which is the same file `HaybaMCPValidationPanel` already reads for the rule
-   disable list. The panel does **not** yet have a strictness control — that
-   is a per-category dropdown over the existing config, and is the one piece of
-   the "configurable in settings" ask that was not built.
-3. **Calibrate the measurement path.** The character-count hints are only as
-   good as `ui_layout_snapshot`'s `available_width`. Once the plugin builds,
-   check a known label against the designer and confirm the numbers agree
-   before leaning on them.
-4. **Grow the ruleset.** 32 rules ship. Adding one means appending an entry to
-   `src/validator/ui/rules.ts` — the runner, the settings surface and the
-   strictness gate all read that array, so nothing else needs touching. Gaps
-   worth filling: focus-navigation graph reachability, per-widget clipping
-   behaviour, ListView entry-class checks, animation-track validation, and
-   input-action binding coverage.
-5. **Not built:** `ui_bind_event` (widget delegate → blueprint event graph) and
-   widget-animation authoring. Both need Kismet graph / MovieScene work that
-   was out of scope here.
+- `ui_build_tree` — 13 widgets across two calls, canvas and box/grid slots, all
+  three padding shapes (scalar, `[l,t,r,b]`, `{left,top,…}`), zero rejected keys
+- `ui_layout_snapshot` — `layout_resolved: true`, geometry matching the authored
+  values, fonts resolved, text measured
+- **Text measurement is exact at the boundary**: 12 chars = 199px fits, 13 chars
+  = 219px overflows, in a 200px box
+- `ui_validate` — every seeded defect caught, `rules_skipped_no_layout` empty,
+  platform gate holds (pc 24px vs console 40px targets; safe areas console-only)
+- Contrast measured 6:1, silent at standard (4.5:1), fires at strict (7:1)
+- Previously-broken paths now work and **persist** (confirmed by re-query):
+  `ui_search_widgets`, `ui_set_slot_layout`, `ui_set_text_style`, `ui_set_brush`
+  (both `Brush` and `Background`), `ui_replace_element` (34 properties copied,
+  name kept), `ui_rename_element` (GUID preserved), `ui_move_element`,
+  `ui_set_variable`, `ui_list_widget_blueprints`
+
+TypeScript: typecheck clean, `lint:legacy-wrappers` clean, 44 UI tests + 27 rule
+tests green. The one repo-wide failure is `landscape-import.test.ts`, which
+fails on a clean tree too (pre-existing, unrelated).
+
+### Needs the next plugin rebuild
+
+Two C++ fixes are committed but **not yet compiled into the running editor**:
+
+1. `ui_duplicate_element` corrupted the tree — `DuplicateObject` keeps every
+   descendant's name and UMG requires tree-wide uniqueness, so UE renamed the
+   collisions to `TRASH_<name>` and left two widgets answering to `Card`. Until
+   the rebuild lands, **do not use this tool**.
+2. `ui_report_findings` — the route that puts findings in the Validation panel.
+
+### Still untested
+
+`ui_remove_element`, `ui_reparent_element`, `ui_get_widget_info`,
+`ui_list_widget_types`, standalone `ui_save_widget`, the
+`validator_strictness` persistence round-trip, and the non-canvas slot rules
+against a real box layout (the box tree exists in the probe, but only four
+rules have been run against it).
+
+The probe blueprint currently contains the corrupt duplicate; clean it after
+the rebuild.
 
 ## Rule catalogue shape
 

--- a/docs/RUNBOOK-reel-filming.md
+++ b/docs/RUNBOOK-reel-filming.md
@@ -1,0 +1,51 @@
+# Reel Filming — Wake-Up Runbook
+
+State captured 2026-07-07 (overnight). Read top-to-bottom; it's the exact path from
+"here" to "recording a reel."
+
+## What's DONE and persists
+- **CC0 conifer assets imported** → `/Game/ReelAssets/` (saved to disk, survives crashes & the 5.8 move):
+  `fir_tree_01` (hero), `pine_sapling_small/medium`, `fir_sapling_medium`, `dandelion_01`, `celandine_01`. (The 982 MB `pine_tree_01` was dropped — too heavy for a scatter; not needed.)
+- **Anchors** in the clean `NewMap` level: `Field_Center`, `Scratch_A`, `Scratch_B`.
+- **Keyless CLI copilot** — branch `local/claude-cli-copilot-backend` (NOT pushed). Provider `claude-cli` drives the copilot via this machine's authenticated `claude` CLI, no API key, warm ~1.5s/turn. Proven through the full SSE panel path.
+- **Native scatter fix** — branch `fix/native-scatter-path` (NOT pushed): world_generate class-filter, pcg_biome landscape source + `MeshSelectorWeighted`, C++ `asset_search` type filter. (Mesh-selector nesting may need one live-validation pass.)
+- **Website**: auto-deploy disabled (`vercel.json`), GitHub deployments pruned to 1.
+
+## The core blocker (why filming stalled)
+1. **The running MCP server is an OLD build** — missing `render_camera`, `foliage_*`, `seq_*`, `niagara_*`, and the CLI copilot. (`list_tool_categories` shows these as unavailable.)
+2. **The 5.7 editor is thrashed** — crashed/stalled ~6× (Water shader compile, gigabyte import, reindex, scatter). You're on **5.8** now anyway.
+3. A correct **native scatter** needs the `fix/native-scatter-path` code **deployed + validated live**.
+
+## Path to filming (in order)
+
+### Step 1 — Get onto a stable editor + current build
+Recommended: **do the 5.8 plugin port** (you're on 5.8):
+- Bump `unreal/HaybaMCPToolkit/HaybaMCPToolkit.uplugin` EngineVersion → 5.8.
+- Regenerate project files + rebuild the plugin (editor CLOSED). Fix any 5.7→5.8 C++ breaks.
+- Open the project on a **fresh** 5.8 editor.
+This also picks up the C++ `asset_search` fix from `fix/native-scatter-path`.
+
+### Step 2 — Run the current MCP node build as the recording server
+- Merge (or stack) `local/claude-cli-copilot-backend` + `fix/native-scatter-path` into a recording branch.
+- `cd mcp-tools/hayba-mcp && npm run build`, then point the `hayba-toolkit` MCP server at this build and reconnect. Now available: `render_camera`, `foliage_scatter_paint`, `seq_*`, `niagara_*`, and the `claude-cli` provider.
+
+### Step 3 — Build the scene (native tools, NO python one-shots)
+Prefer the purpose-built tool over hand-rolled PCG:
+- **Scatter:** `foliage_scatter_paint` (current build) with the ReelAssets conifers on the landscape — OR the fixed `scatter.pcg_biome` sliver (`hayba_sliver_run com.hayba.scatter.pcg_biome`), area_actor = the Landscape. Validate a small count first, then scale.
+- **Water:** `water_body_lake_create` in the low ground (Water plugin already enabled).
+- **Light/sky:** the Open World template has sun/sky/fog; tune to the "misty morning" look.
+- **Verify each beat** with `render_camera` (magic-byte-verified PNG).
+
+### Step 4 — Film
+The reel = the **keyless CLI copilot** building the world live. Select provider
+**"Local Claude CLI (this machine, no key)"** in the panel. Record split-screen
+(UE viewport left, copilot panel right) per `docs/demo-reels-script.md`.
+Capture with **Cap** (auto-zoom) → edit in **DaVinci Resolve**.
+
+## Landmines (learned the hard way)
+- **Do NOT scatter/seed in the old geoforge/grammar level** — its PCG asserts `IsRotationNormalized` on actor spawn (see `project_template_level_pcg_crash`). Use the clean `NewMap`/`ReelStage`.
+- **Gate every editor op behind a "port stably open ~20s" check** — the plugin flaps its TCP port during heavy synchronous work.
+- **No gigabyte PolyHaven hero meshes in a scatter** — saplings + one mid tree only.
+- **Map create/switch = UE UI only** — the python_run world-switch guardrail (PR #301) correctly blocks it from code.
+- **PCGSurfaceSampler pins are `Surface` (required) + `Bounding Shape`**, not `In`. `PCGGetLandscapeSettings.Out` feeds `Surface`.
+- **PCG node properties must be STRING-valued in the graph JSON.** The plugin's property applier (`HaybaMCPLegacyHandler.cpp`) only calls `FProperty::ImportText_Direct` on values that stringify — nested JSON objects/arrays are silently dropped. So the mesh spawner's `MeshSelectorParameters` is set as a UE export-text string: `(MeshEntries=((Descriptor=(StaticMesh="/Game/ReelAssets/.../fir_tree_01_a_LOD0.fir_tree_01_a_LOD0"),Weight=1)))`. **This one line needs LIVE validation** — whether `ImportText` imports the inline sub-object onto the instanced `MeshSelectorParameters` is unproven (there's a `TODO(live-validate)` in `pcg_biome.ts`; fallback is `pcg_set_prop` with nested path `mesh_selector_parameters/mesh_entries`). Validate this the moment the current build is live, before trusting the sliver.

--- a/docs/demo-reels-script.md
+++ b/docs/demo-reels-script.md
@@ -1,0 +1,173 @@
+# Hayba Demo-Reel Scripts
+
+> Storyboards for short screen-recorded marketing reels. Each reel shows an AI copilot
+> driving **real** Unreal Engine work through the Hayba MCP toolkit, from a chat prompt,
+> on the user's own machine with their own API key. Tool names and arguments below are
+> faithful to the shipped codebase (`mcp-tools/hayba-mcp/src/tools/**`) so these scripts
+> double as an executable record-and-verify test plan.
+
+---
+
+## 1. Intro — the narrative arc
+
+The series has one throughline: **you type intent, and a real engine builds it — safely, locally, and reproducibly.** Reel 1 proves *breadth* (a spoken sentence becomes a populated, lit, watered landscape). Reel 2 proves *authorship* (the agent doesn't just place props — it directs a camera and cuts a cinematic). Reel 3 proves *determinism* (a VFX moment advanced to an exact, repeatable frame). Reel 4 proves *trust* (the plan-mode approval gate and known-crasher guardrails turn "AI touching my project" from a risk into a reviewable, crash-proof workflow). The unifying tagline: **"Your engine. Your key. Your machine. The agent just does the work."** No cloud round-trip owns your project; every destructive step is proposed, shown, and approved before it runs.
+
+Positioning notes that must survive editing:
+- **Local-first + BYOK** — the copilot runs against the user's own key; frames should show the key field / model picker once, briefly.
+- **Crash-resilient + honest** — guardrails refuse known-crashers *cleanly*; tools report set-success truthfully (e.g. `render_camera` verifies the file's magic bytes before claiming success).
+- **Breadth, not a toy** — landscape, foliage, lighting, water, sequencer, niagara, PCG, validation — one surface (~230 tools).
+
+---
+
+## 2. Reel scenarios
+
+Each reel: side-by-side UE viewport (left) + copilot Slate panel (right). "Approve" moments are the money shots — hold on them.
+
+---
+
+### Reel 1 — "Prompt to populated landscape"
+**Hook (site caption):** *"One sentence. A whole biome — grounded, lit, and watered. Built live in your editor."*
+**Target length:** ~55s
+
+**Copilot chat prompt (typed by user):**
+> "Turn this open field into a misty pine valley — dense conifers thinning upslope, a lake in the low ground, and cool morning light."
+
+**Beat-by-beat storyboard:**
+
+| # | Viewer sees | Real MCP tool call(s) | Plan-gate? | Caption / VO |
+|---|-------------|----------------------|-----------|--------------|
+| 1 | Empty landscape actor in viewport; user types the prompt, hits enter | — (agent turn begins) | — | "Describe the world you want." |
+| 2 | Agent lists the scene, confirms it found the field | `actor_list { class_filter: "Landscape" }` → `actor_inspect` | no (read) | "It reads your actual scene first." |
+| 3 | A dry-run scatter plan appears as a bounded preview overlay | `world_generate { area_actor: "Field_Center", prompt: "misty pine valley, dense conifers thinning upslope", radius_cm: 12000, count: 220, seed: 1337, dry_run: true }` | no (dry_run) | "Scatter and *prove* — it validates every instance in memory: grounded, non-interpenetrating." |
+| 4 | **Approve card** — "world_generate will spawn 220 instances" — user clicks Approve | `world_generate { …same args…, dry_run: false }` | **YES — non-idempotent spawn** | "Nothing lands until you approve." |
+| 5 | Conifers pop in across the valley, denser low, sparse upslope | (continuation of `world_generate`) | — | "Foliage, grounded to the terrain." |
+| 6 | Undergrowth pass added on slope band | `foliage_type_create { … }` → `foliage_scatter_paint { … }` (approve) | **YES** | "Layered undergrowth, on a slope mask." |
+| 7 | Water fills the low ground | `water_check_plugin` → `water_body_lake_create { location:[…], size:… }` (approve) | **YES** | "A lake finds the low ground." |
+| 8 | Cool morning light sweeps the scene; fog rolls in | `sky_setup { preset:"morning", sun_pitch: 12 }` → `light_set { … color:[cool], intensity:… }` → `fog_configure { density:0.02 }` | **YES** (light spawn is non-idempotent) | "Mood, in one move." |
+| 9 | `wait_for_shaders` spinner, then crisp frame | `wait_for_shaders` → `wait_for_idle` | no | "It waits for shaders so the shot is real." |
+
+**Payoff shot:** `render_camera` to a low golden-hour angle over the lake —
+`render_camera { camera:{ kind:"transform", location:[…], rotation:[…], fov:60 }, output_path:"…/reel1_hero.png", width:1920, height:1080, format:"png" }` — the returned verified PNG fills the screen. Caption: **"From one sentence to a shot you can ship."**
+
+---
+
+### Reel 2 — "Author a cinematic"
+**Hook:** *"The agent doesn't just place props — it directs the camera."*
+**Target length:** ~50s
+
+**Copilot chat prompts:**
+> 1. "Drop a hero rock formation and a lone tree on the ridge, then set up a 6-second flythrough that pushes past them toward the lake."
+> 2. "Give me the final frame at 1440p."
+
+**Beat-by-beat storyboard:**
+
+| # | Viewer sees | Real MCP tool call(s) | Plan-gate? | Caption / VO |
+|---|-------------|----------------------|-----------|--------------|
+| 1 | User types prompt 1 | — | — | "Set the scene." |
+| 2 | Two meshes resolve and spawn on the ridge | `actor_spawn_from_asset { asset_path:"…/SM_Rock_01", label:"Hero_Rock" }`, `actor_spawn_from_asset { asset_path:"…/SM_GiantTree_01", label:"Lone_Tree" }` (approve) | **YES** | "Real assets from your project." |
+| 3 | Tree seats to the ground | `actor_transform { actor_id:"Lone_Tree", location:[…, -380] }` | **YES** | (nod to SM_GiantTree pivot offset) |
+| 4 | A new Level Sequence opens in the editor | `seq_new { name:"Ridge_Flythrough", path:"/Game/Cine" }` → `seq_open` | **YES** | "It authors a real Level Sequence." |
+| 5 | A CineCameraActor is spawned and bound | `actor_spawn { class_path:"/Script/CinematicCamera.CineCameraActor", label:"ReelCam" }` → `seq_bind_actor { sequence:"Ridge_Flythrough", actor_id:"ReelCam" }` | **YES** | "Camera, bound." |
+| 6 | Playback range set to 6s; a transform track appears | `seq_playback_range { start_frame:0, end_frame:180 }` → `seq_track_add { binding:"ReelCam", track:"Transform" }` | **YES** | "Six seconds." |
+| 7 | Two keyframes drawn — a start wide, an end push-in | `seq_transform_keyframe { binding:"ReelCam", frame:0, location:[…], rotation:[…] }`, `seq_transform_keyframe { binding:"ReelCam", frame:180, location:[…closer…], rotation:[…toward lake…] }` | **YES** | "Keyframes it can explain." |
+| 8 | A camera cut track locks the shot to ReelCam | `seq_camera_cut { binding:"ReelCam", start_frame:0, end_frame:180 }` | **YES** | "One clean cut." |
+| 9 | Green validation tick | `seq_validate { sequence:"Ridge_Flythrough" }` | no | "It checks its own work." |
+| 10 | Timeline scrubs; the push-in plays in-viewport | (editor playback) | — | "And it plays." |
+
+**Payoff shot (prompt 2):** `render_camera { camera:{ kind:"actor", actor:"ReelCam" }, output_path:"…/reel2_final.png", width:2560, height:1440, format:"png" }` — final composed frame. Caption: **"Prompt to composed shot, no timeline scrubbing by hand."**
+
+---
+
+### Reel 3 — "A VFX moment, made reproducible"
+**Hook:** *"Spawn it, drive it, and freeze the exact same frame every time."*
+**Target length:** ~40s
+
+**Copilot chat prompt:**
+> "Add embers rising off the rock, dial the spawn rate up, and give me the frame at exactly 2 seconds of sim — I want it identical on every run."
+
+**Beat-by-beat storyboard:**
+
+| # | Viewer sees | Real MCP tool call(s) | Plan-gate? | Caption / VO |
+|---|-------------|----------------------|-----------|--------------|
+| 1 | User types prompt | — | — | "Ask for the effect." |
+| 2 | Agent probes what Niagara can do here | `niagara_capability_probe` → `niagara_systems` | no (read) | "It checks the engine's actual capabilities." |
+| 3 | An ember system is placed at the rock | `niagara_create_from_template { template:"embers" }` → `niagara_place_actor { location:[…rock top…], label:"Embers_FX" }` (approve) | **YES** | "Embers, placed." |
+| 4 | Parameter list surfaces in chat | `niagara_param_list { component:"Embers_FX" }` | no | "Every exposed parameter, listed honestly." |
+| 5 | Spawn rate ramps up live | `niagara_param_set { component:"Embers_FX", name:"SpawnRate", value: 450 }` | **YES** | "Dialed in from chat." |
+| 6 | Sim advances deterministically to t=2s | `niagara_advance_simulation { component:"Embers_FX", seconds: 2.0, fixed_dt: 0.0166 }` | no | "Advanced to an exact sim time — deterministic, not a lucky screenshot." |
+| 7 | Validation tick | `niagara_validate { component:"Embers_FX" }` | no | "Verified." |
+
+**Payoff shot:** `render_camera { camera:{ kind:"transform", location:[…], rotation:[…], fov:50 }, output_path:"…/reel3_embers_t2.png", width:1920, height:1080, format:"png" }`. Run it twice on screen → **byte-identical** result. Caption: **"Same prompt, same frame, every time."**
+
+---
+
+### Reel 4 — "Safe by design"
+**Hook:** *"AI in your project — but nothing destructive happens without your click, and known crashers never fire."*
+**Target length:** ~45s
+
+**Copilot chat prompts:**
+> 1. "Clear out that whole test foliage patch and delete the scratch actors."
+> 2. "Now load the blank benchmark map to start fresh."
+
+**Beat-by-beat storyboard:**
+
+| # | Viewer sees | Real MCP tool call(s) | Plan-gate? | Caption / VO |
+|---|-------------|----------------------|-----------|--------------|
+| 1 | User types prompt 1 | — | — | "Ask for something destructive." |
+| 2 | Agent proposes a plan card listing exactly what it will remove | (proposed) `foliage_clear_type { type:"Undergrowth_01" }`, `actor_delete { actor_id:"Scratch_A" }`, `actor_delete { actor_id:"Scratch_B" }` | **YES — batched approve** | "It proposes. You review the exact operations." |
+| 3 | User clicks Approve; foliage + actors vanish | (same calls execute) | — | "You approve. Then it runs." |
+| 4 | Honest report: "3/3 succeeded" | tool results / `actor_list` re-check | no | "Honest set-success — no silent partial fails." |
+| 5 | User types prompt 2 (the trap) | — | — | "Now ask for a known editor crasher." |
+| 6 | Agent **refuses cleanly** — a guarded message, not a crash | guardrail blocks `load_map` / `new_blank_map` (known-crashers guard, `tools/guards/known-crashers.ts`) | blocked pre-exec | "A known crasher is refused *before* it can touch the editor." |
+| 7 | Agent offers the safe path instead | suggests operator-driven map switch / a non-crashing alternative | — | "It hands you the safe route instead." |
+| 8 | Editor still alive, project intact | `hayba_check_ue_status` → green | no | "Editor still standing. Project intact." |
+
+**Payoff shot:** split card — left: the green "3/3 succeeded" report; right: the clean guardrail refusal message with the editor visibly alive behind it. Caption: **"Powerful automation you can actually trust with your project."**
+
+---
+
+## 3. Production notes
+
+**Window layout (all reels):**
+- **Left ~62%:** Unreal Engine editor, viewport maximized (G to hide gizmos for hero beats), Outliner visible on approve beats so spawns/deletes are legible.
+- **Right ~38%:** the copilot **Slate panel** docked in-editor — prompt box at bottom, streaming tool-call log above, and the **plan-mode Approve card** rendered inline.
+- Show the BYOK model/key row **once** in Reel 1's first 3 seconds (a quick pan), never again — establishes local-first without belaboring it.
+
+**Capture order (efficiency):**
+1. Record Reel 1 first — it produces the populated landscape that Reels 2–4 reuse (rock, tree, foliage patch, lake). Don't tear it down between takes.
+2. Reel 2 (cinematic) on the same level.
+3. Reel 3 (VFX) on the same level — place embers on the Reel 2 rock.
+4. Reel 4 last — it deletes scratch actors, so it must run after the others are captured. Pre-place `Scratch_A`/`Scratch_B` and an `Undergrowth_01` patch just for it.
+
+**What to cut:**
+- Trim shader-compile / `wait_for_shaders` dead time to a ~1s spinner beat (keep one, it sells "the shot is real").
+- Cut streaming-log scroll to the tool name + args line, then the result line — don't show full JSON.
+- Keep every Approve click at full speed; do **not** speed-ramp the approval moment (it's the trust beat).
+
+**Music / pacing:**
+- Ambient, building pad; Reels 1–2 relaxed (~50–55s), Reels 3–4 tighter and punchier (~40–45s).
+- Hit a small stinger on each render_camera payoff reveal.
+- Reel 4 goes quiet on the guardrail refusal beat — silence sells "it stopped."
+
+**Site placement (actual files):** the website package is `website/` (repo root). It is a static, no-build site (`config.js` placeholders are served as-is — see deploy notes). Slot the reels into the landing page **`website/index.html`** as an autoplay-muted `<video>` gallery — add a `#demo-reels` section near the existing hero/showcase area. The dedicated showcase page **`website/showcase/`** is the natural home for the full four-reel set with captions; the hooks above are written to be the on-card captions there. Register the media under `website/assets/` (e.g. `website/assets/reels/reel1-landscape.mp4` … `reel4-safe.mp4`). Reel 1 is the hero (top of `index.html`); Reels 2–4 live in the `showcase/` grid.
+
+---
+
+## 4. Shot list / asset checklist (template project prerequisites)
+
+Before a start-to-finish recording session, the template level must contain:
+
+- [ ] A real **Landscape** actor (not a placeholder StaticMeshActor — SurfaceSampler/scatter need a genuine Landscape; see the landscape_import path). Reasonably large, gently rolling with a clear **low basin** for the lake.
+- [ ] The basin low enough that `water_body_lake_create` reads as "the low ground."
+- [ ] An **area/anchor actor** at valley center labeled `Field_Center` for `world_generate area_actor`.
+- [ ] Project StaticMeshes for `world_generate` to resolve per layer: a **conifer/canopy** mesh, an **undergrowth** mesh, a **rock** mesh, **groundcover**. (world_generate resolves the *project's own* meshes — they must exist and be indexed.)
+- [ ] Hero cinematic meshes: `SM_Rock_01` and `SM_GiantTree_01` (remember the ~+380 pivot → seat at z=-380).
+- [ ] **Water plugin enabled** (`water_check_plugin` should return green) — otherwise Reel 1 beat 7 / lake fails.
+- [ ] **Niagara** available with an ember-style template reachable via `niagara_create_from_template` (verify with `niagara_capability_probe` + `niagara_systems` beforehand).
+- [ ] A **CineCamera** class available (`/Script/CinematicCamera.CineCameraActor`).
+- [ ] Reel 4 scratch content pre-placed: actors `Scratch_A`, `Scratch_B`, and a foliage type `Undergrowth_01` with instances — so the destructive-approve beat has something real to remove.
+- [ ] Copilot configured with a working **BYOK key + model** so the first Reel 1 pan shows a live, connected panel.
+- [ ] A known blank/benchmark map name to *attempt* to load in Reel 4 (the guarded `load_map`/`new_blank_map` trap) — confirm the guardrail actually blocks it in a rehearsal so the refusal is genuine, not staged.
+- [ ] Output dir for `render_camera` writable, and `hayba_check_ue_status` returning healthy at session start.
+
+**Rehearsal gate:** dry-run Reels 1–3 with `dry_run:true` / read-only calls first to confirm scatter plans, bindings, and param names resolve on this template before rolling final capture.

--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -2296,16 +2296,17 @@
       "returns": {
         "shape": "object",
         "fields": [
-          { "name": "widget_blueprint_path", "type": "string" },
           { "name": "widget_name", "type": "string" },
-          { "name": "applied", "type": "array" },
-          { "name": "failed", "type": "array" },
-          { "name": "ok", "type": "boolean" }
+          { "name": "succeeded", "type": "number" },
+          { "name": "failed", "type": "number" },
+          { "name": "failed_properties", "type": "array" },
+          { "name": "unknown_slot_props", "type": "array" },
+          { "name": "warnings", "type": "array" }
         ]
       },
       "agent_callable": true,
-      "has_ts_wrapper": false,
-      "notes": "Edits the authoritative UWidgetBlueprint designer tree and survives compilation when followed by blueprint_compile and asset_save."
+      "has_ts_wrapper": true,
+      "notes": "Edits the authoritative UWidgetBlueprint designer tree and survives compilation when followed by ui_compile_widget and ui_save_widget. Reached through the ui_set_widget_properties TS wrapper and the typed tools (ui_set_property, ui_set_text_style, ui_set_brush, ui_set_visibility, ui_set_slot_layout) that compose onto it."
     },
     "scene_get_actor_relations": {
       "aliases": [],

--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -2284,6 +2284,29 @@
       "has_ts_wrapper": false,
       "notes": ""
     },
+    "ui_set_widget_properties": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPUIHandler::Handle",
+      "params": [
+        { "name": "widget_blueprint_path", "type": "string", "required": true, "description": "Widget Blueprint asset path, for example /Game/UI/WBP_HUD" },
+        { "name": "widget_name", "type": "string", "required": true, "description": "Exact widget name in the authoritative designer WidgetTree" },
+        { "name": "properties", "type": "object", "required": true, "description": "Widget UPROPERTY names mapped to reflection-compatible values" },
+        { "name": "slot_props", "type": "object", "required": false, "description": "Optional typed slot values such as x, y, w, h, padding, and fill" }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          { "name": "widget_blueprint_path", "type": "string" },
+          { "name": "widget_name", "type": "string" },
+          { "name": "applied", "type": "array" },
+          { "name": "failed", "type": "array" },
+          { "name": "ok", "type": "boolean" }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Edits the authoritative UWidgetBlueprint designer tree and survives compilation when followed by blueprint_compile and asset_save."
+    },
     "scene_get_actor_relations": {
       "aliases": [],
       "handler_cpp": "FHaybaMCPSceneGraphHandler::Handle",

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -37,7 +37,10 @@ import { handleFabDownload, meta as fabDownloadMeta } from './fab/download.js';
 
 // ── Material instance-layer tool handlers ───────────────────────────────────
 import { materialCreateHandler, meta as materialCreateMeta } from './material/material-create.js';
-import { materialCreateInstanceHandler, meta as materialCreateInstanceMeta } from './material/material-create-instance.js';
+import {
+  materialCreateInstanceHandler,
+  meta as materialCreateInstanceMeta,
+} from './material/material-create-instance.js';
 import { materialSetParamHandler, meta as materialSetParamMeta } from './material/material-set-param.js';
 import { materialApplyHandler, meta as materialApplyMeta } from './material/material-apply.js';
 import { materialListHandler, meta as materialListMeta } from './material/material-list.js';
@@ -50,34 +53,120 @@ import { materialDeleteNodeHandler, meta as materialDeleteNodeMeta } from './mat
 import { materialAddCommentHandler, meta as materialAddCommentMeta } from './material/material-add-comment.js';
 import { materialDeleteCommentHandler, meta as materialDeleteCommentMeta } from './material/material-delete-comment.js';
 import { materialSetCommentHandler, meta as materialSetCommentMeta } from './material/material-set-comment.js';
-import { materialAddRerouteDeclarationHandler, meta as materialAddRerouteDeclarationMeta } from './material/material-add-reroute-declaration.js';
-import { materialAddRerouteUsageHandler, meta as materialAddRerouteUsageMeta } from './material/material-add-reroute-usage.js';
+import {
+  materialAddRerouteDeclarationHandler,
+  meta as materialAddRerouteDeclarationMeta,
+} from './material/material-add-reroute-declaration.js';
+import {
+  materialAddRerouteUsageHandler,
+  meta as materialAddRerouteUsageMeta,
+} from './material/material-add-reroute-usage.js';
 import { assetDeleteHandler, meta as assetDeleteMeta } from './asset/asset-delete.js';
 import { materialConnectNodesHandler, meta as materialConnectNodesMeta } from './material/material-connect-nodes.js';
-import { materialFunctionCreateHandler, meta as materialFunctionCreateMeta } from './material/material-function-create.js';
-import { materialSetMaterialPropertyHandler, meta as materialSetMaterialPropertyMeta } from './material/material-set-material-property.js';
+import {
+  materialFunctionCreateHandler,
+  meta as materialFunctionCreateMeta,
+} from './material/material-function-create.js';
+import {
+  materialSetMaterialPropertyHandler,
+  meta as materialSetMaterialPropertyMeta,
+} from './material/material-set-material-property.js';
 import { materialCompileHandler, meta as materialCompileMeta } from './material/material-compile.js';
 import { materialDisconnectHandler, meta as materialDisconnectMeta } from './material/material-disconnect.js';
 import { materialValidateHandler, meta as materialValidateMeta } from './material/material-validate.js';
 import { uiCreateWidgetHandler, meta as uiCreateWidgetMeta } from './ui/ui-create-widget.js';
 import { uiAddElementHandler, meta as uiAddElementMeta } from './ui/ui-add-element.js';
-import { uiQueryHandler, meta as uiQueryMeta } from './ui/ui-query.js';
+import { uiQueryHandler, meta as uiQueryMeta, schema as uiQuerySchema } from './ui/ui-query.js';
+import {
+  meta as uiSetWidgetPropertiesMeta,
+  schema as uiSetWidgetPropertiesSchema,
+  uiSetWidgetPropertiesHandler,
+} from './ui/ui-set-widget-properties.js';
+import {
+  meta as uiSetPropertyMeta,
+  schema as uiSetPropertySchema,
+  uiSetPropertyHandler,
+} from './ui/ui-set-property.js';
+import {
+  meta as uiSetTextStyleMeta,
+  schema as uiSetTextStyleSchema,
+  uiSetTextStyleHandler,
+} from './ui/ui-set-text-style.js';
+import { meta as uiSetBrushMeta, schema as uiSetBrushSchema, uiSetBrushHandler } from './ui/ui-set-brush.js';
+import {
+  meta as uiSetVisibilityMeta,
+  schema as uiSetVisibilitySchema,
+  uiSetVisibilityHandler,
+} from './ui/ui-set-visibility.js';
+import {
+  meta as uiSetSlotLayoutMeta,
+  schema as uiSetSlotLayoutSchema,
+  uiSetSlotLayoutHandler,
+} from './ui/ui-set-slot-layout.js';
+import {
+  meta as uiCompileWidgetMeta,
+  schema as uiCompileWidgetSchema,
+  uiCompileWidgetHandler,
+} from './ui/ui-compile-widget.js';
+import { meta as uiSaveWidgetMeta, schema as uiSaveWidgetSchema, uiSaveWidgetHandler } from './ui/ui-save-widget.js';
+import {
+  meta as uiGetWidgetInfoMeta,
+  schema as uiGetWidgetInfoSchema,
+  uiGetWidgetInfoHandler,
+} from './ui/ui-get-widget-info.js';
+import {
+  meta as uiSearchWidgetsMeta,
+  schema as uiSearchWidgetsSchema,
+  uiSearchWidgetsHandler,
+} from './ui/ui-search-widgets.js';
+import {
+  meta as uiListWidgetTypesMeta,
+  schema as uiListWidgetTypesSchema,
+  uiListWidgetTypesHandler,
+} from './ui/ui-list-widget-types.js';
+import {
+  meta as uiRemoveElementMeta,
+  schema as uiRemoveElementSchema,
+  uiRemoveElementHandler,
+} from './ui/ui-remove-element.js';
+import {
+  meta as uiReparentElementMeta,
+  schema as uiReparentElementSchema,
+  uiReparentElementHandler,
+} from './ui/ui-reparent-element.js';
+import {
+  meta as uiReplaceElementMeta,
+  schema as uiReplaceElementSchema,
+  uiReplaceElementHandler,
+} from './ui/ui-replace-element.js';
 import { worldGenerateHandler, meta as worldGenerateMeta } from './world/world-generate.js';
 import {
-  providerListHandler, providerListMeta,
-  providerSetHandler, providerSetMeta,
-  providerTestHandler, providerTestMeta,
-  modelListHandler, modelListMeta,
-  keySetHandler, keySetMeta,
-  keyClearHandler, keyClearMeta,
-  keyStatusHandler, keyStatusMeta,
-  healthHandler, healthMeta,
+  providerListHandler,
+  providerListMeta,
+  providerSetHandler,
+  providerSetMeta,
+  providerTestHandler,
+  providerTestMeta,
+  modelListHandler,
+  modelListMeta,
+  keySetHandler,
+  keySetMeta,
+  keyClearHandler,
+  keyClearMeta,
+  keyStatusHandler,
+  keyStatusMeta,
+  healthHandler,
+  healthMeta,
 } from './copilot/copilot-tools.js';
 import {
-  textureGetInfoHandler, getInfoMeta as textureGetInfoMeta,
-  textureSetCompressionHandler, setCompressionMeta as textureSetCompressionMeta,
-  textureSetSettingsHandler, setSettingsMeta as textureSetSettingsMeta,
-  textureListHandler, listMeta as textureListMeta,
+  textureGetInfoHandler,
+  getInfoMeta as textureGetInfoMeta,
+  textureSetCompressionHandler,
+  setCompressionMeta as textureSetCompressionMeta,
+  textureSetSettingsHandler,
+  setSettingsMeta as textureSetSettingsMeta,
+  textureListHandler,
+  listMeta as textureListMeta,
 } from './texture/texture-tools.js';
 
 // ── Asset-source connectors (pure Node — no UE bridge except python_run) ──────
@@ -112,9 +201,15 @@ import { introspectDescriptor } from './introspect/hayba-introspect.js';
 import { pcgCookAndWaitHandler, schema as pcgCookSchema, meta as pcgCookMeta } from './pcg/pcg-cook-and-wait.js';
 import { pcgScatterMeshHandler, schema as pcgScatterSchema, meta as pcgScatterMeta } from './pcg/pcg-scatter-mesh.js';
 import {
-  pcgAddNodeDescriptor, pcgSetPropDescriptor, pcgWireDescriptor, pcgInspectInstancesDescriptor,
-  pcgRemoveNodeDescriptor, pcgDisconnectDescriptor, pcgLayoutDescriptor,
-  pcgListPinsDescriptor, pcgGetNodeDescriptor,
+  pcgAddNodeDescriptor,
+  pcgSetPropDescriptor,
+  pcgWireDescriptor,
+  pcgInspectInstancesDescriptor,
+  pcgRemoveNodeDescriptor,
+  pcgDisconnectDescriptor,
+  pcgLayoutDescriptor,
+  pcgListPinsDescriptor,
+  pcgGetNodeDescriptor,
 } from './pcg/pcg-primitives.js';
 import { actorPyDescriptors } from './actor/actor-py-tools.js';
 import { editorPyDescriptors } from './editor/editor-py-tools.js';
@@ -129,7 +224,6 @@ import { lightingPyDescriptors } from './lighting/lighting-py-tools.js';
 import { toToolDescriptor } from './py-tool-factory.js';
 import { generateLegacyDescriptors } from './legacy-tool-factory.js';
 
-
 // ── Zone painter tool handlers ────────────────────────────────────────────────
 import { openZonePainterHandler } from './hayba-open-zone-painter.js';
 import { readZonesHandler } from './hayba-read-zones.js';
@@ -143,41 +237,70 @@ import { analyzeConventionsHandler } from './hayba-analyze-conventions.js';
 import { appendNicheBriefing } from './niche-briefing.js';
 import { installToolHooks } from '../validator/index.js';
 import {
-  validatorRunSchema, validatorRunHandler,
-  validatorHistorySchema, validatorHistoryHandler,
-  validatorResolveSchema, validatorResolveHandler,
-  validatorClearSchema, validatorClearHandler,
-  validatorRulesSchema, validatorRulesHandler,
-  validatorSetRuleEnabledSchema, validatorSetRuleEnabledHandler,
+  validatorRunSchema,
+  validatorRunHandler,
+  validatorHistorySchema,
+  validatorHistoryHandler,
+  validatorResolveSchema,
+  validatorResolveHandler,
+  validatorClearSchema,
+  validatorClearHandler,
+  validatorRulesSchema,
+  validatorRulesHandler,
+  validatorSetRuleEnabledSchema,
+  validatorSetRuleEnabledHandler,
   defaultScratchDir as validatorScratchDir,
 } from './validator/tools.js';
 import { ensureConnected as ensureUeForValidator } from '../tcp-client.js';
 
 // ── PLUMB constraint subsystem (quantified validator + constraint language) ──
 import {
-  plumbPrimitivesSchema, plumbPrimitivesHandler,
-  plumbProfileBakeSchema, plumbProfileBakeHandler,
-  plumbProfileAnnotateSchema, plumbProfileAnnotateHandler,
-  plumbProfileListSchema, plumbProfileListHandler,
-  plumbProfileGetSchema, plumbProfileGetHandler,
-  plumbConstraintDefineSchema, plumbConstraintDefineHandler,
-  plumbConstraintListSchema, plumbConstraintListHandler,
-  plumbConstraintRemoveSchema, plumbConstraintRemoveHandler,
-  plumbConstraintProposeSchema, plumbConstraintProposeHandler,
-  plumbValidateSchema, plumbValidateHandler,
-  plumbMaskAddSchema, plumbMaskAddHandler,
-  plumbMaskRemoveSchema, plumbMaskRemoveHandler,
-  plumbLessonAddSchema, plumbLessonAddHandler,
-  plumbLessonListSchema, plumbLessonListHandler,
-  plumbLessonRemoveSchema, plumbLessonRemoveHandler,
-  plumbStudySchema, plumbStudyHandler,
-  plumbStudyTakeSchema, plumbStudyTakeHandler,
-  plumbSegmentSchema, plumbSegmentHandler,
-  plumbProductionDefineSchema, plumbProductionDefineHandler,
-  plumbProductionListSchema, plumbProductionListHandler,
-  plumbProductionRemoveSchema, plumbProductionRemoveHandler,
-  plumbSocketAddSchema, plumbSocketAddHandler,
-  plumbGrammarExpandSchema, plumbGrammarExpandHandler,
+  plumbPrimitivesSchema,
+  plumbPrimitivesHandler,
+  plumbProfileBakeSchema,
+  plumbProfileBakeHandler,
+  plumbProfileAnnotateSchema,
+  plumbProfileAnnotateHandler,
+  plumbProfileListSchema,
+  plumbProfileListHandler,
+  plumbProfileGetSchema,
+  plumbProfileGetHandler,
+  plumbConstraintDefineSchema,
+  plumbConstraintDefineHandler,
+  plumbConstraintListSchema,
+  plumbConstraintListHandler,
+  plumbConstraintRemoveSchema,
+  plumbConstraintRemoveHandler,
+  plumbConstraintProposeSchema,
+  plumbConstraintProposeHandler,
+  plumbValidateSchema,
+  plumbValidateHandler,
+  plumbMaskAddSchema,
+  plumbMaskAddHandler,
+  plumbMaskRemoveSchema,
+  plumbMaskRemoveHandler,
+  plumbLessonAddSchema,
+  plumbLessonAddHandler,
+  plumbLessonListSchema,
+  plumbLessonListHandler,
+  plumbLessonRemoveSchema,
+  plumbLessonRemoveHandler,
+  plumbStudySchema,
+  plumbStudyHandler,
+  plumbStudyTakeSchema,
+  plumbStudyTakeHandler,
+  plumbSegmentSchema,
+  plumbSegmentHandler,
+  plumbProductionDefineSchema,
+  plumbProductionDefineHandler,
+  plumbProductionListSchema,
+  plumbProductionListHandler,
+  plumbProductionRemoveSchema,
+  plumbProductionRemoveHandler,
+  plumbSocketAddSchema,
+  plumbSocketAddHandler,
+  plumbGrammarExpandSchema,
+  plumbGrammarExpandHandler,
 } from './plumb/tools.js';
 
 // SessionManager (Gaea session) parked while terrain features are off — kept
@@ -197,13 +320,14 @@ const dVec3 = z.tuple([z.number(), z.number(), z.number()]);
 // Some MCP clients (incl. Claude Code's tool harness) JSON-stringify nested
 // arrays/booleans before they hit Zod. Wrap so we accept both raw and the
 // stringified form for params we know are commonly affected.
-const dCoerceBool = z.preprocess(
-  (v) => typeof v === 'string' ? v.toLowerCase() === 'true' : v,
-  z.boolean(),
-);
+const dCoerceBool = z.preprocess((v) => (typeof v === 'string' ? v.toLowerCase() === 'true' : v), z.boolean());
 const dCoerceVec3 = z.preprocess((v) => {
   if (typeof v === 'string') {
-    try { return JSON.parse(v); } catch { return v; }
+    try {
+      return JSON.parse(v);
+    } catch {
+      return v;
+    }
   }
   return v;
 }, dVec3);
@@ -246,901 +370,1231 @@ const PACK = 'copilot'; // niche domain for the BYOK copilot config/introspectio
 // Hand-written descriptors. Kept as a named const so the generated legacy list
 // can be de-duplicated against these names before splicing (see below).
 const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
-    // ── World generation (always-on flagship) ────────────────────────────────
-    {
-      name: 'world_generate',
-      description: 'Build an environment from a natural-language biome description. Parses the prompt into layers (canopy/rock/undergrowth/groundcover), resolves one of the PROJECT\'S OWN StaticMeshes per layer, plans a deterministic seeded scatter across an area actor, then PLUMB-VALIDATES and auto-corrects every instance IN MEMORY (grounded, non-interpenetrating) before spawning — "scatter and prove", not scatter-and-hope. Use dry_run to get the validated plan without spawning.',
-      meta: worldGenerateMeta,
-      handler: worldGenerateHandler,
-      cost: 'high',
-      returns: '{ok, center_cm, layers:[{role,keywords,asset}], gaps:[string], planned, validation:{ran,passes,failed_before,failed_after,fixed}, ism_actors, instances, place_errors?, sample?}. Places one Instanced-Static-Mesh actor per resolved mesh with the validated transforms as instances.',
-      schema: {
-        area_actor: z.string().min(1).describe('Label of an actor whose location centres the biome region'),
-        prompt: z.string().min(1).describe('Natural-language biome description'),
-        radius_cm: z.number().positive().optional().describe('Scatter radius in cm (default 1500)'),
-        count: z.number().int().positive().optional().describe('Total instances across all layers (default 40)'),
-        seed: z.number().int().optional().describe('Deterministic seed (default 1337)'),
-        ground_tolerance_m: z.number().positive().optional().describe('Grounded tolerance in metres (default 0.1)'),
-        dry_run: z.boolean().optional().describe('Plan + validate only; do not spawn'),
-      },
+  // ── World generation (always-on flagship) ────────────────────────────────
+  {
+    name: 'world_generate',
+    description:
+      'Build an environment from a natural-language biome description. Parses the prompt into layers (canopy/rock/undergrowth/groundcover), resolves one of the PROJECT\'S OWN StaticMeshes per layer, plans a deterministic seeded scatter across an area actor, then PLUMB-VALIDATES and auto-corrects every instance IN MEMORY (grounded, non-interpenetrating) before spawning — "scatter and prove", not scatter-and-hope. Use dry_run to get the validated plan without spawning.',
+    meta: worldGenerateMeta,
+    handler: worldGenerateHandler,
+    cost: 'high',
+    returns:
+      '{ok, center_cm, layers:[{role,keywords,asset}], gaps:[string], planned, validation:{ran,passes,failed_before,failed_after,fixed}, ism_actors, instances, place_errors?, sample?}. Places one Instanced-Static-Mesh actor per resolved mesh with the validated transforms as instances.',
+    schema: {
+      area_actor: z.string().min(1).describe('Label of an actor whose location centres the biome region'),
+      prompt: z.string().min(1).describe('Natural-language biome description'),
+      radius_cm: z.number().positive().optional().describe('Scatter radius in cm (default 1500)'),
+      count: z.number().int().positive().optional().describe('Total instances across all layers (default 40)'),
+      seed: z.number().int().optional().describe('Deterministic seed (default 1337)'),
+      ground_tolerance_m: z.number().positive().optional().describe('Grounded tolerance in metres (default 0.1)'),
+      dry_run: z.boolean().optional().describe('Plan + validate only; do not spawn'),
     },
+  },
 
-    // ── Actor domain ────────────────────────────────────────────────────────
-    {
-      name: 'actor_spawn',
-      description: 'Spawn a new actor in the active level.',
-      meta: actorSpawnMeta,
-      handler: actorSpawnHandler,
-      cost: 'medium',
-      returns: '{actor_id, label, class}',
-      schema: {
-        class_path: z.string().describe('UE class path, e.g. "/Script/Engine.StaticMeshActor"'),
-        location: dCoerceVec3.optional(),
-        rotation: dCoerceVec3.optional(),
-        scale: dCoerceVec3.optional(),
-        label: z.string().optional(),
-      },
+  // ── Actor domain ────────────────────────────────────────────────────────
+  {
+    name: 'actor_spawn',
+    description: 'Spawn a new actor in the active level.',
+    meta: actorSpawnMeta,
+    handler: actorSpawnHandler,
+    cost: 'medium',
+    returns: '{actor_id, label, class}',
+    schema: {
+      class_path: z.string().describe('UE class path, e.g. "/Script/Engine.StaticMeshActor"'),
+      location: dCoerceVec3.optional(),
+      rotation: dCoerceVec3.optional(),
+      scale: dCoerceVec3.optional(),
+      label: z.string().optional(),
     },
-    {
-      name: 'actor_list',
-      description: 'Enumerate actors in the active level.',
-      meta: actorListMeta,
-      handler: actorListHandler,
-      cost: 'low',
-      returns: '{actors:[{id,label,class,location}], count}',
-      schema: {
-        class_filter: z.string().optional().describe('Exact class name filter'),
-        tag: z.string().optional().describe('Tag filter'),
-      },
+  },
+  {
+    name: 'actor_list',
+    description: 'Enumerate actors in the active level.',
+    meta: actorListMeta,
+    handler: actorListHandler,
+    cost: 'low',
+    returns: '{actors:[{id,label,class,location}], count}',
+    schema: {
+      class_filter: z.string().optional().describe('Exact class name filter'),
+      tag: z.string().optional().describe('Tag filter'),
     },
-    {
-      name: 'actor_delete',
-      description: 'Destroy an actor in the active level.',
-      meta: actorDeleteMeta,
-      handler: actorDeleteHandler,
-      cost: 'low',
-      returns: '{ok, actor_id}',
-      schema: { actor_id: z.string() },
+  },
+  {
+    name: 'actor_delete',
+    description: 'Destroy an actor in the active level.',
+    meta: actorDeleteMeta,
+    handler: actorDeleteHandler,
+    cost: 'low',
+    returns: '{ok, actor_id}',
+    schema: { actor_id: z.string() },
+  },
+  {
+    name: 'actor_transform',
+    description: 'Reposition, rotate, or scale an existing actor.',
+    meta: actorTransformMeta,
+    handler: actorTransformHandler,
+    cost: 'low',
+    returns: '{ok, actor_id, before, after}',
+    schema: {
+      actor_id: z.string(),
+      location: dCoerceVec3.optional(),
+      rotation: dCoerceVec3.optional(),
+      scale: dCoerceVec3.optional(),
     },
-    {
-      name: 'actor_transform',
-      description: 'Reposition, rotate, or scale an existing actor.',
-      meta: actorTransformMeta,
-      handler: actorTransformHandler,
-      cost: 'low',
-      returns: '{ok, actor_id, before, after}',
-      schema: {
-        actor_id: z.string(),
-        location: dCoerceVec3.optional(),
-        rotation: dCoerceVec3.optional(),
-        scale: dCoerceVec3.optional(),
-      },
-    },
+  },
 
-    // ── Material instance-layer domain ────────────────────────────────────────
-    {
-      name: 'material_create',
-      description: 'Create a new material asset.',
-      meta: materialCreateMeta,
-      handler: materialCreateHandler,
-      cost: 'low',
-      returns: '{path, name}',
-      niche: M,
-      schema: {
-        package_path: z.string().min(1).describe('UE content path for the new material'),
-        name: z.string().min(1).describe('Name of the material asset'),
-      },
+  // ── Material instance-layer domain ────────────────────────────────────────
+  {
+    name: 'material_create',
+    description: 'Create a new material asset.',
+    meta: materialCreateMeta,
+    handler: materialCreateHandler,
+    cost: 'low',
+    returns: '{path, name}',
+    niche: M,
+    schema: {
+      package_path: z.string().min(1).describe('UE content path for the new material'),
+      name: z.string().min(1).describe('Name of the material asset'),
     },
-    {
-      name: 'material_create_instance',
-      description: 'Create a new material instance derived from a parent material.',
-      meta: materialCreateInstanceMeta,
-      handler: materialCreateInstanceHandler,
-      cost: 'low',
-      returns: '{path, name}',
-      niche: M,
-      schema: {
-        parent_material_path: z.string().min(1).describe('Path to the parent material asset'),
-        package_path: z.string().min(1).describe('UE content path for the new material instance'),
-        name: z.string().min(1).describe('Name of the material instance asset'),
-      },
+  },
+  {
+    name: 'material_create_instance',
+    description: 'Create a new material instance derived from a parent material.',
+    meta: materialCreateInstanceMeta,
+    handler: materialCreateInstanceHandler,
+    cost: 'low',
+    returns: '{path, name}',
+    niche: M,
+    schema: {
+      parent_material_path: z.string().min(1).describe('Path to the parent material asset'),
+      package_path: z.string().min(1).describe('UE content path for the new material instance'),
+      name: z.string().min(1).describe('Name of the material instance asset'),
     },
-    {
-      name: 'material_set_param',
-      description: 'Set a scalar, vector (rgba), or texture parameter on a material instance.',
-      meta: materialSetParamMeta,
-      handler: materialSetParamHandler,
-      cost: 'low',
-      returns: '{ok}',
-      niche: M,
-      schema: {
-        instance_path: z.string().min(1).describe('Path to the material instance'),
-        param_name: z.string().min(1).describe('Name of the parameter to set'),
-        value: z.union([
+  },
+  {
+    name: 'material_set_param',
+    description: 'Set a scalar, vector (rgba), or texture parameter on a material instance.',
+    meta: materialSetParamMeta,
+    handler: materialSetParamHandler,
+    cost: 'low',
+    returns: '{ok}',
+    niche: M,
+    schema: {
+      instance_path: z.string().min(1).describe('Path to the material instance'),
+      param_name: z.string().min(1).describe('Name of the parameter to set'),
+      value: z
+        .union([
           z.number().describe('Scalar value'),
           z.array(z.number()).min(1).max(4).describe('Vector value (1-4 components for rgba)'),
           z.string().describe('Texture asset path'),
-        ]).describe('Parameter value: scalar, vector (1-4 elements), or texture asset path'),
-      },
+        ])
+        .describe('Parameter value: scalar, vector (1-4 elements), or texture asset path'),
     },
-    {
-      name: 'material_apply',
-      description: 'Apply a material to an actor in the level (optionally specifying a material slot).',
-      meta: materialApplyMeta,
-      handler: materialApplyHandler,
-      cost: 'medium',
-      returns: '{ok, actor_id, material_path, slot}',
-      niche: M,
-      schema: {
-        actor_id: z.string().min(1).describe('ID of the actor to apply the material to'),
-        material_path: z.string().min(1).describe('Path to the material asset to apply'),
-        slot_index: z.number().int().nonnegative().optional().describe('Material slot index (default 0)'),
-      },
+  },
+  {
+    name: 'material_apply',
+    description: 'Apply a material to an actor in the level (optionally specifying a material slot).',
+    meta: materialApplyMeta,
+    handler: materialApplyHandler,
+    cost: 'medium',
+    returns: '{ok, actor_id, material_path, slot}',
+    niche: M,
+    schema: {
+      actor_id: z.string().min(1).describe('ID of the actor to apply the material to'),
+      material_path: z.string().min(1).describe('Path to the material asset to apply'),
+      slot_index: z.number().int().nonnegative().optional().describe('Material slot index (default 0)'),
     },
-    {
-      name: 'material_list',
-      description: 'List materials and material instances in the project or a specific path.',
-      meta: materialListMeta,
-      handler: materialListHandler,
-      cost: 'low',
-      returns: '{materials:[{path,type,is_instance}]}',
-      niche: M,
-      schema: {
-        path: z.string().optional().describe('UE content path filter (default: list all)'),
-      },
+  },
+  {
+    name: 'material_list',
+    description: 'List materials and material instances in the project or a specific path.',
+    meta: materialListMeta,
+    handler: materialListHandler,
+    cost: 'low',
+    returns: '{materials:[{path,type,is_instance}]}',
+    niche: M,
+    schema: {
+      path: z.string().optional().describe('UE content path filter (default: list all)'),
     },
-    {
-      name: 'material_get_info',
-      description: 'Inspect a material, material function, or material instance: properties, parameters, and the full expression graph. For materials/functions, each expression input includes its source edge (from_node + from_output), each node reports output_consumed + reachable_from_output, and a top-level dead_nodes[] lists every node NOT reachable from any material output — i.e. provably dead, safe to delete (no delete-recompile-compare needed).',
-      meta: materialGetInfoMeta,
-      handler: materialGetInfoHandler,
-      cost: 'low',
-      returns: "{kind, name, expressions:[{id,class,x,y,output_consumed,reachable_from_output,reroute_name?,reroute_kind?,inputs:[{name,index,connected,from_node,from_output}],outputs:[{name,index}]}], dead_nodes:[{id,class}], comments} | instance:{kind,name,parent,parameters:[{name,type,value}]}. Named-reroute nodes report reroute_name + reroute_kind('declaration'|'usage') so you can bind a usage to a declaration WITHOUT scanning expressions in python. outputs[] gives a node's real output pin order (esp. MaterialFunctionCall, whose order follows FunctionOutput sort priority, NOT the visual layout) — wire from_output by these.",
-      niche: M,
-      schema: {
-        path: z.string().min(1).describe('Path to the material or material instance to inspect'),
-      },
+  },
+  {
+    name: 'material_get_info',
+    description:
+      'Inspect a material, material function, or material instance: properties, parameters, and the full expression graph. For materials/functions, each expression input includes its source edge (from_node + from_output), each node reports output_consumed + reachable_from_output, and a top-level dead_nodes[] lists every node NOT reachable from any material output — i.e. provably dead, safe to delete (no delete-recompile-compare needed).',
+    meta: materialGetInfoMeta,
+    handler: materialGetInfoHandler,
+    cost: 'low',
+    returns:
+      "{kind, name, expressions:[{id,class,x,y,output_consumed,reachable_from_output,reroute_name?,reroute_kind?,inputs:[{name,index,connected,from_node,from_output}],outputs:[{name,index}]}], dead_nodes:[{id,class}], comments} | instance:{kind,name,parent,parameters:[{name,type,value}]}. Named-reroute nodes report reroute_name + reroute_kind('declaration'|'usage') so you can bind a usage to a declaration WITHOUT scanning expressions in python. outputs[] gives a node's real output pin order (esp. MaterialFunctionCall, whose order follows FunctionOutput sort priority, NOT the visual layout) — wire from_output by these.",
+    niche: M,
+    schema: {
+      path: z.string().min(1).describe('Path to the material or material instance to inspect'),
     },
+  },
 
-    // ── Material graph-layer domain ───────────────────────────────────────────
-    {
-      name: 'material_add_node',
-      description: 'Add a new expression node to a material graph. For a MaterialFunctionCall, pass properties.function (asset path) — the node\'s inputs/outputs are rebuilt immediately (UpdateFromFunctionResource), so its output pins are wirable right away and are returned in outputs[]. No recompile/refresh dance needed.',
-      meta: materialAddNodeMeta,
-      handler: materialAddNodeHandler,
-      cost: 'low',
-      returns: '{node_id, outputs?:[{name,index}]}  — outputs[] present for MaterialFunctionCall nodes (the pin names to use as from_output)',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
-        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
-        expression_class: z.string().min(1).describe('UE expression class name, e.g. "MaterialExpressionVectorParameter"'),
-        node_pos: z.tuple([z.number(), z.number()]).optional().describe('Graph position [x, y] for the new node'),
-        properties: z.record(z.string(), z.unknown()).optional().describe('Initial properties for the node. For a MaterialFunctionCall set "function" (or "function_path") to the function asset path — outputs are rebuilt immediately and returned.'),
-      },
+  // ── Material graph-layer domain ───────────────────────────────────────────
+  {
+    name: 'material_add_node',
+    description:
+      "Add a new expression node to a material graph. For a MaterialFunctionCall, pass properties.function (asset path) — the node's inputs/outputs are rebuilt immediately (UpdateFromFunctionResource), so its output pins are wirable right away and are returned in outputs[]. No recompile/refresh dance needed.",
+    meta: materialAddNodeMeta,
+    handler: materialAddNodeHandler,
+    cost: 'low',
+    returns:
+      '{node_id, outputs?:[{name,index}]}  — outputs[] present for MaterialFunctionCall nodes (the pin names to use as from_output)',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the material asset (either this or function_path required)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to the material function asset (either this or material_path required)'),
+      expression_class: z
+        .string()
+        .min(1)
+        .describe('UE expression class name, e.g. "MaterialExpressionVectorParameter"'),
+      node_pos: z.tuple([z.number(), z.number()]).optional().describe('Graph position [x, y] for the new node'),
+      properties: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe(
+          'Initial properties for the node. For a MaterialFunctionCall set "function" (or "function_path") to the function asset path — outputs are rebuilt immediately and returned.',
+        ),
     },
-    {
-      name: 'material_set_node',
-      description: 'Move and/or set properties on an existing node in a material graph.',
-      meta: materialSetNodeMeta,
-      handler: materialSetNodeHandler,
-      cost: 'low',
-      returns: '{node_id}',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
-        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
-        node_id: z.string().min(1).describe('ID/name of the existing node to update'),
-        node_pos: z.tuple([z.number(), z.number()]).optional().describe('New graph position [x, y]'),
-        properties: z.record(z.string(), z.unknown()).optional().describe('Properties to set on the node'),
-      },
+  },
+  {
+    name: 'material_set_node',
+    description: 'Move and/or set properties on an existing node in a material graph.',
+    meta: materialSetNodeMeta,
+    handler: materialSetNodeHandler,
+    cost: 'low',
+    returns: '{node_id}',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the material asset (either this or function_path required)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to the material function asset (either this or material_path required)'),
+      node_id: z.string().min(1).describe('ID/name of the existing node to update'),
+      node_pos: z.tuple([z.number(), z.number()]).optional().describe('New graph position [x, y]'),
+      properties: z.record(z.string(), z.unknown()).optional().describe('Properties to set on the node'),
     },
-    {
-      name: 'material_delete_node',
-      description: 'Delete an existing node from a material graph.',
-      meta: materialDeleteNodeMeta,
-      handler: materialDeleteNodeHandler,
-      cost: 'low',
-      returns: '{deleted}',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
-        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
-        node_id: z.string().min(1).describe('ID/name of the node to delete'),
-      },
+  },
+  {
+    name: 'material_delete_node',
+    description: 'Delete an existing node from a material graph.',
+    meta: materialDeleteNodeMeta,
+    handler: materialDeleteNodeHandler,
+    cost: 'low',
+    returns: '{deleted}',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the material asset (either this or function_path required)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to the material function asset (either this or material_path required)'),
+      node_id: z.string().min(1).describe('ID/name of the node to delete'),
     },
-    {
-      name: 'material_set_property',
-      description: 'Set master-material settings (blend mode, domain, shading model, two-sided, opacity mask clip).',
-      meta: materialSetMaterialPropertyMeta,
-      handler: materialSetMaterialPropertyHandler,
-      cost: 'low',
-      returns: '{applied:[keys]}',
-      niche: M,
-      schema: {
-        material_path: z.string().min(1).describe('Path to the master material asset'),
-        properties: z.record(z.string(), z.unknown()).describe('Settings; aliases: domain, blend_mode, shading_model, two_sided, opacity_mask_clip_value, enable_tessellation'),
-      },
+  },
+  {
+    name: 'material_set_property',
+    description: 'Set master-material settings (blend mode, domain, shading model, two-sided, opacity mask clip).',
+    meta: materialSetMaterialPropertyMeta,
+    handler: materialSetMaterialPropertyHandler,
+    cost: 'low',
+    returns: '{applied:[keys]}',
+    niche: M,
+    schema: {
+      material_path: z.string().min(1).describe('Path to the master material asset'),
+      properties: z
+        .record(z.string(), z.unknown())
+        .describe(
+          'Settings; aliases: domain, blend_mode, shading_model, two_sided, opacity_mask_clip_value, enable_tessellation',
+        ),
     },
-    {
-      name: 'material_compile',
-      description: 'Finalize a material OR material FUNCTION: write it to disk, apply staged settings, surface translator errors + shader optimization stats (materials). Graph edits DEFER the disk write — call this once the graph is complete. NOTE: material functions no longer auto-save either, so after editing a function call material_compile with function_path to persist it (this avoids a half-built function crashing the editor when it is opened/compiled).',
-      meta: materialCompileMeta,
-      handler: materialCompileHandler,
-      cost: 'medium',
-      returns: '{errors:[string], has_errors, saved, stats:{shaders:[{name,instructions}], texture_samples, ...}} (materials) | {saved} (functions)',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the master material asset to compile (either this or function_path)'),
-        function_path: z.string().optional().describe('Path to a material FUNCTION to finalize + save (either this or material_path)'),
-      },
+  },
+  {
+    name: 'material_compile',
+    description:
+      'Finalize a material OR material FUNCTION: write it to disk, apply staged settings, surface translator errors + shader optimization stats (materials). Graph edits DEFER the disk write — call this once the graph is complete. NOTE: material functions no longer auto-save either, so after editing a function call material_compile with function_path to persist it (this avoids a half-built function crashing the editor when it is opened/compiled).',
+    meta: materialCompileMeta,
+    handler: materialCompileHandler,
+    cost: 'medium',
+    returns:
+      '{errors:[string], has_errors, saved, stats:{shaders:[{name,instructions}], texture_samples, ...}} (materials) | {saved} (functions)',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the master material asset to compile (either this or function_path)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to a material FUNCTION to finalize + save (either this or material_path)'),
     },
-    {
-      name: 'material_validate',
-      description: 'Statically check a material OR material FUNCTION graph for translator-crash-prone wiring WITHOUT compiling: reroutes/named-reroutes used downstream that resolve to no input, and connections to non-existent output indices — both trigger an uncatchable HLSL-translator assert that kills the editor. material_compile runs these same checks and refuses to compile when any fail, so call this first to fix issues safely.',
-      meta: materialValidateMeta,
-      handler: materialValidateHandler,
-      cost: 'low',
-      returns: '{ok:boolean, problems:[string]}',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the master material to validate (either this or function_path)'),
-        function_path: z.string().optional().describe('Path to a material FUNCTION to validate (either this or material_path)'),
-      },
+  },
+  {
+    name: 'material_validate',
+    description:
+      'Statically check a material OR material FUNCTION graph for translator-crash-prone wiring WITHOUT compiling: reroutes/named-reroutes used downstream that resolve to no input, and connections to non-existent output indices — both trigger an uncatchable HLSL-translator assert that kills the editor. material_compile runs these same checks and refuses to compile when any fail, so call this first to fix issues safely.',
+    meta: materialValidateMeta,
+    handler: materialValidateHandler,
+    cost: 'low',
+    returns: '{ok:boolean, problems:[string]}',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the master material to validate (either this or function_path)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to a material FUNCTION to validate (either this or material_path)'),
     },
-    {
-      name: 'texture_get_info',
-      description: 'Inspect a Texture2D: dimensions, source/platform format, mip count, compression settings, LOD group, sRGB, never-stream, address modes.',
-      meta: textureGetInfoMeta,
-      handler: textureGetInfoHandler,
-      cost: 'low',
-      returns: '{path, width, height, format, num_mips, compression_settings, lod_group, srgb, never_stream, address_x, address_y}',
-      schema: {
-        path: z.string().min(1).describe('Texture asset path, e.g. /Game/Tex/T_Rock'),
-      },
+  },
+  {
+    name: 'texture_get_info',
+    description:
+      'Inspect a Texture2D: dimensions, source/platform format, mip count, compression settings, LOD group, sRGB, never-stream, address modes.',
+    meta: textureGetInfoMeta,
+    handler: textureGetInfoHandler,
+    cost: 'low',
+    returns:
+      '{path, width, height, format, num_mips, compression_settings, lod_group, srgb, never_stream, address_x, address_y}',
+    schema: {
+      path: z.string().min(1).describe('Texture asset path, e.g. /Game/Tex/T_Rock'),
     },
-    {
-      name: 'texture_set_compression',
-      description: 'Set a texture\'s compression (TC_*) and optionally LOD group + sRGB. Re-imports the texture resource. For other properties (mip gen, max size, filter, address, ...) use texture_set_settings.',
-      meta: textureSetCompressionMeta,
-      handler: textureSetCompressionHandler,
-      cost: 'low',
-      returns: '{ok, path, compression_settings, lod_group, srgb}',
-      schema: {
-        path: z.string().min(1).describe('Texture asset path'),
-        compression_settings: z.string().min(1).describe('TextureCompressionSettings, e.g. Normalmap / Masks / Default (TC_ prefix optional)'),
-        lod_group: z.string().optional().describe('TextureGroup, e.g. World / WorldNormalMap (TEXTUREGROUP_ prefix optional)'),
-        srgb: z.boolean().optional().describe('sRGB flag'),
-      },
+  },
+  {
+    name: 'texture_set_compression',
+    description:
+      "Set a texture's compression (TC_*) and optionally LOD group + sRGB. Re-imports the texture resource. For other properties (mip gen, max size, filter, address, ...) use texture_set_settings.",
+    meta: textureSetCompressionMeta,
+    handler: textureSetCompressionHandler,
+    cost: 'low',
+    returns: '{ok, path, compression_settings, lod_group, srgb}',
+    schema: {
+      path: z.string().min(1).describe('Texture asset path'),
+      compression_settings: z
+        .string()
+        .min(1)
+        .describe('TextureCompressionSettings, e.g. Normalmap / Masks / Default (TC_ prefix optional)'),
+      lod_group: z
+        .string()
+        .optional()
+        .describe('TextureGroup, e.g. World / WorldNormalMap (TEXTUREGROUP_ prefix optional)'),
+      srgb: z.boolean().optional().describe('sRGB flag'),
     },
-    {
-      name: 'texture_set_settings',
-      description: 'Set any texture properties at once via reflection. Aliases: compression_settings, lod_group, srgb, never_stream, address_x, address_y, mip_gen_settings, max_texture_size, flip_green_channel, filter, virtual_texture_streaming, lod_bias. Any raw UTexture UPROPERTY name also works. Re-imports the resource after applying.',
-      meta: textureSetSettingsMeta,
-      handler: textureSetSettingsHandler,
-      cost: 'low',
-      returns: '{ok, path, applied:[string], compression_settings, lod_group, srgb, never_stream}',
-      schema: {
-        path: z.string().min(1).describe('Texture asset path'),
-        properties: z.record(z.string(), z.unknown()).describe('Settings to set, e.g. { compression_settings: "Normalmap", srgb: false, mip_gen_settings: "Sharpen4" }'),
-      },
+  },
+  {
+    name: 'texture_set_settings',
+    description:
+      'Set any texture properties at once via reflection. Aliases: compression_settings, lod_group, srgb, never_stream, address_x, address_y, mip_gen_settings, max_texture_size, flip_green_channel, filter, virtual_texture_streaming, lod_bias. Any raw UTexture UPROPERTY name also works. Re-imports the resource after applying.',
+    meta: textureSetSettingsMeta,
+    handler: textureSetSettingsHandler,
+    cost: 'low',
+    returns: '{ok, path, applied:[string], compression_settings, lod_group, srgb, never_stream}',
+    schema: {
+      path: z.string().min(1).describe('Texture asset path'),
+      properties: z
+        .record(z.string(), z.unknown())
+        .describe(
+          'Settings to set, e.g. { compression_settings: "Normalmap", srgb: false, mip_gen_settings: "Sharpen4" }',
+        ),
     },
-    {
-      name: 'texture_list',
-      description: 'List Texture2D assets, optionally filtered by path prefix.',
-      meta: textureListMeta,
-      handler: textureListHandler,
-      cost: 'low',
-      returns: '{textures:[{path, width, height, compression_settings}], count}',
-      schema: {
-        path_prefix: z.string().optional().describe('Only list textures whose path starts with this, e.g. /Game/Tex'),
-      },
+  },
+  {
+    name: 'texture_list',
+    description: 'List Texture2D assets, optionally filtered by path prefix.',
+    meta: textureListMeta,
+    handler: textureListHandler,
+    cost: 'low',
+    returns: '{textures:[{path, width, height, compression_settings}], count}',
+    schema: {
+      path_prefix: z.string().optional().describe('Only list textures whose path starts with this, e.g. /Game/Tex'),
     },
-    {
-      name: 'material_add_comment',
-      description: 'Add a titled comment box around a group of nodes in a material or function graph.',
-      meta: materialAddCommentMeta,
-      handler: materialAddCommentHandler,
-      cost: 'low',
-      returns: '{comment_id}',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
-        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
-        text: z.string().describe('Comment title/text shown on the box'),
-        node_pos: z.tuple([z.number(), z.number()]).optional().describe('Top-left graph position [x, y]'),
-        size: z.tuple([z.number(), z.number()]).optional().describe('Box size [width, height]'),
-        color: z.array(z.number()).min(3).max(4).optional().describe('Box color [r, g, b] or [r, g, b, a] (0..1)'),
-        font_size: z.number().int().optional().describe('Title font size (default 18)'),
-      },
+  },
+  {
+    name: 'material_add_comment',
+    description: 'Add a titled comment box around a group of nodes in a material or function graph.',
+    meta: materialAddCommentMeta,
+    handler: materialAddCommentHandler,
+    cost: 'low',
+    returns: '{comment_id}',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the material asset (either this or function_path required)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to the material function asset (either this or material_path required)'),
+      text: z.string().describe('Comment title/text shown on the box'),
+      node_pos: z.tuple([z.number(), z.number()]).optional().describe('Top-left graph position [x, y]'),
+      size: z.tuple([z.number(), z.number()]).optional().describe('Box size [width, height]'),
+      color: z.array(z.number()).min(3).max(4).optional().describe('Box color [r, g, b] or [r, g, b, a] (0..1)'),
+      font_size: z.number().int().optional().describe('Title font size (default 18)'),
     },
-    {
-      name: 'material_delete_comment',
-      description: 'Delete a comment box from a material or function graph (comment_id from material_get_info.comments[].id). Named reroutes are nodes — use material_delete_node for those.',
-      meta: materialDeleteCommentMeta,
-      handler: materialDeleteCommentHandler,
-      cost: 'low',
-      returns: '{deleted}',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
-        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
-        comment_id: z.string().min(1).describe('Comment id to delete (from material_get_info.comments[].id)'),
-      },
+  },
+  {
+    name: 'material_delete_comment',
+    description:
+      'Delete a comment box from a material or function graph (comment_id from material_get_info.comments[].id). Named reroutes are nodes — use material_delete_node for those.',
+    meta: materialDeleteCommentMeta,
+    handler: materialDeleteCommentHandler,
+    cost: 'low',
+    returns: '{deleted}',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the material asset (either this or function_path required)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to the material function asset (either this or material_path required)'),
+      comment_id: z.string().min(1).describe('Comment id to delete (from material_get_info.comments[].id)'),
     },
-    {
-      name: 'material_set_comment',
-      description: 'Edit an existing comment box (move/resize/retitle/recolor) by id — only the fields you pass change. Completes comment CRUD so comments never need a Python fallback.',
-      meta: materialSetCommentMeta,
-      handler: materialSetCommentHandler,
-      cost: 'low',
-      returns: '{comment_id}',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
-        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
-        comment_id: z.string().min(1).describe('Comment id to edit (from material_get_info.comments[].id)'),
-        text: z.string().optional().describe('New title/text'),
-        node_pos: z.tuple([z.number(), z.number()]).optional().describe('New top-left graph position [x, y]'),
-        size: z.tuple([z.number(), z.number()]).optional().describe('New box size [width, height]'),
-        color: z.array(z.number()).min(3).max(4).optional().describe('New color [r, g, b] or [r, g, b, a] (0..1)'),
-        font_size: z.number().int().optional().describe('New title font size'),
-      },
+  },
+  {
+    name: 'material_set_comment',
+    description:
+      'Edit an existing comment box (move/resize/retitle/recolor) by id — only the fields you pass change. Completes comment CRUD so comments never need a Python fallback.',
+    meta: materialSetCommentMeta,
+    handler: materialSetCommentHandler,
+    cost: 'low',
+    returns: '{comment_id}',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the material asset (either this or function_path required)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to the material function asset (either this or material_path required)'),
+      comment_id: z.string().min(1).describe('Comment id to edit (from material_get_info.comments[].id)'),
+      text: z.string().optional().describe('New title/text'),
+      node_pos: z.tuple([z.number(), z.number()]).optional().describe('New top-left graph position [x, y]'),
+      size: z.tuple([z.number(), z.number()]).optional().describe('New box size [width, height]'),
+      color: z.array(z.number()).min(3).max(4).optional().describe('New color [r, g, b] or [r, g, b, a] (0..1)'),
+      font_size: z.number().int().optional().describe('New title font size'),
     },
-    {
-      name: 'material_add_reroute_declaration',
-      description: 'Create a named-reroute declaration (source anchor) so a value can be referenced by name instead of long wires.',
-      meta: materialAddRerouteDeclarationMeta,
-      handler: materialAddRerouteDeclarationHandler,
-      cost: 'low',
-      returns: '{node_id}',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
-        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
-        name: z.string().min(1).describe('The reroute name (what usages bind to)'),
-        node_pos: z.tuple([z.number(), z.number()]).optional().describe('Graph position [x, y]'),
-        color: z.array(z.number()).min(3).max(4).optional().describe('Node color [r, g, b] or [r, g, b, a] (0..1)'),
-      },
+  },
+  {
+    name: 'material_add_reroute_declaration',
+    description:
+      'Create a named-reroute declaration (source anchor) so a value can be referenced by name instead of long wires.',
+    meta: materialAddRerouteDeclarationMeta,
+    handler: materialAddRerouteDeclarationHandler,
+    cost: 'low',
+    returns: '{node_id}',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the material asset (either this or function_path required)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to the material function asset (either this or material_path required)'),
+      name: z.string().min(1).describe('The reroute name (what usages bind to)'),
+      node_pos: z.tuple([z.number(), z.number()]).optional().describe('Graph position [x, y]'),
+      color: z.array(z.number()).min(3).max(4).optional().describe('Node color [r, g, b] or [r, g, b, a] (0..1)'),
     },
-    {
-      name: 'material_add_reroute_usage',
-      description: 'Create a named-reroute usage bound to a declaration by name (replaces a long wire).',
-      meta: materialAddRerouteUsageMeta,
-      handler: materialAddRerouteUsageHandler,
-      cost: 'low',
-      returns: '{node_id}',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
-        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
-        declaration_id: z.string().min(1).describe('node_id of the reroute declaration to bind to'),
-        node_pos: z.tuple([z.number(), z.number()]).optional().describe('Graph position [x, y]'),
-      },
+  },
+  {
+    name: 'material_add_reroute_usage',
+    description: 'Create a named-reroute usage bound to a declaration by name (replaces a long wire).',
+    meta: materialAddRerouteUsageMeta,
+    handler: materialAddRerouteUsageHandler,
+    cost: 'low',
+    returns: '{node_id}',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the material asset (either this or function_path required)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to the material function asset (either this or material_path required)'),
+      declaration_id: z.string().min(1).describe('node_id of the reroute declaration to bind to'),
+      node_pos: z.tuple([z.number(), z.number()]).optional().describe('Graph position [x, y]'),
     },
-    {
-      name: 'asset_delete',
-      description: 'Permanently delete a content asset by object path.',
-      meta: assetDeleteMeta,
-      handler: assetDeleteHandler,
-      cost: 'low',
-      returns: '{deleted}',
-      schema: {
-        path: z.string().min(1).describe('Object path of the asset to delete, e.g. /Game/Foo/MF_X.MF_X'),
-      },
+  },
+  {
+    name: 'asset_delete',
+    description: 'Permanently delete a content asset by object path.',
+    meta: assetDeleteMeta,
+    handler: assetDeleteHandler,
+    cost: 'low',
+    returns: '{deleted}',
+    schema: {
+      path: z.string().min(1).describe('Object path of the asset to delete, e.g. /Game/Foo/MF_X.MF_X'),
     },
-    {
-      name: 'material_connect_nodes',
-      description: "Connect two nodes in a material graph or connect a node output to a material property. IMPORTANT for multi-output sources (esp. MaterialFunctionCall): you MUST pick the output pin with from_output (the pin NAME) or from_output_index — otherwise the call is rejected, because defaulting to the first output silently swaps function outputs (e.g. Albedo<->F0). Get the real pin names/order from material_get_info.expressions[].outputs[]. May return clutter-prevention suggestions: use named reroutes when a source fans out to 2+ targets, or a reroute knee node when a wire would run backward/over another node.",
-      meta: materialConnectNodesMeta,
-      handler: materialConnectNodesHandler,
-      cost: 'low',
-      returns: '{connected, from_node_fanout?, suggestions?[]}',
-      niche: M,
-      schema: {
-        material_path: z.string().optional().describe('Path to the material asset (either this or function_path required)'),
-        function_path: z.string().optional().describe('Path to the material function asset (either this or material_path required)'),
-        from_node: z.string().min(1).describe('ID or name of the source node'),
-        from_output: z.string().optional().describe('Output pin NAME on the source node (from material_get_info.expressions[].outputs[].name). REQUIRED when the source has >1 output (e.g. a material function) unless you pass from_output_index.'),
-        to_node: z.string().optional().describe('ID or name of the target node'),
-        to_input: z.string().optional().describe('Input pin name on the target node'),
-        to_input_index: z.number().int().optional().describe('Target input pin by index (unnamed pins, e.g. Substrate slab inputs)'),
-        from_output_index: z.number().int().optional().describe('Source output pin by index (default 0)'),
-        to_property: z.string().optional().describe('Target material output, e.g. base_color, normal, front_material (Substrate), displacement (Nanite tessellation - needs material_set_property enable_tessellation=true)'),
-      },
+  },
+  {
+    name: 'material_connect_nodes',
+    description:
+      'Connect two nodes in a material graph or connect a node output to a material property. IMPORTANT for multi-output sources (esp. MaterialFunctionCall): you MUST pick the output pin with from_output (the pin NAME) or from_output_index — otherwise the call is rejected, because defaulting to the first output silently swaps function outputs (e.g. Albedo<->F0). Get the real pin names/order from material_get_info.expressions[].outputs[]. May return clutter-prevention suggestions: use named reroutes when a source fans out to 2+ targets, or a reroute knee node when a wire would run backward/over another node.',
+    meta: materialConnectNodesMeta,
+    handler: materialConnectNodesHandler,
+    cost: 'low',
+    returns: '{connected, from_node_fanout?, suggestions?[]}',
+    niche: M,
+    schema: {
+      material_path: z
+        .string()
+        .optional()
+        .describe('Path to the material asset (either this or function_path required)'),
+      function_path: z
+        .string()
+        .optional()
+        .describe('Path to the material function asset (either this or material_path required)'),
+      from_node: z.string().min(1).describe('ID or name of the source node'),
+      from_output: z
+        .string()
+        .optional()
+        .describe(
+          'Output pin NAME on the source node (from material_get_info.expressions[].outputs[].name). REQUIRED when the source has >1 output (e.g. a material function) unless you pass from_output_index.',
+        ),
+      to_node: z.string().optional().describe('ID or name of the target node'),
+      to_input: z.string().optional().describe('Input pin name on the target node'),
+      to_input_index: z
+        .number()
+        .int()
+        .optional()
+        .describe('Target input pin by index (unnamed pins, e.g. Substrate slab inputs)'),
+      from_output_index: z.number().int().optional().describe('Source output pin by index (default 0)'),
+      to_property: z
+        .string()
+        .optional()
+        .describe(
+          'Target material output, e.g. base_color, normal, front_material (Substrate), displacement (Nanite tessellation - needs material_set_property enable_tessellation=true)',
+        ),
     },
-    {
-      name: 'material_function_create',
-      description: 'Create a new material function asset in the project.',
-      meta: materialFunctionCreateMeta,
-      handler: materialFunctionCreateHandler,
-      cost: 'low',
-      returns: '{path, name}',
-      niche: M,
-      schema: {
-        package_path: z.string().min(1).describe('UE content path for the new material function'),
-        name: z.string().min(1).describe('Name of the material function asset'),
-      },
+  },
+  {
+    name: 'material_function_create',
+    description: 'Create a new material function asset in the project.',
+    meta: materialFunctionCreateMeta,
+    handler: materialFunctionCreateHandler,
+    cost: 'low',
+    returns: '{path, name}',
+    niche: M,
+    schema: {
+      package_path: z.string().min(1).describe('UE content path for the new material function'),
+      name: z.string().min(1).describe('Name of the material function asset'),
     },
-    {
-      name: 'material_disconnect',
-      description: 'Break a connection in a material graph — clear a node input or a material output property.',
-      meta: materialDisconnectMeta,
-      handler: materialDisconnectHandler,
-      cost: 'low',
-      returns: '{disconnected}',
-      niche: M,
-      schema: {
-        material_path: z.string().min(1).describe('Path to the material asset'),
-        to_node: z.string().optional().describe('ID or name of the target node whose input should be disconnected'),
-        to_input: z.string().optional().describe('Input pin name on the target node (defaults to first input)'),
-        to_input_index: z.number().int().nonnegative().optional().describe('Zero-based input pin index (alternative to to_input)'),
-        to_property: z.string().optional().describe('Material output property name to disconnect (e.g. base_color, normal)'),
-      },
+  },
+  {
+    name: 'material_disconnect',
+    description: 'Break a connection in a material graph — clear a node input or a material output property.',
+    meta: materialDisconnectMeta,
+    handler: materialDisconnectHandler,
+    cost: 'low',
+    returns: '{disconnected}',
+    niche: M,
+    schema: {
+      material_path: z.string().min(1).describe('Path to the material asset'),
+      to_node: z.string().optional().describe('ID or name of the target node whose input should be disconnected'),
+      to_input: z.string().optional().describe('Input pin name on the target node (defaults to first input)'),
+      to_input_index: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('Zero-based input pin index (alternative to to_input)'),
+      to_property: z
+        .string()
+        .optional()
+        .describe('Material output property name to disconnect (e.g. base_color, normal)'),
     },
+  },
 
-    // ── UMG / Widget Blueprint domain ─────────────────────────────────────────
-    // Native TS wrappers over the modern FHaybaMCPUIHandler (GetDomain()=="ui").
-    // Param names mirror HaybaMCPUIHandler.cpp exactly (the source of truth):
-    // ui_add_element takes slot_props (not "properties"); ui_query takes path
-    // (not widget_blueprint_path).
-    {
-      name: 'ui_create_widget',
-      description: 'Create a new UMG Widget Blueprint asset (designer-editable UI). Seeds a root CanvasPanel. Use the real UMG pipeline instead of hand-building the tree in C++.',
-      meta: uiCreateWidgetMeta,
-      handler: uiCreateWidgetHandler,
-      cost: 'medium',
-      returns: '{path, name, parent_class, root?}',
-      niche: UI,
-      schema: {
-        path: z.string().min(1).describe('UE content package directory, e.g. "/Game/Aphrosia/UI"'),
-        name: z.string().min(1).describe('Asset name, e.g. "WBP_StartScreen"'),
-        parent_class: z.string().optional().describe('Parent class (must descend from UserWidget); class path or short name. Defaults to UserWidget.'),
-      },
+  // ── UMG / Widget Blueprint domain ─────────────────────────────────────────
+  // Native TS wrappers over the modern FHaybaMCPUIHandler (GetDomain()=="ui").
+  // Param names mirror HaybaMCPUIHandler.cpp exactly (the source of truth):
+  // ui_add_element takes slot_props (not "properties"); ui_query takes path
+  // (not widget_blueprint_path).
+  // Property editing tools compose down to ui_set_widget_properties.
+  // Structural tools compose down to ui_mutate_tree.
+  {
+    name: 'ui_create_widget',
+    description:
+      'Create a new UMG Widget Blueprint asset (designer-editable UI). Seeds a root CanvasPanel. Use the real UMG pipeline instead of hand-building the tree in C++.',
+    meta: uiCreateWidgetMeta,
+    handler: uiCreateWidgetHandler,
+    cost: 'medium',
+    returns: '{path, name, parent_class, root?}',
+    niche: UI,
+    schema: {
+      path: z.string().min(1).describe('UE content package directory, e.g. "/Game/Aphrosia/UI"'),
+      name: z.string().min(1).describe('Asset name, e.g. "WBP_StartScreen"'),
+      parent_class: z
+        .string()
+        .optional()
+        .describe('Parent class (must descend from UserWidget); class path or short name. Defaults to UserWidget.'),
     },
-    {
-      name: 'ui_add_element',
-      description: 'Add a widget (Button/TextBlock/Image/panel/…) to an existing Widget Blueprint tree, optionally under a named panel, with slot layout props. Marks the BP structurally modified + dirty.',
-      meta: uiAddElementMeta,
-      handler: uiAddElementHandler,
-      cost: 'medium',
-      returns: '{widget_blueprint_path, parent, name, class, slot_class}',
-      niche: UI,
-      schema: {
-        widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
-        child_class: z.string().min(1).describe('Widget class — short name (Button, TextBlock, CanvasPanel, HorizontalBox, …) or full class path'),
-        parent_widget_name: z.string().optional().describe('Name of an existing PANEL widget to parent under; defaults to the root panel'),
-        name: z.string().optional().describe('Name for the new widget (auto-generated if omitted)'),
-        slot_props: z.record(z.union([z.number(), z.string(), z.boolean()])).optional()
-          .describe('Slot layout props: x/y/w/h (canvas), fill/padding (box); other keys set on the slot by reflection'),
-      },
+  },
+  {
+    name: 'ui_add_element',
+    description:
+      'Add a widget (Button/TextBlock/Image/panel/…) to an existing Widget Blueprint tree, optionally under a named panel, with slot layout props. Marks the BP structurally modified + dirty.',
+    meta: uiAddElementMeta,
+    handler: uiAddElementHandler,
+    cost: 'medium',
+    returns: '{widget_blueprint_path, parent, name, class, slot_class}',
+    niche: UI,
+    schema: {
+      widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+      child_class: z
+        .string()
+        .min(1)
+        .describe('Widget class — short name (Button, TextBlock, CanvasPanel, HorizontalBox, …) or full class path'),
+      parent_widget_name: z
+        .string()
+        .optional()
+        .describe('Name of an existing PANEL widget to parent under; defaults to the root panel'),
+      name: z.string().optional().describe('Name for the new widget (auto-generated if omitted)'),
+      slot_props: z
+        .record(z.union([z.number(), z.string(), z.boolean()]))
+        .optional()
+        .describe('Slot layout props: x/y/w/h (canvas), fill/padding (box); other keys set on the slot by reflection'),
     },
-    {
-      name: 'ui_query',
-      description: 'Return the widget tree of a Widget Blueprint — per-widget name, class, slot (offsets/fill/padding) and nested children.',
-      meta: uiQueryMeta,
-      handler: uiQueryHandler,
-      cost: 'low',
-      returns: '{path, parent_class, root:{name, class, slot, children:[…]}}',
-      niche: UI,
-      schema: {
-        path: z.string().min(1).describe('Full path of the Widget Blueprint to inspect'),
-      },
-    },
+  },
+  {
+    name: 'ui_query',
+    description:
+      'Return the widget tree of a Widget Blueprint — per-widget name, class, slot, variable GUID, and typed properties. Use include_properties/include_guid/include_slot to control detail depth.',
+    meta: uiQueryMeta,
+    handler: uiQueryHandler,
+    cost: 'low',
+    returns: '{path, parent_class, root:{name, class, slot, guid?, properties?, children:[…]}}',
+    niche: UI,
+    schema: uiQuerySchema.shape,
+  },
+  {
+    name: 'ui_set_widget_properties',
+    description:
+      'Generic tool: set named properties + slot layout on a designer widget in a Widget Blueprint. Operates on the authoritative WidgetTree (not the generated template). Uses FScopedTransaction for undo. Prefer the typed tools (ui_set_property, ui_set_text_style, ui_set_slot_layout, etc.) for common operations.',
+    meta: uiSetWidgetPropertiesMeta,
+    handler: uiSetWidgetPropertiesHandler,
+    cost: 'medium',
+    returns: '{succeeded, failed, failed_properties?}',
+    niche: UI,
+    schema: uiSetWidgetPropertiesSchema.shape,
+  },
+  {
+    name: 'ui_set_property',
+    description:
+      'Set a single arbitrary property on a designer widget by name and value. Typed wrapper around ui_set_widget_properties for the common case of changing one thing.',
+    meta: uiSetPropertyMeta,
+    handler: uiSetPropertyHandler,
+    cost: 'low',
+    returns: '{succeeded, failed, failed_properties?}',
+    niche: UI,
+    schema: uiSetPropertySchema.shape,
+  },
+  {
+    name: 'ui_set_text_style',
+    description:
+      'Set text styling on a TextBlock widget in a Widget Blueprint: font, typeface, size, letter spacing, color, outline, shadow, justification. All values survive compile+save+restart.',
+    meta: uiSetTextStyleMeta,
+    handler: uiSetTextStyleHandler,
+    cost: 'low',
+    returns: '{succeeded, failed}',
+    niche: UI,
+    schema: uiSetTextStyleSchema.shape,
+  },
+  {
+    name: 'ui_set_brush',
+    description:
+      'Set the brush on an Image or Border widget in a Widget Blueprint: texture/material resource, tint color, draw style, image size, and 9-slice margins.',
+    meta: uiSetBrushMeta,
+    handler: uiSetBrushHandler,
+    cost: 'low',
+    returns: '{succeeded, failed}',
+    niche: UI,
+    schema: uiSetBrushSchema.shape,
+  },
+  {
+    name: 'ui_set_visibility',
+    description:
+      'Set the visibility of a designer widget in a Widget Blueprint. Changes survive compile, save, and editor restart.',
+    meta: uiSetVisibilityMeta,
+    handler: uiSetVisibilityHandler,
+    cost: 'low',
+    returns: '{succeeded, failed}',
+    niche: UI,
+    schema: uiSetVisibilitySchema.shape,
+  },
+  {
+    name: 'ui_set_slot_layout',
+    description:
+      'Set CanvasPanel slot layout properties (anchors, position, size, alignment, Z-order) on a designer widget in a Widget Blueprint. For non-Canvas slots use the slot_layout field in ui_set_widget_properties.',
+    meta: uiSetSlotLayoutMeta,
+    handler: uiSetSlotLayoutHandler,
+    cost: 'low',
+    returns: '{succeeded, failed}',
+    niche: UI,
+    schema: uiSetSlotLayoutSchema.shape,
+  },
+  {
+    name: 'ui_compile_widget',
+    description:
+      'Compile a Widget Blueprint asset. Returns compilation status (UpToDate/Error/Dirty), warnings, and errors. Optionally save on successful compilation.',
+    meta: uiCompileWidgetMeta,
+    handler: uiCompileWidgetHandler,
+    cost: 'high',
+    returns: '{success, status, warnings, errors}',
+    niche: UI,
+    schema: uiCompileWidgetSchema.shape,
+  },
+  {
+    name: 'ui_save_widget',
+    description:
+      'Save a Widget Blueprint package to disk. Optionally compile before save. Returns whether the save succeeded and whether the package is still dirty.',
+    meta: uiSaveWidgetMeta,
+    handler: uiSaveWidgetHandler,
+    cost: 'medium',
+    returns: '{saved_path, success, package_dirty_after_save}',
+    niche: UI,
+    schema: uiSaveWidgetSchema.shape,
+  },
+  {
+    name: 'ui_get_widget_info',
+    description:
+      'Get detailed info about a Widget Blueprint: full widget tree with properties, variable GUIDs, slot layout, and typed property values per widget.',
+    meta: uiGetWidgetInfoMeta,
+    handler: uiGetWidgetInfoHandler,
+    cost: 'low',
+    returns: '{path, parent_class, root:{name, class, guid?, properties?, slot?, children:[…]}}',
+    niche: UI,
+    schema: uiGetWidgetInfoSchema.shape,
+  },
+  {
+    name: 'ui_search_widgets',
+    description:
+      'Search within a Widget Blueprint for widgets matching a name pattern or class filter. Returns matching widget paths and properties.',
+    meta: uiSearchWidgetsMeta,
+    handler: uiSearchWidgetsHandler,
+    cost: 'low',
+    returns: '{results:[{path, name, class, properties?}]}',
+    niche: UI,
+    schema: uiSearchWidgetsSchema.shape,
+  },
+  {
+    name: 'ui_list_widget_types',
+    description:
+      'List all available UMG widget classes that can be added to a Widget Blueprint via ui_add_element or ui_replace_element. Optionally filter by name.',
+    meta: uiListWidgetTypesMeta,
+    handler: uiListWidgetTypesHandler,
+    cost: 'low',
+    returns: '{widget_types:[{name, class_path, is_panel, description}]}',
+    niche: UI,
+    schema: uiListWidgetTypesSchema.shape,
+  },
+  {
+    name: 'ui_remove_element',
+    description:
+      'Remove a widget from a Widget Blueprint designer tree. Cannot remove the root without an explicit replacement_root. Widget variable GUID and member state are cleaned up.',
+    meta: uiRemoveElementMeta,
+    handler: uiRemoveElementHandler,
+    cost: 'medium',
+    returns: '{widget_blueprint_path, operation, removed_widget, parent_before_removal, child_index}',
+    niche: UI,
+    schema: uiRemoveElementSchema.shape,
+  },
+  {
+    name: 'ui_reparent_element',
+    description:
+      'Move an existing designer widget from its current parent to a new parent panel. Preserves widget instance and GUID. Creates the correct slot class for the new parent.',
+    meta: uiReparentElementMeta,
+    handler: uiReparentElementHandler,
+    cost: 'medium',
+    returns: '{widget_blueprint_path, operation, widget_name, old_parent, new_parent, old_index, new_index}',
+    niche: UI,
+    schema: uiReparentElementSchema.shape,
+  },
+  {
+    name: 'ui_replace_element',
+    description:
+      'Replace a designer widget with a new widget of a different class at the same position. Preserves parent, child index, and optionally the name and variable GUID.',
+    meta: uiReplaceElementMeta,
+    handler: uiReplaceElementHandler,
+    cost: 'medium',
+    returns:
+      '{widget_blueprint_path, operation, old_widget, old_class, new_widget, new_class, parent, child_index, preserved_guid, migrated_properties, discarded_properties}',
+    niche: UI,
+    schema: uiReplaceElementSchema.shape,
+  },
 
-    // ── Scene domain ──────────────────────────────────────────────────────────
-    {
-      name: 'scene_export',
-      description: 'Export a 3D scene graph for LLM reasoning (flat / relational / hierarchical).',
-      meta: sceneExportMeta,
-      handler: sceneExportHandler,
-      cost: 'medium',
-      returns: 'mode-specific shape',
-      schema: {
-        mode: z.enum(['flat', 'relational', 'hierarchical']).optional(),
-        window: z.object({ min: dVec3, max: dVec3 }).optional(),
-        max_items: z.coerce.number().int().optional(),
-      },
+  // ── Scene domain ──────────────────────────────────────────────────────────
+  {
+    name: 'scene_export',
+    description: 'Export a 3D scene graph for LLM reasoning (flat / relational / hierarchical).',
+    meta: sceneExportMeta,
+    handler: sceneExportHandler,
+    cost: 'medium',
+    returns: 'mode-specific shape',
+    schema: {
+      mode: z.enum(['flat', 'relational', 'hierarchical']).optional(),
+      window: z.object({ min: dVec3, max: dVec3 }).optional(),
+      max_items: z.coerce.number().int().optional(),
     },
-    {
-      name: 'scene_validate_physics',
-      description: 'Detect floating / interpenetrating actors in the level.',
-      meta: scenePhysicsMeta,
-      handler: sceneValidatePhysicsHandler,
-      cost: 'medium',
-      returns: '{valid, floating, interpenetrating, checked_count, scanned_actors, skipped_system_actors}',
-      schema: {
-        deep_check: dCoerceBool.optional(),
-        window: z.object({ min: dVec3, max: dVec3 }).optional(),
-      },
+  },
+  {
+    name: 'scene_validate_physics',
+    description: 'Detect floating / interpenetrating actors in the level.',
+    meta: scenePhysicsMeta,
+    handler: sceneValidatePhysicsHandler,
+    cost: 'medium',
+    returns: '{valid, floating, interpenetrating, checked_count, scanned_actors, skipped_system_actors}',
+    schema: {
+      deep_check: dCoerceBool.optional(),
+      window: z.object({ min: dVec3, max: dVec3 }).optional(),
     },
+  },
 
-    // ── Editor domain ─────────────────────────────────────────────────────────
-    // editor_capture_viewport and editor_stream_log are hand-written below:
-    //   - editor_capture_viewport: custom wait_for_shaders pre-step closure +
-    //     server.tool-vs-reg schema divergence (wait_for_shaders field in
-    //     eager schema, omitted from reg). Cannot cleanly fit the descriptor.
-    //   - editor_stream_log: reg adds regex_filter/severity_filter/format that
-    //     are NOT in the eager server.tool shape — schema divergence, left as-is.
-    {
-      name: 'editor_start_pie',
-      description: 'Start Play-In-Editor.',
-      meta: pieMeta,
-      handler: editorStartPieHandler,
-      cost: 'high',
-      returns: '{ok, pie_world_id}',
-      schema: {
-        single_step: dCoerceBool.optional(),
-      },
+  // ── Editor domain ─────────────────────────────────────────────────────────
+  // editor_capture_viewport and editor_stream_log are hand-written below:
+  //   - editor_capture_viewport: custom wait_for_shaders pre-step closure +
+  //     server.tool-vs-reg schema divergence (wait_for_shaders field in
+  //     eager schema, omitted from reg). Cannot cleanly fit the descriptor.
+  //   - editor_stream_log: reg adds regex_filter/severity_filter/format that
+  //     are NOT in the eager server.tool shape — schema divergence, left as-is.
+  {
+    name: 'editor_start_pie',
+    description: 'Start Play-In-Editor.',
+    meta: pieMeta,
+    handler: editorStartPieHandler,
+    cost: 'high',
+    returns: '{ok, pie_world_id}',
+    schema: {
+      single_step: dCoerceBool.optional(),
     },
+  },
 
-    // ── Wait / capture helpers ──────────────────────────────────────────────
-    // These tools were eagerly registered but absent from recordEagerSchemas,
-    // meaning get_tool_signature had no schema to return for them. Migration
-    // adds them to the single-source list so the schema is recorded once.
-    {
-      name: 'wait_for_shaders',
-      description: 'Wait for UE shader compilation to settle (or timeout). Thin wrapper around wait_for_idle({subsystems:["shaders"]}).',
-      meta: waitForShadersMeta,
-      handler: async (args, _session) => handleWaitForShaders(args as any) as never,
-      cost: 'high',
-      returns: '{settled:bool, waited_ms:int} or legacy {status, subsystems}',
-      schema: {
-        max_seconds: z.number().int().min(1).max(600).optional().describe('Upper bound in seconds (default 60).'),
-        poll_seconds: z.number().min(0.05).max(10).optional().describe('Poll interval in seconds (default 1). NOTE: ignored — UE-side polling is fixed at 250ms.'),
-      },
+  // ── Wait / capture helpers ──────────────────────────────────────────────
+  // These tools were eagerly registered but absent from recordEagerSchemas,
+  // meaning get_tool_signature had no schema to return for them. Migration
+  // adds them to the single-source list so the schema is recorded once.
+  {
+    name: 'wait_for_shaders',
+    description:
+      'Wait for UE shader compilation to settle (or timeout). Thin wrapper around wait_for_idle({subsystems:["shaders"]}).',
+    meta: waitForShadersMeta,
+    handler: async (args, _session) => handleWaitForShaders(args as any) as never,
+    cost: 'high',
+    returns: '{settled:bool, waited_ms:int} or legacy {status, subsystems}',
+    schema: {
+      max_seconds: z.number().int().min(1).max(600).optional().describe('Upper bound in seconds (default 60).'),
+      poll_seconds: z
+        .number()
+        .min(0.05)
+        .max(10)
+        .optional()
+        .describe('Poll interval in seconds (default 1). NOTE: ignored — UE-side polling is fixed at 250ms.'),
     },
-    {
-      name: 'wait_for_idle',
-      description: 'Wait for UE subsystems (shaders/assets/gc/pcg/world_tick) to settle before reading back or rendering. Default = shaders+assets+gc+pcg.',
-      meta: waitForIdleMeta,
-      handler: async (args, _session) => handleWaitForIdle(args as never) as never,
-      cost: 'high',
-      returns: '{settled, subsystems:{shaders,assets,gc,pcg,world_tick}}',
-      schema: waitForIdleSchema.shape,
-    },
-    {
-      name: 'render_camera',
-      description: 'Render a camera view to disk and VERIFY the file landed (magic bytes + dimensions). Accepts either an actor reference or an inline transform. Calls wait_for_idle internally before capture.',
-      meta: renderCameraMeta,
-      handler: async (args, _session) => handleRenderCamera(args as never) as never,
-      cost: 'high',
-      returns: '{ok, path, width, height, format, bytes}',
-      schema: renderCameraSchema.shape,
-    },
+  },
+  {
+    name: 'wait_for_idle',
+    description:
+      'Wait for UE subsystems (shaders/assets/gc/pcg/world_tick) to settle before reading back or rendering. Default = shaders+assets+gc+pcg.',
+    meta: waitForIdleMeta,
+    handler: async (args, _session) => handleWaitForIdle(args as never) as never,
+    cost: 'high',
+    returns: '{settled, subsystems:{shaders,assets,gc,pcg,world_tick}}',
+    schema: waitForIdleSchema.shape,
+  },
+  {
+    name: 'render_camera',
+    description:
+      'Render a camera view to disk and VERIFY the file landed (magic bytes + dimensions). Accepts either an actor reference or an inline transform. Calls wait_for_idle internally before capture.',
+    meta: renderCameraMeta,
+    handler: async (args, _session) => handleRenderCamera(args as never) as never,
+    cost: 'high',
+    returns: '{ok, path, width, height, format, bytes}',
+    schema: renderCameraSchema.shape,
+  },
 
-    // ── Fab connector domain ────────────────────────────────────────────────
-    {
-      name: 'hayba_fab_login_status',
-      description: 'Check whether the user is currently logged into Fab through the UE editor.',
-      meta: fabLoginStatusMeta,
-      handler: async (args, _session) => handleFabLoginStatus(args as any),
-      cost: 'low',
-      returns: '{logged_in:bool, user?:string}',
-      schema: {},
+  // ── Fab connector domain ────────────────────────────────────────────────
+  {
+    name: 'hayba_fab_login_status',
+    description: 'Check whether the user is currently logged into Fab through the UE editor.',
+    meta: fabLoginStatusMeta,
+    handler: async (args, _session) => handleFabLoginStatus(args as any),
+    cost: 'low',
+    returns: '{logged_in:bool, user?:string}',
+    schema: {},
+  },
+  {
+    name: 'hayba_fab_library_list',
+    description: "List a page of the user's Fab library (assets they own).",
+    meta: fabLibraryListMeta,
+    handler: async (args, _session) => handleFabLibraryList(args as any),
+    cost: 'medium',
+    returns: '{assets:[{id,title,type}], next_cursor?}',
+    schema: {
+      count: z.number().int().min(1).max(100).optional().describe('Number of results per page (default 20).'),
+      page: z.string().optional().describe('Pagination cursor from previous call.'),
     },
-    {
-      name: 'hayba_fab_library_list',
-      description: "List a page of the user's Fab library (assets they own).",
-      meta: fabLibraryListMeta,
-      handler: async (args, _session) => handleFabLibraryList(args as any),
-      cost: 'medium',
-      returns: '{assets:[{id,title,type}], next_cursor?}',
-      schema: {
-        count: z.number().int().min(1).max(100).optional().describe('Number of results per page (default 20).'),
-        page: z.string().optional().describe('Pagination cursor from previous call.'),
-      },
+  },
+  {
+    name: 'hayba_fab_marketplace_search',
+    description: 'Search the public Fab marketplace for assets matching a query.',
+    meta: fabMarketplaceSearchMeta,
+    handler: async (args, _session) => handleFabMarketplaceSearch(args as any),
+    cost: 'medium',
+    returns: '{assets:[{id,title,type,price}], next_cursor?}',
+    schema: {
+      query: z.string().min(1).describe('Search query string.'),
+      type: z.string().optional().describe('Filter by asset type (e.g. "Material", "StaticMesh").'),
+      page: z.string().optional().describe('Pagination cursor from previous call.'),
     },
-    {
-      name: 'hayba_fab_marketplace_search',
-      description: 'Search the public Fab marketplace for assets matching a query.',
-      meta: fabMarketplaceSearchMeta,
-      handler: async (args, _session) => handleFabMarketplaceSearch(args as any),
-      cost: 'medium',
-      returns: '{assets:[{id,title,type,price}], next_cursor?}',
-      schema: {
-        query: z.string().min(1).describe('Search query string.'),
-        type: z.string().optional().describe('Filter by asset type (e.g. "Material", "StaticMesh").'),
-        page: z.string().optional().describe('Pagination cursor from previous call.'),
-      },
+  },
+  {
+    name: 'hayba_fab_download',
+    description: 'Download a Fab asset into the active UE project.',
+    meta: fabDownloadMeta,
+    handler: async (args, _session) => handleFabDownload(args as any),
+    cost: 'high',
+    returns: '{ok, import_path}',
+    schema: {
+      asset_id: z.string().min(1).describe('Fab asset identifier.'),
+      download_url: z.string().url().describe('Signed download URL from library_list / search result item.'),
+      target_dir: z
+        .string()
+        .optional()
+        .describe('Project content path, e.g. /Game/Fab/MyAsset. Defaults to /Game/Fab/<asset_id>.'),
+      wait: z
+        .boolean()
+        .optional()
+        .describe('If true, blocks until download completes (up to 10min cap on the C++ side). Default true.'),
     },
-    {
-      name: 'hayba_fab_download',
-      description: 'Download a Fab asset into the active UE project.',
-      meta: fabDownloadMeta,
-      handler: async (args, _session) => handleFabDownload(args as any),
-      cost: 'high',
-      returns: '{ok, import_path}',
-      schema: {
-        asset_id: z.string().min(1).describe('Fab asset identifier.'),
-        download_url: z.string().url().describe('Signed download URL from library_list / search result item.'),
-        target_dir: z.string().optional().describe('Project content path, e.g. /Game/Fab/MyAsset. Defaults to /Game/Fab/<asset_id>.'),
-        wait: z.boolean().optional().describe('If true, blocks until download completes (up to 10min cap on the C++ side). Default true.'),
-      },
-    },
+  },
 
-    // ── Asset-source connectors (Poly Haven / ambientCG / Sketchfab) ────────
-    {
-      name: 'hayba_polyhaven_search',
-      description: 'Search Poly Haven for CC0 HDRIs, textures, or models.',
-      meta: polyhavenSearchMeta,
-      handler: async (args, _session) => handlePolyhavenSearch(args as any),
-      cost: 'medium',
-      returns: '{assets:[{id,name,type,categories,download_count}]}',
-      schema: {
-        query: z.string().min(1).describe('Search query string.'),
-        type: z.enum(['hdris', 'textures', 'models']).optional().describe('Asset type filter (default "textures").'),
-        categories: z.string().optional().describe('Comma-separated Poly Haven category filter.'),
-      },
+  // ── Asset-source connectors (Poly Haven / ambientCG / Sketchfab) ────────
+  {
+    name: 'hayba_polyhaven_search',
+    description: 'Search Poly Haven for CC0 HDRIs, textures, or models.',
+    meta: polyhavenSearchMeta,
+    handler: async (args, _session) => handlePolyhavenSearch(args as any),
+    cost: 'medium',
+    returns: '{assets:[{id,name,type,categories,download_count}]}',
+    schema: {
+      query: z.string().min(1).describe('Search query string.'),
+      type: z.enum(['hdris', 'textures', 'models']).optional().describe('Asset type filter (default "textures").'),
+      categories: z.string().optional().describe('Comma-separated Poly Haven category filter.'),
     },
-    {
-      name: 'hayba_polyhaven_download',
-      description: 'Download a Poly Haven asset (HDRI / texture maps / glTF model) and import into UE.',
-      meta: polyhavenDownloadMeta,
-      handler: async (args, _session) => handlePolyhavenDownload(args as any),
-      cost: 'high',
-      returns: '{ok, imported_paths:[string], target_dir}',
-      schema: {
-        asset_id: z.string().min(1).describe('Poly Haven asset slug.'),
-        type: z.enum(['hdris', 'textures', 'models']).optional().describe('Asset type (default "textures").'),
-        resolution: z.enum(['1k', '2k', '4k', '8k']).optional().describe('Resolution tier (default "2k").'),
-        target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/polyhaven/<asset_id>.'),
-      },
+  },
+  {
+    name: 'hayba_polyhaven_download',
+    description: 'Download a Poly Haven asset (HDRI / texture maps / glTF model) and import into UE.',
+    meta: polyhavenDownloadMeta,
+    handler: async (args, _session) => handlePolyhavenDownload(args as any),
+    cost: 'high',
+    returns: '{ok, imported_paths:[string], target_dir}',
+    schema: {
+      asset_id: z.string().min(1).describe('Poly Haven asset slug.'),
+      type: z.enum(['hdris', 'textures', 'models']).optional().describe('Asset type (default "textures").'),
+      resolution: z.enum(['1k', '2k', '4k', '8k']).optional().describe('Resolution tier (default "2k").'),
+      target_dir: z
+        .string()
+        .optional()
+        .describe('UE content path. Defaults to /Game/AssetConnectors/polyhaven/<asset_id>.'),
     },
-    {
-      name: 'hayba_ambientcg_search',
-      description: 'Search ambientCG for CC0 PBR materials, decals, or 3D models.',
-      meta: ambientcgSearchMeta,
-      handler: async (args, _session) => handleAmbientCgSearch(args as any),
-      cost: 'medium',
-      returns: '{assets:[{id,name,downloadCount,tags}]}',
-      schema: {
-        query: z.string().min(1).describe('Search query string.'),
-        type: z.string().optional().describe('ambientCG asset type (default "Material").'),
-        limit: z.number().int().min(1).max(100).optional().describe('Max results (default 20).'),
-      },
+  },
+  {
+    name: 'hayba_ambientcg_search',
+    description: 'Search ambientCG for CC0 PBR materials, decals, or 3D models.',
+    meta: ambientcgSearchMeta,
+    handler: async (args, _session) => handleAmbientCgSearch(args as any),
+    cost: 'medium',
+    returns: '{assets:[{id,name,downloadCount,tags}]}',
+    schema: {
+      query: z.string().min(1).describe('Search query string.'),
+      type: z.string().optional().describe('ambientCG asset type (default "Material").'),
+      limit: z.number().int().min(1).max(100).optional().describe('Max results (default 20).'),
     },
-    {
-      name: 'hayba_ambientcg_download',
-      description: 'Download an ambientCG material zip and import into UE.',
-      meta: ambientcgDownloadMeta,
-      handler: async (args, _session) => handleAmbientCgDownload(args as any),
-      cost: 'high',
-      returns: '{ok, imported_paths:[string], target_dir}',
-      schema: {
-        asset_id: z.string().min(1).describe('ambientCG asset id (e.g. "Bricks075A").'),
-        resolution: z.string().optional().describe('Attribute string (e.g. "1K-JPG", "2K-JPG", "4K-PNG"). Default "2K-JPG".'),
-        target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/ambientcg/<asset_id>.'),
-      },
+  },
+  {
+    name: 'hayba_ambientcg_download',
+    description: 'Download an ambientCG material zip and import into UE.',
+    meta: ambientcgDownloadMeta,
+    handler: async (args, _session) => handleAmbientCgDownload(args as any),
+    cost: 'high',
+    returns: '{ok, imported_paths:[string], target_dir}',
+    schema: {
+      asset_id: z.string().min(1).describe('ambientCG asset id (e.g. "Bricks075A").'),
+      resolution: z
+        .string()
+        .optional()
+        .describe('Attribute string (e.g. "1K-JPG", "2K-JPG", "4K-PNG"). Default "2K-JPG".'),
+      target_dir: z
+        .string()
+        .optional()
+        .describe('UE content path. Defaults to /Game/AssetConnectors/ambientcg/<asset_id>.'),
     },
-    {
-      name: 'hayba_sketchfab_search',
-      description: 'Search Sketchfab for downloadable 3D models. Requires SKETCHFAB_API_TOKEN env var.',
-      meta: sketchfabSearchMeta,
-      handler: async (args, _session) => handleSketchfabSearch(args as any),
-      cost: 'medium',
-      returns: '{models:[{uid,name,license,downloadCount}]}',
-      schema: {
-        query: z.string().min(1).describe('Search query string.'),
-        downloadable: z.boolean().optional().describe('Filter to downloadable-only models (default true).'),
-        count: z.number().int().min(1).max(48).optional().describe('Max results (default 24).'),
-      },
+  },
+  {
+    name: 'hayba_sketchfab_search',
+    description: 'Search Sketchfab for downloadable 3D models. Requires SKETCHFAB_API_TOKEN env var.',
+    meta: sketchfabSearchMeta,
+    handler: async (args, _session) => handleSketchfabSearch(args as any),
+    cost: 'medium',
+    returns: '{models:[{uid,name,license,downloadCount}]}',
+    schema: {
+      query: z.string().min(1).describe('Search query string.'),
+      downloadable: z.boolean().optional().describe('Filter to downloadable-only models (default true).'),
+      count: z.number().int().min(1).max(48).optional().describe('Max results (default 24).'),
     },
-    {
-      name: 'hayba_sketchfab_download',
-      description: 'Download a Sketchfab model and import into UE. Requires SKETCHFAB_API_TOKEN env var.',
-      meta: sketchfabDownloadMeta,
-      handler: async (args, _session) => handleSketchfabDownload(args as any),
-      cost: 'high',
-      returns: '{ok, imported_path, uid}',
-      schema: {
-        uid: z.string().min(1).describe('Sketchfab model uid.'),
-        flavour: z.enum(['gltf', 'usdz', 'source']).optional().describe('Download flavour (default "gltf").'),
-        target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/sketchfab/<uid>.'),
-      },
+  },
+  {
+    name: 'hayba_sketchfab_download',
+    description: 'Download a Sketchfab model and import into UE. Requires SKETCHFAB_API_TOKEN env var.',
+    meta: sketchfabDownloadMeta,
+    handler: async (args, _session) => handleSketchfabDownload(args as any),
+    cost: 'high',
+    returns: '{ok, imported_path, uid}',
+    schema: {
+      uid: z.string().min(1).describe('Sketchfab model uid.'),
+      flavour: z.enum(['gltf', 'usdz', 'source']).optional().describe('Download flavour (default "gltf").'),
+      target_dir: z.string().optional().describe('UE content path. Defaults to /Game/AssetConnectors/sketchfab/<uid>.'),
     },
+  },
 
-    // ── Agent-ergonomics tools (HANDOFF postmortem) — factory path ────────────
-    // These 5 python-backed tools are expressed as PyToolDescriptors and adapted
-    // here via toToolDescriptor so they flow through the same always-record /
-    // eager-register loops as every other STANDARD_DESCRIPTORS entry.
-    // pcg_cook_and_wait is a 3-step TS orchestrator and stays hand-written below.
-    toToolDescriptor(introspectDescriptor),
-    toToolDescriptor(pcgAddNodeDescriptor),
-    toToolDescriptor(pcgSetPropDescriptor),
-    toToolDescriptor(pcgWireDescriptor),
-    toToolDescriptor(pcgInspectInstancesDescriptor),
-    // PCG graph-EDIT tools (2026-07 postmortem §2a–2e): the destructive/introspect
-    // half that previously forced python_run fallbacks.
-    toToolDescriptor(pcgRemoveNodeDescriptor),
-    toToolDescriptor(pcgDisconnectDescriptor),
-    toToolDescriptor(pcgLayoutDescriptor),
-    toToolDescriptor(pcgListPinsDescriptor),
-    toToolDescriptor(pcgGetNodeDescriptor),
+  // ── Agent-ergonomics tools (HANDOFF postmortem) — factory path ────────────
+  // These 5 python-backed tools are expressed as PyToolDescriptors and adapted
+  // here via toToolDescriptor so they flow through the same always-record /
+  // eager-register loops as every other STANDARD_DESCRIPTORS entry.
+  // pcg_cook_and_wait is a 3-step TS orchestrator and stays hand-written below.
+  toToolDescriptor(introspectDescriptor),
+  toToolDescriptor(pcgAddNodeDescriptor),
+  toToolDescriptor(pcgSetPropDescriptor),
+  toToolDescriptor(pcgWireDescriptor),
+  toToolDescriptor(pcgInspectInstancesDescriptor),
+  // PCG graph-EDIT tools (2026-07 postmortem §2a–2e): the destructive/introspect
+  // half that previously forced python_run fallbacks.
+  toToolDescriptor(pcgRemoveNodeDescriptor),
+  toToolDescriptor(pcgDisconnectDescriptor),
+  toToolDescriptor(pcgLayoutDescriptor),
+  toToolDescriptor(pcgListPinsDescriptor),
+  toToolDescriptor(pcgGetNodeDescriptor),
 
-    // ── Actor-domain P0 breadth tools (Phase 2 Wave 1) — factory path ─────────
-    // Net-new actor tools (inspect/find/selection/spawn-from-asset/batch-
-    // transform/focus/set-folder), generated as UE Python via the pyTemplate
-    // factory. See src/tools/actor/actor-py-tools.ts for the overlap analysis.
-    ...actorPyDescriptors.map((d) => toToolDescriptor(d)),
+  // ── Actor-domain P0 breadth tools (Phase 2 Wave 1) — factory path ─────────
+  // Net-new actor tools (inspect/find/selection/spawn-from-asset/batch-
+  // transform/focus/set-folder), generated as UE Python via the pyTemplate
+  // factory. See src/tools/actor/actor-py-tools.ts for the overlap analysis.
+  ...actorPyDescriptors.map((d) => toToolDescriptor(d)),
 
-    // ── Editor-introspection & observability P0 tools (Phase 2 Wave 2) ────────
-    // Net-new editor/reflection/asset-registry read + gating tools, generated as
-    // UE Python via the pyTemplate factory. See src/tools/editor/editor-py-tools.ts
-    // for the catalog overlap/skip analysis.
-    ...editorPyDescriptors.map((d) => toToolDescriptor(d)),
+  // ── Editor-introspection & observability P0 tools (Phase 2 Wave 2) ────────
+  // Net-new editor/reflection/asset-registry read + gating tools, generated as
+  // UE Python via the pyTemplate factory. See src/tools/editor/editor-py-tools.ts
+  // for the catalog overlap/skip analysis.
+  ...editorPyDescriptors.map((d) => toToolDescriptor(d)),
 
-    // ── Asset & mesh P0 tools (Phase 2 Wave 2, Task 2) — factory path ─────────
-    // Net-new asset-provenance/save/folder tools and StaticMesh-asset readbacks
-    // (sockets/LODs/materials/bounds + material-slot setter), generated as UE
-    // Python via the pyTemplate factory. See src/tools/asset/asset-py-tools.ts
-    // and src/tools/mesh/mesh-py-tools.ts for the catalog overlap/skip analysis.
-    ...assetPyDescriptors.map((d) => toToolDescriptor(d)),
-    ...meshPyDescriptors.map((d) => toToolDescriptor(d)),
+  // ── Asset & mesh P0 tools (Phase 2 Wave 2, Task 2) — factory path ─────────
+  // Net-new asset-provenance/save/folder tools and StaticMesh-asset readbacks
+  // (sockets/LODs/materials/bounds + material-slot setter), generated as UE
+  // Python via the pyTemplate factory. See src/tools/asset/asset-py-tools.ts
+  // and src/tools/mesh/mesh-py-tools.ts for the catalog overlap/skip analysis.
+  ...assetPyDescriptors.map((d) => toToolDescriptor(d)),
+  ...meshPyDescriptors.map((d) => toToolDescriptor(d)),
 
-    // ── Sequencer & cinematics P0/P1 tools (Phase 2 Wave 4, Task 1) ───────────
-    // Net-new sequence authoring/inspection/validation tools, generated as UE
-    // Python via the pyTemplate factory. Names are deliberately non-colliding
-    // with the dormant HaybaMCPSequencer satellite-plugin C++ commands (render
-    // tools wrapped-and-skipped). See src/tools/sequencer/sequencer-py-tools.ts
-    // for the 3-surface overlap audit and render decision.
-    ...sequencerPyDescriptors.map((d) => toToolDescriptor(d)),
+  // ── Sequencer & cinematics P0/P1 tools (Phase 2 Wave 4, Task 1) ───────────
+  // Net-new sequence authoring/inspection/validation tools, generated as UE
+  // Python via the pyTemplate factory. Names are deliberately non-colliding
+  // with the dormant HaybaMCPSequencer satellite-plugin C++ commands (render
+  // tools wrapped-and-skipped). See src/tools/sequencer/sequencer-py-tools.ts
+  // for the 3-surface overlap audit and render decision.
+  ...sequencerPyDescriptors.map((d) => toToolDescriptor(d)),
 
-    // ── Niagara & VFX P0/P1 tools (Phase 2 Wave 4, Task 2) ────────────────────
-    // Net-new Niagara discovery/inspection/spawn/param/validation tools,
-    // generated as UE Python via the pyTemplate factory. Names are deliberately
-    // non-colliding with the dormant HaybaMCPNiagara satellite-plugin C++
-    // commands (niagara_list/niagara_spawn/niagara_set_param). See
-    // src/tools/niagara/niagara-py-tools.ts for the 3-surface overlap audit and
-    // wrap-and-skip decisions.
-    ...niagaraPyDescriptors.map((d) => toToolDescriptor(d)),
+  // ── Niagara & VFX P0/P1 tools (Phase 2 Wave 4, Task 2) ────────────────────
+  // Net-new Niagara discovery/inspection/spawn/param/validation tools,
+  // generated as UE Python via the pyTemplate factory. Names are deliberately
+  // non-colliding with the dormant HaybaMCPNiagara satellite-plugin C++
+  // commands (niagara_list/niagara_spawn/niagara_set_param). See
+  // src/tools/niagara/niagara-py-tools.ts for the 3-surface overlap audit and
+  // wrap-and-skip decisions.
+  ...niagaraPyDescriptors.map((d) => toToolDescriptor(d)),
 
-    // ── Water system P0 tools (Phase 2 Wave 4, Task 3) ────────────────────────
-    // Net-new water body/zone/wave discovery, spawn, tuning and PLUMB-style
-    // validation, generated as UE Python via the pyTemplate factory. All names
-    // are net-new + unique across all 3 surfaces (no water_* command exists in
-    // sidecar/index/list-tool-categories or any unreal GetCommands). The Water
-    // plugin may be DISABLED — water_check_plugin is the honest gate and every
-    // tool degrades to a clean plugin-disabled envelope. See
-    // src/tools/water/water-py-tools.ts for the overlap audit + plugin-probe.
-    ...waterPyDescriptors.map((d) => toToolDescriptor(d)),
+  // ── Water system P0 tools (Phase 2 Wave 4, Task 3) ────────────────────────
+  // Net-new water body/zone/wave discovery, spawn, tuning and PLUMB-style
+  // validation, generated as UE Python via the pyTemplate factory. All names
+  // are net-new + unique across all 3 surfaces (no water_* command exists in
+  // sidecar/index/list-tool-categories or any unreal GetCommands). The Water
+  // plugin may be DISABLED — water_check_plugin is the honest gate and every
+  // tool degrades to a clean plugin-disabled envelope. See
+  // src/tools/water/water-py-tools.ts for the overlap audit + plugin-probe.
+  ...waterPyDescriptors.map((d) => toToolDescriptor(d)),
 
-    // ── Landscape & terrain P0/P1 tools (Phase 2 Wave 3, Task 1) — factory path ─
-    // Net-new landscape read/introspection (list/inspect/layer-list/get-material/
-    // list-splines) + set-to-value reflection writers (set-material/set-lod/
-    // set-nanite) + LayerInfo authoring (add-layer). See
-    // src/tools/landscape/landscape-py-tools.ts for the catalog overlap/skip
-    // analysis (C++ edit-data & import handlers deliberately not re-implemented).
-    ...landscapePyDescriptors.map((d) => toToolDescriptor(d)),
+  // ── Landscape & terrain P0/P1 tools (Phase 2 Wave 3, Task 1) — factory path ─
+  // Net-new landscape read/introspection (list/inspect/layer-list/get-material/
+  // list-splines) + set-to-value reflection writers (set-material/set-lod/
+  // set-nanite) + LayerInfo authoring (add-layer). See
+  // src/tools/landscape/landscape-py-tools.ts for the catalog overlap/skip
+  // analysis (C++ edit-data & import handlers deliberately not re-implemented).
+  ...landscapePyDescriptors.map((d) => toToolDescriptor(d)),
 
-    // ── Foliage & scatter P0 tools (Phase 2 Wave 3, Task 2) — factory path ─────
-    // Net-new foliage-SYSTEM authoring: capability-probe + type/instance reads,
-    // set-to-value typed-param + mesh writers, and non-idempotent create/add/
-    // scatter/remove/clear verbs, generated as UE Python via the pyTemplate
-    // factory. Direct low-level foliage authoring — NOT the PLUMB-validated
-    // world_generate flagship. See src/tools/foliage/foliage-py-tools.ts for the
-    // catalog overlap/skip analysis and UNCERTAIN-API flags.
-    ...foliagePyDescriptors.map((d) => toToolDescriptor(d)),
+  // ── Foliage & scatter P0 tools (Phase 2 Wave 3, Task 2) — factory path ─────
+  // Net-new foliage-SYSTEM authoring: capability-probe + type/instance reads,
+  // set-to-value typed-param + mesh writers, and non-idempotent create/add/
+  // scatter/remove/clear verbs, generated as UE Python via the pyTemplate
+  // factory. Direct low-level foliage authoring — NOT the PLUMB-validated
+  // world_generate flagship. See src/tools/foliage/foliage-py-tools.ts for the
+  // catalog overlap/skip analysis and UNCERTAIN-API flags.
+  ...foliagePyDescriptors.map((d) => toToolDescriptor(d)),
 
-    // ── Lighting & post-process P0/P1 tools (Phase 2 Wave 3, Task 3) — factory ──
-    // Net-new lighting/post-process AUTHORING: capability-probe + light/PPV reads,
-    // set-to-value light/PP/exposure/Lumen/color-grade/fog writers (each PP writer
-    // sets the bOverride_* flag alongside the value + writes the settings struct
-    // back), and non-idempotent light_spawn / postprocess_spawn_volume / sky_setup.
-    // Skips the render/vision-loop/job-envelope + PLUMB-validator catalog entries.
-    // See src/tools/lighting/lighting-py-tools.ts for the 3-surface overlap audit,
-    // the bOverride gotcha handling, skip analysis and UNCERTAIN-API flags.
-    ...lightingPyDescriptors.map((d) => toToolDescriptor(d)),
+  // ── Lighting & post-process P0/P1 tools (Phase 2 Wave 3, Task 3) — factory ──
+  // Net-new lighting/post-process AUTHORING: capability-probe + light/PPV reads,
+  // set-to-value light/PP/exposure/Lumen/color-grade/fog writers (each PP writer
+  // sets the bOverride_* flag alongside the value + writes the settings struct
+  // back), and non-idempotent light_spawn / postprocess_spawn_volume / sky_setup.
+  // Skips the render/vision-loop/job-envelope + PLUMB-validator catalog entries.
+  // See src/tools/lighting/lighting-py-tools.ts for the 3-surface overlap audit,
+  // the bOverride gotcha handling, skip analysis and UNCERTAIN-API flags.
+  ...lightingPyDescriptors.map((d) => toToolDescriptor(d)),
 
-    // ── BYOK copilot config/introspection (Task 5) ────────────────────────────
-    // Pure-TS descriptors reading/writing the SAME in-memory config store the
-    // /chat/config sidecar routes use (src/chat/chat-server.ts). See
-    // src/tools/copilot/copilot-tools.ts for the vault TODO (Task 6).
-    {
-      name: 'copilot_provider_list',
-      description: 'List the BYOK provider catalog, flagging which provider is active and whether a key is configured for it (masked last-4 only).',
-      meta: providerListMeta,
-      handler: providerListHandler,
-      cost: 'low',
-      returns: '{providers:[{id,label,protocol,needs_key,key_hint,default_model,base_url_default,active,key_configured,key_last4}], active_provider}',
-      niche: PACK,
-      schema: {
-        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
-      },
+  // ── BYOK copilot config/introspection (Task 5) ────────────────────────────
+  // Pure-TS descriptors reading/writing the SAME in-memory config store the
+  // /chat/config sidecar routes use (src/chat/chat-server.ts). See
+  // src/tools/copilot/copilot-tools.ts for the vault TODO (Task 6).
+  {
+    name: 'copilot_provider_list',
+    description:
+      'List the BYOK provider catalog, flagging which provider is active and whether a key is configured for it (masked last-4 only).',
+    meta: providerListMeta,
+    handler: providerListHandler,
+    cost: 'low',
+    returns:
+      '{providers:[{id,label,protocol,needs_key,key_hint,default_model,base_url_default,active,key_configured,key_last4}], active_provider}',
+    niche: PACK,
+    schema: {
+      session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
     },
-    {
-      name: 'copilot_provider_set',
-      description: 'Set the active BYOK provider (and optional model/base URL) for a copilot session.',
-      meta: providerSetMeta,
-      handler: providerSetHandler,
-      cost: 'low',
-      returns: '{ok, provider, model, base_url, key_last4}',
-      niche: PACK,
-      schema: {
-        provider: z.string().min(1).describe('Provider id from copilot_provider_list, e.g. "anthropic"'),
-        model: z.string().optional().describe('Override the provider default model'),
-        base_url: z.string().optional().describe('Override the provider default base URL (e.g. self-hosted OpenAI-compat endpoint)'),
-        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
-      },
+  },
+  {
+    name: 'copilot_provider_set',
+    description: 'Set the active BYOK provider (and optional model/base URL) for a copilot session.',
+    meta: providerSetMeta,
+    handler: providerSetHandler,
+    cost: 'low',
+    returns: '{ok, provider, model, base_url, key_last4}',
+    niche: PACK,
+    schema: {
+      provider: z.string().min(1).describe('Provider id from copilot_provider_list, e.g. "anthropic"'),
+      model: z.string().optional().describe('Override the provider default model'),
+      base_url: z
+        .string()
+        .optional()
+        .describe('Override the provider default base URL (e.g. self-hosted OpenAI-compat endpoint)'),
+      session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
     },
-    {
-      name: 'copilot_provider_test',
-      description: 'Preflight-check a BYOK provider: fails clean with {ok:false, reason:"no_key"} (no network call) if a key is required but absent; otherwise runs a minimal completion probe and reports latency.',
-      meta: providerTestMeta,
-      handler: providerTestHandler,
-      cost: 'low',
-      returns: '{ok, latency_ms?, model?, reason?, detail?}',
-      niche: PACK,
-      schema: {
-        provider: z.string().optional().describe('Provider id to test; defaults to the configured active provider'),
-        model: z.string().optional().describe('Model id to test; defaults to the configured/default model'),
-        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
-      },
+  },
+  {
+    name: 'copilot_provider_test',
+    description:
+      'Preflight-check a BYOK provider: fails clean with {ok:false, reason:"no_key"} (no network call) if a key is required but absent; otherwise runs a minimal completion probe and reports latency.',
+    meta: providerTestMeta,
+    handler: providerTestHandler,
+    cost: 'low',
+    returns: '{ok, latency_ms?, model?, reason?, detail?}',
+    niche: PACK,
+    schema: {
+      provider: z.string().optional().describe('Provider id to test; defaults to the configured active provider'),
+      model: z.string().optional().describe('Model id to test; defaults to the configured/default model'),
+      session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
     },
-    {
-      name: 'copilot_model_list',
-      description: 'List known model ids for a BYOK provider (advisory starting point only — BYOK users may use any id their key/endpoint supports).',
-      meta: modelListMeta,
-      handler: modelListHandler,
-      cost: 'low',
-      returns: '{provider, default_model, configured_model, known_models:[string], advisory:true, note}',
-      niche: PACK,
-      schema: {
-        provider: z.string().min(1).describe('Provider id from copilot_provider_list'),
-        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
-      },
+  },
+  {
+    name: 'copilot_model_list',
+    description:
+      'List known model ids for a BYOK provider (advisory starting point only — BYOK users may use any id their key/endpoint supports).',
+    meta: modelListMeta,
+    handler: modelListHandler,
+    cost: 'low',
+    returns: '{provider, default_model, configured_model, known_models:[string], advisory:true, note}',
+    niche: PACK,
+    schema: {
+      provider: z.string().min(1).describe('Provider id from copilot_provider_list'),
+      session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
     },
-    {
-      name: 'copilot_key_set',
-      description: 'Set the BYOK API key for a provider. The key is NEVER echoed back or logged — the response contains only a masked last-4. Stored in-memory (TODO Task 6: swaps to the C++ DPAPI vault).',
-      meta: keySetMeta,
-      handler: keySetHandler,
-      cost: 'low',
-      returns: '{ok, provider, key_last4}',
-      niche: PACK,
-      schema: {
-        provider: z.string().min(1).describe('Provider id from copilot_provider_list'),
-        api_key: z.string().min(1).describe('The raw API key (never returned or logged)'),
-        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
-      },
+  },
+  {
+    name: 'copilot_key_set',
+    description:
+      'Set the BYOK API key for a provider. The key is NEVER echoed back or logged — the response contains only a masked last-4. Stored in-memory (TODO Task 6: swaps to the C++ DPAPI vault).',
+    meta: keySetMeta,
+    handler: keySetHandler,
+    cost: 'low',
+    returns: '{ok, provider, key_last4}',
+    niche: PACK,
+    schema: {
+      provider: z.string().min(1).describe('Provider id from copilot_provider_list'),
+      api_key: z.string().min(1).describe('The raw API key (never returned or logged)'),
+      session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
     },
-    {
-      name: 'copilot_key_clear',
-      description: 'Clear the stored BYOK API key for a provider. Destructive — plan-gated when Plan Mode is on.',
-      meta: keyClearMeta,
-      handler: keyClearHandler,
-      cost: 'low',
-      returns: '{ok, provider, cleared}',
-      niche: PACK,
-      schema: {
-        provider: z.string().min(1).describe('Provider id whose key should be cleared'),
-        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
-      },
+  },
+  {
+    name: 'copilot_key_clear',
+    description: 'Clear the stored BYOK API key for a provider. Destructive — plan-gated when Plan Mode is on.',
+    meta: keyClearMeta,
+    handler: keyClearHandler,
+    cost: 'low',
+    returns: '{ok, provider, cleared}',
+    niche: PACK,
+    schema: {
+      provider: z.string().min(1).describe('Provider id whose key should be cleared'),
+      session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
     },
-    {
-      name: 'copilot_key_status',
-      description: 'Report, per provider, whether a BYOK key is configured (masked last-4 only, no network call).',
-      meta: keyStatusMeta,
-      handler: keyStatusHandler,
-      cost: 'low',
-      returns: '{providers:[{provider,configured,last4?}]}',
-      niche: PACK,
-      schema: {
-        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
-      },
+  },
+  {
+    name: 'copilot_key_status',
+    description: 'Report, per provider, whether a BYOK key is configured (masked last-4 only, no network call).',
+    meta: keyStatusMeta,
+    handler: keyStatusHandler,
+    cost: 'low',
+    returns: '{providers:[{provider,configured,last4?}]}',
+    niche: PACK,
+    schema: {
+      session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
     },
-    {
-      name: 'copilot_health',
-      description: 'Cheap health snapshot for the copilot stack: sidecar chat routes registered, UE bridge reachable, tool registry size, and the active provider.',
-      meta: healthMeta,
-      handler: healthHandler,
-      cost: 'low',
-      returns: '{sidecar_ok, ue_connected, tools_available, active_provider}',
-      niche: PACK,
-      schema: {
-        session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
-      },
+  },
+  {
+    name: 'copilot_health',
+    description:
+      'Cheap health snapshot for the copilot stack: sidecar chat routes registered, UE bridge reachable, tool registry size, and the active provider.',
+    meta: healthMeta,
+    handler: healthHandler,
+    cost: 'low',
+    returns: '{sidecar_ok, ue_connected, tools_available, active_provider}',
+    niche: PACK,
+    schema: {
+      session_id: z.string().optional().describe('Chat session id; omitted = the default/global config slot'),
     },
+  },
 ];
 
 // Single-source tool descriptor list = hand-written entries + the sidecar-
@@ -1153,9 +1607,7 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
 // presence and the no-drift / no-duplicate invariants.
 export const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
   ...HANDWRITTEN_STANDARD_DESCRIPTORS,
-  ...generateLegacyDescriptors(
-    new Set(HANDWRITTEN_STANDARD_DESCRIPTORS.map((d) => d.name)),
-  ),
+  ...generateLegacyDescriptors(new Set(HANDWRITTEN_STANDARD_DESCRIPTORS.map((d) => d.name))),
 ];
 
 export async function registerTools(server: McpServer, session: SessionManagerStub): Promise<RoutingHandle | null> {
@@ -1227,16 +1679,16 @@ export async function registerTools(server: McpServer, session: SessionManagerSt
  * deriveDomainPacks buckets by this dir, and ToolIndex indexes by it).
  */
 export function inferDir(name: string): string | null {
-  if (name.startsWith('actor_'))          return 'actor';
-  if (name.startsWith('scene_'))          return 'scene';
-  if (name.startsWith('editor_'))         return 'editor';
-  if (name.startsWith('material_'))       return 'material';
-  if (name.startsWith('ui_'))             return 'ui';
-  if (name.startsWith('hayba_fab_'))      return 'fab';
-  if (name.startsWith('hayba_polyhaven_'))return 'asset-sources';
-  if (name.startsWith('hayba_ambientcg_'))return 'asset-sources';
-  if (name.startsWith('hayba_sketchfab_'))return 'asset-sources';
-  if (name === 'python_run')              return 'python';
+  if (name.startsWith('actor_')) return 'actor';
+  if (name.startsWith('scene_')) return 'scene';
+  if (name.startsWith('editor_')) return 'editor';
+  if (name.startsWith('material_')) return 'material';
+  if (name.startsWith('ui_')) return 'ui';
+  if (name.startsWith('hayba_fab_')) return 'fab';
+  if (name.startsWith('hayba_polyhaven_')) return 'asset-sources';
+  if (name.startsWith('hayba_ambientcg_')) return 'asset-sources';
+  if (name.startsWith('hayba_sketchfab_')) return 'asset-sources';
+  if (name === 'python_run') return 'python';
   if (name === 'list_tool_categories' || name === 'get_tool_signature') return 'code-mode';
   return null;
 }
@@ -1251,7 +1703,6 @@ function withNicheBriefing(
 }
 
 function registerToolsCore(server: McpServer, session: SessionManagerStub): void {
-
   // Fire-and-forget: dynamic import resolves in <1ms; MCP handshake takes longer
   // so any tool call is guaranteed to find DEFAULT_SENDER set.
   void installLiveSender();
@@ -1286,15 +1737,24 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     'hayba_propose_plan',
     'Propose a step-by-step plan to the user before performing destructive operations. Required when Plan Mode is on. Steps may be strings or {title, description, tool} objects.',
     {
-      steps: z.array(z.union([
-        z.string(),
-        z.object({
-          title: z.string(),
-          description: z.string().optional(),
-          tool: z.string().optional(),
-        }),
-      ])).describe('Ordered list of plan steps'),
-      await_seconds: z.number().int().min(0).max(600).optional()
+      steps: z
+        .array(
+          z.union([
+            z.string(),
+            z.object({
+              title: z.string(),
+              description: z.string().optional(),
+              tool: z.string().optional(),
+            }),
+          ]),
+        )
+        .describe('Ordered list of plan steps'),
+      await_seconds: z
+        .number()
+        .int()
+        .min(0)
+        .max(600)
+        .optional()
         .describe('How long the agent will wait for human approval (informational; default 30)'),
     },
     async (params) => {
@@ -1314,9 +1774,10 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     'hayba_mark_plan_step',
     'Update the status of a single step in the proposed plan shown in the UE Plan panel. Marking a step "completed" auto-advances the next step to "running". Call this as you work through an approved plan so the user sees live progress.',
     {
-      index: z.number().int().min(0)
-        .describe('Zero-based index of the plan step to update'),
-      status: z.enum(['running', 'completed', 'failed']).default('completed')
+      index: z.number().int().min(0).describe('Zero-based index of the plan step to update'),
+      status: z
+        .enum(['running', 'completed', 'failed'])
+        .default('completed')
         .describe('New status for the step (default "completed")'),
     },
     async (params) => {
@@ -1334,29 +1795,38 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
 
   server.tool(
     'list_tool_categories',
-    appendMeta('List all HaybaOS command domains and their commands. Call this first to discover what is available before requesting a specific schema.', listMeta),
+    appendMeta(
+      'List all HaybaOS command domains and their commands. Call this first to discover what is available before requesting a specific schema.',
+      listMeta,
+    ),
     {},
     async () => {
       const r = await listToolCategoriesHandler({}, session);
       return { content: r.content, isError: r.isError };
-    }
+    },
   );
   remember('list_tool_categories', listMeta);
 
   server.tool(
     'get_tool_signature',
-    appendMeta('Return the JSON schema (params, return shape, cost) for a specific HaybaOS command. Call list_tool_categories first to find command names.', sigMeta),
+    appendMeta(
+      'Return the JSON schema (params, return shape, cost) for a specific HaybaOS command. Call list_tool_categories first to find command names.',
+      sigMeta,
+    ),
     { command: z.string().describe('Exact command name, e.g. "actor_spawn"') },
     async (params) => {
       const r = await getToolSignatureHandler(params as Record<string, unknown>, session);
       return { content: r.content, isError: r.isError };
-    }
+    },
   );
   remember('get_tool_signature', sigMeta);
 
   server.tool(
     'python_run',
-    appendMeta('Execute a Python script inside UE via PythonScriptPlugin. Universal escape hatch for invoking any UE command not otherwise exposed.', pyMeta),
+    appendMeta(
+      'Execute a Python script inside UE via PythonScriptPlugin. Universal escape hatch for invoking any UE command not otherwise exposed.',
+      pyMeta,
+    ),
     {
       script: z.string().describe('Python source to execute'),
       allow_unsafe: z.boolean().optional().describe('Override Tier 3 filesystem/subprocess block (DANGEROUS)'),
@@ -1364,7 +1834,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const r = await pythonRunHandler(params as Record<string, unknown>, session);
       return { content: r.content, isError: r.isError };
-    }
+    },
   );
   remember('python_run', pyMeta);
 
@@ -1385,10 +1855,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
   // booleans before they hit Zod. Wrap so we accept both raw and the
   // stringified form for params we know are commonly affected. (vec3/coerceVec3
   // now live at module scope as dVec3/dCoerceVec3, used by the descriptor list.)
-  const coerceBool = z.preprocess(
-    (v) => typeof v === 'string' ? v.toLowerCase() === 'true' : v,
-    z.boolean()
-  );
+  const coerceBool = z.preprocess((v) => (typeof v === 'string' ? v.toLowerCase() === 'true' : v), z.boolean());
 
   // ── Standard tools (actor / material / scene) ───────────────────────────────
   // Registered from the single descriptor list. Each descriptor declares the
@@ -1400,11 +1867,17 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
 
   server.tool(
     'editor_capture_viewport',
-    appendMeta('Capture the active editor viewport and return it as an inline image block (plus a small text block with camera/width/height). Set HAYBA_CAPTURE_TO_FILE to also spill the image to a temp file path.', captureMeta),
+    appendMeta(
+      'Capture the active editor viewport and return it as an inline image block (plus a small text block with camera/width/height). Set HAYBA_CAPTURE_TO_FILE to also spill the image to a temp file path.',
+      captureMeta,
+    ),
     {
       width: z.coerce.number().int().optional(),
       height: z.coerce.number().int().optional(),
-      wait_for_shaders: z.boolean().optional().describe('If true, calls wait_for_shaders first (max_seconds=60, poll_seconds=1).'),
+      wait_for_shaders: z
+        .boolean()
+        .optional()
+        .describe('If true, calls wait_for_shaders first (max_seconds=60, poll_seconds=1).'),
     },
     async (params) => {
       if ((params as any).wait_for_shaders === true) {
@@ -1412,7 +1885,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
       }
       const r = await editorCaptureViewportHandler(params as Record<string, unknown>, session);
       return { content: r.content, isError: r.isError };
-    }
+    },
   );
   remember('editor_capture_viewport', captureMeta);
 
@@ -1428,7 +1901,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const r = await editorStreamLogHandler(params as Record<string, unknown>, session);
       return { content: r.content, isError: r.isError };
-    }
+    },
   );
   remember('editor_stream_log', streamLogMeta);
 
@@ -1440,23 +1913,29 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
 
   server.tool(
     'pcg_cook_and_wait',
-    appendMeta('Regenerate an actor\'s PCGComponent, block on the PCG graph settling (NOT world_tick), and return per-mesh ISM instance counts — all in one call.', pcgCookMeta),
+    appendMeta(
+      "Regenerate an actor's PCGComponent, block on the PCG graph settling (NOT world_tick), and return per-mesh ISM instance counts — all in one call.",
+      pcgCookMeta,
+    ),
     pcgCookSchema.shape,
     async (params) => {
       const r = await pcgCookAndWaitHandler(params as never);
       return { content: r.content, isError: r.isError };
-    }
+    },
   );
   remember('pcg_cook_and_wait', pcgCookMeta);
 
   server.tool(
     'pcg_scatter_mesh',
-    appendMeta('Scatter a mesh (or weighted mesh set) across a surface in ONE call — build the jittered PCG graph, spawn a bound PCGVolume, generate, and return instance counts. Hard-fails on 0 instances.', pcgScatterMeta),
+    appendMeta(
+      'Scatter a mesh (or weighted mesh set) across a surface in ONE call — build the jittered PCG graph, spawn a bound PCGVolume, generate, and return instance counts. Hard-fails on 0 instances.',
+      pcgScatterMeta,
+    ),
     pcgScatterSchema.shape,
     async (params) => {
       const r = await pcgScatterMeshHandler(params as never);
       return { content: r.content, isError: r.isError };
-    }
+    },
   );
   remember('pcg_scatter_mesh', pcgScatterMeta);
 
@@ -1471,30 +1950,26 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async ({ query }) => {
       const result = await searchNodeCatalog({ query });
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
-  server.tool(
-    'hayba_get_node_details',
-    { class: z.string().describe('PCGEx node class name') },
-    async (params) => {
-      const result = await getNodeDetails({ class: params.class });
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
-  );
+  server.tool('hayba_get_node_details', { class: z.string().describe('PCGEx node class name') }, async (params) => {
+    const result = await getNodeDetails({ class: params.class });
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  });
   // no meta registered (PCGEx pure-TS handler)
 
   server.tool(
     'hayba_create_pcg_graph',
     {
       graph: z.string().describe('JSON string of the PCGEx graph topology'),
-      name: z.string().describe('Asset name for the new PCGGraph')
+      name: z.string().describe('Asset name for the new PCGGraph'),
     },
     async ({ graph, name }) => {
       const result = await createPcgGraph({ graph, name });
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1504,7 +1979,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async ({ graph }) => {
       const result = await validatePcgGraph({ graph });
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1514,7 +1989,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async ({ path }) => {
       const result = await listPcgAssets({ path });
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1524,7 +1999,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async ({ assetPath }) => {
       const result = await exportPcgGraph({ assetPath });
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1534,18 +2009,14 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async ({ assetPath }) => {
       const result = await executePcgGraph({ assetPath });
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
-  server.tool(
-    'hayba_check_ue_status',
-    {},
-    async () => {
-      const result = await checkUeStatus();
-      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
-  );
+  server.tool('hayba_check_ue_status', {}, async () => {
+    const result = await checkUeStatus();
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  });
   // no meta registered (PCGEx pure-TS handler)
 
   server.tool(
@@ -1558,7 +2029,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await scrapeNodeRegistry(params as unknown as ScrapeNodeRegistryParams);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1572,7 +2043,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await matchPinNames(params);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1585,7 +2056,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await validateAttributeFlow(params as unknown as ValidateAttributeFlowParams);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1599,18 +2070,20 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await diffAgainstWorkingAsset(params as unknown as DiffAgainstWorkingAssetParams);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
   server.tool(
     'hayba_format_graph_topology',
     {
-      graph: z.string().describe(
-        'JSON string of the PCGEx graph to layout. ' +
-        'Edges accept either canonical (fromNode/fromPin/toNode/toPin) or legacy (from/fromPin/to/toPin) keys. ' +
-        'Output nodes carry a position:{x,y} object; the C++ legacy handler reads that.'
-      ),
+      graph: z
+        .string()
+        .describe(
+          'JSON string of the PCGEx graph to layout. ' +
+            'Edges accept either canonical (fromNode/fromPin/toNode/toPin) or legacy (from/fromPin/to/toPin) keys. ' +
+            'Output nodes carry a position:{x,y} object; the C++ legacy handler reads that.',
+        ),
       algorithm: z.enum(['layered', 'grid']).optional().describe('Layout algorithm (default: layered)'),
       nodeWidth: z.number().int().optional().describe('Node width in pixels (default: 200)'),
       nodeHeight: z.number().int().optional().describe('Node height in pixels (default: 100)'),
@@ -1621,7 +2094,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await formatGraphTopology(params as unknown as FormatGraphTopologyParams);
       return { content: [{ type: 'text', text: result }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1635,7 +2108,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await abstractToSubgraph(params as unknown as AbstractToSubgraphParams);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1643,16 +2116,20 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     'hayba_parameterize_graph_inputs',
     {
       graph: z.string().describe('JSON string of the PCGEx graph'),
-      targets: z.array(z.object({
-        nodeId: z.string().describe('Node ID containing the hardcoded property'),
-        property: z.string().describe('Property name to parameterize'),
-        parameterName: z.string().optional().describe('Name for the graph parameter'),
-      })).describe('List of properties to promote to graph parameters'),
+      targets: z
+        .array(
+          z.object({
+            nodeId: z.string().describe('Node ID containing the hardcoded property'),
+            property: z.string().describe('Property name to parameterize'),
+            parameterName: z.string().optional().describe('Name for the graph parameter'),
+          }),
+        )
+        .describe('List of properties to promote to graph parameters'),
     },
     async (params) => {
       const result = await parameterizeGraphInputs(params);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1660,12 +2137,16 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     'hayba_query_pcgex_docs',
     {
       query: z.string().describe('Node class name or keyword to search documentation'),
-      includeSourceSnippet: z.boolean().optional().default(false).describe('Include up to 80 lines from the header file'),
+      includeSourceSnippet: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe('Include up to 80 lines from the header file'),
     },
     async (params) => {
       const result = await queryPcgexDocs(params as unknown as QueryPcgexDocsParams);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1680,15 +2161,18 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await initiateInfrastructureBrainstorm(params);
       return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify(result, null, 2) +
-            '\n\n---\nIMPORTANT: This is a PROPOSAL ONLY. Do NOT call hayba_create_pcg_graph, ' +
-            'hayba_validate_attribute_flow, hayba_abstract_to_subgraph, or any graph-mutation tool ' +
-            'until the user has explicitly approved an approach above.',
-        }]
+        content: [
+          {
+            type: 'text',
+            text:
+              JSON.stringify(result, null, 2) +
+              '\n\n---\nIMPORTANT: This is a PROPOSAL ONLY. Do NOT call hayba_create_pcg_graph, ' +
+              'hayba_validate_attribute_flow, hayba_abstract_to_subgraph, or any graph-mutation tool ' +
+              'until the user has explicitly approved an approach above.',
+          },
+        ],
       };
-    }
+    },
   );
   // no meta registered (PCGEx pure-TS handler)
 
@@ -1928,7 +2412,10 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     'Multi-turn wizard to configure UE project conventions. Call repeatedly with advancing stages.',
     {
       stage: z.enum(['start', 'folders', 'naming', 'workflow', 'confirm', 'save']).describe('Current wizard stage'),
-      preset: z.enum(['epic-default', 'gamedevtv', 'custom']).optional().describe('Preset to load (required at start stage)'),
+      preset: z
+        .enum(['epic-default', 'gamedevtv', 'custom'])
+        .optional()
+        .describe('Preset to load (required at start stage)'),
       answers: z.record(z.unknown()).optional().describe('Accumulated user responses from previous stages'),
       target: z.enum(['global', 'project']).optional().describe('Where to save (required at save stage)'),
       projectRoot: z.string().optional().describe('UE project root path (required if target is project)'),
@@ -1936,7 +2423,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await setupConventionsHandler(params as Record<string, unknown>);
       return { content: result.content, isError: result.isError };
-    }
+    },
   );
   // no meta registered (conventions pure-TS handler)
 
@@ -1951,7 +2438,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await analyzeConventionsHandler(params as Record<string, unknown>);
       return { content: result.content, isError: result.isError };
-    }
+    },
   );
   // no meta registered (conventions pure-TS handler)
 
@@ -1992,12 +2479,15 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     {
       projectId: z.string().optional().describe('Existing project ID. Omit to create a new project.'),
       projectName: z.string().optional().describe('Name for the new project (used when projectId is omitted).'),
-      phase: z.enum(['a', 'b']).optional().describe('Phase A = blank canvas, Phase B = heightmap overlay (default: a).'),
+      phase: z
+        .enum(['a', 'b'])
+        .optional()
+        .describe('Phase A = blank canvas, Phase B = heightmap overlay (default: a).'),
     },
     async (params) => {
       const result = await openZonePainterHandler(params as Record<string, unknown>);
       return { content: result.content, isError: result.isError };
-    }
+    },
   );
   // no meta registered (zone painter pure-TS handler)
 
@@ -2005,12 +2495,15 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     'hayba_read_zones',
     {
       projectId: z.string().optional().describe('Project ID to read submitted zones from.'),
-      scratchSessionId: z.string().optional().describe('Scratch session ID (for standalone zone painting without a project).'),
+      scratchSessionId: z
+        .string()
+        .optional()
+        .describe('Scratch session ID (for standalone zone painting without a project).'),
     },
     async (params) => {
       const result = await readZonesHandler(params as Record<string, unknown>);
       return { content: result.content, isError: result.isError };
-    }
+    },
   );
   // no meta registered (zone painter pure-TS handler)
 
@@ -2023,7 +2516,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     async (params) => {
       const result = await setPainterHeightmapHandler(params as Record<string, unknown>);
       return { content: result.content, isError: result.isError };
-    }
+    },
   );
   // no meta registered (zone painter pure-TS handler)
 
@@ -2045,12 +2538,16 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
   installToolHooks();
 
   const getUe = async () => {
-    try { return await ensureUeForValidator().catch(() => null); } catch { return null; }
+    try {
+      return await ensureUeForValidator().catch(() => null);
+    } catch {
+      return null;
+    }
   };
 
   server.tool(
     'validator_run',
-    'CATCHES SILENT WRONGNESS YOU CANNOT SEE: runs the validator rules over the current scene and returns concrete post-condition findings — actors floating above ground, interpenetrating meshes, off-grid/mis-scaled placements, missing expected results, and PLUMB constraint violations. Pass scope=\'all\' (default) or { rule_ids: [...] }; findings persist to history and the Validation panel. USE_WHEN: after ANY scene mutation (spawn / move / delete / scatter / foliage / PCG execute / world_generate / landscape / lighting change), AND before you declare a task done or report success. NOT_WHEN: you have made no scene change since the last run. WHY: you have no viewport — this is how you verify placement actually landed correctly instead of assuming it did.',
+    "CATCHES SILENT WRONGNESS YOU CANNOT SEE: runs the validator rules over the current scene and returns concrete post-condition findings — actors floating above ground, interpenetrating meshes, off-grid/mis-scaled placements, missing expected results, and PLUMB constraint violations. Pass scope='all' (default) or { rule_ids: [...] }; findings persist to history and the Validation panel. USE_WHEN: after ANY scene mutation (spawn / move / delete / scatter / foliage / PCG execute / world_generate / landscape / lighting change), AND before you declare a task done or report success. NOT_WHEN: you have made no scene change since the last run. WHY: you have no viewport — this is how you verify placement actually landed correctly instead of assuming it did.",
     validatorRunSchema,
     async (args: { scope?: 'all' | { rule_ids?: string[] }; persist?: boolean }) => {
       const ue = await getUe();
@@ -2091,7 +2588,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
 
   server.tool(
     'validator_rules',
-    'List the validator rule catalog — every post-condition check and bound PLUMB constraint that validator_run / plumb_validate will evaluate, with each rule\'s message, hint, refs, and disabled state. USE_WHEN: you want to know WHAT validation can catch before running it, or to confirm the right rule is enabled for the task at hand. NOT_WHEN: you just want to run the checks — call validator_run.',
+    "List the validator rule catalog — every post-condition check and bound PLUMB constraint that validator_run / plumb_validate will evaluate, with each rule's message, hint, refs, and disabled state. USE_WHEN: you want to know WHAT validation can catch before running it, or to confirm the right rule is enabled for the task at hand. NOT_WHEN: you just want to run the checks — call validator_run.",
     validatorRulesSchema,
     async (args: { include_disabled_state?: boolean }) => {
       const r = await validatorRulesHandler(args);
@@ -2116,103 +2613,162 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
   // grammar (10 primitives) never grows. See src/plumb/.
   const j = (r: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] });
 
-  server.tool('plumb_primitives',
+  server.tool(
+    'plumb_primitives',
     'List the COMPLETE closed constraint grammar — the 10 primitives, their gate, hard/soft default, params, and docs. Author constraints by picking one and filling params.',
-    plumbPrimitivesSchema, async () => j(await plumbPrimitivesHandler()));
+    plumbPrimitivesSchema,
+    async () => j(await plumbPrimitivesHandler()),
+  );
 
   // Auto-fetch StaticMesh bounds (cm) via the UE mesh_get_info command when the
   // caller omits origin_cm/extent_cm — "point at an SM and bake".
   const fetchMeshBounds = async (asset: string) => {
-    const data = await executeCommand('mesh_get_info', { path: asset }) as { bounds?: { min: Record<string, number>; max: Record<string, number>; extents: Record<string, number> } };
+    const data = (await executeCommand('mesh_get_info', { path: asset })) as {
+      bounds?: { min: Record<string, number>; max: Record<string, number>; extents: Record<string, number> };
+    };
     const b = data?.bounds;
     if (!b) throw new Error('mesh_get_info returned no bounds');
     const v = (o: Record<string, number>): [number, number, number] => [o.x ?? 0, o.y ?? 0, o.z ?? 0];
     return { min: v(b.min), max: v(b.max), extents: v(b.extents) };
   };
-  server.tool('plumb_profile_bake',
+  server.tool(
+    'plumb_profile_bake',
     'Bake the deterministic geometry/physics half of a Physical Asset Profile. Pass just the asset to auto-fetch bounds from UE (mesh_get_info), or supply origin_cm + extent_cm (+ optional pivot_to_base_cm) explicitly. Persists to the profile store.',
-    plumbProfileBakeSchema, async (a) => j(await plumbProfileBakeHandler(a, new Date().toISOString(), fetchMeshBounds)));
+    plumbProfileBakeSchema,
+    async (a) => j(await plumbProfileBakeHandler(a, new Date().toISOString(), fetchMeshBounds)),
+  );
 
-  server.tool('plumb_profile_annotate',
+  server.tool(
+    'plumb_profile_annotate',
     'Layer AI/human qualitative semantics (class, up/front vectors, named affordance regions) onto a baked profile, with optional field locks. Qualitative constraints can only hard-gate on locked fields.',
-    plumbProfileAnnotateSchema, async (a) => j(await plumbProfileAnnotateHandler(a)));
+    plumbProfileAnnotateSchema,
+    async (a) => j(await plumbProfileAnnotateHandler(a)),
+  );
 
-  server.tool('plumb_profile_list',
+  server.tool(
+    'plumb_profile_list',
     'List baked profiles (asset_id, archetype, affordance count, locked fields). Feeds the Memory tab.',
-    plumbProfileListSchema, async () => j(await plumbProfileListHandler()));
+    plumbProfileListSchema,
+    async () => j(await plumbProfileListHandler()),
+  );
 
-  server.tool('plumb_profile_get',
+  server.tool(
+    'plumb_profile_get',
     'Fetch one full Physical Asset Profile by asset path.',
-    plumbProfileGetSchema, async (a) => j(await plumbProfileGetHandler(a)));
+    plumbProfileGetSchema,
+    async (a) => j(await plumbProfileGetHandler(a)),
+  );
 
-  server.tool('plumb_constraint_define',
+  server.tool(
+    'plumb_constraint_define',
     'Author/upsert a bound constraint: a primitive id + params + a binding (exactly one of {asset, tag}). Validated against the closed primitive set — invalid primitives/params/bindings are rejected.',
-    plumbConstraintDefineSchema, async (a) => j(await plumbConstraintDefineHandler(a)));
+    plumbConstraintDefineSchema,
+    async (a) => j(await plumbConstraintDefineHandler(a)),
+  );
 
-  server.tool('plumb_constraint_list',
+  server.tool(
+    'plumb_constraint_list',
     'List the constraint library (optionally filtered to an asset binding).',
-    plumbConstraintListSchema, async (a) => j(await plumbConstraintListHandler(a)));
+    plumbConstraintListSchema,
+    async (a) => j(await plumbConstraintListHandler(a)),
+  );
 
-  server.tool('plumb_constraint_remove',
+  server.tool(
+    'plumb_constraint_remove',
     'Remove a constraint from the library by id.',
-    plumbConstraintRemoveSchema, async (a) => j(await plumbConstraintRemoveHandler(a)));
+    plumbConstraintRemoveSchema,
+    async (a) => j(await plumbConstraintRemoveHandler(a)),
+  );
 
-  server.tool('plumb_constraint_propose',
+  server.tool(
+    'plumb_constraint_propose',
     'Draft (does not save) constraints for an asset from its baked profile, using only closed primitives. Review/edit then call plumb_constraint_define.',
-    plumbConstraintProposeSchema, async (a) => j(await plumbConstraintProposeHandler(a)));
+    plumbConstraintProposeSchema,
+    async (a) => j(await plumbConstraintProposeHandler(a)),
+  );
 
-  server.tool('plumb_validate',
+  server.tool(
+    'plumb_validate',
     'VERIFY PLACEMENT IS ACTUALLY CORRECT: runs the PLUMB constraint library over a set of instances and returns a directional Verdict — per-gate ok, signed value_m (how far off, and which way), and a FixVector telling you exactly how to move each instance to satisfy it. Catches grounding, clearance, alignment, spacing and interpenetration violations the viewport would reveal but you cannot. Hard fails set stopped_at; soft fails accumulate soft_cost. USE_WHEN: immediately after placing/scattering/spawning/transforming instances, and before declaring the layout done — feed the FixVector back into a transform to correct, then re-validate. NOT_WHEN: no constraints are bound for these assets (check plumb_constraint_list / validator_rules first). WHY: this is the quantified check that turns "looks placed" into "provably grounded and non-overlapping".',
-    plumbValidateSchema, async (a) => j(await plumbValidateHandler(a)));
+    plumbValidateSchema,
+    async (a) => j(await plumbValidateHandler(a)),
+  );
 
-  server.tool('plumb_mask_add',
+  server.tool(
+    'plumb_mask_add',
     'Add or update a mask (surface = triangle set; volume = translucent shape) on a baked profile. Surface/volume masks are the regions constraints reference.',
-    plumbMaskAddSchema, async (a) => j(await plumbMaskAddHandler(a)));
-  server.tool('plumb_mask_remove',
-    'Remove a mask from a profile by id.',
-    plumbMaskRemoveSchema, async (a) => j(await plumbMaskRemoveHandler(a)));
+    plumbMaskAddSchema,
+    async (a) => j(await plumbMaskAddHandler(a)),
+  );
+  server.tool('plumb_mask_remove', 'Remove a mask from a profile by id.', plumbMaskRemoveSchema, async (a) =>
+    j(await plumbMaskRemoveHandler(a)),
+  );
 
-  server.tool('plumb_lesson_add',
+  server.tool(
+    'plumb_lesson_add',
     'Add/update a lesson — the durable [[slug]] knowledge that explains WHY a constraint exists (browsed in the Studio Lessons panel; cited by constraint/validator refs).',
-    plumbLessonAddSchema, async (a) => j(await plumbLessonAddHandler(a, new Date().toISOString())));
-  server.tool('plumb_lesson_list',
-    'List lessons (slug + title + refs).',
-    plumbLessonListSchema, async () => j(await plumbLessonListHandler()));
-  server.tool('plumb_lesson_remove',
-    'Remove a lesson by slug.',
-    plumbLessonRemoveSchema, async (a) => j(await plumbLessonRemoveHandler(a)));
+    plumbLessonAddSchema,
+    async (a) => j(await plumbLessonAddHandler(a, new Date().toISOString())),
+  );
+  server.tool('plumb_lesson_list', 'List lessons (slug + title + refs).', plumbLessonListSchema, async () =>
+    j(await plumbLessonListHandler()),
+  );
+  server.tool('plumb_lesson_remove', 'Remove a lesson by slug.', plumbLessonRemoveSchema, async (a) =>
+    j(await plumbLessonRemoveHandler(a)),
+  );
 
-  server.tool('plumb_study',
-    'AI study entry point: returns the asset\'s baked profile (if any) + the closed primitive grammar + mask kinds + guidance, so the agent can propose masks (plumb_mask_add) and constraints (plumb_constraint_define).',
-    plumbStudySchema, async (a) => j(await plumbStudyHandler(a)));
+  server.tool(
+    'plumb_study',
+    "AI study entry point: returns the asset's baked profile (if any) + the closed primitive grammar + mask kinds + guidance, so the agent can propose masks (plumb_mask_add) and constraints (plumb_constraint_define).",
+    plumbStudySchema,
+    async (a) => j(await plumbStudyHandler(a)),
+  );
 
-  server.tool('plumb_study_take',
+  server.tool(
+    'plumb_study_take',
     'Drain pending "Study with AI" requests from the Semantic Studio button. Returns the assets to study (then call plumb_study + author masks/constraints for each).',
-    plumbStudyTakeSchema, async () => j(await plumbStudyTakeHandler()));
+    plumbStudyTakeSchema,
+    async () => j(await plumbStudyTakeHandler()),
+  );
 
-  server.tool('plumb_segment',
-    'AI-segment a studied asset: given the study_render color passes, the agent\'s themed part labels + a box/points per view, runs SAM in the visual sidecar and back-projects to geometry-hugging surface masks (triangles via the world-position pass + a UV display texture), written into the profile. Replaces hand-placed blocky masks.',
-    plumbSegmentSchema, async (a) => j(await plumbSegmentHandler(a)));
+  server.tool(
+    'plumb_segment',
+    "AI-segment a studied asset: given the study_render color passes, the agent's themed part labels + a box/points per view, runs SAM in the visual sidecar and back-projects to geometry-hugging surface masks (triangles via the world-position pass + a UV display texture), written into the profile. Replaces hand-placed blocky masks.",
+    plumbSegmentSchema,
+    async (a) => j(await plumbSegmentHandler(a)),
+  );
 
-  server.tool('plumb_production_define',
+  server.tool(
+    'plumb_production_define',
     'Author/upsert a grammar production rule: an LHS symbol kind (+ optional attribute guards) → an RHS sequence of emit ops (shell/asset/symbol/scatter/decal/fill). Guards are constraint ids that must pass before the production fires.',
-    plumbProductionDefineSchema, async (a) => j(await plumbProductionDefineHandler(a)));
+    plumbProductionDefineSchema,
+    async (a) => j(await plumbProductionDefineHandler(a)),
+  );
 
-  server.tool('plumb_production_list',
+  server.tool(
+    'plumb_production_list',
     'List all grammar productions in the store.',
-    plumbProductionListSchema, async () => j(await plumbProductionListHandler()));
+    plumbProductionListSchema,
+    async () => j(await plumbProductionListHandler()),
+  );
 
-  server.tool('plumb_production_remove',
-    'Remove a grammar production by id.',
-    plumbProductionRemoveSchema, async (a) => j(await plumbProductionRemoveHandler(a)));
+  server.tool('plumb_production_remove', 'Remove a grammar production by id.', plumbProductionRemoveSchema, async (a) =>
+    j(await plumbProductionRemoveHandler(a)),
+  );
 
-  server.tool('plumb_socket_add',
+  server.tool(
+    'plumb_socket_add',
     'Add or replace a socket (connection point) on a baked profile. Idempotent on socket id.',
-    plumbSocketAddSchema, async (a) => j(await plumbSocketAddHandler(a)));
+    plumbSocketAddSchema,
+    async (a) => j(await plumbSocketAddHandler(a)),
+  );
 
-  server.tool('plumb_grammar_expand',
+  server.tool(
+    'plumb_grammar_expand',
     'Expand a seed symbol using the stored production rules + the PLUMB constraint store as guards. Returns a PlacementPlan. In dry-run (no UE scene), geometry-dependent constraints self-skip — rejections only reflect TS-evaluable constraints.',
-    plumbGrammarExpandSchema, async (a) => j(await plumbGrammarExpandHandler(a)));
+    plumbGrammarExpandSchema,
+    async (a) => j(await plumbGrammarExpandHandler(a)),
+  );
 
   // ── Landscape import (TS wrapper for UE-side landscape_import handler) ────
   server.tool(
@@ -2221,7 +2777,11 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     {
       heightmapPath: z.string().describe('Absolute path to a PNG or R16 heightmap file'),
       worldSizeKm: z.number().optional().default(8.0).describe('Landscape XY size in km'),
-      maxHeightM: z.number().optional().default(600.0).describe('Maximum height in m (0..maxHeightM mapped from uint16)'),
+      maxHeightM: z
+        .number()
+        .optional()
+        .default(600.0)
+        .describe('Maximum height in m (0..maxHeightM mapped from uint16)'),
       actorLabel: z.string().optional().default('Hayba_Terrain').describe('Label for the spawned Landscape actor'),
       landscapeMaterial: z.string().optional().describe('UE material path; empty = no material'),
     },
@@ -2234,7 +2794,7 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
       } catch (e) {
         return errorResult(`Error importing landscape: ${(e as Error).message}`);
       }
-    }
+    },
   );
   // no meta registered (thin UE bridge wrapper)
 }
@@ -2243,15 +2803,10 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
 // server.tool() calls above, but lives independently of the Code Mode gate
 // so get_tool_signature can derive params from real schemas at runtime.
 // New tools should add an entry here when first registered.
-function recordEagerSchemas(
-  reg: (name: string, shape: z.ZodRawShape, cost: Cost, returns: string) => void,
-): void {
+function recordEagerSchemas(reg: (name: string, shape: z.ZodRawShape, cost: Cost, returns: string) => void): void {
   // coerceBool still used by hayba_validate_attribute_flow below. vec3/coerceVec3
   // moved to module scope (dVec3/dCoerceVec3) and consumed via STANDARD_DESCRIPTORS.
-  const coerceBool = z.preprocess(
-    (v) => typeof v === 'string' ? v.toLowerCase() === 'true' : v,
-    z.boolean(),
-  );
+  const coerceBool = z.preprocess((v) => (typeof v === 'string' ? v.toLowerCase() === 'true' : v), z.boolean());
 
   // ── Standard tools (actor / material / scene) ──────────────────────────────
   // Schema recording from the single descriptor list. recordToolSchema mirrors
@@ -2260,164 +2815,331 @@ function recordEagerSchemas(
 
   // ── Code Mode meta ────────────────────────────────────────────────────────
   reg('list_tool_categories', {}, 'low', '{categories:[{domain,commands:[string]}]}');
-  reg('get_tool_signature',
+  reg(
+    'get_tool_signature',
     { command: z.string().describe('Exact command name, e.g. "actor_spawn"') },
-    'low', '{command, params, returns, cost} or {status:"no_schema_available", did_you_mean}');
-  reg('python_run', {
-    script: z.string().describe('Python source to execute'),
-    allow_unsafe: z.boolean().optional().describe('Override Tier 3 filesystem/subprocess block (DANGEROUS)'),
-  }, 'high', '{ok, tier, stdout, stderr}');
+    'low',
+    '{command, params, returns, cost} or {status:"no_schema_available", did_you_mean}',
+  );
+  reg(
+    'python_run',
+    {
+      script: z.string().describe('Python source to execute'),
+      allow_unsafe: z.boolean().optional().describe('Override Tier 3 filesystem/subprocess block (DANGEROUS)'),
+    },
+    'high',
+    '{ok, tier, stdout, stderr}',
+  );
 
   // ── Editor domain ─────────────────────────────────────────────────────────
-  reg('editor_capture_viewport', {
-    width: z.coerce.number().int().optional(),
-    height: z.coerce.number().int().optional(),
-  }, 'medium', '{image_base64, width, height, camera}');
+  reg(
+    'editor_capture_viewport',
+    {
+      width: z.coerce.number().int().optional(),
+      height: z.coerce.number().int().optional(),
+    },
+    'medium',
+    '{image_base64, width, height, camera}',
+  );
   // editor_start_pie is now in STANDARD_DESCRIPTORS — recordToolSchema(d) called above.
-  reg('editor_stream_log', {
-    filter: z.string().optional().describe('Plain substring filter (legacy)'),
-    regex_filter: z.string().optional().describe('Perl-style regex applied to each line'),
-    severity_filter: z.string().optional().describe('Comma-separated severities: Verbose,Display,Log,Warning,Error,Fatal'),
-    format: z.enum(['raw', 'structured']).optional().describe('"structured" emits {line, category, severity, msg, raw} objects'),
-    since_line: z.coerce.number().int().min(0).optional(),
-  }, 'low', '{lines:[string|object], next_line:int, format}');
+  reg(
+    'editor_stream_log',
+    {
+      filter: z.string().optional().describe('Plain substring filter (legacy)'),
+      regex_filter: z.string().optional().describe('Perl-style regex applied to each line'),
+      severity_filter: z
+        .string()
+        .optional()
+        .describe('Comma-separated severities: Verbose,Display,Log,Warning,Error,Fatal'),
+      format: z
+        .enum(['raw', 'structured'])
+        .optional()
+        .describe('"structured" emits {line, category, severity, msg, raw} objects'),
+      since_line: z.coerce.number().int().min(0).optional(),
+    },
+    'low',
+    '{lines:[string|object], next_line:int, format}',
+  );
 
   // ── Agent-ergonomics tools (HANDOFF postmortem) ───────────────────────────
   // hayba_introspect, pcg_add_node, pcg_set_prop, pcg_wire, pcg_inspect_instances:
   // now in STANDARD_DESCRIPTORS — recordToolSchema(d) called by the loop above.
-  reg('pcg_cook_and_wait', pcgCookSchema.shape, 'high',
-    '{ok, cook:{components}, idle, result:{ism:[{mesh,count}], total}}');
-  reg('pcg_scatter_mesh', pcgScatterSchema.shape, 'high',
-    '{ok, graph_asset, volume_actor, instances, result:{ism:[{mesh,count}], total}} — ok:false when instances==0');
+  reg(
+    'pcg_cook_and_wait',
+    pcgCookSchema.shape,
+    'high',
+    '{ok, cook:{components}, idle, result:{ism:[{mesh,count}], total}}',
+  );
+  reg(
+    'pcg_scatter_mesh',
+    pcgScatterSchema.shape,
+    'high',
+    '{ok, graph_asset, volume_actor, instances, result:{ism:[{mesh,count}], total}} — ok:false when instances==0',
+  );
 
   // ── PCGEx domain ──────────────────────────────────────────────────────────
-  reg('hayba_search_node_catalog', {
-    query: z.string().describe('Search query — keyword, node class, or category'),
-  }, 'low', '{results:[{class,category,description,inputs,outputs,key_properties}], matchType}');
-  reg('hayba_get_node_details', {
-    class: z.string().describe('PCGEx node class name'),
-  }, 'low', '{class, category, description, inputs, outputs, properties}');
-  reg('hayba_create_pcg_graph', {
-    graph: z.string().describe('JSON string of the PCGEx graph topology'),
-    name: z.string().describe('Asset name for the new PCGGraph'),
-  }, 'high', '{ok, asset_path}');
-  reg('hayba_validate_pcg_graph', {
-    graph: z.string().describe('JSON string of the PCGEx graph to validate'),
-  }, 'medium', '{valid, errors:[{type,node,pin,detail}], errorCount}');
-  reg('hayba_list_pcg_assets', {
-    path: z.string().optional().describe('Content path filter (default: /Game/)'),
-  }, 'low', '{assets:[{name,path,nodeCount,edgeCount}], count}');
-  reg('hayba_export_pcg_graph', {
-    assetPath: z.string().describe('Full UE asset path to the PCGGraph'),
-  }, 'medium', '{graph:{version,meta,nodes,edges,metadata}}');
-  reg('hayba_execute_pcg_graph', {
-    assetPath: z.string().describe('Full UE asset path to execute'),
-  }, 'high', '{ok, generated_count, duration_ms}');
+  reg(
+    'hayba_search_node_catalog',
+    {
+      query: z.string().describe('Search query — keyword, node class, or category'),
+    },
+    'low',
+    '{results:[{class,category,description,inputs,outputs,key_properties}], matchType}',
+  );
+  reg(
+    'hayba_get_node_details',
+    {
+      class: z.string().describe('PCGEx node class name'),
+    },
+    'low',
+    '{class, category, description, inputs, outputs, properties}',
+  );
+  reg(
+    'hayba_create_pcg_graph',
+    {
+      graph: z.string().describe('JSON string of the PCGEx graph topology'),
+      name: z.string().describe('Asset name for the new PCGGraph'),
+    },
+    'high',
+    '{ok, asset_path}',
+  );
+  reg(
+    'hayba_validate_pcg_graph',
+    {
+      graph: z.string().describe('JSON string of the PCGEx graph to validate'),
+    },
+    'medium',
+    '{valid, errors:[{type,node,pin,detail}], errorCount}',
+  );
+  reg(
+    'hayba_list_pcg_assets',
+    {
+      path: z.string().optional().describe('Content path filter (default: /Game/)'),
+    },
+    'low',
+    '{assets:[{name,path,nodeCount,edgeCount}], count}',
+  );
+  reg(
+    'hayba_export_pcg_graph',
+    {
+      assetPath: z.string().describe('Full UE asset path to the PCGGraph'),
+    },
+    'medium',
+    '{graph:{version,meta,nodes,edges,metadata}}',
+  );
+  reg(
+    'hayba_execute_pcg_graph',
+    {
+      assetPath: z.string().describe('Full UE asset path to execute'),
+    },
+    'high',
+    '{ok, generated_count, duration_ms}',
+  );
   reg('hayba_check_ue_status', {}, 'low', '{connected, status, ueVersion, plugin, pluginVersion}');
 
   // ── Asset domain — added Initiative #6 + #10 (ref-preserving move, deps) ─
-  reg('asset_move', {
-    path: z.string().describe('Source asset path, e.g. "/Game/Foo/Bar.Bar"'),
-    target_dir: z.string().describe('Target content-browser folder, e.g. "/Game/Archive"'),
-  }, 'medium', '{ok, old_path, new_path}');
-  reg('asset_fix_redirectors', {
-    path: z.string().optional().describe('Content path to scan (default /Game)'),
-  }, 'medium', '{fixed_count, path}');
-  reg('asset_get_dependencies', {
-    path: z.string().describe('Asset path; returns what this asset depends on'),
-  }, 'low', '{dependencies:[string], count}');
-  reg('asset_get_referencers', {
-    path: z.string().describe('Asset path; returns who depends on this asset (blast radius)'),
-  }, 'low', '{referencers:[string], count}');
-  reg('hayba_scrape_node_registry', {
-    pluginSourcePath: z.string().optional().describe('Path to PCGExtendedToolkit/Source/ directory'),
-    outputDbPath: z.string().optional().describe('Output SQLite DB path (default: Resources/pcgex_registry.db)'),
-    forceRescan: z.boolean().optional().describe('Force re-scan even if DB exists'),
-  }, 'high', '{nodes_scanned, pins_scanned, properties_scanned, db_path, catalog_path}');
-  reg('hayba_match_pin_names', {
-    fromClass: z.string().describe('Source node class'),
-    fromPin: z.string().describe('Pin name on source node (may be approximate)'),
-    toClass: z.string().describe('Target node class to find a matching input pin on'),
-  }, 'low', '{matches:[{pin,confidence,reason}]}');
-  reg('hayba_validate_attribute_flow', {
-    graph: z.string().describe('JSON string of the PCGEx graph to validate attribute flow'),
-    strictMode: coerceBool.optional().describe('If true, also flag orphan writes (written but never consumed)'),
-  }, 'medium', '{valid, errors:[{type,node,attribute,detail}]}');
-  reg('hayba_diff_against_working_asset', {
-    wipGraph: z.string().describe('JSON string of the work-in-progress graph'),
-    referenceAssetPath: z.string().describe('Full UE asset path to the reference PCGGraph'),
-    diffMode: z.enum(['structural', 'properties', 'full']).optional().describe('What to diff (default: full)'),
-  }, 'medium', '{added, removed, modified, identical}');
-  reg('hayba_format_graph_topology', {
-    graph: z.string().describe('JSON string of the PCGEx graph to layout'),
-    algorithm: z.enum(['layered', 'grid']).optional(),
-    nodeWidth: z.number().int().optional(),
-    nodeHeight: z.number().int().optional(),
-    horizontalSpacing: z.number().int().optional(),
-    verticalSpacing: z.number().int().optional(),
-    addCommentBlocks: z.boolean().optional(),
-  }, 'low', 'JSON string of laid-out graph (nodes carry position:{x,y})');
-  reg('hayba_abstract_to_subgraph', {
-    graph: z.string().describe('JSON string of the full PCGEx graph'),
-    nodeIds: z.array(z.string()).describe('Array of node IDs to extract into a subgraph'),
-    subgraphName: z.string().optional().describe('Name for the extracted subgraph (default: SubGraph)'),
-  }, 'medium', '{subgraph, mainGraph}');
-  reg('hayba_parameterize_graph_inputs', {
-    graph: z.string().describe('JSON string of the PCGEx graph'),
-    targets: z.array(z.object({
-      nodeId: z.string(),
-      property: z.string(),
-      parameterName: z.string().optional(),
-    })),
-  }, 'medium', '{graph, parameters:[{name,type,defaultValue}]}');
-  reg('hayba_query_pcgex_docs', {
-    query: z.string().describe('Node class name or keyword to search documentation'),
-    includeSourceSnippet: z.boolean().optional().describe('Include up to 80 lines from the header file'),
-  }, 'low', '{results:[{class,description,sourceSnippet?}]}');
-  reg('hayba_initiate_infrastructure_brainstorm', {
-    topic: z.string().describe('The infrastructure or system design topic to brainstorm'),
-    context: z.string().optional(),
-    constraints: z.array(z.string()).optional(),
-  }, 'low', '{approaches:[{name,description,nodes,tradeoffs}]} — PROPOSAL ONLY');
+  reg(
+    'asset_move',
+    {
+      path: z.string().describe('Source asset path, e.g. "/Game/Foo/Bar.Bar"'),
+      target_dir: z.string().describe('Target content-browser folder, e.g. "/Game/Archive"'),
+    },
+    'medium',
+    '{ok, old_path, new_path}',
+  );
+  reg(
+    'asset_fix_redirectors',
+    {
+      path: z.string().optional().describe('Content path to scan (default /Game)'),
+    },
+    'medium',
+    '{fixed_count, path}',
+  );
+  reg(
+    'asset_get_dependencies',
+    {
+      path: z.string().describe('Asset path; returns what this asset depends on'),
+    },
+    'low',
+    '{dependencies:[string], count}',
+  );
+  reg(
+    'asset_get_referencers',
+    {
+      path: z.string().describe('Asset path; returns who depends on this asset (blast radius)'),
+    },
+    'low',
+    '{referencers:[string], count}',
+  );
+  reg(
+    'hayba_scrape_node_registry',
+    {
+      pluginSourcePath: z.string().optional().describe('Path to PCGExtendedToolkit/Source/ directory'),
+      outputDbPath: z.string().optional().describe('Output SQLite DB path (default: Resources/pcgex_registry.db)'),
+      forceRescan: z.boolean().optional().describe('Force re-scan even if DB exists'),
+    },
+    'high',
+    '{nodes_scanned, pins_scanned, properties_scanned, db_path, catalog_path}',
+  );
+  reg(
+    'hayba_match_pin_names',
+    {
+      fromClass: z.string().describe('Source node class'),
+      fromPin: z.string().describe('Pin name on source node (may be approximate)'),
+      toClass: z.string().describe('Target node class to find a matching input pin on'),
+    },
+    'low',
+    '{matches:[{pin,confidence,reason}]}',
+  );
+  reg(
+    'hayba_validate_attribute_flow',
+    {
+      graph: z.string().describe('JSON string of the PCGEx graph to validate attribute flow'),
+      strictMode: coerceBool.optional().describe('If true, also flag orphan writes (written but never consumed)'),
+    },
+    'medium',
+    '{valid, errors:[{type,node,attribute,detail}]}',
+  );
+  reg(
+    'hayba_diff_against_working_asset',
+    {
+      wipGraph: z.string().describe('JSON string of the work-in-progress graph'),
+      referenceAssetPath: z.string().describe('Full UE asset path to the reference PCGGraph'),
+      diffMode: z.enum(['structural', 'properties', 'full']).optional().describe('What to diff (default: full)'),
+    },
+    'medium',
+    '{added, removed, modified, identical}',
+  );
+  reg(
+    'hayba_format_graph_topology',
+    {
+      graph: z.string().describe('JSON string of the PCGEx graph to layout'),
+      algorithm: z.enum(['layered', 'grid']).optional(),
+      nodeWidth: z.number().int().optional(),
+      nodeHeight: z.number().int().optional(),
+      horizontalSpacing: z.number().int().optional(),
+      verticalSpacing: z.number().int().optional(),
+      addCommentBlocks: z.boolean().optional(),
+    },
+    'low',
+    'JSON string of laid-out graph (nodes carry position:{x,y})',
+  );
+  reg(
+    'hayba_abstract_to_subgraph',
+    {
+      graph: z.string().describe('JSON string of the full PCGEx graph'),
+      nodeIds: z.array(z.string()).describe('Array of node IDs to extract into a subgraph'),
+      subgraphName: z.string().optional().describe('Name for the extracted subgraph (default: SubGraph)'),
+    },
+    'medium',
+    '{subgraph, mainGraph}',
+  );
+  reg(
+    'hayba_parameterize_graph_inputs',
+    {
+      graph: z.string().describe('JSON string of the PCGEx graph'),
+      targets: z.array(
+        z.object({
+          nodeId: z.string(),
+          property: z.string(),
+          parameterName: z.string().optional(),
+        }),
+      ),
+    },
+    'medium',
+    '{graph, parameters:[{name,type,defaultValue}]}',
+  );
+  reg(
+    'hayba_query_pcgex_docs',
+    {
+      query: z.string().describe('Node class name or keyword to search documentation'),
+      includeSourceSnippet: z.boolean().optional().describe('Include up to 80 lines from the header file'),
+    },
+    'low',
+    '{results:[{class,description,sourceSnippet?}]}',
+  );
+  reg(
+    'hayba_initiate_infrastructure_brainstorm',
+    {
+      topic: z.string().describe('The infrastructure or system design topic to brainstorm'),
+      context: z.string().optional(),
+      constraints: z.array(z.string()).optional(),
+    },
+    'low',
+    '{approaches:[{name,description,nodes,tradeoffs}]} — PROPOSAL ONLY',
+  );
 
   // ── Conventions domain ────────────────────────────────────────────────────
-  reg('hayba_setup_conventions', {
-    stage: z.enum(['start', 'folders', 'naming', 'workflow', 'confirm', 'save']),
-    preset: z.enum(['epic-default', 'gamedevtv', 'custom']).optional(),
-    answers: z.record(z.unknown()).optional(),
-    target: z.enum(['global', 'project']).optional(),
-    projectRoot: z.string().optional(),
-  }, 'low', '{stage, question?, next_stage?, saved_to?}');
-  reg('hayba_analyze_conventions', {
-    projectRoot: z.string().describe('Path to UE project root (contains .uproject file)'),
-    save: z.boolean().optional(),
-    target: z.enum(['global', 'project']).optional(),
-  }, 'medium', '{inferred:{folders, naming, workflow}, saved_to?}');
-
+  reg(
+    'hayba_setup_conventions',
+    {
+      stage: z.enum(['start', 'folders', 'naming', 'workflow', 'confirm', 'save']),
+      preset: z.enum(['epic-default', 'gamedevtv', 'custom']).optional(),
+      answers: z.record(z.unknown()).optional(),
+      target: z.enum(['global', 'project']).optional(),
+      projectRoot: z.string().optional(),
+    },
+    'low',
+    '{stage, question?, next_stage?, saved_to?}',
+  );
+  reg(
+    'hayba_analyze_conventions',
+    {
+      projectRoot: z.string().describe('Path to UE project root (contains .uproject file)'),
+      save: z.boolean().optional(),
+      target: z.enum(['global', 'project']).optional(),
+    },
+    'medium',
+    '{inferred:{folders, naming, workflow}, saved_to?}',
+  );
 
   // ── Landscape import ──────────────────────────────────────────────────────
-  reg('hayba_import_landscape', {
-    heightmapPath: z.string().describe('Absolute path to a PNG or R16 heightmap file'),
-    worldSizeKm: z.number().optional().default(8.0).describe('Landscape XY size in km'),
-    maxHeightM: z.number().optional().default(600.0).describe('Maximum height in m (0..maxHeightM mapped from uint16)'),
-    actorLabel: z.string().optional().default('Hayba_Terrain').describe('Label for the spawned Landscape actor'),
-    landscapeMaterial: z.string().optional().describe('UE material path; empty = no material'),
-  }, 'high', '{actorLabel, heightmapPath, worldSizeKm, maxHeightM}');
+  reg(
+    'hayba_import_landscape',
+    {
+      heightmapPath: z.string().describe('Absolute path to a PNG or R16 heightmap file'),
+      worldSizeKm: z.number().optional().default(8.0).describe('Landscape XY size in km'),
+      maxHeightM: z
+        .number()
+        .optional()
+        .default(600.0)
+        .describe('Maximum height in m (0..maxHeightM mapped from uint16)'),
+      actorLabel: z.string().optional().default('Hayba_Terrain').describe('Label for the spawned Landscape actor'),
+      landscapeMaterial: z.string().optional().describe('UE material path; empty = no material'),
+    },
+    'high',
+    '{actorLabel, heightmapPath, worldSizeKm, maxHeightM}',
+  );
 
   // ── Zone painter domain ───────────────────────────────────────────────────
-  reg('hayba_open_zone_painter', {
-    projectId: z.string().optional(),
-    projectName: z.string().optional(),
-    phase: z.enum(['a', 'b']).optional(),
-  }, 'low', '{ok, url, projectId}');
-  reg('hayba_read_zones', {
-    projectId: z.string().optional(),
-    scratchSessionId: z.string().optional(),
-  }, 'low', '{zones:[{id,label,mask_path,bounds}]}');
-  reg('hayba_set_painter_heightmap', {
-    projectId: z.string(),
-    heightmapPath: z.string(),
-  }, 'low', '{ok}');
+  reg(
+    'hayba_open_zone_painter',
+    {
+      projectId: z.string().optional(),
+      projectName: z.string().optional(),
+      phase: z.enum(['a', 'b']).optional(),
+    },
+    'low',
+    '{ok, url, projectId}',
+  );
+  reg(
+    'hayba_read_zones',
+    {
+      projectId: z.string().optional(),
+      scratchSessionId: z.string().optional(),
+    },
+    'low',
+    '{zones:[{id,label,mask_path,bounds}]}',
+  );
+  reg(
+    'hayba_set_painter_heightmap',
+    {
+      projectId: z.string(),
+      heightmapPath: z.string(),
+    },
+    'low',
+    '{ok}',
+  );
 
   // ── PLUMB constraint subsystem ────────────────────────────────────────────
   reg('plumb_primitives', plumbPrimitivesSchema, 'low', '{primitives:[{id,gate,default_hard,qualitative,params,doc}]}');

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -59,6 +59,9 @@ import { materialSetMaterialPropertyHandler, meta as materialSetMaterialProperty
 import { materialCompileHandler, meta as materialCompileMeta } from './material/material-compile.js';
 import { materialDisconnectHandler, meta as materialDisconnectMeta } from './material/material-disconnect.js';
 import { materialValidateHandler, meta as materialValidateMeta } from './material/material-validate.js';
+import { uiCreateWidgetHandler, meta as uiCreateWidgetMeta } from './ui/ui-create-widget.js';
+import { uiAddElementHandler, meta as uiAddElementMeta } from './ui/ui-add-element.js';
+import { uiQueryHandler, meta as uiQueryMeta } from './ui/ui-query.js';
 import { worldGenerateHandler, meta as worldGenerateMeta } from './world/world-generate.js';
 import {
   providerListHandler, providerListMeta,
@@ -238,6 +241,7 @@ const dCoerceVec3 = z.preprocess((v) => {
  * are now generated automatically from this list.
  */
 const M = 'material'; // niche domain for the material toolset
+const UI = 'ui'; // niche domain for the UMG / Widget Blueprint toolset
 const PACK = 'copilot'; // niche domain for the BYOK copilot config/introspection toolset
 // Hand-written descriptors. Kept as a named const so the generated legacy list
 // can be de-duplicated against these names before splicing (see below).
@@ -672,6 +676,55 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
         to_input: z.string().optional().describe('Input pin name on the target node (defaults to first input)'),
         to_input_index: z.number().int().nonnegative().optional().describe('Zero-based input pin index (alternative to to_input)'),
         to_property: z.string().optional().describe('Material output property name to disconnect (e.g. base_color, normal)'),
+      },
+    },
+
+    // ── UMG / Widget Blueprint domain ─────────────────────────────────────────
+    // Native TS wrappers over the modern FHaybaMCPUIHandler (GetDomain()=="ui").
+    // Param names mirror HaybaMCPUIHandler.cpp exactly (the source of truth):
+    // ui_add_element takes slot_props (not "properties"); ui_query takes path
+    // (not widget_blueprint_path).
+    {
+      name: 'ui_create_widget',
+      description: 'Create a new UMG Widget Blueprint asset (designer-editable UI). Seeds a root CanvasPanel. Use the real UMG pipeline instead of hand-building the tree in C++.',
+      meta: uiCreateWidgetMeta,
+      handler: uiCreateWidgetHandler,
+      cost: 'medium',
+      returns: '{path, name, parent_class, root?}',
+      niche: UI,
+      schema: {
+        path: z.string().min(1).describe('UE content package directory, e.g. "/Game/Aphrosia/UI"'),
+        name: z.string().min(1).describe('Asset name, e.g. "WBP_StartScreen"'),
+        parent_class: z.string().optional().describe('Parent class (must descend from UserWidget); class path or short name. Defaults to UserWidget.'),
+      },
+    },
+    {
+      name: 'ui_add_element',
+      description: 'Add a widget (Button/TextBlock/Image/panel/…) to an existing Widget Blueprint tree, optionally under a named panel, with slot layout props. Marks the BP structurally modified + dirty.',
+      meta: uiAddElementMeta,
+      handler: uiAddElementHandler,
+      cost: 'medium',
+      returns: '{widget_blueprint_path, parent, name, class, slot_class}',
+      niche: UI,
+      schema: {
+        widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+        child_class: z.string().min(1).describe('Widget class — short name (Button, TextBlock, CanvasPanel, HorizontalBox, …) or full class path'),
+        parent_widget_name: z.string().optional().describe('Name of an existing PANEL widget to parent under; defaults to the root panel'),
+        name: z.string().optional().describe('Name for the new widget (auto-generated if omitted)'),
+        slot_props: z.record(z.union([z.number(), z.string(), z.boolean()])).optional()
+          .describe('Slot layout props: x/y/w/h (canvas), fill/padding (box); other keys set on the slot by reflection'),
+      },
+    },
+    {
+      name: 'ui_query',
+      description: 'Return the widget tree of a Widget Blueprint — per-widget name, class, slot (offsets/fill/padding) and nested children.',
+      meta: uiQueryMeta,
+      handler: uiQueryHandler,
+      cost: 'low',
+      returns: '{path, parent_class, root:{name, class, slot, children:[…]}}',
+      niche: UI,
+      schema: {
+        path: z.string().min(1).describe('Full path of the Widget Blueprint to inspect'),
       },
     },
 
@@ -1168,12 +1221,17 @@ export async function registerTools(server: McpServer, session: SessionManagerSt
 /**
  * Infer the pack-source directory for a tool name by matching against the
  * known top-level dirs under src/tools/. Root-level tools return null.
+ *
+ * Exported so the deferred-routing regression tests can assert a domain's
+ * tools group under the expected pack (the "hidden until searched" surface —
+ * deriveDomainPacks buckets by this dir, and ToolIndex indexes by it).
  */
-function inferDir(name: string): string | null {
+export function inferDir(name: string): string | null {
   if (name.startsWith('actor_'))          return 'actor';
   if (name.startsWith('scene_'))          return 'scene';
   if (name.startsWith('editor_'))         return 'editor';
   if (name.startsWith('material_'))       return 'material';
+  if (name.startsWith('ui_'))             return 'ui';
   if (name.startsWith('hayba_fab_'))      return 'fab';
   if (name.startsWith('hayba_polyhaven_'))return 'asset-sources';
   if (name.startsWith('hayba_ambientcg_'))return 'asset-sources';

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -124,6 +124,31 @@ import {
   schema as uiListWidgetTypesSchema,
   uiListWidgetTypesHandler,
 } from './ui/ui-list-widget-types.js';
+import { meta as uiBuildTreeMeta, schema as uiBuildTreeSchema, uiBuildTreeHandler } from './ui/ui-build-tree.js';
+import {
+  meta as uiDuplicateElementMeta,
+  schema as uiDuplicateElementSchema,
+  uiDuplicateElementHandler,
+} from './ui/ui-duplicate-element.js';
+import { meta as uiMoveElementMeta, schema as uiMoveElementSchema, uiMoveElementHandler } from './ui/ui-move-element.js';
+import {
+  meta as uiRenameElementMeta,
+  schema as uiRenameElementSchema,
+  uiRenameElementHandler,
+} from './ui/ui-rename-element.js';
+import { meta as uiSetVariableMeta, schema as uiSetVariableSchema, uiSetVariableHandler } from './ui/ui-set-variable.js';
+import {
+  meta as uiListWidgetBlueprintsMeta,
+  schema as uiListWidgetBlueprintsSchema,
+  uiListWidgetBlueprintsHandler,
+} from './ui/ui-list-widget-blueprints.js';
+import { meta as uiValidateMeta, schema as uiValidateSchema, uiValidateHandler } from './ui/ui-validate.js';
+import { meta as uiMeasureTextMeta, schema as uiMeasureTextSchema, uiMeasureTextHandler } from './ui/ui-measure-text.js';
+import {
+  meta as uiLayoutSnapshotMeta,
+  schema as uiLayoutSnapshotSchema,
+  uiLayoutSnapshotHandler,
+} from './ui/ui-layout-snapshot.js';
 import {
   meta as uiRemoveElementMeta,
   schema as uiRemoveElementSchema,
@@ -249,6 +274,8 @@ import {
   validatorRulesHandler,
   validatorSetRuleEnabledSchema,
   validatorSetRuleEnabledHandler,
+  validatorStrictnessHandler,
+  validatorStrictnessSchema,
   defaultScratchDir as validatorScratchDir,
 } from './validator/tools.js';
 import { ensureConnected as ensureUeForValidator } from '../tcp-client.js';
@@ -986,7 +1013,7 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
   {
     name: 'ui_query',
     description:
-      'Return the widget tree of a Widget Blueprint — per-widget name, class, slot, variable GUID, and typed properties. Use include_properties/include_guid/include_slot to control detail depth.',
+      'Return the widget tree of a Widget Blueprint - per-widget name, class, slot, variable GUID and typed properties. Pass name_pattern / class_filter / flatten to get a flat list of matching widgets instead of the whole tree.',
     meta: uiQueryMeta,
     handler: uiQueryHandler,
     cost: 'low',
@@ -997,7 +1024,7 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
   {
     name: 'ui_set_widget_properties',
     description:
-      'Generic tool: set named properties + slot layout on a designer widget in a Widget Blueprint. Operates on the authoritative WidgetTree (not the generated template). Uses FScopedTransaction for undo. Prefer the typed tools (ui_set_property, ui_set_text_style, ui_set_slot_layout, etc.) for common operations.',
+      'Generic tool: set named properties and/or slot layout on a designer widget. Operates on the authoritative WidgetTree (not the generated template). Property values may be nested objects for struct properties (Brush, Font). Reports per-key outcomes: succeeded, failed_properties, unknown_slot_props. NOT transacted - these edits deliberately stay out of the editor undo stack, because the transaction buffer can pin PIE references and crash the editor. Prefer the typed tools (ui_set_property, ui_set_text_style, ui_set_slot_layout) for common operations.',
     meta: uiSetWidgetPropertiesMeta,
     handler: uiSetWidgetPropertiesHandler,
     cost: 'medium',
@@ -1107,22 +1134,22 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
   {
     name: 'ui_list_widget_types',
     description:
-      'List all available UMG widget classes that can be added to a Widget Blueprint via ui_add_element or ui_replace_element. Optionally filter by name.',
+      'List UMG widget classes that can be added via ui_add_element or ui_replace_element. Native classes by default; pass include_blueprints to also list your own Widget Blueprint classes, or panels_only to narrow to containers.',
     meta: uiListWidgetTypesMeta,
     handler: uiListWidgetTypesHandler,
     cost: 'low',
-    returns: '{widget_types:[{name, class_path, is_panel, description}]}',
+    returns: '{types:[{name, class_path, is_panel, is_native, description}]}',
     niche: UI,
     schema: uiListWidgetTypesSchema.shape,
   },
   {
     name: 'ui_remove_element',
     description:
-      'Remove a widget from a Widget Blueprint designer tree. Cannot remove the root without an explicit replacement_root. Widget variable GUID and member state are cleaned up.',
+      'Remove a widget from a Widget Blueprint designer tree, together with its whole subtree. Variable GUIDs for every removed descendant are purged, not just the named widget. Removing the root requires an explicit replacement_root.',
     meta: uiRemoveElementMeta,
     handler: uiRemoveElementHandler,
     cost: 'medium',
-    returns: '{widget_blueprint_path, operation, removed_widget, parent_before_removal, child_index}',
+    returns: '{widget_blueprint_path, operation, widget_name, old_parent, old_child_index?}',
     niche: UI,
     schema: uiRemoveElementSchema.shape,
   },
@@ -1133,21 +1160,124 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
     meta: uiReparentElementMeta,
     handler: uiReparentElementHandler,
     cost: 'medium',
-    returns: '{widget_blueprint_path, operation, widget_name, old_parent, new_parent, old_index, new_index}',
+    returns: '{widget_blueprint_path, operation, widget_name, old_parent, old_child_index, new_parent, new_child_index, new_slot_class, unknown_slot_props?}',
     niche: UI,
     schema: uiReparentElementSchema.shape,
   },
   {
     name: 'ui_replace_element',
     description:
-      'Replace a designer widget with a new widget of a different class at the same position. Preserves parent, child index, and optionally the name and variable GUID.',
+      'Replace a designer widget with a different class at the same position. Preserves parent, child index and slot layout; optionally the name, the variable GUID (preserve_guid) and every property the two classes share by name and type (preserve_properties).',
     meta: uiReplaceElementMeta,
     handler: uiReplaceElementHandler,
     cost: 'medium',
     returns:
-      '{widget_blueprint_path, operation, old_widget, old_class, new_widget, new_class, parent, child_index, preserved_guid, migrated_properties, discarded_properties}',
+      '{widget_blueprint_path, operation, widget_name, old_class, new_class, new_name, child_index, properties_copied}',
     niche: UI,
     schema: uiReplaceElementSchema.shape,
+  },
+
+  {
+    name: 'ui_build_tree',
+    description:
+      'Build a whole widget subtree from one nested spec - {class, name?, properties?, slot_props?, children?}. One call instead of one ui_add_element per widget. Depth-first in order; on failure the widgets already created are KEPT and named in the error so you can see exactly how far it got.',
+    meta: uiBuildTreeMeta,
+    handler: uiBuildTreeHandler,
+    cost: 'medium',
+    returns: '{widget_blueprint_path, parent, created, names[], warnings?[], error?, partial?}',
+    niche: UI,
+    schema: uiBuildTreeSchema.shape,
+  },
+  {
+    name: 'ui_duplicate_element',
+    description:
+      'Duplicate a widget and its entire subtree, cloning properties and slot layout. The copy and every duplicated descendant are registered as designer variables. Use for repeated rows, cards and list entries.',
+    meta: uiDuplicateElementMeta,
+    handler: uiDuplicateElementHandler,
+    cost: 'medium',
+    returns: '{widget_blueprint_path, operation, source, name, parent, widgets_duplicated}',
+    niche: UI,
+    schema: uiDuplicateElementSchema.shape,
+  },
+  {
+    name: 'ui_move_element',
+    description:
+      'Reorder a widget among its siblings. Child order is draw order and tab order in box panels. Slot layout is preserved across the move; an out-of-range index is rejected with the valid range.',
+    meta: uiMoveElementMeta,
+    handler: uiMoveElementHandler,
+    cost: 'medium',
+    returns: '{widget_blueprint_path, operation, widget_name, parent, old_index, new_index}',
+    niche: UI,
+    schema: uiMoveElementSchema.shape,
+  },
+  {
+    name: 'ui_rename_element',
+    description:
+      'Rename a designer widget, carrying its variable GUID across so existing bindings keep resolving. The widget name IS the variable name the graph and C++ BindWidget use, so this is an API change.',
+    meta: uiRenameElementMeta,
+    handler: uiRenameElementHandler,
+    cost: 'medium',
+    returns: '{widget_blueprint_path, operation, old_name, new_name, guid_preserved}',
+    niche: UI,
+    schema: uiRenameElementSchema.shape,
+  },
+  {
+    name: 'ui_set_variable',
+    description:
+      'Expose (or hide) a widget as a blueprint variable - the designer Is Variable checkbox. Without it the graph and C++ BindWidget cannot reach the widget at all.',
+    meta: uiSetVariableMeta,
+    handler: uiSetVariableHandler,
+    cost: 'low',
+    returns: '{widget_name, is_variable, category?}',
+    niche: UI,
+    schema: uiSetVariableSchema.shape,
+  },
+  {
+    name: 'ui_list_widget_blueprints',
+    description:
+      'List the Widget Blueprints that exist in the project, with the _C class path needed to use one as a child widget or as a parent class. Reads the asset registry, so no blueprint is loaded.',
+    meta: uiListWidgetBlueprintsMeta,
+    handler: uiListWidgetBlueprintsHandler,
+    cost: 'low',
+    returns: '{widget_blueprints:[{name, path, package, parent_class?, class_path}], count}',
+    niche: UI,
+    schema: uiListWidgetBlueprintsSchema.shape,
+  },
+  {
+    name: 'ui_layout_snapshot',
+    description:
+      'Resolve the real on-screen geometry of every widget by running a Slate prepass on the compiled widget class, plus per-widget font, measured text width and brush facts. This is the measurement layer ui_validate judges. layout_resolved:false means the blueprint could not be instantiated (usually: compile it first) and geometry is absent rather than zero.',
+    meta: uiLayoutSnapshotMeta,
+    handler: uiLayoutSnapshotHandler,
+    cost: 'medium',
+    returns:
+      '{widget_blueprint_path, screen_width, screen_height, layout_resolved, layout_error?, widget_count, widgets:[{name, class, x, y, width, height, depth, anchors?, text_info?, brush_info?}]}',
+    niche: UI,
+    schema: uiLayoutSnapshotSchema.shape,
+  },
+  {
+    name: 'ui_measure_text',
+    description:
+      'Measure a string exactly, through the Slate font measure service, in a widget real font or an explicit one. Returns rendered width/height plus how many characters fit in the box: the actual string, typical mixed-case prose, and the worst case if every glyph were the font widest. Use this to size a label for variable-length runtime text (player names, item names, translations) BEFORE it clips in game.',
+    meta: uiMeasureTextMeta,
+    handler: uiMeasureTextHandler,
+    cost: 'low',
+    returns:
+      '{text, width_px, height_px, available_width_px, overflows, chars_that_fit, typical_chars_that_fit, worst_case_chars_that_fit, font_size, font_object?}',
+    niche: UI,
+    schema: uiMeasureTextSchema.shape,
+  },
+  {
+    name: 'ui_validate',
+    description:
+      'CHECK A SCREEN AGAINST GAME-UI STANDARDS: runs the UI rule catalogue over a real Slate layout and reports precise, actionable findings - text that overflows (and the exact character count at which it does), labels with no room for translation growth, content inside TV title/action-safe margins, touch targets below the platform minimum, overlapping siblings, contrast below WCAG, controls gamepad focus cannot reach, and performance traps. Judged per platform (pc/console/handheld/mobile) and per strictness (relaxed/standard/strict). USE_WHEN: after building or editing a Widget Blueprint, and before calling the screen done. NOT_WHEN: you only need the tree (ui_query) or one measurement (ui_measure_text). Rules that need geometry are reported as SKIPPED when the layout cannot be resolved - never as passing.',
+    meta: uiValidateMeta,
+    handler: uiValidateHandler,
+    cost: 'medium',
+    returns:
+      '{widget_blueprint_path, platform, strictness, layout_resolved, findings:[{ruleId, severity, widget?, message, hint, data}], rules_evaluated, rules_skipped_no_layout[], rules_disabled[], rules_below_strictness[], counts}',
+    niche: UI,
+    schema: uiValidateSchema.shape,
   },
 
   // ── Scene domain ──────────────────────────────────────────────────────────
@@ -2602,6 +2732,16 @@ function registerToolsCore(server: McpServer, session: SessionManagerStub): void
     validatorSetRuleEnabledSchema,
     async (args: { rule_id: string; enabled: boolean }) => {
       const r = await validatorSetRuleEnabledHandler(args);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'validator_strictness',
+    "Read or set validation strictness. Three modes — relaxed (only what is broken), standard (plus established conventions), strict (plus house-style polish) — set globally or per category (ui, pcg, landscape, material, blueprint, python, asset, general). A rule declares the lowest mode at which it fires, so raising strictness only ever adds findings. Call with no arguments to read the current settings. Persists to .scratch/validator-config.json, the same file the editor Configure panel reads.",
+    validatorStrictnessSchema,
+    async (args: Parameters<typeof validatorStrictnessHandler>[0]) => {
+      const r = await validatorStrictnessHandler(args);
       return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
     },
   );

--- a/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
+++ b/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
@@ -35,23 +35,45 @@ INSTANCE LAYER
 `.trim(),
 
   ui: `
-UMG / WIDGET BLUEPRINT TOOLSET (3 tools) — first-touch briefing
-================================================================
-Author designer-editable UI the real UMG way (font picker works, artists can
-tweak) instead of hand-building the tree in C++. Param names mirror the C++
-handler exactly.
+UMG / WIDGET BLUEPRINT TOOLSET (17 tools) — first-touch briefing
+=================================================================
+Widget Blueprint editing operates on the authoritative designer WidgetTree.
+Changes survive compile, save, editor restart, and PIE.
 
-  ui_create_widget   Create a Widget Blueprint asset (seeds a root CanvasPanel).
-                     path + name (+ optional parent_class descending from UserWidget).
-  ui_add_element     Add a widget to an existing BP tree. widget_blueprint_path +
-                     child_class (Button/TextBlock/Image/CanvasPanel/…), optional
-                     parent_widget_name (a panel), name, and slot_props
-                     (x/y/w/h for canvas, fill/padding for boxes).
-  ui_query           Read back the widget tree: per-widget name/class/slot/children.
+PERSISTENCE INVARIANT (CRITICAL):
+  ui_set_widget_properties and typed tools (ui_set_text_style etc.) call
+  Modify()+PostEditChange()+MarkBlueprintAsModified but do NOT compile or save.
+  Call ui_compile_widget to apply staged changes, then ui_save_widget to persist.
 
-Tip: pass parent_class="/Script/<Module>.<CppWidget>" to keep C++ logic while
-setting fonts/brushes visually in the BP — this fixes the UFontFace preview-tile
-bug (Slate needs a composite UFont, or a font assigned through the designer).
+CREATION
+  ui_create_widget     Create a new Widget Blueprint asset
+  ui_add_element       Add a child widget to an existing BP tree
+
+INSPECTION
+  ui_query             Return the widget tree (name/class/slot/children)
+  ui_get_widget_info   Extended query with properties + GUIDs
+  ui_search_widgets    Find widgets by name pattern or class
+  ui_list_widget_types List available UMG widget classes
+
+PROPERTY EDITING (survive compile+save+restart)
+  ui_set_widget_properties  Generic: set named properties + slot layout
+  ui_set_property           Set a single property by name
+  ui_set_text_style         Font, size, color, outline, shadow, justification
+  ui_set_brush              Texture/material resource, tint, draw style
+  ui_set_visibility         Visible/Hidden/Collapsed
+  ui_set_slot_layout        Canvas anchors, position, size, alignment, Z-order
+
+PERSISTENCE
+  ui_compile_widget     Compile the BP; returns warnings/errors
+  ui_save_widget        Save to disk; optionally compile first
+
+STRUCTURAL
+  ui_remove_element     Remove a widget from the tree
+  ui_reparent_element   Move a widget to a new parent
+  ui_replace_element    Swap a widget's class at the same position
+
+After any edit: ui_compile_widget → ui_save_widget → ui_query with
+include_properties=true to verify values survive.
 `.trim(),
 };
 
@@ -74,9 +96,6 @@ export function appendNicheBriefing(
   if (!session.briefNicheOnce(domain)) return result;
   return {
     ...result,
-    content: [
-      ...result.content,
-      { type: 'text' as const, text: briefing },
-    ],
+    content: [...result.content, { type: 'text' as const, text: briefing }],
   };
 }

--- a/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
+++ b/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
@@ -33,6 +33,26 @@ INSTANCE LAYER
   material_set_param           Set a scalar, vector (rgba), or texture parameter on a material instance
   material_apply               Apply a material (or instance) to an actor in the level
 `.trim(),
+
+  ui: `
+UMG / WIDGET BLUEPRINT TOOLSET (3 tools) — first-touch briefing
+================================================================
+Author designer-editable UI the real UMG way (font picker works, artists can
+tweak) instead of hand-building the tree in C++. Param names mirror the C++
+handler exactly.
+
+  ui_create_widget   Create a Widget Blueprint asset (seeds a root CanvasPanel).
+                     path + name (+ optional parent_class descending from UserWidget).
+  ui_add_element     Add a widget to an existing BP tree. widget_blueprint_path +
+                     child_class (Button/TextBlock/Image/CanvasPanel/…), optional
+                     parent_widget_name (a panel), name, and slot_props
+                     (x/y/w/h for canvas, fill/padding for boxes).
+  ui_query           Read back the widget tree: per-widget name/class/slot/children.
+
+Tip: pass parent_class="/Script/<Module>.<CppWidget>" to keep C++ logic while
+setting fonts/brushes visually in the BP — this fixes the UFontFace preview-tile
+bug (Slate needs a composite UFont, or a font assigned through the designer).
+`.trim(),
 };
 
 /**

--- a/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
+++ b/mcp-tools/hayba-mcp/src/tools/niche-briefing.ts
@@ -35,45 +35,80 @@ INSTANCE LAYER
 `.trim(),
 
   ui: `
-UMG / WIDGET BLUEPRINT TOOLSET (17 tools) — first-touch briefing
+UMG / WIDGET BLUEPRINT TOOLSET (26 tools) - first-touch briefing
 =================================================================
 Widget Blueprint editing operates on the authoritative designer WidgetTree.
 Changes survive compile, save, editor restart, and PIE.
 
 PERSISTENCE INVARIANT (CRITICAL):
-  ui_set_widget_properties and typed tools (ui_set_text_style etc.) call
-  Modify()+PostEditChange()+MarkBlueprintAsModified but do NOT compile or save.
+  Every editing tool marks the blueprint modified but does NOT compile or save.
   Call ui_compile_widget to apply staged changes, then ui_save_widget to persist.
+  ui_layout_snapshot / ui_validate need a COMPILED class - compile first or they
+  report layout_resolved:false and skip every geometry rule.
 
 CREATION
   ui_create_widget     Create a new Widget Blueprint asset
-  ui_add_element       Add a child widget to an existing BP tree
+  ui_add_element       Add one child widget to an existing tree
+  ui_build_tree        Build a whole subtree from one nested spec (prefer this
+                       for a new screen - one call, not one per widget)
+  ui_duplicate_element Clone a widget + its subtree, properties and slot layout
 
 INSPECTION
-  ui_query             Return the widget tree (name/class/slot/children)
+  ui_query             Widget tree; name_pattern/class_filter/flatten for a
+                       flat match list instead of the whole tree
   ui_get_widget_info   Extended query with properties + GUIDs
-  ui_search_widgets    Find widgets by name pattern or class
-  ui_list_widget_types List available UMG widget classes
+  ui_search_widgets    Find widgets by name substring or class
+  ui_list_widget_types Native UMG classes (include_blueprints for your own)
+  ui_list_widget_blueprints  Widget Blueprints in the project, with _C paths
 
-PROPERTY EDITING (survive compile+save+restart)
-  ui_set_widget_properties  Generic: set named properties + slot layout
-  ui_set_property           Set a single property by name
+PROPERTY EDITING
+  ui_set_widget_properties  Generic: named properties + slot layout. Values may
+                            be NESTED objects for struct properties.
+  ui_set_property           One property by name
   ui_set_text_style         Font, size, color, outline, shadow, justification
-  ui_set_brush              Texture/material resource, tint, draw style
-  ui_set_visibility         Visible/Hidden/Collapsed
-  ui_set_slot_layout        Canvas anchors, position, size, alignment, Z-order
-
-PERSISTENCE
-  ui_compile_widget     Compile the BP; returns warnings/errors
-  ui_save_widget        Save to disk; optionally compile first
+  ui_set_brush              Resource, tint, draw style (brush_property:
+                            "Brush" for Image, "Background" for Border)
+  ui_set_visibility         Visible/Hidden/Collapsed/HitTestInvisible
+  ui_set_slot_layout        Canvas anchors/position/size/z-order, box
+                            padding/fill/alignment, grid row/column
+  ui_set_variable           Expose a widget as a blueprint variable. Without
+                            this the graph and C++ BindWidget cannot reach it.
 
 STRUCTURAL
-  ui_remove_element     Remove a widget from the tree
-  ui_reparent_element   Move a widget to a new parent
-  ui_replace_element    Swap a widget's class at the same position
+  ui_remove_element     Remove a widget and its whole subtree
+  ui_reparent_element   Move to a different parent (optional index, slot_props)
+  ui_move_element       Reorder among siblings (= draw and tab order)
+  ui_rename_element     Rename, carrying the variable GUID across
+  ui_replace_element    Swap class in place (preserve_guid, preserve_properties)
 
-After any edit: ui_compile_widget → ui_save_widget → ui_query with
-include_properties=true to verify values survive.
+MEASUREMENT AND VALIDATION
+  ui_layout_snapshot   Real Slate layout: every widget's resolved rectangle,
+                       font, measured text width, brush facts
+  ui_measure_text      Exact rendered width of a string, and how many characters
+                       fit: the actual string, typical prose, and the worst case
+                       if every glyph were the font's widest
+  ui_validate          Run the UI rule catalogue - text overflow with the exact
+                       character count, localisation headroom, TV safe areas,
+                       touch targets, overlap, WCAG contrast, gamepad focus,
+                       performance traps. Per platform (pc/console/handheld/
+                       mobile) and per strictness (relaxed/standard/strict,
+                       set with validator_strictness).
+
+REPORTING CONTRACT
+  Editing tools report per-key outcomes: succeeded, failed_properties,
+  unknown_slot_props, warnings. A key the widget or slot did not accept comes
+  back named - it is never silently dropped.
+  ui_validate reports rules_skipped_no_layout separately from findings: a
+  geometry rule with no geometry has checked NOTHING, and is never counted
+  as a pass.
+
+FONTS
+  Assign a composite UFont, never a UFontFace. Slate renders a raw font face as
+  its glyph-preview tiles instead of as text. Both the property setter and
+  ui_validate flag this.
+
+Suggested loop: ui_build_tree -> ui_compile_widget -> ui_validate -> fix ->
+ui_compile_widget -> ui_save_widget.
 `.trim(),
 };
 

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -65,6 +65,7 @@ export const ALWAYS_ON_META = new Set<string>([
   'validator_clear',
   'validator_rules',
   'validator_set_rule_enabled',
+  'validator_strictness',
   'plumb_primitives',
   'plumb_profile_bake',
   'plumb_profile_annotate',
@@ -299,6 +300,7 @@ export async function registerDeferredRouting(
   passthrough('validator_clear');
   passthrough('validator_rules');
   passthrough('validator_set_rule_enabled');
+  passthrough('validator_strictness');
   // PLUMB constraint subsystem — always-on so the Validator/Memory panels and
   // any agent can bake profiles, author constraints, and run Verdicts without
   // loading a pack.

--- a/mcp-tools/hayba-mcp/src/tools/tool-executor.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-executor.ts
@@ -3,13 +3,7 @@ import type { TcpResponse } from '../tcp-client.js';
 import { getToolMeta } from './tool-meta-registry.js';
 import { isHeavyOp, HEAVY_OP_TIMEOUT_MS } from './heavy-ops.js';
 
-export type UeToolErrorCode =
-  | 'transport'
-  | 'timeout'
-  | 'plan_gate'
-  | 'tool_disabled'
-  | 'ue_error'
-  | 'editor_busy';
+export type UeToolErrorCode = 'transport' | 'timeout' | 'plan_gate' | 'tool_disabled' | 'ue_error' | 'editor_busy';
 
 export class UeToolError extends Error {
   readonly code: UeToolErrorCode;
@@ -36,9 +30,9 @@ function mapUeCode(raw: string | undefined): UeToolErrorCode {
 //                   job envelope in Task 9; until then high-cost ops must not
 //                   pre-time-out while UE is still working)
 const COST_TIMEOUTS_MS: Record<HaybaToolCost, number> = {
-  low:    2_000,
+  low: 2_000,
   medium: 10_000,
-  high:   120_000,
+  high: 120_000,
 };
 
 /**
@@ -141,6 +135,10 @@ export const NON_IDEMPOTENT = new Set<string>([
   'gas_create_effect',
   // UI
   'ui_create_widget',
+  'ui_set_widget_properties',
+  'ui_mutate_tree',
+  'ui_compile_widget',
+  'ui_save_widget',
   // Data
   'data_create',
   // Input
@@ -174,8 +172,7 @@ export function resolveTimeoutMs(cmd: string): number {
  */
 async function makeEditorBusyError(cmd: string, cause: unknown): Promise<UeToolError> {
   const causeMsg = (cause as Error)?.message ?? String(cause);
-  let processHint =
-    'Re-check the editor with hayba_check_ue_status before retrying — do NOT auto-retry this op.';
+  let processHint = 'Re-check the editor with hayba_check_ue_status before retrying — do NOT auto-retry this op.';
   try {
     // Lazy import so this module stays unit-testable without the process probe.
     const { probeEditorProcess } = await import('./heavy-op-probe.js');
@@ -198,11 +195,7 @@ async function makeEditorBusyError(cmd: string, cause: unknown): Promise<UeToolE
   );
 }
 
-export type Sender = (
-  cmd: string,
-  params: Record<string, unknown>,
-  timeoutMs: number,
-) => Promise<TcpResponse>;
+export type Sender = (cmd: string, params: Record<string, unknown>, timeoutMs: number) => Promise<TcpResponse>;
 
 export interface ExecuteOpts {
   /** Override the cost-derived default timeout. */
@@ -215,7 +208,9 @@ let DEFAULT_SENDER: Sender | null = null;
 
 /** Install the production (TCP) sender. Lazy on purpose so unit tests
  *  can use this module without importing tcp-client. */
-export function setDefaultSender(s: Sender): void { DEFAULT_SENDER = s; }
+export function setDefaultSender(s: Sender): void {
+  DEFAULT_SENDER = s;
+}
 
 export async function executeCommand<T = Record<string, unknown>>(
   cmd: string,

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-add-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-add-element.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'adding a widget (Button/TextBlock/Image/panels/…) to an existing Widget Blueprint tree',
+  not_when: 'creating the Widget Blueprint itself (use ui_create_widget first)',
+};
+
+// slot_props keys x/y/w/h (canvas offsets), fill/padding (box slots) are handled
+// explicitly by the C++ handler; any other key falls through to reflection on the
+// slot object. Values are primitives (number/string/bool) — see HaybaMCPUIHandler.cpp.
+export const schema = z.object({
+  widget_blueprint_path: z
+    .string()
+    .min(1)
+    .describe('Full path of the target Widget Blueprint, e.g. "/Game/Aphrosia/UI/WBP_StartScreen"'),
+  child_class: z
+    .string()
+    .min(1)
+    .describe(
+      'Widget class to add — short name (Button, TextBlock, Image, CanvasPanel, HorizontalBox, VerticalBox, Overlay, ScrollBox, Border, GridPanel, UniformGridPanel, SizeBox, Spacer, CheckBox, EditableTextBox, ProgressBar, Slider) or a full class path.',
+    ),
+  parent_widget_name: z
+    .string()
+    .optional()
+    .describe('Name of an existing PANEL widget to parent under. Defaults to the root panel; errors if the root is not a panel and none is given.'),
+  name: z.string().optional().describe('Name for the new widget (auto-generated if omitted).'),
+  slot_props: z
+    .record(z.union([z.number(), z.string(), z.boolean()]))
+    .optional()
+    .describe(
+      'Slot layout props. Canvas slot: x, y, w, h (offsets). Box slot: fill, padding. Any other key is set on the slot by reflection.',
+    ),
+});
+
+export const uiAddElementHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_add_element', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-build-tree.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-build-tree.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'building a whole screen or subtree at once — the layout is known up front',
+  not_when: 'adding a single widget to an existing tree (use ui_add_element)',
+};
+
+const propertyValue: z.ZodType<unknown> = z.lazy(() =>
+  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(propertyValue), z.record(propertyValue)]),
+);
+
+// Recursive by construction: a node's children are nodes. z.lazy is required
+// because the schema refers to itself.
+const nodeSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.object({
+    class: z
+      .string()
+      .min(1)
+      .describe(
+        'Widget class — short name ("VerticalBox", "TextBlock") or a full class path, including your own /Game/... widget blueprint classes',
+      ),
+    name: z.string().optional().describe('Name for this widget. Must be unique in the blueprint; auto-generated if omitted.'),
+    properties: z.record(propertyValue).optional().describe('Properties set on the widget itself'),
+    slot_props: z.record(propertyValue).optional().describe('Layout properties for this widget slot in its parent'),
+    children: z.array(nodeSchema).optional().describe('Child nodes. Only valid when `class` is a panel widget.'),
+  }),
+);
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  parent_widget_name: z.string().optional().describe('Existing panel to build under. Defaults to the root panel.'),
+  tree: z
+    .union([nodeSchema, z.array(nodeSchema)])
+    .describe(
+      'A node, or an array of sibling nodes, each {class, name?, properties?, slot_props?, children?}. Built depth-first in order. On failure the widgets created before the failing node are KEPT and named in the error.',
+    ),
+});
+
+export const uiBuildTreeHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_build_tree', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-compile-widget.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-compile-widget.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'compiling a Widget Blueprint to apply pending graph changes and surface compile errors',
+  not_when: 'saving without compiling (use ui_save_widget) or editing widget properties',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the Widget Blueprint to compile'),
+  save_on_success: z.boolean().optional().default(false).describe('Save the package on successful compile'),
+});
+
+export const uiCompileWidgetHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_compile_widget', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-create-widget.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-create-widget.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['creates_asset'],
+  when: 'creating a new UMG Widget Blueprint asset (designer-editable UI) in the project',
+  not_when: 'adding a widget to an EXISTING Widget Blueprint (use ui_add_element)',
+};
+
+export const schema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe('UE content package directory for the new Widget Blueprint, e.g. "/Game/Aphrosia/UI"'),
+  name: z.string().min(1).describe('Asset name for the new Widget Blueprint, e.g. "WBP_StartScreen"'),
+  parent_class: z
+    .string()
+    .optional()
+    .describe(
+      'Parent class the widget derives from — MUST descend from UserWidget. A class path like "/Script/Aphrosia.StartScreenWidget" or "/Script/UMG.UserWidget", or a short name. Defaults to UserWidget.',
+    ),
+});
+
+export const uiCreateWidgetHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_create_widget', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-dispatch.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-dispatch.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { InMemoryToolExecutor, setDefaultSender } from '../tool-executor.js';
+
+import { uiSearchWidgetsHandler } from './ui-search-widgets.js';
+import { uiSetSlotLayoutHandler } from './ui-set-slot-layout.js';
+import { uiSetWidgetPropertiesHandler } from './ui-set-widget-properties.js';
+import { uiSetBrushHandler } from './ui-set-brush.js';
+import { uiSetTextStyleHandler } from './ui-set-text-style.js';
+import { uiBuildTreeHandler } from './ui-build-tree.js';
+import { uiDuplicateElementHandler } from './ui-duplicate-element.js';
+import { uiMoveElementHandler } from './ui-move-element.js';
+import { uiRenameElementHandler } from './ui-rename-element.js';
+import { uiSetVariableHandler } from './ui-set-variable.js';
+import { uiListWidgetBlueprintsHandler } from './ui-list-widget-blueprints.js';
+import { uiMeasureTextHandler } from './ui-measure-text.js';
+import { uiLayoutSnapshotHandler } from './ui-layout-snapshot.js';
+
+// Regression tests for wrapper→handler dispatch.
+//
+// Every case here corresponds to a payload that the C++ handler did not read,
+// which meant the tool reported nothing useful (or failed outright) while
+// looking perfectly well-formed from the caller's side. The assertions pin the
+// exact param names HaybaMCPUIHandler.cpp reads.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexSrc = readFileSync(join(__dirname, '..', 'index.ts'), 'utf-8');
+
+function textOf(r: { content: Array<{ type: string; text: string }> }): string {
+  return r.content[0]!.text;
+}
+
+const ok = (data: Record<string, unknown>) => ({ ok: true, data });
+
+describe('ui_search_widgets', () => {
+  it('sends `path` and the handler-side filter names', async () => {
+    // It used to forward its own field names, so no `path` reached the handler
+    // and every single call failed with "ui_query: missing path".
+    let seen: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor().on('ui_query', (p) => {
+      seen = p;
+      return ok({ matches: [], match_count: 0 });
+    });
+    setDefaultSender(exec.send);
+
+    const r = await uiSearchWidgetsHandler(
+      { widget_blueprint_path: '/Game/UI/WBP_Test', widget_name_pattern: 'Btn', widget_class: 'Button' },
+      undefined as never,
+    );
+
+    expect(r.isError).toBeFalsy();
+    expect(seen).toMatchObject({
+      path: '/Game/UI/WBP_Test',
+      name_pattern: 'Btn',
+      class_filter: 'Button',
+      flatten: true,
+    });
+    expect(seen).not.toHaveProperty('widget_blueprint_path');
+  });
+});
+
+describe('ui_set_slot_layout', () => {
+  it('sends slot_props, not the slot_layout shape no handler ever read', async () => {
+    let seen: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor().on('ui_set_widget_properties', (p) => {
+      seen = p;
+      return ok({ succeeded: 3, failed: 0 });
+    });
+    setDefaultSender(exec.send);
+
+    const r = await uiSetSlotLayoutHandler(
+      {
+        widget_blueprint_path: '/Game/UI/WBP_Test',
+        widget_name: 'Title',
+        anchors_min: [0.5, 0],
+        position: [0, 40],
+        z_order: 3,
+      },
+      undefined as never,
+    );
+
+    expect(r.isError).toBeFalsy();
+    expect(seen).toHaveProperty('slot_props');
+    expect(seen).not.toHaveProperty('slot_layout');
+    expect((seen as unknown as { slot_props: Record<string, unknown> }).slot_props).toEqual({
+      anchors_min: [0.5, 0],
+      position: [0, 40],
+      z_order: 3,
+    });
+  });
+
+  it('omits fields the caller did not set rather than sending undefined', async () => {
+    let seen: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor().on('ui_set_widget_properties', (p) => {
+      seen = p;
+      return ok({ succeeded: 1, failed: 0 });
+    });
+    setDefaultSender(exec.send);
+
+    await uiSetSlotLayoutHandler(
+      { widget_blueprint_path: '/Game/UI/WBP_Test', widget_name: 'Title', padding: 0 },
+      undefined as never,
+    );
+
+    // Zero padding must survive: it is how a caller clears a margin.
+    expect((seen as unknown as { slot_props: Record<string, unknown> }).slot_props).toEqual({ padding: 0 });
+  });
+
+  it('refuses a call with no layout fields instead of round-tripping a no-op', async () => {
+    const r = await uiSetSlotLayoutHandler(
+      { widget_blueprint_path: '/Game/UI/WBP_Test', widget_name: 'Title' },
+      undefined as never,
+    );
+    expect(r.isError).toBe(true);
+  });
+});
+
+describe('ui_set_widget_properties', () => {
+  it('accepts nested struct values', async () => {
+    // The schema used to reject nested objects, so no caller could set a Brush
+    // or a Font through the generic tool at all.
+    let seen: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor().on('ui_set_widget_properties', (p) => {
+      seen = p;
+      return ok({ succeeded: 1, failed: 0 });
+    });
+    setDefaultSender(exec.send);
+
+    const r = await uiSetWidgetPropertiesHandler(
+      {
+        widget_blueprint_path: '/Game/UI/WBP_Test',
+        widget_name: 'Title',
+        properties: { Font: { Size: 32, TypefaceFontName: 'Bold' } },
+      },
+      undefined as never,
+    );
+
+    expect(r.isError).toBeFalsy();
+    expect(seen).toMatchObject({ properties: { Font: { Size: 32, TypefaceFontName: 'Bold' } } });
+  });
+
+  it('rejects a call with neither properties nor slot_props', async () => {
+    const r = await uiSetWidgetPropertiesHandler(
+      { widget_blueprint_path: '/Game/UI/WBP_Test', widget_name: 'Title' },
+      undefined as never,
+    );
+    expect(r.isError).toBe(true);
+  });
+});
+
+describe('ui_set_brush', () => {
+  it('sends the resource as a bare asset path', async () => {
+    let seen: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor().on('ui_set_widget_properties', (p) => {
+      seen = p;
+      return ok({ succeeded: 1, failed: 0 });
+    });
+    setDefaultSender(exec.send);
+
+    await uiSetBrushHandler(
+      { widget_blueprint_path: '/Game/UI/WBP_Test', widget_name: 'Bg', resource: '/Game/UI/T_Panel', tint: [1, 1, 1, 1] },
+      undefined as never,
+    );
+
+    const props = (seen as unknown as { properties: { Brush: Record<string, unknown> } }).properties;
+    expect(props.Brush.ResourceObject).toBe('/Game/UI/T_Panel');
+  });
+
+  it('writes Background rather than Brush when targeting a Border', async () => {
+    let seen: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor().on('ui_set_widget_properties', (p) => {
+      seen = p;
+      return ok({ succeeded: 1, failed: 0 });
+    });
+    setDefaultSender(exec.send);
+
+    await uiSetBrushHandler(
+      {
+        widget_blueprint_path: '/Game/UI/WBP_Test',
+        widget_name: 'Card',
+        tint: [0, 0, 0, 0.5],
+        brush_property: 'Background',
+      },
+      undefined as never,
+    );
+
+    const props = (seen as unknown as { properties: Record<string, unknown> }).properties;
+    expect(props).toHaveProperty('Background');
+    expect(props).not.toHaveProperty('Brush');
+  });
+});
+
+describe('ui_set_text_style', () => {
+  it('uses the real FSlateFontInfo field names', async () => {
+    let seen: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor().on('ui_set_widget_properties', (p) => {
+      seen = p;
+      return ok({ succeeded: 1, failed: 0 });
+    });
+    setDefaultSender(exec.send);
+
+    await uiSetTextStyleHandler(
+      {
+        widget_blueprint_path: '/Game/UI/WBP_Test',
+        widget_name: 'Title',
+        font_asset: '/Game/UI/Fonts/Cormorant',
+        typeface: 'Bold',
+        size: 48,
+      },
+      undefined as never,
+    );
+
+    const font = (seen as unknown as { properties: { Font: Record<string, unknown> } }).properties.Font;
+    // `Typeface: {FontName}` matched no property on the struct; the field is
+    // TypefaceFontName and FontObject takes an asset path.
+    expect(font).toEqual({ FontObject: '/Game/UI/Fonts/Cormorant', Size: 48, TypefaceFontName: 'Bold' });
+  });
+});
+
+describe('tree mutation wrappers map onto ui_mutate_tree operations', () => {
+  const cases: Array<[string, (a: Record<string, unknown>) => Promise<{ isError?: boolean }>, Record<string, unknown>]> = [
+    ['duplicate', (a) => uiDuplicateElementHandler(a, undefined as never), { widget_name: 'Row' }],
+    ['move', (a) => uiMoveElementHandler(a, undefined as never), { widget_name: 'Row', index: 2 }],
+    ['rename', (a) => uiRenameElementHandler(a, undefined as never), { widget_name: 'Row', new_name: 'FirstRow' }],
+  ];
+
+  for (const [operation, run, args] of cases) {
+    it(`ui_${operation === 'move' ? 'move_element' : operation}s via operation:"${operation}"`, async () => {
+      let seen: Record<string, unknown> | null = null;
+      const exec = new InMemoryToolExecutor().on('ui_mutate_tree', (p) => {
+        seen = p;
+        return ok({ operation });
+      });
+      setDefaultSender(exec.send);
+
+      const r = await run({ widget_blueprint_path: '/Game/UI/WBP_Test', ...args });
+      expect(r.isError).toBeFalsy();
+      expect(seen).toMatchObject({ operation, widget_blueprint_path: '/Game/UI/WBP_Test', ...args });
+    });
+  }
+});
+
+describe('new commands dispatch to their own handler names', () => {
+  it('ui_build_tree forwards the nested spec unchanged', async () => {
+    let seen: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor().on('ui_build_tree', (p) => {
+      seen = p;
+      return ok({ created: 2, names: ['Col', 'Title'] });
+    });
+    setDefaultSender(exec.send);
+
+    const tree = {
+      class: 'VerticalBox',
+      name: 'Col',
+      children: [{ class: 'TextBlock', name: 'Title', properties: { Text: 'Hi' } }],
+    };
+    const r = await uiBuildTreeHandler({ widget_blueprint_path: '/Game/UI/WBP_Test', tree }, undefined as never);
+
+    expect(r.isError).toBeFalsy();
+    expect(seen).toMatchObject({ tree });
+  });
+
+  it('ui_build_tree rejects a node with no class', async () => {
+    const r = await uiBuildTreeHandler(
+      { widget_blueprint_path: '/Game/UI/WBP_Test', tree: { name: 'Col' } },
+      undefined as never,
+    );
+    expect(r.isError).toBe(true);
+  });
+
+  it('ui_set_variable defaults is_variable to true', async () => {
+    let seen: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor().on('ui_set_variable', (p) => {
+      seen = p;
+      return ok({ is_variable: true });
+    });
+    setDefaultSender(exec.send);
+
+    await uiSetVariableHandler(
+      { widget_blueprint_path: '/Game/UI/WBP_Test', widget_name: 'Title' },
+      undefined as never,
+    );
+    expect(seen).toMatchObject({ is_variable: true });
+  });
+
+  it('ui_list_widget_blueprints dispatches with no required args', async () => {
+    const exec = new InMemoryToolExecutor().on('ui_list_widget_blueprints', () => ok({ widget_blueprints: [], count: 0 }));
+    setDefaultSender(exec.send);
+    const r = await uiListWidgetBlueprintsHandler({}, undefined as never);
+    expect(r.isError).toBeFalsy();
+  });
+
+  it('ui_layout_snapshot dispatches with the blueprint path', async () => {
+    const exec = new InMemoryToolExecutor().on('ui_layout_snapshot', (p) => {
+      expect(p).toMatchObject({ widget_blueprint_path: '/Game/UI/WBP_Test' });
+      return ok({ layout_resolved: true, widgets: [] });
+    });
+    setDefaultSender(exec.send);
+    const r = await uiLayoutSnapshotHandler({ widget_blueprint_path: '/Game/UI/WBP_Test' }, undefined as never);
+    expect(r.isError).toBeFalsy();
+  });
+});
+
+describe('ui_measure_text', () => {
+  it('measures against a widget font when a widget is given', async () => {
+    const exec = new InMemoryToolExecutor().on('ui_measure_text', (p) => {
+      expect(p).toMatchObject({ widget_blueprint_path: '/Game/UI/WBP_Test', widget_name: 'Title', text: 'Hello' });
+      return ok({ width_px: 80, chars_that_fit: 5 });
+    });
+    setDefaultSender(exec.send);
+    const r = await uiMeasureTextHandler(
+      { text: 'Hello', widget_blueprint_path: '/Game/UI/WBP_Test', widget_name: 'Title' },
+      undefined as never,
+    );
+    expect(r.isError).toBeFalsy();
+  });
+
+  it('refuses a call with neither a widget nor a font size', async () => {
+    // Without one of the two there is nothing to measure with, and guessing a
+    // font would produce a precise, wrong answer.
+    const r = await uiMeasureTextHandler({ text: 'Hello' }, undefined as never);
+    expect(r.isError).toBe(true);
+    expect(textOf(r as { content: Array<{ type: string; text: string }> })).toMatch(/font_size/);
+  });
+});
+
+describe('descriptor registration', () => {
+  const NEW_TOOLS = [
+    'ui_build_tree',
+    'ui_duplicate_element',
+    'ui_move_element',
+    'ui_rename_element',
+    'ui_set_variable',
+    'ui_list_widget_blueprints',
+    'ui_layout_snapshot',
+    'ui_measure_text',
+    'ui_validate',
+  ];
+
+  for (const name of NEW_TOOLS) {
+    it(`${name} has a descriptor entry`, () => {
+      expect(new RegExp(`name:\\s*['"]${name}['"]`).test(indexSrc)).toBe(true);
+    });
+  }
+});

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-dispatch.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-dispatch.test.ts
@@ -326,6 +326,38 @@ describe('ui_measure_text', () => {
   });
 });
 
+// The duplicate path is C++, so what is pinned here is the invariant that made
+// it wrong: a live editor produced "TRASH_CardCopy_0" and left two widgets both
+// named "Card", because DuplicateObject copies the subtree with every
+// descendant keeping its source name and UMG requires tree-wide uniqueness.
+describe('ui_duplicate_element subtree renaming (C++ invariant)', () => {
+  const handlerSrc = readFileSync(
+    join(
+      __dirname,
+      '..', '..', '..', '..', '..',
+      'unreal', 'HaybaMCPToolkit', 'Source', 'HaybaMCPToolkit', 'Private', 'handlers', 'HaybaMCPUIHandler.cpp',
+    ),
+    'utf-8',
+  );
+
+  const duplicateBlock = handlerSrc.slice(
+    handlerSrc.indexOf("Operation == TEXT(\"duplicate\")"),
+    handlerSrc.indexOf('ui_mutate_tree: unknown operation'),
+  );
+
+  it('duplicates under a scratch name rather than the requested one', () => {
+    expect(duplicateBlock).toContain('HaybaMCP_DuplicateScratch');
+    // The old code passed the caller's name straight to DuplicateObject, which
+    // is what let UE trash the colliding descendants.
+    expect(duplicateBlock).toMatch(/DuplicateObject<UWidget>\(Source, WBP->WidgetTree, ScratchName\)/);
+  });
+
+  it('renames the whole copied subtree, not just its root', () => {
+    expect(duplicateBlock).toContain('CollectSubtree(Copy, Copied)');
+    expect(duplicateBlock).toContain('MakeUniqueObjectName');
+  });
+});
+
 describe('descriptor registration', () => {
   const NEW_TOOLS = [
     'ui_build_tree',

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-duplicate-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-duplicate-element.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'copying an existing widget — with its children, properties and slot layout — to build repeated rows or cards',
+  not_when: 'creating a fresh widget from a class (use ui_add_element)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to duplicate. Its whole subtree is copied.'),
+  new_name: z.string().optional().describe('Name for the copy. Auto-uniquified from the source name if omitted.'),
+  parent_widget_name: z
+    .string()
+    .optional()
+    .describe('Panel to place the copy under. Defaults to the source widget own parent (i.e. a sibling copy).'),
+  slot_props: z
+    .record(z.union([z.number(), z.string(), z.boolean(), z.array(z.number())]))
+    .optional()
+    .describe('Slot layout overrides for the copy, applied after the source slot layout is cloned.'),
+});
+
+export const uiDuplicateElementHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_mutate_tree', {
+    operation: 'duplicate',
+    ...parsed.data,
+  } as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-get-widget-info.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-get-widget-info.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'getting detailed information about a widget blueprint including properties and GUIDs',
+  not_when:
+    'searching for widgets by name/class (use ui_search_widgets) or listing available widget types (use ui_list_widget_types)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the Widget Blueprint to inspect'),
+  include_properties: z.boolean().optional().default(true).describe('Include widget properties in the response'),
+  include_guid: z.boolean().optional().default(true).describe('Include GUIDs in the response'),
+});
+
+export const uiGetWidgetInfoHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const { widget_blueprint_path, include_properties, include_guid } = parsed.data;
+  const data = await executeCommand('ui_query', {
+    path: widget_blueprint_path,
+    include_properties: include_properties ?? true,
+    include_guid: include_guid ?? true,
+    include_slot: true,
+  } as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-layout-snapshot.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-layout-snapshot.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'you need the resolved on-screen rectangle, font and measured text width of every widget in a blueprint',
+  not_when: 'you want the problems rather than the raw data (use ui_validate), or just the tree (use ui_query)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the Widget Blueprint to lay out'),
+  screen_width: z
+    .number()
+    .optional()
+    .describe('Resolution to lay out at. Defaults to the blueprint’s design-time size.'),
+  screen_height: z
+    .number()
+    .optional()
+    .describe('Resolution to lay out at. Defaults to the blueprint’s design-time size.'),
+});
+
+export const uiLayoutSnapshotHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  // Runs a real Slate prepass on an instance of the compiled widget class, so
+  // `layout_resolved: false` in the response means the blueprint could not be
+  // instantiated (usually: it needs compiling first) and every geometry field
+  // is absent rather than zero.
+  const data = await executeCommand('ui_layout_snapshot', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-list-widget-blueprints.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-list-widget-blueprints.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'discovering the Widget Blueprints that already exist in the project, e.g. to reuse one as a child widget',
+  not_when: 'listing native UMG widget classes (use ui_list_widget_types)',
+};
+
+export const schema = z.object({
+  path: z.string().optional().describe('Restrict to a content path, e.g. "/Game/UI". Searched recursively.'),
+  filter: z.string().optional().describe('Case-sensitive substring the asset name must contain'),
+});
+
+export const uiListWidgetBlueprintsHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_list_widget_blueprints', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-list-widget-types.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-list-widget-types.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'listing available widget classes that can be added to a Widget Blueprint',
+  not_when: 'inspecting a specific widget blueprint (use ui_query or ui_get_widget_info)',
+};
+
+export const schema = z.object({
+  filter: z.string().optional().describe('Optional text filter for widget class names'),
+});
+
+export const uiListWidgetTypesHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_list_widget_types', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-measure-text.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-measure-text.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'finding out how wide a string renders, or how many characters fit in a box, before committing to a layout',
+  not_when: 'validating a whole screen (use ui_validate)',
+};
+
+export const schema = z.object({
+  text: z.string().describe('The string to measure'),
+
+  // Either measure with a live widget's real font...
+  widget_blueprint_path: z
+    .string()
+    .optional()
+    .describe('Measure using this blueprint widget’s actual font. Pair with widget_name.'),
+  widget_name: z
+    .string()
+    .optional()
+    .describe('Widget whose font (and, by default, box width) to measure against.'),
+
+  // ...or with an explicit font.
+  font_asset: z
+    .string()
+    .optional()
+    .describe('Composite UFont asset path. A UFontFace is rejected — Slate cannot measure or render one as text.'),
+  font_size: z.number().optional().describe('Font size in px. Required when not measuring against a widget.'),
+  typeface: z.string().optional().describe('Typeface name within the font, e.g. "Bold"'),
+
+  available_width: z
+    .number()
+    .optional()
+    .describe('Box width in px to fit against. Defaults to the widget’s laid-out width when a widget is given.'),
+  font_scale: z.number().optional().default(1).describe('DPI/application scale to measure at'),
+});
+
+export const uiMeasureTextHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const d = parsed.data;
+  const hasWidget = Boolean(d.widget_blueprint_path && d.widget_name);
+  if (!hasWidget && d.font_size === undefined) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: 'Pass either (widget_blueprint_path + widget_name) to measure with a widget’s real font, or font_size (optionally with font_asset) to measure with an explicit one.',
+        },
+      ],
+      isError: true,
+    };
+  }
+  const data = await executeCommand('ui_measure_text', d as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-move-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-move-element.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'reordering a widget among its siblings — child order is draw order and tab order in box panels',
+  not_when: 'moving a widget to a DIFFERENT parent (use ui_reparent_element)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to reorder'),
+  index: z
+    .number()
+    .int()
+    .min(0)
+    .describe('New zero-based index among its siblings. Out-of-range values are rejected with the valid range.'),
+});
+
+export const uiMoveElementHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_mutate_tree', {
+    operation: 'move',
+    ...parsed.data,
+  } as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
@@ -15,6 +15,9 @@ export const schema = z.object({
     .string()
     .min(1)
     .describe('Full path of the Widget Blueprint to inspect, e.g. "/Game/Aphrosia/UI/WBP_StartScreen"'),
+  include_properties: z.boolean().optional().default(false).describe('Include widget properties in the response'),
+  include_guid: z.boolean().optional().default(false).describe('Include GUIDs in the response'),
+  include_slot: z.boolean().optional().default(true).describe('Include slot layout info in the response'),
 });
 
 export const uiQueryHandler: ToolHandler = async (args) => {

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
@@ -18,6 +18,24 @@ export const schema = z.object({
   include_properties: z.boolean().optional().default(false).describe('Include widget properties in the response'),
   include_guid: z.boolean().optional().default(false).describe('Include GUIDs in the response'),
   include_slot: z.boolean().optional().default(true).describe('Include slot layout info in the response'),
+
+  // Passing any of these switches the response from a nested tree to a flat
+  // `matches` list. They must be declared here or Zod strips them before
+  // dispatch and the handler silently returns the whole tree instead.
+  name_pattern: z
+    .string()
+    .optional()
+    .describe('Case-sensitive substring a widget name must contain. Returns a flat `matches` list instead of the tree.'),
+  class_filter: z
+    .string()
+    .optional()
+    .describe(
+      'Class a widget must be or derive from, e.g. "PanelWidget" for every panel. Returns a flat `matches` list instead of the tree.',
+    ),
+  flatten: z
+    .boolean()
+    .optional()
+    .describe('Return the flat `matches` list even when no filter is given.'),
 });
 
 export const uiQueryHandler: ToolHandler = async (args) => {

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'inspecting the widget tree of an existing Widget Blueprint (per-widget class + slot + children)',
+  not_when: 'you are mutating the tree (use ui_add_element)',
+};
+
+export const schema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe('Full path of the Widget Blueprint to inspect, e.g. "/Game/Aphrosia/UI/WBP_StartScreen"'),
+});
+
+export const uiQueryHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_query', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-remove-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-remove-element.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'removing a widget from a Widget Blueprint tree',
+  not_when: 'reparenting a widget (use ui_reparent_element) or replacing a widget (use ui_replace_element)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to remove'),
+  replacement_root: z
+    .string()
+    .optional()
+    .describe('If removing the root widget, provide a replacement widget class to become the new root'),
+});
+
+export const uiRemoveElementHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_mutate_tree', {
+    operation: 'remove',
+    ...parsed.data,
+  } as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-rename-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-rename-element.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'giving a widget a meaningful name — the name is the variable the blueprint graph and C++ BindWidget resolve against',
+  not_when: 'changing a widget class (use ui_replace_element)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Current name of the widget'),
+  new_name: z.string().min(1).describe('New name. Must be unique within this widget tree.'),
+});
+
+export const uiRenameElementHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_mutate_tree', {
+    operation: 'rename',
+    ...parsed.data,
+  } as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-reparent-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-reparent-element.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'reparenting a widget to a new parent panel in the Widget Blueprint tree',
+  not_when: 'removing a widget (use ui_remove_element) or replacing a widget class (use ui_replace_element)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to reparent'),
+  new_parent_name: z.string().min(1).describe('Name of the existing panel widget to reparent under'),
+  slot_props: z
+    .record(z.union([z.number(), z.string(), z.boolean()]))
+    .optional()
+    .describe('Optional slot layout props for the new parent slot'),
+});
+
+export const uiReparentElementHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_mutate_tree', {
+    operation: 'reparent',
+    ...parsed.data,
+  } as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-replace-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-replace-element.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'replacing a widget with a different widget class while optionally preserving its GUID and/or properties',
+  not_when: 'removing a widget (use ui_remove_element) or reparenting (use ui_reparent_element)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to replace'),
+  new_class: z.string().min(1).describe('New widget class to replace with (short name or full class path)'),
+  new_name: z.string().optional().describe('New name for the replacement widget (defaults to original name)'),
+  preserve_guid: z.boolean().optional().default(true).describe('Preserve the original widget GUID'),
+  preserve_properties: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Preserve original widget properties on the replacement'),
+});
+
+export const uiReplaceElementHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_mutate_tree', {
+    operation: 'replace',
+    ...parsed.data,
+  } as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-save-widget.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-save-widget.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'saving a Widget Blueprint package to disk after edits',
+  not_when: 'compiling without saving (use ui_compile_widget)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the Widget Blueprint to save'),
+  compile_first: z.boolean().optional().default(false).describe('Run compile before saving'),
+});
+
+export const uiSaveWidgetHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_save_widget', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-search-widgets.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-search-widgets.ts
@@ -6,16 +6,22 @@ import type { HaybaToolMeta } from '../hayba-tool-meta.js';
 export const meta: HaybaToolMeta = {
   cost: 'low',
   effects: [],
-  when: 'searching for specific widgets within a Widget Blueprint by name pattern or class type',
+  when: 'finding widgets inside a Widget Blueprint by name substring or class, without paying for the whole tree',
   not_when:
-    'getting full widget tree info (use ui_get_widget_info) or listing available widget types (use ui_list_widget_types)',
+    'you want the full hierarchy (use ui_query) or the list of widget classes you could add (use ui_list_widget_types)',
 };
 
 export const schema = z.object({
   widget_blueprint_path: z.string().min(1).describe('Full path of the Widget Blueprint to search'),
-  widget_name_pattern: z.string().optional().describe('Substring or pattern to match widget names'),
-  widget_class: z.string().optional().describe('Filter by widget class name (e.g. "TextBlock", "Button", "Image")'),
-  include_properties: z.boolean().optional().default(false).describe('Include widget properties in results'),
+  widget_name_pattern: z.string().optional().describe('Case-sensitive substring to match widget names against'),
+  widget_class: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by widget class. Matches the exact class or any ancestor, so "PanelWidget" returns every panel and "TextBlock" returns TextBlocks and RichTextBlocks that derive from it.',
+    ),
+  include_properties: z.boolean().optional().default(false).describe('Include widget properties in each result'),
+  include_guid: z.boolean().optional().default(false).describe('Include the designer variable GUID in each result'),
 });
 
 export const uiSearchWidgetsHandler: ToolHandler = async (args) => {
@@ -23,6 +29,20 @@ export const uiSearchWidgetsHandler: ToolHandler = async (args) => {
   if (!parsed.success) {
     return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
   }
-  const data = await executeCommand('ui_query', parsed.data as Record<string, unknown>);
+  const { widget_blueprint_path, widget_name_pattern, widget_class, include_properties, include_guid } = parsed.data;
+
+  // The UE command reads `path`, and the filters are named `name_pattern` /
+  // `class_filter` there. Forwarding this tool's own field names sent no `path`
+  // at all, so every call failed with "ui_query: missing path".
+  const data = await executeCommand('ui_query', {
+    path: widget_blueprint_path,
+    name_pattern: widget_name_pattern,
+    class_filter: widget_class,
+    include_properties: include_properties ?? false,
+    include_guid: include_guid ?? false,
+    // Force the flat result shape even when no filter is supplied, so this tool
+    // always returns a match list rather than sometimes returning a tree.
+    flatten: true,
+  } as Record<string, unknown>);
   return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
 };

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-search-widgets.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-search-widgets.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'searching for specific widgets within a Widget Blueprint by name pattern or class type',
+  not_when:
+    'getting full widget tree info (use ui_get_widget_info) or listing available widget types (use ui_list_widget_types)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the Widget Blueprint to search'),
+  widget_name_pattern: z.string().optional().describe('Substring or pattern to match widget names'),
+  widget_class: z.string().optional().describe('Filter by widget class name (e.g. "TextBlock", "Button", "Image")'),
+  include_properties: z.boolean().optional().default(false).describe('Include widget properties in results'),
+});
+
+export const uiSearchWidgetsHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_query', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-brush.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-brush.ts
@@ -21,6 +21,11 @@ export const schema = z.object({
   draw_as: z.enum(['Image', 'Border', 'Mask', 'RoundedBox']).optional().describe('Brush draw style'),
   image_size: z.array(z.number()).length(2).optional().describe('Image size [Width, Height]'),
   margin: z.array(z.number()).length(4).optional().describe('9-slice margins [Left, Top, Right, Bottom]'),
+  brush_property: z
+    .enum(['Brush', 'Background'])
+    .optional()
+    .default('Brush')
+    .describe('Which brush to write. Image widgets use "Brush" (the default); Border widgets expose theirs as "Background".'),
 });
 
 export const uiSetBrushHandler: ToolHandler = async (args) => {
@@ -29,19 +34,23 @@ export const uiSetBrushHandler: ToolHandler = async (args) => {
     return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
   }
 
-  const { widget_blueprint_path, widget_name, resource, tint, draw_as, image_size, margin } = parsed.data;
+  const { widget_blueprint_path, widget_name, resource, tint, draw_as, image_size, margin, brush_property } = parsed.data;
   const brush: Record<string, unknown> = {};
 
-  if (resource !== undefined) brush.ResourceObject = { ObjectPath: resource };
+  if (resource !== undefined) brush.ResourceObject = resource;
   if (tint !== undefined) brush.TintColor = { SpecifiedColor: tint };
   if (draw_as !== undefined) brush.DrawAs = draw_as;
   if (image_size !== undefined) brush.ImageSize = { X: image_size[0], Y: image_size[1] };
   if (margin !== undefined) brush.Margin = { Left: margin[0], Top: margin[1], Right: margin[2], Bottom: margin[3] };
 
+  // Image exposes its brush as `Brush`; Border exposes the same struct as
+  // `Background`. Send both — the handler reports per-property outcomes, and
+  // the one that does not exist on this widget comes back in failed_properties
+  // rather than aborting the call.
   const data = await executeCommand('ui_set_widget_properties', {
     widget_blueprint_path,
     widget_name,
-    properties: { Brush: brush },
+    properties: brush_property === 'Background' ? { Background: brush } : { Brush: brush },
   } as Record<string, unknown>);
 
   return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-brush.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-brush.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'setting brush properties on an Image or Border widget (texture, tint, draw style, image size, 9-slice margin)',
+  not_when: 'setting text properties (use ui_set_text_style) or visibility (use ui_set_visibility)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the Image or Border widget'),
+  resource: z
+    .string()
+    .optional()
+    .describe('Texture2D or Material asset path for the brush, e.g. "/Game/Aphrosia/UI/Icons/T_RoundedBorder"'),
+  tint: z.array(z.number()).length(4).optional().describe('RGBA tint color (0-1)'),
+  draw_as: z.enum(['Image', 'Border', 'Mask', 'RoundedBox']).optional().describe('Brush draw style'),
+  image_size: z.array(z.number()).length(2).optional().describe('Image size [Width, Height]'),
+  margin: z.array(z.number()).length(4).optional().describe('9-slice margins [Left, Top, Right, Bottom]'),
+});
+
+export const uiSetBrushHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+
+  const { widget_blueprint_path, widget_name, resource, tint, draw_as, image_size, margin } = parsed.data;
+  const brush: Record<string, unknown> = {};
+
+  if (resource !== undefined) brush.ResourceObject = { ObjectPath: resource };
+  if (tint !== undefined) brush.TintColor = { SpecifiedColor: tint };
+  if (draw_as !== undefined) brush.DrawAs = draw_as;
+  if (image_size !== undefined) brush.ImageSize = { X: image_size[0], Y: image_size[1] };
+  if (margin !== undefined) brush.Margin = { Left: margin[0], Top: margin[1], Right: margin[2], Bottom: margin[3] };
+
+  const data = await executeCommand('ui_set_widget_properties', {
+    widget_blueprint_path,
+    widget_name,
+    properties: { Brush: brush },
+  } as Record<string, unknown>);
+
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-property.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-property.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'setting a single widget property by name with a typed value',
+  not_when:
+    'setting multiple properties at once (use ui_set_widget_properties) or text/brush/visibility-specific tools',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to set the property on'),
+  property_name: z.string().min(1).describe('UE property name to set (e.g. "Text", "ColorAndOpacity", "Visibility")'),
+  value: z
+    .union([z.string(), z.number(), z.boolean(), z.array(z.number())])
+    .describe('Property value — string, number, boolean, or array of numbers for colors/vectors'),
+});
+
+export const uiSetPropertyHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const { property_name, value, ...rest } = parsed.data;
+  const data = await executeCommand('ui_set_widget_properties', {
+    ...rest,
+    properties: { [property_name]: value },
+  } as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-slot-layout.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-slot-layout.ts
@@ -6,20 +6,42 @@ import type { HaybaToolMeta } from '../hayba-tool-meta.js';
 export const meta: HaybaToolMeta = {
   cost: 'medium',
   effects: ['modifies_asset'],
-  when: 'setting canvas slot layout on a widget (anchors, position, size, alignment, z-order)',
+  when: 'positioning a widget inside its parent panel (canvas anchors/position/size, or box padding/fill/alignment)',
   not_when: 'setting widget properties like text/brush/visibility (use the typed convenience tools)',
 };
 
 export const schema = z.object({
   widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
-  widget_name: z.string().min(1).describe('Name of the widget to set slot layout on'),
-  anchors_min: z.array(z.number()).length(2).optional().describe('Min anchor values [X, Y]'),
-  anchors_max: z.array(z.number()).length(2).optional().describe('Max anchor values [X, Y]'),
-  position: z.array(z.number()).length(2).optional().describe('Position [X, Y]'),
-  size: z.array(z.number()).length(2).optional().describe('Size [Width, Height]'),
-  alignment: z.array(z.number()).length(2).optional().describe('Alignment [X, Y] (0-1)'),
-  auto_size: z.boolean().optional().describe('Enable auto-sizing'),
-  z_order: z.number().int().optional().describe('Z-order'),
+  widget_name: z.string().min(1).describe('Name of the widget whose SLOT is being laid out'),
+
+  // Canvas slot
+  anchors_min: z.array(z.number()).length(2).optional().describe('Canvas: min anchor [X, Y] in 0-1 screen fractions'),
+  anchors_max: z.array(z.number()).length(2).optional().describe('Canvas: max anchor [X, Y] in 0-1 screen fractions'),
+  position: z.array(z.number()).length(2).optional().describe('Canvas: position [X, Y] in px relative to the anchor'),
+  size: z.array(z.number()).length(2).optional().describe('Canvas: size [Width, Height] in px'),
+  alignment: z.array(z.number()).length(2).optional().describe('Canvas: pivot [X, Y] in 0-1 (0.5,0.5 centres on the position)'),
+  auto_size: z.boolean().optional().describe('Canvas: size to the widget’s desired size instead of the explicit size'),
+  z_order: z.number().int().optional().describe('Canvas: draw order among siblings (higher draws on top)'),
+
+  // Box / grid / overlay slots
+  padding: z
+    .union([z.number(), z.array(z.number()).length(4), z.object({
+      left: z.number().optional(),
+      top: z.number().optional(),
+      right: z.number().optional(),
+      bottom: z.number().optional(),
+    })])
+    .optional()
+    .describe('Box/grid/overlay/border/size-box slots: padding as a single number, [L,T,R,B], or {left,top,right,bottom}. Zero is honoured, so this can clear padding.'),
+  fill: z.number().optional().describe('Horizontal/VerticalBox slots: fill weight. 0 means size-to-content.'),
+  horizontal_alignment: z.enum(['Fill', 'Left', 'Center', 'Right']).optional().describe('Alignment within the slot'),
+  vertical_alignment: z.enum(['Fill', 'Top', 'Center', 'Bottom']).optional().describe('Alignment within the slot'),
+
+  // Grid slots
+  row: z.number().int().optional().describe('Grid/UniformGrid slots: row index'),
+  column: z.number().int().optional().describe('Grid/UniformGrid slots: column index'),
+  row_span: z.number().int().optional().describe('Grid slots: rows spanned'),
+  column_span: z.number().int().optional().describe('Grid slots: columns spanned'),
 });
 
 export const uiSetSlotLayoutHandler: ToolHandler = async (args) => {
@@ -29,20 +51,28 @@ export const uiSetSlotLayoutHandler: ToolHandler = async (args) => {
   }
 
   const { widget_blueprint_path, widget_name, ...slotFields } = parsed.data;
-  const slot_layout: Record<string, unknown> = { type: 'Canvas' };
 
-  if (slotFields.anchors_min !== undefined) slot_layout.anchors_min = slotFields.anchors_min;
-  if (slotFields.anchors_max !== undefined) slot_layout.anchors_max = slotFields.anchors_max;
-  if (slotFields.position !== undefined) slot_layout.position = slotFields.position;
-  if (slotFields.size !== undefined) slot_layout.size = slotFields.size;
-  if (slotFields.alignment !== undefined) slot_layout.alignment = slotFields.alignment;
-  if (slotFields.auto_size !== undefined) slot_layout.auto_size = slotFields.auto_size;
-  if (slotFields.z_order !== undefined) slot_layout.z_order = slotFields.z_order;
+  // Only forward keys the caller actually set. Sending undefined entries would
+  // make the handler report them as unknown slot props.
+  const slot_props: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(slotFields)) {
+    if (value !== undefined) slot_props[key] = value;
+  }
 
+  if (Object.keys(slot_props).length === 0) {
+    return {
+      content: [{ type: 'text', text: 'Nothing to do: pass at least one slot layout field.' }],
+      isError: true,
+    };
+  }
+
+  // The UE handler reads `slot_props`. This tool used to send `slot_layout`,
+  // which no handler revision ever read, so every call failed outright with
+  // "no properties or slot_props provided".
   const data = await executeCommand('ui_set_widget_properties', {
     widget_blueprint_path,
     widget_name,
-    slot_layout,
+    slot_props,
   } as Record<string, unknown>);
 
   return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-slot-layout.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-slot-layout.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'setting canvas slot layout on a widget (anchors, position, size, alignment, z-order)',
+  not_when: 'setting widget properties like text/brush/visibility (use the typed convenience tools)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to set slot layout on'),
+  anchors_min: z.array(z.number()).length(2).optional().describe('Min anchor values [X, Y]'),
+  anchors_max: z.array(z.number()).length(2).optional().describe('Max anchor values [X, Y]'),
+  position: z.array(z.number()).length(2).optional().describe('Position [X, Y]'),
+  size: z.array(z.number()).length(2).optional().describe('Size [Width, Height]'),
+  alignment: z.array(z.number()).length(2).optional().describe('Alignment [X, Y] (0-1)'),
+  auto_size: z.boolean().optional().describe('Enable auto-sizing'),
+  z_order: z.number().int().optional().describe('Z-order'),
+});
+
+export const uiSetSlotLayoutHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+
+  const { widget_blueprint_path, widget_name, ...slotFields } = parsed.data;
+  const slot_layout: Record<string, unknown> = { type: 'Canvas' };
+
+  if (slotFields.anchors_min !== undefined) slot_layout.anchors_min = slotFields.anchors_min;
+  if (slotFields.anchors_max !== undefined) slot_layout.anchors_max = slotFields.anchors_max;
+  if (slotFields.position !== undefined) slot_layout.position = slotFields.position;
+  if (slotFields.size !== undefined) slot_layout.size = slotFields.size;
+  if (slotFields.alignment !== undefined) slot_layout.alignment = slotFields.alignment;
+  if (slotFields.auto_size !== undefined) slot_layout.auto_size = slotFields.auto_size;
+  if (slotFields.z_order !== undefined) slot_layout.z_order = slotFields.z_order;
+
+  const data = await executeCommand('ui_set_widget_properties', {
+    widget_blueprint_path,
+    widget_name,
+    slot_layout,
+  } as Record<string, unknown>);
+
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-text-style.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-text-style.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'styling a TextBlock widget (text content, font, color, justification, outline, shadow)',
+  not_when: 'setting non-text properties (use ui_set_widget_properties) or setting brush/tint (use ui_set_brush)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the TextBlock widget to style'),
+  text: z.string().optional().describe('Text content to display'),
+  font_asset: z.string().optional().describe('Font asset path, e.g. "/Game/Aphrosia/UI/Fonts/Cormorant-SemiBold"'),
+  typeface: z.string().optional().describe('Font typeface name (e.g. "Regular", "Bold", "Italic")'),
+  size: z.number().optional().describe('Font size in points'),
+  letter_spacing: z.number().optional().describe('Letter spacing value'),
+  color: z.array(z.number()).length(4).optional().describe('Text color as RGBA (0-1)'),
+  outline_size: z.number().optional().describe('Outline size'),
+  outline_color: z.array(z.number()).length(4).optional().describe('Outline color as RGBA (0-1)'),
+  shadow_offset: z.array(z.number()).length(2).optional().describe('Shadow offset [X, Y]'),
+  shadow_color: z.array(z.number()).length(4).optional().describe('Shadow color as RGBA (0-1)'),
+  justification: z.enum(['Left', 'Center', 'Right']).optional().describe('Text justification'),
+});
+
+export const uiSetTextStyleHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+
+  const {
+    widget_blueprint_path,
+    widget_name,
+    text,
+    font_asset,
+    typeface,
+    size,
+    letter_spacing,
+    color,
+    outline_size,
+    outline_color,
+    shadow_offset,
+    shadow_color,
+    justification,
+  } = parsed.data;
+  const properties: Record<string, unknown> = {};
+
+  if (text !== undefined) properties.Text = text;
+  if (letter_spacing !== undefined) properties.LetterSpacing = letter_spacing;
+  if (color !== undefined) properties.ColorAndOpacity = color;
+  if (justification !== undefined) properties.Justification = justification;
+
+  if (font_asset !== undefined || size !== undefined || typeface !== undefined) {
+    const font: Record<string, unknown> = {};
+    if (font_asset !== undefined) font.FontObject = { ObjectPath: font_asset };
+    if (size !== undefined) font.Size = size;
+    if (typeface !== undefined) font.Typeface = { FontName: typeface };
+    properties.Font = font;
+  }
+
+  if (outline_size !== undefined || outline_color !== undefined) {
+    const outline: Record<string, unknown> = {};
+    if (outline_size !== undefined) outline.OutlineSize = outline_size;
+    if (outline_color !== undefined) outline.OutlineColor = outline_color;
+    properties.OutlineSettings = outline;
+  }
+
+  if (shadow_offset !== undefined || shadow_color !== undefined) {
+    const shadow: Record<string, unknown> = {};
+    if (shadow_offset !== undefined) shadow.ShadowOffset = shadow_offset;
+    if (shadow_color !== undefined) shadow.ShadowColorAndOpacity = shadow_color;
+    properties.ShadowSettings = shadow;
+  }
+
+  const data = await executeCommand('ui_set_widget_properties', {
+    widget_blueprint_path,
+    widget_name,
+    properties,
+  } as Record<string, unknown>);
+
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-text-style.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-text-style.ts
@@ -14,7 +14,12 @@ export const schema = z.object({
   widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
   widget_name: z.string().min(1).describe('Name of the TextBlock widget to style'),
   text: z.string().optional().describe('Text content to display'),
-  font_asset: z.string().optional().describe('Font asset path, e.g. "/Game/Aphrosia/UI/Fonts/Cormorant-SemiBold"'),
+  font_asset: z
+    .string()
+    .optional()
+    .describe(
+      'Path to a composite UFont asset, e.g. "/Game/UI/Fonts/Cormorant". Must NOT be a UFontFace — Slate renders a raw font face as its glyph-preview tiles instead of as text, and the handler warns when it sees one.',
+    ),
   typeface: z.string().optional().describe('Font typeface name (e.g. "Regular", "Bold", "Italic")'),
   size: z.number().optional().describe('Font size in points'),
   letter_spacing: z.number().optional().describe('Letter spacing value'),
@@ -56,9 +61,9 @@ export const uiSetTextStyleHandler: ToolHandler = async (args) => {
 
   if (font_asset !== undefined || size !== undefined || typeface !== undefined) {
     const font: Record<string, unknown> = {};
-    if (font_asset !== undefined) font.FontObject = { ObjectPath: font_asset };
+    if (font_asset !== undefined) font.FontObject = font_asset;
     if (size !== undefined) font.Size = size;
-    if (typeface !== undefined) font.Typeface = { FontName: typeface };
+    if (typeface !== undefined) font.TypefaceFontName = typeface;
     properties.Font = font;
   }
 

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-variable.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-variable.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['modifies_asset'],
+  when: 'exposing a widget as a blueprint variable so the graph (or a C++ BindWidget) can reach it',
+  not_when: 'renaming the widget (use ui_rename_element)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to expose or hide'),
+  is_variable: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('true exposes the widget as a variable (the designer "Is Variable" checkbox); false hides it again.'),
+  category: z.string().optional().describe('Variable category shown in the blueprint variable list'),
+});
+
+export const uiSetVariableHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_set_variable', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-visibility.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-visibility.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'changing the visibility of a widget (Visible, Hidden, Collapsed, HitTestInvisible, SelfHitTestInvisible)',
+  not_when: 'setting other widget properties (use ui_set_widget_properties)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to change visibility on'),
+  visibility: z
+    .enum(['Visible', 'Hidden', 'Collapsed', 'HitTestInvisible', 'SelfHitTestInvisible'])
+    .describe('New visibility state'),
+});
+
+export const uiSetVisibilityHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_set_widget_properties', {
+    widget_blueprint_path: parsed.data.widget_blueprint_path,
+    widget_name: parsed.data.widget_name,
+    properties: { Visibility: parsed.data.visibility },
+  } as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-widget-properties.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-widget-properties.ts
@@ -6,39 +6,44 @@ import type { HaybaToolMeta } from '../hayba-tool-meta.js';
 export const meta: HaybaToolMeta = {
   cost: 'medium',
   effects: ['modifies_asset'],
-  when: 'setting one or more widget properties (including slot layout) on an existing widget in a Widget Blueprint',
+  when: 'setting one or more widget properties (and/or its slot layout) on an existing widget in a Widget Blueprint',
   not_when: 'setting a single typed property (use ui_set_property) or text styling (use ui_set_text_style)',
 };
+
+// UE property values can nest arbitrarily: FSlateBrush contains an FSlateColor
+// which contains an FLinearColor. The handler applies nested JSON objects field
+// by field via reflection, so the schema must not flatten them away.
+const propertyValue: z.ZodType<unknown> = z.lazy(() =>
+  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(propertyValue), z.record(propertyValue)]),
+);
 
 export const schema = z.object({
   widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
   widget_name: z.string().min(1).describe('Name of the widget to set properties on'),
   properties: z
-    .record(z.union([z.string(), z.number(), z.boolean(), z.array(z.number())]))
+    .record(propertyValue)
     .optional()
-    .describe('Flat or nested property values keyed by UE property name'),
-  slot_layout: z
-    .object({
-      type: z
-        .string()
-        .optional()
-        .describe('Slot type (e.g. "Canvas", "HorizontalBox", "VerticalBox", "Overlay", "Grid")'),
-      anchors_min: z.array(z.number()).length(2).optional().describe('Min anchor values [X, Y]'),
-      anchors_max: z.array(z.number()).length(2).optional().describe('Max anchor values [X, Y]'),
-      position: z.array(z.number()).length(2).optional().describe('Position [X, Y]'),
-      size: z.array(z.number()).length(2).optional().describe('Size [Width, Height]'),
-      alignment: z.array(z.number()).length(2).optional().describe('Alignment [X, Y] (0-1)'),
-      auto_size: z.boolean().optional().describe('Enable auto-sizing'),
-      z_order: z.number().int().optional().describe('Z-order'),
-    })
+    .describe(
+      'Property values keyed by their real UE property name (e.g. "Text", "ColorAndOpacity", "Font"). Values may be nested objects for struct properties, arrays for colors/vectors, or an asset path string for object references.',
+    ),
+  slot_props: z
+    .record(propertyValue)
     .optional()
-    .describe('Slot layout properties (NOT inside properties — sibling field)'),
+    .describe(
+      'Layout properties applied to the widget’s PANEL SLOT rather than the widget: canvas (anchors/position/size/alignment/auto_size/z_order), box (fill/padding/alignment), grid (row/column/spans). Keys the slot type does not support come back in unknown_slot_props instead of being silently dropped.',
+    ),
 });
 
 export const uiSetWidgetPropertiesHandler: ToolHandler = async (args) => {
   const parsed = schema.safeParse(args);
   if (!parsed.success) {
     return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  if (parsed.data.properties === undefined && parsed.data.slot_props === undefined) {
+    return {
+      content: [{ type: 'text', text: 'Nothing to do: pass `properties`, `slot_props`, or both.' }],
+      isError: true,
+    };
   }
   const data = await executeCommand('ui_set_widget_properties', parsed.data as Record<string, unknown>);
   return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-widget-properties.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-widget-properties.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'setting one or more widget properties (including slot layout) on an existing widget in a Widget Blueprint',
+  not_when: 'setting a single typed property (use ui_set_property) or text styling (use ui_set_text_style)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
+  widget_name: z.string().min(1).describe('Name of the widget to set properties on'),
+  properties: z
+    .record(z.union([z.string(), z.number(), z.boolean(), z.array(z.number())]))
+    .optional()
+    .describe('Flat or nested property values keyed by UE property name'),
+  slot_layout: z
+    .object({
+      type: z
+        .string()
+        .optional()
+        .describe('Slot type (e.g. "Canvas", "HorizontalBox", "VerticalBox", "Overlay", "Grid")'),
+      anchors_min: z.array(z.number()).length(2).optional().describe('Min anchor values [X, Y]'),
+      anchors_max: z.array(z.number()).length(2).optional().describe('Max anchor values [X, Y]'),
+      position: z.array(z.number()).length(2).optional().describe('Position [X, Y]'),
+      size: z.array(z.number()).length(2).optional().describe('Size [Width, Height]'),
+      alignment: z.array(z.number()).length(2).optional().describe('Alignment [X, Y] (0-1)'),
+      auto_size: z.boolean().optional().describe('Enable auto-sizing'),
+      z_order: z.number().int().optional().describe('Z-order'),
+    })
+    .optional()
+    .describe('Slot layout properties (NOT inside properties — sibling field)'),
+});
+
+export const uiSetWidgetPropertiesHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('ui_set_widget_properties', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-tools.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-tools.test.ts
@@ -128,16 +128,16 @@ describe('UMG / Widget Blueprint wrappers', () => {
       expect(isSchemaRecorded('ui_query')).toBe(true);
     });
 
-    it('dispatches ui_query with path (not widget_blueprint_path)', async () => {
+    it('dispatches ui_query with path plus optional filters', async () => {
       const exec = new InMemoryToolExecutor().on('ui_query', (p) => {
-        expect(p).toEqual({ path: '/Game/UI/WBP_Test' });
+        expect(p).toMatchObject({ path: '/Game/UI/WBP_Test' });
+        expect(p).toHaveProperty('include_properties');
+        expect(p).toHaveProperty('include_guid');
+        expect(p).toHaveProperty('include_slot');
         return { ok: true, data: { path: '/Game/UI/WBP_Test', root: { class: 'CanvasPanel' } } };
       });
       setDefaultSender(exec.send);
-      const r = await uiQueryHandler(
-        { path: '/Game/UI/WBP_Test' },
-        undefined as never,
-      );
+      const r = await uiQueryHandler({ path: '/Game/UI/WBP_Test' }, undefined as never);
       expect(r.isError).toBeFalsy();
       expect(textOf(r)).toContain('CanvasPanel');
     });

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-tools.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-tools.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { InMemoryToolExecutor, setDefaultSender } from '../tool-executor.js';
+import { inferDir } from '../index.js';
+import { deriveDomainPacks } from '../routing/pack-discovery.js';
+import { uiCreateWidgetHandler } from './ui-create-widget.js';
+import { uiAddElementHandler } from './ui-add-element.js';
+import { uiQueryHandler } from './ui-query.js';
+
+const UI_TOOLS = ['ui_create_widget', 'ui_add_element', 'ui_query'] as const;
+
+/**
+ * Smoke test for the three UMG / Widget Blueprint wrapper tools:
+ * - ui_create_widget
+ * - ui_add_element
+ * - ui_query
+ *
+ * Asserts each wrapper is (1) declared as a descriptor consumed by the
+ * registerTool/recordToolSchema loops so it is registered + schema-recorded
+ * (→ callable via hayba_invoke and surfaced by list_tool_categories), (2) wired
+ * to executeCommand with the correct command name, and (3) forwards the exact
+ * param names the C++ handler reads (HaybaMCPUIHandler.cpp is the source of
+ * truth: ui_add_element→slot_props, ui_query→path).
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexSrc = readFileSync(join(__dirname, '..', 'index.ts'), 'utf-8');
+
+const REGISTRAR_LOOP = /for\s*\(\s*const\s+d\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*registerTool\(/;
+const SCHEMA_LOOP = /for\s*\(\s*const\s+d\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*recordToolSchema\(/;
+function isToolRegistered(name: string): boolean {
+  const descriptor = new RegExp(`name:\\s*['"]${name}['"]`);
+  return descriptor.test(indexSrc) && REGISTRAR_LOOP.test(indexSrc);
+}
+function isSchemaRecorded(name: string): boolean {
+  const descriptor = new RegExp(`name:\\s*['"]${name}['"]`);
+  return descriptor.test(indexSrc) && SCHEMA_LOOP.test(indexSrc);
+}
+
+/** Text of the first content block of a ToolResult. */
+function textOf(r: { content: Array<{ type: string; text: string }> }): string {
+  return r.content[0].text;
+}
+
+describe('UMG / Widget Blueprint wrappers', () => {
+  describe('ui_create_widget', () => {
+    it('is registered + schema-recorded via the descriptor loops', () => {
+      expect(isToolRegistered('ui_create_widget')).toBe(true);
+      expect(isSchemaRecorded('ui_create_widget')).toBe(true);
+    });
+
+    it('dispatches ui_create_widget with path/name/parent_class', async () => {
+      const exec = new InMemoryToolExecutor().on('ui_create_widget', (p) => {
+        expect(p).toMatchObject({ path: '/Game/UI', name: 'WBP_Test', parent_class: '/Script/UMG.UserWidget' });
+        return { ok: true, data: { path: '/Game/UI/WBP_Test.WBP_Test', name: 'WBP_Test' } };
+      });
+      setDefaultSender(exec.send);
+      const r = await uiCreateWidgetHandler(
+        { path: '/Game/UI', name: 'WBP_Test', parent_class: '/Script/UMG.UserWidget' },
+        undefined as never,
+      );
+      expect(r.isError).toBeFalsy();
+      expect(textOf(r)).toContain('WBP_Test');
+    });
+
+    it('rejects missing required fields', async () => {
+      const r = await uiCreateWidgetHandler({ path: '/Game/UI' }, undefined as never);
+      expect(r.isError).toBe(true);
+      expect(textOf(r)).toMatch(/Validation error/);
+    });
+  });
+
+  describe('ui_add_element', () => {
+    it('is registered + schema-recorded via the descriptor loops', () => {
+      expect(isToolRegistered('ui_add_element')).toBe(true);
+      expect(isSchemaRecorded('ui_add_element')).toBe(true);
+    });
+
+    it('forwards slot_props verbatim (matches the C++ param name)', async () => {
+      const exec = new InMemoryToolExecutor().on('ui_add_element', (p) => {
+        expect(p).toMatchObject({
+          widget_blueprint_path: '/Game/UI/WBP_Test',
+          child_class: 'TextBlock',
+          parent_widget_name: 'Root',
+          slot_props: { x: 40, y: 40 },
+        });
+        return { ok: true, data: { name: 'TextBlock_0', class: 'TextBlock' } };
+      });
+      setDefaultSender(exec.send);
+      const r = await uiAddElementHandler(
+        {
+          widget_blueprint_path: '/Game/UI/WBP_Test',
+          child_class: 'TextBlock',
+          parent_widget_name: 'Root',
+          slot_props: { x: 40, y: 40 },
+        },
+        undefined as never,
+      );
+      expect(r.isError).toBeFalsy();
+      expect(textOf(r)).toContain('TextBlock');
+    });
+  });
+
+  // In deferred routing (the default "hidden until searched" mode) tools are
+  // captured, indexed for hayba_search_tools, and bucketed into a domain pack by
+  // inferDir. This proves the ui_* tools land in their own loadable 'ui' pack.
+  describe('deferred routing / pack discovery', () => {
+    it('groups every ui_* tool under the "ui" dir', () => {
+      for (const name of UI_TOOLS) {
+        expect(inferDir(name), name).toBe('ui');
+      }
+    });
+
+    it('derives a loadable "ui" domain pack containing all three tools', () => {
+      const toolDirs = new Map<string, string | null>(UI_TOOLS.map((n) => [n, inferDir(n)]));
+      const packs = deriveDomainPacks(toolDirs, new Map());
+      const ui = packs.find((p) => p.name === 'ui');
+      expect(ui).toBeDefined();
+      expect(ui!.kind).toBe('domain');
+      expect(ui!.tools.sort()).toEqual([...UI_TOOLS].sort());
+    });
+  });
+
+  describe('ui_query', () => {
+    it('is registered + schema-recorded via the descriptor loops', () => {
+      expect(isToolRegistered('ui_query')).toBe(true);
+      expect(isSchemaRecorded('ui_query')).toBe(true);
+    });
+
+    it('dispatches ui_query with path (not widget_blueprint_path)', async () => {
+      const exec = new InMemoryToolExecutor().on('ui_query', (p) => {
+        expect(p).toEqual({ path: '/Game/UI/WBP_Test' });
+        return { ok: true, data: { path: '/Game/UI/WBP_Test', root: { class: 'CanvasPanel' } } };
+      });
+      setDefaultSender(exec.send);
+      const r = await uiQueryHandler(
+        { path: '/Game/UI/WBP_Test' },
+        undefined as never,
+      );
+      expect(r.isError).toBeFalsy();
+      expect(textOf(r)).toContain('CanvasPanel');
+    });
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-validate.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-validate.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { InMemoryToolExecutor, setDefaultSender } from '../tool-executor.js';
+import { uiValidateHandler } from './ui-validate.js';
+import { setHistoryPath } from '../../validator/history.js';
+import { setConfigPath } from '../../validator/config.js';
+
+// Regression tests for the reporting path.
+//
+// The rules themselves are covered in src/validator/ui/ui-rules.test.ts. What
+// is pinned here is that findings actually REACH somewhere the user looks: a
+// live editor showed the validator working correctly while the Validation
+// panel stayed empty, because nothing routed the findings anywhere.
+
+let tmp: string;
+let historyPath: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'hayba-ui-validate-'));
+  historyPath = join(tmp, 'validator-history.jsonl');
+  setHistoryPath(historyPath);
+  setConfigPath(join(tmp, 'validator-config.json'));
+});
+
+afterEach(() => {
+  setHistoryPath(null);
+  setConfigPath(null);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+/** A snapshot with one guaranteed finding: text that overflows its box. */
+function snapshotWithOverflow() {
+  return {
+    widget_blueprint_path: '/Game/UI/WBP_Probe',
+    screen_width: 1920,
+    screen_height: 1080,
+    layout_resolved: true,
+    widget_count: 1,
+    widgets: [
+      {
+        name: 'NameLabel',
+        class: 'TextBlock',
+        parent: '',
+        slot_class: 'CanvasPanelSlot',
+        is_panel: false,
+        is_variable: true,
+        visibility: 'ESlateVisibility::Visible',
+        render_opacity: 1,
+        is_enabled: true,
+        is_interactive: false,
+        is_focusable: false,
+        laid_out: true,
+        x: 100,
+        y: 100,
+        width: 200,
+        height: 40,
+        depth: 0,
+        text_info: {
+          text: 'Bartholomew Ravensworth III',
+          font_size: 24,
+          auto_wrap: false,
+          measured_width: 421,
+          available_width: 200,
+          overflows: true,
+          chars_that_fit: 12,
+        },
+      },
+    ],
+  };
+}
+
+function historyLines(): Array<Record<string, unknown>> {
+  if (!existsSync(historyPath)) return [];
+  return readFileSync(historyPath, 'utf-8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+describe('ui_validate reporting', () => {
+  it('pushes findings to the editor panel and writes them to history', async () => {
+    let pushed: Record<string, unknown> | null = null;
+    const exec = new InMemoryToolExecutor()
+      .on('ui_layout_snapshot', () => ({ ok: true, data: snapshotWithOverflow() }))
+      .on('ui_report_findings', (p) => {
+        pushed = p;
+        return { ok: true, data: { received: 1 } };
+      });
+    setDefaultSender(exec.send);
+
+    const r = await uiValidateHandler({ widget_blueprint_path: '/Game/UI/WBP_Probe' }, undefined as never);
+    expect(r.isError).toBeFalsy();
+
+    // Reached the panel.
+    expect(pushed).not.toBeNull();
+    const findings = (pushed as unknown as { findings: Array<Record<string, unknown>> }).findings;
+    expect(findings.some((f) => f.rule_id === 'ui_text_overflows_box')).toBe(true);
+    // The hint is the actionable half — it must survive the trip.
+    expect(findings[0]!.hint).toBeTruthy();
+    expect(findings[0]!.severity).toBe('error');
+    expect(findings[0]!.widget).toBe('NameLabel');
+
+    // And reached the history file.
+    const lines = historyLines();
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.some((l) => l.ruleId === 'ui_text_overflows_box')).toBe(true);
+    const context = lines[0]!.context as Record<string, unknown>;
+    expect(context.widget_blueprint_path).toBe('/Game/UI/WBP_Probe');
+    expect(context.platform).toBe('pc');
+  });
+
+  it('gives each finding a distinct history key so they can be resolved individually', async () => {
+    const twoFindings = snapshotWithOverflow();
+    twoFindings.widgets.push({
+      ...twoFindings.widgets[0]!,
+      name: 'OtherLabel',
+    });
+    twoFindings.widget_count = 2;
+
+    const exec = new InMemoryToolExecutor()
+      .on('ui_layout_snapshot', () => ({ ok: true, data: twoFindings }))
+      .on('ui_report_findings', () => ({ ok: true, data: {} }));
+    setDefaultSender(exec.send);
+
+    await uiValidateHandler({ widget_blueprint_path: '/Game/UI/WBP_Probe' }, undefined as never);
+
+    const stamps = historyLines().map((l) => l.timestamp);
+    expect(stamps.length).toBe(2);
+    expect(new Set(stamps).size).toBe(2);
+  });
+
+  it('still returns findings when the plugin is too old to accept the push', async () => {
+    // An older plugin build has no ui_report_findings. Losing the whole run
+    // over a failed push would be worse than losing the panel update.
+    const exec = new InMemoryToolExecutor()
+      .on('ui_layout_snapshot', () => ({ ok: true, data: snapshotWithOverflow() }))
+      .on('ui_report_findings', () => ({ ok: false, error: 'Unknown command: ui_report_findings' }));
+    setDefaultSender(exec.send);
+
+    const r = await uiValidateHandler({ widget_blueprint_path: '/Game/UI/WBP_Probe' }, undefined as never);
+
+    expect(r.isError).toBeFalsy();
+    expect(r.content[0]!.text).toContain('ui_text_overflows_box');
+    // History is still written even though the panel push failed.
+    expect(historyLines().length).toBeGreaterThan(0);
+  });
+
+  it('persist:false leaves no trace anywhere', async () => {
+    let pushed = false;
+    const exec = new InMemoryToolExecutor()
+      .on('ui_layout_snapshot', () => ({ ok: true, data: snapshotWithOverflow() }))
+      .on('ui_report_findings', () => {
+        pushed = true;
+        return { ok: true, data: {} };
+      });
+    setDefaultSender(exec.send);
+
+    const r = await uiValidateHandler(
+      { widget_blueprint_path: '/Game/UI/WBP_Probe', persist: false },
+      undefined as never,
+    );
+
+    expect(r.isError).toBeFalsy();
+    expect(r.content[0]!.text).toContain('ui_text_overflows_box');
+    expect(pushed).toBe(false);
+    expect(historyLines()).toHaveLength(0);
+  });
+
+  it('reports skipped geometry rules rather than passing them when layout failed', async () => {
+    const noLayout = {
+      ...snapshotWithOverflow(),
+      layout_resolved: false,
+      layout_error: 'widget blueprint has no GeneratedClass — compile it first',
+    };
+    const exec = new InMemoryToolExecutor()
+      .on('ui_layout_snapshot', () => ({ ok: true, data: noLayout }))
+      .on('ui_report_findings', () => ({ ok: true, data: {} }));
+    setDefaultSender(exec.send);
+
+    const r = await uiValidateHandler({ widget_blueprint_path: '/Game/UI/WBP_Probe' }, undefined as never);
+    const parsed = JSON.parse(r.content[0]!.text) as {
+      layout_resolved: boolean;
+      layout_error?: string;
+      rules_skipped_no_layout: string[];
+    };
+
+    expect(parsed.layout_resolved).toBe(false);
+    expect(parsed.layout_error).toContain('compile it first');
+    expect(parsed.rules_skipped_no_layout).toContain('ui_text_overflows_box');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-validate.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-validate.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { validateUiSnapshot, UI_PLATFORMS, type UiSnapshot } from '../../validator/ui/index.js';
+import { STRICTNESS_MODES } from '../../validator/config.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'checking a Widget Blueprint against game-UI standards — text overflow, safe areas, target sizes, contrast, focus, performance',
+  not_when: 'you only need the widget tree (use ui_query) or a single string measurement (use ui_measure_text)',
+};
+
+export const schema = z.object({
+  widget_blueprint_path: z.string().min(1).describe('Full path of the Widget Blueprint to validate'),
+  platform: z
+    .enum(UI_PLATFORMS)
+    .optional()
+    .default('pc')
+    .describe(
+      'Which conventions to judge against. "console" applies TV safe areas and the 28px legibility floor; "mobile" applies 44px touch targets; "handheld" sits between them.',
+    ),
+  strictness: z
+    .enum(STRICTNESS_MODES)
+    .optional()
+    .describe(
+      'Override the configured UI strictness for this run. relaxed = only what is broken; standard = plus UI conventions; strict = plus house-style polish. Defaults to the validator setting.',
+    ),
+  screen_width: z.number().optional().describe('Resolution to evaluate at. Defaults to the blueprint design size.'),
+  screen_height: z.number().optional().describe('Resolution to evaluate at. Defaults to the blueprint design size.'),
+  rule_ids: z.array(z.string()).optional().describe('Run only these rules, by id.'),
+});
+
+export const uiValidateHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const { widget_blueprint_path, platform, strictness, screen_width, screen_height, rule_ids } = parsed.data;
+
+  // The engine does the measuring (Slate prepass + font metrics); the rules
+  // are judged here so they can be extended and configured without a plugin
+  // rebuild.
+  const snapshot = (await executeCommand('ui_layout_snapshot', {
+    widget_blueprint_path,
+    screen_width,
+    screen_height,
+  } as Record<string, unknown>)) as UiSnapshot;
+
+  const result = validateUiSnapshot(snapshot, { platform, strictness, ruleIds: rule_ids });
+
+  return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-validate.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-validate.ts
@@ -58,9 +58,31 @@ export const uiValidateHandler: ToolHandler = async (args) => {
 
   const result = validateUiSnapshot(snapshot, { platform, strictness, ruleIds: rule_ids });
 
-  // Persist to the shared history file. The editor's Validation panel reads
-  // .scratch/validator-history.jsonl — findings that only come back in the tool
-  // response never reach the surface the user actually watches.
+  // Surface the findings in the editor's Validation panel. That panel is
+  // push-only from inside UE, so a rule judged here has no other way to reach
+  // the window the user actually watches — without this it only ever existed
+  // in a tool response.
+  if (persist !== false && result.findings.length > 0) {
+    try {
+      await executeCommand('ui_report_findings', {
+        findings: result.findings.map((f) => ({
+          rule_id: f.ruleId,
+          severity: f.severity,
+          message: f.message,
+          hint: f.hint,
+          widget: f.widget,
+        })),
+        append: false,
+      } as Record<string, unknown>);
+    } catch {
+      // An older plugin build has no ui_report_findings. The findings are still
+      // returned to the caller and written to history, so a failed push must
+      // not fail the validation run.
+    }
+  }
+
+  // Persist to the shared history file as well, so findings survive an editor
+  // restart and can be reviewed with validator_history.
   if (persist !== false && result.findings.length > 0) {
     const timestamp = new Date().toISOString();
     for (const f of result.findings) {

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-validate.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-validate.ts
@@ -2,8 +2,9 @@ import { z } from 'zod';
 import type { ToolHandler } from '../types.js';
 import { executeCommand } from '../tool-executor.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
-import { validateUiSnapshot, UI_PLATFORMS, type UiSnapshot } from '../../validator/ui/index.js';
+import { validateUiSnapshot, UI_PLATFORMS, type UiFinding, type UiSnapshot } from '../../validator/ui/index.js';
 import { STRICTNESS_MODES } from '../../validator/config.js';
+import { appendFinding } from '../../validator/history.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'medium',
@@ -30,6 +31,13 @@ export const schema = z.object({
   screen_width: z.number().optional().describe('Resolution to evaluate at. Defaults to the blueprint design size.'),
   screen_height: z.number().optional().describe('Resolution to evaluate at. Defaults to the blueprint design size.'),
   rule_ids: z.array(z.string()).optional().describe('Run only these rules, by id.'),
+  persist: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'Write the findings to the validator history so they appear in the editor Validation panel. Set false for a read-only check that leaves no trace.',
+    ),
 });
 
 export const uiValidateHandler: ToolHandler = async (args) => {
@@ -37,7 +45,7 @@ export const uiValidateHandler: ToolHandler = async (args) => {
   if (!parsed.success) {
     return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
   }
-  const { widget_blueprint_path, platform, strictness, screen_width, screen_height, rule_ids } = parsed.data;
+  const { widget_blueprint_path, platform, strictness, screen_width, screen_height, rule_ids, persist } = parsed.data;
 
   // The engine does the measuring (Slate prepass + font metrics); the rules
   // are judged here so they can be extended and configured without a plugin
@@ -50,5 +58,34 @@ export const uiValidateHandler: ToolHandler = async (args) => {
 
   const result = validateUiSnapshot(snapshot, { platform, strictness, ruleIds: rule_ids });
 
+  // Persist to the shared history file. The editor's Validation panel reads
+  // .scratch/validator-history.jsonl — findings that only come back in the tool
+  // response never reach the surface the user actually watches.
+  if (persist !== false && result.findings.length > 0) {
+    const timestamp = new Date().toISOString();
+    for (const f of result.findings) {
+      await appendFinding({
+        ruleId: f.ruleId,
+        severity: f.severity,
+        message: f.message,
+        hint: f.hint,
+        context: toContext(f, widget_blueprint_path, platform),
+        // Distinct per finding so resolve/clear can address them individually;
+        // the runner emits them in one pass, so a shared stamp would collide.
+        timestamp: `${timestamp}#${f.ruleId}:${f.widget ?? '-'}`,
+        toolName: 'ui_validate',
+      });
+    }
+  }
+
   return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
 };
+
+function toContext(f: UiFinding, blueprintPath: string, platform: string): Record<string, unknown> {
+  return {
+    widget_blueprint_path: blueprintPath,
+    platform,
+    ...(f.widget ? { widget: f.widget } : {}),
+    ...(f.data ?? {}),
+  };
+}

--- a/mcp-tools/hayba-mcp/src/tools/validator/tools.ts
+++ b/mcp-tools/hayba-mcp/src/tools/validator/tools.ts
@@ -20,6 +20,18 @@ import {
   type ValidatorContext,
   type ValidatorRule,
 } from '../../validator/index.js';
+import {
+  RULE_CATEGORIES,
+  STRICTNESS_MODES,
+  clearCategoryStrictness,
+  getStrictness,
+  getStrictnessConfig,
+  meetsStrictness,
+  setStrictness,
+  type RuleCategory,
+  type Strictness,
+} from '../../validator/config.js';
+import { UI_RULES } from '../../validator/ui/index.js';
 import type { UETcpClient } from '../../tcp-client.js';
 import { loadConstraints, primitivesById } from '../../plumb/index.js';
 
@@ -119,6 +131,11 @@ export interface RuleCatalogEntry {
   trigger: ValidatorRule['trigger'];
   has_evaluator: boolean;
   disabled?: boolean;
+  /** Present on rules that declare one (currently the UI ruleset). */
+  category?: string;
+  min_strictness?: string;
+  /** Whether the rule fires at the category's current strictness setting. */
+  active?: boolean;
 }
 
 export async function validatorRulesHandler(args: { include_disabled_state?: boolean }): Promise<{
@@ -155,7 +172,70 @@ export async function validatorRulesHandler(args: { include_disabled_state?: boo
     };
   });
 
-  return { rules: [...floppy, ...constraintRules] };
+  // UI rules are catalogued alongside the rest so one settings surface covers
+  // everything. They carry a category and a minimum strictness, which is what
+  // the Configure panel needs to show why a rule is or is not currently firing.
+  const uiRules: RuleCatalogEntry[] = UI_RULES.map(r => ({
+    id: r.id,
+    severity: r.severity,
+    message: r.title,
+    hint: r.needsLayout
+      ? 'Needs resolved layout — skipped (and reported as skipped) when the blueprint cannot be laid out.'
+      : 'Evaluated from the widget tree alone.',
+    trigger: 'manual' as ValidatorRule['trigger'],
+    has_evaluator: true,
+    category: r.category,
+    min_strictness: r.minStrictness,
+    active: meetsStrictness(r.minStrictness, getStrictness(r.category)),
+    ...(includeState ? { disabled: isRuleDisabled(r.id) } : {}),
+  }));
+
+  return { rules: [...floppy, ...constraintRules, ...uiRules] };
+}
+
+export const validatorStrictnessSchema = {
+  mode: z
+    .enum(STRICTNESS_MODES)
+    .optional()
+    .describe('New strictness. Omit to read the current settings without changing anything.'),
+  category: z
+    .enum(RULE_CATEGORIES)
+    .optional()
+    .describe('Set strictness for one category only. Omit to set the global default.'),
+  reset_category: z
+    .enum(RULE_CATEGORIES)
+    .optional()
+    .describe('Clear a category override so it follows the global default again.'),
+};
+
+export interface StrictnessView {
+  default: string;
+  by_category: Record<string, string>;
+  /** Effective mode for every category, after applying the default. */
+  effective: Record<string, string>;
+  modes: readonly string[];
+  categories: readonly string[];
+}
+
+export async function validatorStrictnessHandler(args: {
+  mode?: Strictness;
+  category?: RuleCategory;
+  reset_category?: RuleCategory;
+}): Promise<StrictnessView> {
+  if (args.reset_category) clearCategoryStrictness(args.reset_category);
+  if (args.mode) setStrictness(args.mode, args.category);
+
+  const config = getStrictnessConfig();
+  const effective: Record<string, string> = {};
+  for (const c of RULE_CATEGORIES) effective[c] = getStrictness(c);
+
+  return {
+    default: config.default,
+    by_category: { ...config.byCategory },
+    effective,
+    modes: STRICTNESS_MODES,
+    categories: RULE_CATEGORIES,
+  };
 }
 
 export const validatorSetRuleEnabledSchema = {

--- a/mcp-tools/hayba-mcp/src/validator/config.ts
+++ b/mcp-tools/hayba-mcp/src/validator/config.ts
@@ -1,10 +1,39 @@
-// Per-rule enable/disable configuration.
+// Validator configuration: per-rule enable/disable plus per-category strictness.
 //
-// Persisted to JSON so the UE plugin's Configure panel can toggle rules
-// without round-tripping through MCP. Schema is tiny: `{ disabled: string[] }`.
+// Persisted to JSON so the UE plugin's Configure panel can change settings
+// without round-tripping through MCP. Schema:
+//   { "disabled": ["rule_id", ...],
+//     "strictness": { "default": "standard", "byCategory": { "ui": "strict" } } }
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+
+/** How eagerly the validator speaks up.
+ *  - relaxed:  only things that are outright broken or will visibly ship wrong.
+ *  - standard: the above plus established UI conventions (the default).
+ *  - strict:   the above plus house-style and polish nits.
+ *  A rule declares the LOWEST mode at which it fires, so raising strictness only
+ *  ever adds findings — it never silences one. */
+export const STRICTNESS_MODES = ['relaxed', 'standard', 'strict'] as const;
+export type Strictness = (typeof STRICTNESS_MODES)[number];
+
+const STRICTNESS_RANK: Record<Strictness, number> = { relaxed: 0, standard: 1, strict: 2 };
+
+/** Domains a rule can belong to. Strictness is set per category so a team can
+ *  run UI checks strictly while keeping PCG advisory. */
+export const RULE_CATEGORIES = [
+  'ui',
+  'pcg',
+  'landscape',
+  'material',
+  'blueprint',
+  'python',
+  'asset',
+  'general',
+] as const;
+export type RuleCategory = (typeof RULE_CATEGORIES)[number];
+
+export const DEFAULT_STRICTNESS: Strictness = 'standard';
 
 let CONFIG_PATH_OVERRIDE: string | null = null;
 
@@ -22,19 +51,54 @@ function getConfigPath(): string {
   return CONFIG_PATH_OVERRIDE ?? defaultConfigPath();
 }
 
+export interface StrictnessConfig {
+  default: Strictness;
+  byCategory: Partial<Record<RuleCategory, Strictness>>;
+}
+
 interface ValidatorConfig {
   disabled: string[];
+  strictness: StrictnessConfig;
+}
+
+function isStrictness(v: unknown): v is Strictness {
+  return typeof v === 'string' && (STRICTNESS_MODES as readonly string[]).includes(v);
+}
+
+function isCategory(v: unknown): v is RuleCategory {
+  return typeof v === 'string' && (RULE_CATEGORIES as readonly string[]).includes(v);
+}
+
+function emptyConfig(): ValidatorConfig {
+  return { disabled: [], strictness: { default: DEFAULT_STRICTNESS, byCategory: {} } };
 }
 
 function loadConfig(): ValidatorConfig {
   const path = getConfigPath();
-  if (!existsSync(path)) return { disabled: [] };
+  if (!existsSync(path)) return emptyConfig();
   try {
     const raw = readFileSync(path, 'utf-8');
     const parsed = JSON.parse(raw) as Partial<ValidatorConfig>;
-    return { disabled: Array.isArray(parsed.disabled) ? parsed.disabled : [] };
+    const config = emptyConfig();
+
+    if (Array.isArray(parsed.disabled)) {
+      config.disabled = parsed.disabled.filter((x): x is string => typeof x === 'string');
+    }
+
+    // Unknown or malformed values fall back to the default rather than throwing:
+    // a hand-edited settings file should never take the validator offline.
+    const s = parsed.strictness;
+    if (s && typeof s === 'object') {
+      if (isStrictness(s.default)) config.strictness.default = s.default;
+      if (s.byCategory && typeof s.byCategory === 'object') {
+        for (const [key, value] of Object.entries(s.byCategory)) {
+          if (isCategory(key) && isStrictness(value)) config.strictness.byCategory[key] = value;
+        }
+      }
+    }
+    return config;
   } catch {
-    return { disabled: [] };
+    return emptyConfig();
   }
 }
 
@@ -53,10 +117,51 @@ export function setRuleDisabled(id: string, disabled: boolean): void {
   const c = loadConfig();
   const has = c.disabled.includes(id);
   if (disabled && !has) c.disabled.push(id);
-  if (!disabled && has) c.disabled = c.disabled.filter(x => x !== id);
+  if (!disabled && has) c.disabled = c.disabled.filter((x) => x !== id);
   saveConfig(c);
 }
 
 export function listDisabledRules(): string[] {
   return loadConfig().disabled.slice();
+}
+
+/** Effective strictness for a category: its own setting, else the global default. */
+export function getStrictness(category?: RuleCategory): Strictness {
+  const c = loadConfig().strictness;
+  if (category) {
+    const override = c.byCategory[category];
+    if (override) return override;
+  }
+  return c.default;
+}
+
+export function getStrictnessConfig(): StrictnessConfig {
+  return loadConfig().strictness;
+}
+
+/** Set strictness globally (no category) or for one category. */
+export function setStrictness(mode: Strictness, category?: RuleCategory): void {
+  const c = loadConfig();
+  if (category) c.strictness.byCategory[category] = mode;
+  else c.strictness.default = mode;
+  saveConfig(c);
+}
+
+/** Clear a category override so it follows the global default again. */
+export function clearCategoryStrictness(category: RuleCategory): void {
+  const c = loadConfig();
+  delete c.strictness.byCategory[category];
+  saveConfig(c);
+}
+
+/** Whether a rule requiring `required` fires at the `active` setting. */
+export function meetsStrictness(required: Strictness, active: Strictness): boolean {
+  return STRICTNESS_RANK[active] >= STRICTNESS_RANK[required];
+}
+
+/** Whether a rule should run right now, accounting for both the disable list
+ *  and the category's strictness setting. */
+export function isRuleActive(id: string, category: RuleCategory, minStrictness: Strictness): boolean {
+  if (isRuleDisabled(id)) return false;
+  return meetsStrictness(minStrictness, getStrictness(category));
 }

--- a/mcp-tools/hayba-mcp/src/validator/ui/index.ts
+++ b/mcp-tools/hayba-mcp/src/validator/ui/index.ts
@@ -1,0 +1,132 @@
+// UI validation entry point.
+//
+// Runs the catalogue over a snapshot, honouring the disable list and the
+// category's strictness setting, and reports what it did NOT check as
+// explicitly as what it did.
+
+import { getStrictness, isRuleDisabled, meetsStrictness, type Strictness } from '../config.js';
+import { UI_RULES, uiRulesById } from './rules.js';
+import { resolveThresholds } from './thresholds.js';
+import type {
+  UiFinding,
+  UiPlatform,
+  UiRuleContext,
+  UiSeverity,
+  UiSnapshot,
+  UiValidationResult,
+  UiWidget,
+} from './types.js';
+
+export * from './types.js';
+export { UI_RULES, uiRulesById } from './rules.js';
+export { resolveThresholds, contrastRatio, relativeLuminance } from './thresholds.js';
+
+const SEVERITY_ORDER: Record<UiSeverity, number> = { error: 0, warning: 1, info: 2 };
+
+export interface UiValidationOptions {
+  platform?: UiPlatform;
+  /** Overrides the configured strictness for this run only. */
+  strictness?: Strictness;
+  /** Restrict the run to these rule ids. */
+  ruleIds?: string[];
+}
+
+function buildContext(
+  snapshot: UiSnapshot,
+  platform: UiPlatform,
+  strictness: Strictness,
+): UiRuleContext {
+  const byName = new Map<string, UiWidget>();
+  for (const w of snapshot.widgets) byName.set(w.name, w);
+
+  const childrenOf = new Map<string, UiWidget[]>();
+  for (const w of snapshot.widgets) {
+    if (!w.parent) continue;
+    const list = childrenOf.get(w.parent);
+    if (list) list.push(w);
+    else childrenOf.set(w.parent, [w]);
+  }
+
+  return {
+    snapshot,
+    platform,
+    strictness,
+    thresholds: resolveThresholds(platform, strictness, snapshot.screen_height),
+    byName,
+    childrenOf,
+  };
+}
+
+export function validateUiSnapshot(
+  snapshot: UiSnapshot,
+  options: UiValidationOptions = {},
+): UiValidationResult {
+  const platform = options.platform ?? 'pc';
+  const strictness = options.strictness ?? getStrictness('ui');
+  const ctx = buildContext(snapshot, platform, strictness);
+
+  const byId = uiRulesById();
+  const selected = options.ruleIds
+    ? options.ruleIds.map((id) => byId.get(id)).filter((r): r is NonNullable<typeof r> => r !== undefined)
+    : UI_RULES;
+
+  const findings: UiFinding[] = [];
+  const skippedNoLayout: string[] = [];
+  const disabled: string[] = [];
+  const belowStrictness: string[] = [];
+  let evaluated = 0;
+
+  for (const rule of selected) {
+    if (isRuleDisabled(rule.id)) {
+      disabled.push(rule.id);
+      continue;
+    }
+    if (!meetsStrictness(rule.minStrictness, strictness)) {
+      belowStrictness.push(rule.id);
+      continue;
+    }
+    if (rule.needsLayout && !snapshot.layout_resolved) {
+      // Reported, not silently passed. A geometry rule with no geometry has
+      // checked nothing, and saying otherwise would be the same lie the old
+      // slot-props path told.
+      skippedNoLayout.push(rule.id);
+      continue;
+    }
+
+    evaluated++;
+    try {
+      findings.push(...rule.evaluate(ctx));
+    } catch (e) {
+      findings.push({
+        ruleId: rule.id,
+        category: rule.category,
+        severity: 'info',
+        message: `Rule "${rule.id}" threw while evaluating and was skipped.`,
+        hint: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  findings.sort((a, b) => {
+    const bySeverity = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    if (bySeverity !== 0) return bySeverity;
+    return a.ruleId.localeCompare(b.ruleId);
+  });
+
+  const counts: Record<UiSeverity, number> = { error: 0, warning: 0, info: 0 };
+  for (const f of findings) counts[f.severity]++;
+
+  return {
+    widget_blueprint_path: snapshot.widget_blueprint_path,
+    platform,
+    strictness,
+    layout_resolved: snapshot.layout_resolved,
+    layout_error: snapshot.layout_error,
+    findings,
+    rules_evaluated: evaluated,
+    rules_skipped_no_layout: skippedNoLayout,
+    rules_disabled: disabled,
+    rules_below_strictness: belowStrictness,
+    counts,
+  };
+}

--- a/mcp-tools/hayba-mcp/src/validator/ui/rules.ts
+++ b/mcp-tools/hayba-mcp/src/validator/ui/rules.ts
@@ -699,8 +699,12 @@ export const UI_RULES: UiRule[] = [
   {
     id: 'ui_canvas_child_top_left_anchored',
     category: 'ui',
-    severity: 'warning',
-    minStrictness: 'standard',
+    severity: 'info',
+    // Demoted to strict after the first live run: nearly every widget on a
+    // canvas-authored screen uses the default anchor, so at standard this rule
+    // produced one finding per widget and buried the real defects. It is a
+    // real responsiveness concern, but it is house style rather than a bug.
+    minStrictness: 'strict',
     title: 'Canvas child is pinned to the top-left and will not adapt',
     needsLayout: false,
     evaluate: (ctx) => {
@@ -716,7 +720,7 @@ export const UI_RULES: UiRule[] = [
         if (nearCorner) continue;
         out.push(
           finding(
-            { id: 'ui_canvas_child_top_left_anchored', category: 'ui', severity: 'warning' },
+            { id: 'ui_canvas_child_top_left_anchored', category: 'ui', severity: 'info' },
             `"${w.name}" uses the default top-left anchor but sits at (${Math.round(r.x)}, ${Math.round(r.y)}).`,
             'With a top-left anchor the widget keeps that pixel offset at every resolution, so it drifts away from where you placed it on wider or shorter screens. Anchor it to the region it belongs to (centre, bottom-right, or a stretched anchor).',
             w.name,
@@ -953,6 +957,9 @@ export const UI_RULES: UiRule[] = [
         if ((w.child_count ?? 0) > 0) continue;
         // A NamedSlot is a deliberate hole for a caller to fill.
         if (w.class === 'NamedSlot') continue;
+        // Buttons and check boxes are panels, but an empty one is already
+        // reported by ui_button_without_content with better advice.
+        if (w.class === 'Button' || w.class === 'CheckBox') continue;
         out.push(
           finding(
             { id: 'ui_empty_panel', category: 'ui', severity: 'info' },

--- a/mcp-tools/hayba-mcp/src/validator/ui/rules.ts
+++ b/mcp-tools/hayba-mcp/src/validator/ui/rules.ts
@@ -66,11 +66,14 @@ function backgroundColorOf(ctx: UiRuleContext, w: UiWidget): [number, number, nu
   let current = ctx.byName.get(w.parent);
   let guard = 0;
   while (current && guard++ < 64) {
-    const tint = current.brush_info?.tint;
-    // Only an opaque fill is a defensible "background" to measure against.
-    // A translucent panel sits on top of something unknown, and guessing would
-    // produce a contrast number that is precise and wrong.
-    if (tint && tint[3] >= 0.95) return tint;
+    const brush = current.brush_info;
+    // A brush WITH a texture or material uses its tint as a multiplier, not as
+    // the colour — the pixels come from the art. Reading the tint as the
+    // background there says "white" for the default [1,1,1,1] tint over a dark
+    // panel texture, which is how a live HUD reported 1.1:1 against a
+    // background that is actually dark. Only an untextured fill is a
+    // defensible colour to measure against.
+    if (brush?.tint && !brush.has_resource && brush.tint[3] >= 0.95) return brush.tint;
     current = ctx.byName.get(current.parent);
   }
   return null;

--- a/mcp-tools/hayba-mcp/src/validator/ui/rules.ts
+++ b/mcp-tools/hayba-mcp/src/validator/ui/rules.ts
@@ -1,0 +1,1253 @@
+// The UI rule catalogue.
+//
+// Each rule is a pure function of the snapshot, so every one of them is
+// unit-testable and none of them needs a live editor to exercise. Rules that
+// depend on resolved geometry declare `needsLayout` and are SKIPPED (and
+// reported as skipped) when the blueprint could not be laid out — a rule that
+// silently passes because it had no data is worse than no rule.
+//
+// Adding a rule: append an entry here. Nothing else needs touching — the
+// runner, the settings surface and the strictness gate all read this array.
+
+import type { UiFinding, UiRule, UiRuleContext, UiWidget } from './types.js';
+import { contrastRatio } from './thresholds.js';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+const round = (v: number) => Math.round(v * 100) / 100;
+
+/** Widgets Slate actually gave a box to. */
+function laidOut(ctx: UiRuleContext): UiWidget[] {
+  return ctx.snapshot.widgets.filter((w) => w.laid_out && w.width !== undefined && w.height !== undefined);
+}
+
+function rect(w: UiWidget): { x: number; y: number; w: number; h: number } {
+  return { x: w.x ?? 0, y: w.y ?? 0, w: w.width ?? 0, h: w.height ?? 0 };
+}
+
+function overlapArea(a: UiWidget, b: UiWidget): number {
+  const ra = rect(a);
+  const rb = rect(b);
+  const ox = Math.min(ra.x + ra.w, rb.x + rb.w) - Math.max(ra.x, rb.x);
+  const oy = Math.min(ra.y + ra.h, rb.y + rb.h) - Math.max(ra.y, rb.y);
+  if (ox <= 0 || oy <= 0) return 0;
+  return ox * oy;
+}
+
+/** True when `ancestor` is above `w` in the tree. */
+function isAncestor(ctx: UiRuleContext, ancestor: string, w: UiWidget): boolean {
+  let current: UiWidget | undefined = w;
+  const seen = new Set<string>();
+  while (current && current.parent) {
+    if (seen.has(current.name)) return false; // defensive: malformed snapshot
+    seen.add(current.name);
+    if (current.parent === ancestor) return true;
+    current = ctx.byName.get(current.parent);
+  }
+  return false;
+}
+
+/** Widgets that are siblings (same parent) and both laid out. */
+function siblingPairs(ctx: UiRuleContext, filter: (w: UiWidget) => boolean): Array<[UiWidget, UiWidget]> {
+  const pairs: Array<[UiWidget, UiWidget]> = [];
+  for (const [, children] of ctx.childrenOf) {
+    const eligible = children.filter((c) => c.laid_out && filter(c));
+    for (let i = 0; i < eligible.length; i++) {
+      for (let j = i + 1; j < eligible.length; j++) {
+        pairs.push([eligible[i]!, eligible[j]!]);
+      }
+    }
+  }
+  return pairs;
+}
+
+/** Nearest ancestor that paints a solid background, for contrast checks. */
+function backgroundColorOf(ctx: UiRuleContext, w: UiWidget): [number, number, number, number] | null {
+  let current = ctx.byName.get(w.parent);
+  let guard = 0;
+  while (current && guard++ < 64) {
+    const tint = current.brush_info?.tint;
+    // Only an opaque fill is a defensible "background" to measure against.
+    // A translucent panel sits on top of something unknown, and guessing would
+    // produce a contrast number that is precise and wrong.
+    if (tint && tint[3] >= 0.95) return tint;
+    current = ctx.byName.get(current.parent);
+  }
+  return null;
+}
+
+function isTextWidget(w: UiWidget): boolean {
+  return w.text_info !== undefined;
+}
+
+const PLACEHOLDER_TEXT = [
+  'text block',
+  'textblock',
+  'lorem ipsum',
+  'lorem',
+  'placeholder',
+  'todo',
+  'tbd',
+  'sample text',
+  'your text here',
+  'button',
+  'xxx',
+  'asdf',
+  'test',
+];
+
+/** UMG's auto-generated names look like "TextBlock_42" / "Button_0". */
+const DEFAULT_NAME_RE = /^(?:[A-Z][A-Za-z]*)_\d+$/;
+
+function finding(
+  rule: Pick<UiRule, 'id' | 'category' | 'severity'>,
+  message: string,
+  hint: string,
+  widget?: string,
+  data?: Record<string, unknown>,
+): UiFinding {
+  return { ruleId: rule.id, category: rule.category, severity: rule.severity, widget, message, hint, data };
+}
+
+// ── rules ───────────────────────────────────────────────────────────────────
+
+export const UI_RULES: UiRule[] = [
+  // ══ Text fit and localisation ═════════════════════════════════════════════
+  {
+    id: 'ui_text_overflows_box',
+    category: 'ui',
+    severity: 'error',
+    minStrictness: 'relaxed',
+    title: 'Text is wider than the box it sits in',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of laidOut(ctx)) {
+        const t = w.text_info;
+        if (!t?.overflows || t.measured_width === undefined || t.available_width === undefined) continue;
+        if (t.auto_wrap) continue; // wrapping text is meant to exceed one line
+        const text = t.text ?? '';
+        const fits = t.chars_that_fit ?? 0;
+        out.push(
+          finding(
+            { id: 'ui_text_overflows_box', category: 'ui', severity: 'error' },
+            `"${w.name}" overflows: its text is ${round(t.measured_width)}px wide in a ${round(t.available_width)}px box.`,
+            `The string is ${text.length} characters and only the first ${fits} fit — it is clipped from "${text.slice(0, fits)}" onward. Widen the box to at least ${Math.ceil(t.measured_width)}px, drop the font size, or turn on auto-wrap.`,
+            w.name,
+            {
+              measured_width: t.measured_width,
+              available_width: t.available_width,
+              text_length: text.length,
+              chars_that_fit: fits,
+              overflow_px: round(t.measured_width - t.available_width),
+            },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_text_near_overflow',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Text nearly fills its box, so any longer string will clip',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of laidOut(ctx)) {
+        const t = w.text_info;
+        if (!t || t.overflows || t.measured_width === undefined || t.available_width === undefined) continue;
+        if (t.auto_wrap || t.available_width <= 0) continue;
+        const ratio = t.measured_width / t.available_width;
+        if (ratio < ctx.thresholds.textFillWarnRatio) continue;
+        const text = t.text ?? '';
+        const typical = t.typical_chars_that_fit ?? 0;
+        const worst = t.worst_case_chars_that_fit ?? 0;
+        out.push(
+          finding(
+            { id: 'ui_text_near_overflow', category: 'ui', severity: 'warning' },
+            `"${w.name}" fills ${Math.round(ratio * 100)}% of its box — it will overlap or clip as soon as the text gets longer.`,
+            `At this font and box width, ${typical} characters of typical text fit and only ${worst} fit if the string is all wide glyphs (caps, W/M). The current string is ${text.length}. If this label ever shows variable content — a player name, an item name, a localised string — budget for at most ${worst} characters or make the box wider.`,
+            w.name,
+            {
+              fill_ratio: round(ratio),
+              text_length: text.length,
+              typical_chars_that_fit: typical,
+              worst_case_chars_that_fit: worst,
+              available_width: t.available_width,
+            },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_text_no_localization_headroom',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Label has no room to grow when translated',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      const headroom = ctx.thresholds.localizationHeadroom;
+      if (headroom <= 1) return out;
+      for (const w of laidOut(ctx)) {
+        const t = w.text_info;
+        if (!t || t.measured_width === undefined || t.available_width === undefined) continue;
+        if (t.auto_wrap || t.available_width <= 0 || !t.text) continue;
+        // Already reported by the overflow/near-overflow rules; don't pile on.
+        if (t.measured_width / t.available_width >= ctx.thresholds.textFillWarnRatio) continue;
+        const needed = t.measured_width * headroom;
+        if (needed <= t.available_width) continue;
+        out.push(
+          finding(
+            { id: 'ui_text_no_localization_headroom', category: 'ui', severity: 'warning' },
+            `"${w.name}" fits in English but not with ${Math.round((headroom - 1) * 100)}% translation growth.`,
+            `The string measures ${round(t.measured_width)}px in a ${round(t.available_width)}px box, but a German or Russian translation of a string this short commonly runs ${Math.round((headroom - 1) * 100)}% longer, which needs ${Math.ceil(needed)}px. Widen the box by ${Math.ceil(needed - t.available_width)}px, or turn on auto-wrap / text auto-sizing.`,
+            w.name,
+            {
+              measured_width: t.measured_width,
+              available_width: t.available_width,
+              required_width: round(needed),
+              headroom,
+            },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_font_too_small',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'relaxed',
+    title: 'Font is below the legible minimum for the target platform',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        const size = w.text_info?.font_size;
+        if (size === undefined || size <= 0) continue;
+        if (size >= ctx.thresholds.minFontPx) continue;
+        out.push(
+          finding(
+            { id: 'ui_font_too_small', category: 'ui', severity: 'warning' },
+            `"${w.name}" uses ${size}px text, below the ${ctx.thresholds.minFontPx}px minimum for ${ctx.platform}.`,
+            ctx.platform === 'console'
+              ? `Console UI is read from about 3m away. Body text under ${ctx.thresholds.minFontPx}px at this design resolution is not reliably legible and is a common certification finding. Raise it to at least ${ctx.thresholds.comfortableFontPx}px.`
+              : `Raise it to at least ${ctx.thresholds.minFontPx}px (${ctx.thresholds.comfortableFontPx}px is comfortable for ${ctx.platform}).`,
+            w.name,
+            { font_size: size, minimum: ctx.thresholds.minFontPx, platform: ctx.platform },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_font_below_comfortable',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'strict',
+    title: 'Font is legible but below the comfortable size',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        const size = w.text_info?.font_size;
+        if (size === undefined || size <= 0) continue;
+        if (size < ctx.thresholds.minFontPx) continue; // the harder rule owns this
+        if (size >= ctx.thresholds.comfortableFontPx) continue;
+        out.push(
+          finding(
+            { id: 'ui_font_below_comfortable', category: 'ui', severity: 'info' },
+            `"${w.name}" is ${size}px; ${ctx.thresholds.comfortableFontPx}px reads more comfortably on ${ctx.platform}.`,
+            'This is a polish note, not a defect — it only fires in strict mode.',
+            w.name,
+            { font_size: size, comfortable: ctx.thresholds.comfortableFontPx },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_font_is_font_face',
+    category: 'ui',
+    severity: 'error',
+    minStrictness: 'relaxed',
+    title: 'A UFontFace is assigned where Slate needs a composite UFont',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (!w.text_info?.font_is_font_face) continue;
+        out.push(
+          finding(
+            { id: 'ui_font_is_font_face', category: 'ui', severity: 'error' },
+            `"${w.name}" has a UFontFace assigned as its font.`,
+            `Slate cannot render a raw font face — it draws the face's glyph-preview atlas instead, which is why the widget shows "BASIC LATIN / A / 0000-007F" tiles rather than text. Create (or pick) the composite UFont asset that wraps this face and assign that. Current asset: ${w.text_info.font_object ?? 'unknown'}.`,
+            w.name,
+            { font_object: w.text_info.font_object },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_text_empty',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Text widget has no text',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (!isTextWidget(w)) continue;
+        const text = w.text_info?.text;
+        if (text === undefined || text.trim().length > 0) continue;
+        out.push(
+          finding(
+            { id: 'ui_text_empty', category: 'ui', severity: 'warning' },
+            `"${w.name}" is a text widget with no text.`,
+            'If it is filled in at runtime this is fine — mark it as a variable (ui_set_variable) so the intent is visible. If it is not, it is dead weight in the tree.',
+            w.name,
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_placeholder_text',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Placeholder text left in the widget',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        const text = w.text_info?.text?.trim().toLowerCase();
+        if (!text) continue;
+        if (!PLACEHOLDER_TEXT.includes(text)) continue;
+        out.push(
+          finding(
+            { id: 'ui_placeholder_text', category: 'ui', severity: 'warning' },
+            `"${w.name}" still reads "${w.text_info?.text}".`,
+            'This is UMG default or scratch copy. Replace it with the real string before this screen ships.',
+            w.name,
+            { text: w.text_info?.text },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_bounded_text_without_wrap',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'standard',
+    title: 'Long text in a fixed-width box with wrapping off',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of laidOut(ctx)) {
+        const t = w.text_info;
+        if (!t || t.auto_wrap !== false || !t.text) continue;
+        // Only meaningful for prose; a short label is supposed to be one line.
+        if (t.text.length < 40) continue;
+        if (t.available_width === undefined || t.available_width <= 0) continue;
+        out.push(
+          finding(
+            { id: 'ui_bounded_text_without_wrap', category: 'ui', severity: 'info' },
+            `"${w.name}" holds ${t.text.length} characters on a single unwrapped line.`,
+            'Turn on Auto Wrap Text so the paragraph reflows instead of running out of its box at longer strings or in translation.',
+            w.name,
+            { text_length: t.text.length },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+
+  // ══ Safe areas ════════════════════════════════════════════════════════════
+  {
+    id: 'ui_outside_action_safe',
+    category: 'ui',
+    severity: 'error',
+    minStrictness: 'relaxed',
+    title: 'Content sits outside the action-safe area',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      const f = ctx.thresholds.actionSafeFraction;
+      if (f <= 0) return out;
+      const { screen_width: sw, screen_height: sh } = ctx.snapshot;
+      const marginX = sw * f;
+      const marginY = sh * f;
+      for (const w of laidOut(ctx)) {
+        if (w.is_panel) continue; // panels legitimately span the screen
+        const r = rect(w);
+        const violations: string[] = [];
+        if (r.x < marginX) violations.push(`left edge ${round(marginX - r.x)}px inside the margin`);
+        if (r.y < marginY) violations.push(`top edge ${round(marginY - r.y)}px inside the margin`);
+        if (r.x + r.w > sw - marginX) violations.push(`right edge ${round(r.x + r.w - (sw - marginX))}px inside the margin`);
+        if (r.y + r.h > sh - marginY) violations.push(`bottom edge ${round(r.y + r.h - (sh - marginY))}px inside the margin`);
+        if (violations.length === 0) continue;
+        out.push(
+          finding(
+            { id: 'ui_outside_action_safe', category: 'ui', severity: 'error' },
+            `"${w.name}" extends into the ${Math.round(f * 100)}% action-safe margin (${violations.join('; ')}).`,
+            `On ${ctx.platform} anything inside this margin can be cropped by the display. Move it at least ${Math.ceil(Math.max(marginX, marginY))}px from the screen edges, or parent it under a SafeZone widget which does this automatically.`,
+            w.name,
+            { rect: r, margin_x: round(marginX), margin_y: round(marginY) },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_outside_title_safe',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Text or interactive content sits outside the title-safe area',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      const f = ctx.thresholds.titleSafeFraction;
+      const action = ctx.thresholds.actionSafeFraction;
+      if (f <= 0) return out;
+      const { screen_width: sw, screen_height: sh } = ctx.snapshot;
+      const marginX = sw * f;
+      const marginY = sh * f;
+      const actionX = sw * action;
+      const actionY = sh * action;
+      for (const w of laidOut(ctx)) {
+        // Only critical content — readable text and things you can press.
+        if (!isTextWidget(w) && !w.is_interactive) continue;
+        const r = rect(w);
+        const insideTitle =
+          r.x < marginX || r.y < marginY || r.x + r.w > sw - marginX || r.y + r.h > sh - marginY;
+        if (!insideTitle) continue;
+        // The action-safe rule already reports the worse violation.
+        const insideAction =
+          r.x < actionX || r.y < actionY || r.x + r.w > sw - actionX || r.y + r.h > sh - actionY;
+        if (insideAction) continue;
+        out.push(
+          finding(
+            { id: 'ui_outside_title_safe', category: 'ui', severity: 'warning' },
+            `"${w.name}" is inside the ${Math.round(f * 100)}% title-safe margin.`,
+            'Text and interactive elements should stay within the title-safe area so they are fully readable on every display. Non-critical decoration may live out here.',
+            w.name,
+            { rect: r, margin_x: round(marginX), margin_y: round(marginY) },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_outside_screen',
+    category: 'ui',
+    severity: 'error',
+    minStrictness: 'relaxed',
+    title: 'Widget is partly or fully off-screen',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      const { screen_width: sw, screen_height: sh } = ctx.snapshot;
+      for (const w of laidOut(ctx)) {
+        const r = rect(w);
+        if (r.w <= 0 || r.h <= 0) continue;
+        const fullyOff = r.x + r.w <= 0 || r.y + r.h <= 0 || r.x >= sw || r.y >= sh;
+        const partlyOff = r.x < 0 || r.y < 0 || r.x + r.w > sw || r.y + r.h > sh;
+        if (!partlyOff) continue;
+        out.push(
+          finding(
+            { id: 'ui_outside_screen', category: 'ui', severity: 'error' },
+            fullyOff
+              ? `"${w.name}" is entirely off-screen at ${sw}x${sh}.`
+              : `"${w.name}" hangs off the ${sw}x${sh} screen.`,
+            fullyOff
+              ? 'Nothing here will ever be visible. Either it is dead, or its anchors/position are wrong.'
+              : 'Check the anchors: a widget anchored to the top-left with a large offset falls off the edge as soon as the resolution changes.',
+            w.name,
+            { rect: r, screen: { width: sw, height: sh }, fully_offscreen: fullyOff },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+
+  // ══ Overlap and geometry ══════════════════════════════════════════════════
+  {
+    id: 'ui_widgets_overlap',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'relaxed',
+    title: 'Two siblings overlap on screen',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      // Only content widgets: panels overlapping is how layering works, but
+      // anything that actually paints — text, controls, images — colliding
+      // with a sibling is a real visual defect.
+      const isContent = (w: UiWidget) =>
+        !w.is_panel && (isTextWidget(w) || w.is_interactive || w.class === 'Image');
+      for (const [a, b] of siblingPairs(ctx, isContent)) {
+        const area = overlapArea(a, b);
+        if (area <= 1) continue;
+        // An Overlay panel exists precisely to stack its children.
+        const parent = ctx.byName.get(a.parent);
+        if (parent && (parent.class === 'Overlay' || parent.class === 'WidgetSwitcher')) continue;
+        const za = a.z_order ?? 0;
+        const zb = b.z_order ?? 0;
+        out.push(
+          finding(
+            { id: 'ui_widgets_overlap', category: 'ui', severity: 'warning' },
+            `"${a.name}" and "${b.name}" overlap by ${Math.round(area)}px².`,
+            za === zb
+              ? `Both are at Z-order ${za}, so which one draws on top is decided by child order and can change. Separate them, or set an explicit Z-order.`
+              : `"${za > zb ? a.name : b.name}" draws on top. If that is intentional, put them in an Overlay panel to make it explicit.`,
+            a.name,
+            { other: b.name, overlap_area: Math.round(area), z_order_a: za, z_order_b: zb },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_interactive_targets_touch',
+    category: 'ui',
+    severity: 'error',
+    minStrictness: 'relaxed',
+    title: 'Interactive widget is smaller than the minimum target size',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      const min = ctx.thresholds.minTouchTargetPx;
+      for (const w of laidOut(ctx)) {
+        if (!w.is_interactive) continue;
+        const r = rect(w);
+        if (r.w <= 0 || r.h <= 0) continue;
+        const short = Math.min(r.w, r.h);
+        if (short >= min) continue;
+        out.push(
+          finding(
+            { id: 'ui_interactive_targets_touch', category: 'ui', severity: 'error' },
+            `"${w.name}" is ${Math.round(r.w)}x${Math.round(r.h)}px; the ${ctx.platform} minimum target is ${min}px on the short side.`,
+            ctx.platform === 'mobile'
+              ? `Apple HIG asks for 44x44pt and Material for 48x48dp. Grow the widget, or wrap it in a SizeBox of at least ${min}px so the hit area is bigger than the visible art.`
+              : `Grow the widget or wrap it in a SizeBox of at least ${min}px. The hit area can be larger than the visible art.`,
+            w.name,
+            { width: Math.round(r.w), height: Math.round(r.h), minimum: min, platform: ctx.platform },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_interactive_too_close',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Interactive widgets are too close to each other',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      const minGap = ctx.thresholds.minInteractiveGapPx;
+      for (const [a, b] of siblingPairs(ctx, (w) => w.is_interactive)) {
+        const ra = rect(a);
+        const rb = rect(b);
+        // Gap along whichever axis actually separates them.
+        const gapX = Math.max(ra.x, rb.x) - Math.min(ra.x + ra.w, rb.x + rb.w);
+        const gapY = Math.max(ra.y, rb.y) - Math.min(ra.y + ra.h, rb.y + rb.h);
+        const gap = Math.max(gapX, gapY);
+        if (gap < 0) continue; // overlapping — the overlap rule owns this
+        if (gap >= minGap) continue;
+        out.push(
+          finding(
+            { id: 'ui_interactive_too_close', category: 'ui', severity: 'warning' },
+            `"${a.name}" and "${b.name}" are only ${round(gap)}px apart (minimum ${minGap}px).`,
+            'Adjacent controls this close get mis-pressed. Add padding to the slots or a Spacer between them.',
+            a.name,
+            { other: b.name, gap: round(gap), minimum: minGap },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_zero_size_widget',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'relaxed',
+    title: 'Widget lays out to zero size',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (!w.laid_out) continue;
+        const r = rect(w);
+        if (r.w > 0.5 && r.h > 0.5) continue;
+        // A Spacer with an explicit zero dimension is a legitimate shim.
+        if (w.class === 'Spacer') continue;
+        out.push(
+          finding(
+            { id: 'ui_zero_size_widget', category: 'ui', severity: 'warning' },
+            `"${w.name}" (${w.class}) lays out to ${Math.round(r.w)}x${Math.round(r.h)}px — nothing will be visible.`,
+            'Usually a slot with no size set, an empty panel with no children to size it, or a fill weight of 0 in a box that gives it nothing.',
+            w.name,
+            { width: r.w, height: r.h },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_child_exceeds_parent',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Child is drawn outside its parent panel',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of laidOut(ctx)) {
+        const parent = ctx.byName.get(w.parent);
+        if (!parent?.laid_out) continue;
+        const rp = rect(parent);
+        if (rp.w <= 0 || rp.h <= 0) continue;
+        const r = rect(w);
+        const overflowRight = r.x + r.w - (rp.x + rp.w);
+        const overflowBottom = r.y + r.h - (rp.y + rp.h);
+        const overflowLeft = rp.x - r.x;
+        const overflowTop = rp.y - r.y;
+        const worst = Math.max(overflowRight, overflowBottom, overflowLeft, overflowTop);
+        if (worst <= 1) continue;
+        out.push(
+          finding(
+            { id: 'ui_child_exceeds_parent', category: 'ui', severity: 'warning' },
+            `"${w.name}" extends ${Math.round(worst)}px beyond its parent "${parent.name}".`,
+            'Whether this is visible or clipped depends on the parent Clipping setting, so it renders differently in different panels. Resize the child, or set the parent to clip deliberately.',
+            w.name,
+            { parent: parent.name, overflow_px: Math.round(worst) },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_off_spacing_grid',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'strict',
+    title: 'Position or size is off the spacing grid',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      const grid = ctx.thresholds.spacingGridPx;
+      if (grid <= 1) return out;
+      for (const w of laidOut(ctx)) {
+        if (w.is_panel) continue;
+        const r = rect(w);
+        const offenders: string[] = [];
+        // Sub-pixel results from fill/centre layout are not authored numbers,
+        // so only flag values that are visibly off the grid.
+        const off = (v: number) => {
+          const m = Math.abs(v % grid);
+          return m > 0.5 && m < grid - 0.5;
+        };
+        if (off(r.x)) offenders.push(`x=${round(r.x)}`);
+        if (off(r.y)) offenders.push(`y=${round(r.y)}`);
+        if (off(r.w)) offenders.push(`width=${round(r.w)}`);
+        if (off(r.h)) offenders.push(`height=${round(r.h)}`);
+        if (offenders.length === 0) continue;
+        out.push(
+          finding(
+            { id: 'ui_off_spacing_grid', category: 'ui', severity: 'info' },
+            `"${w.name}" is off the ${grid}px grid (${offenders.join(', ')}).`,
+            `Snapping positions and sizes to multiples of ${grid} keeps rhythm consistent across screens. Strict-mode nit.`,
+            w.name,
+            { grid, values: offenders },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+
+  // ══ Anchors and responsiveness ════════════════════════════════════════════
+  {
+    id: 'ui_canvas_child_top_left_anchored',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Canvas child is pinned to the top-left and will not adapt',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        const a = w.anchors;
+        if (!a) continue;
+        const isTopLeft = a.min_x === 0 && a.min_y === 0 && a.max_x === 0 && a.max_y === 0;
+        if (!isTopLeft) continue;
+        // Something at the actual top-left corner is fine pinned there.
+        const r = rect(w);
+        const nearCorner = r.x < ctx.snapshot.screen_width * 0.25 && r.y < ctx.snapshot.screen_height * 0.25;
+        if (nearCorner) continue;
+        out.push(
+          finding(
+            { id: 'ui_canvas_child_top_left_anchored', category: 'ui', severity: 'warning' },
+            `"${w.name}" uses the default top-left anchor but sits at (${Math.round(r.x)}, ${Math.round(r.y)}).`,
+            'With a top-left anchor the widget keeps that pixel offset at every resolution, so it drifts away from where you placed it on wider or shorter screens. Anchor it to the region it belongs to (centre, bottom-right, or a stretched anchor).',
+            w.name,
+            { anchors: a, position: { x: round(r.x), y: round(r.y) } },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_stretched_anchor_with_pivot',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'strict',
+    title: 'Stretched anchor combined with a non-zero alignment',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        const a = w.anchors;
+        if (!a) continue;
+        const stretched = a.max_x - a.min_x > 0.001 || a.max_y - a.min_y > 0.001;
+        if (!stretched) continue;
+        if (w.auto_size !== true) continue;
+        out.push(
+          finding(
+            { id: 'ui_stretched_anchor_with_pivot', category: 'ui', severity: 'info' },
+            `"${w.name}" has a stretched anchor and auto-size enabled at the same time.`,
+            'A stretched anchor tells the widget to fill the anchor region; auto-size tells it to shrink to its content. The two fight, and which wins is not obvious from the designer. Pick one.',
+            w.name,
+            { anchors: a },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+
+  // ══ Contrast and visibility ═══════════════════════════════════════════════
+  {
+    id: 'ui_text_contrast_below_minimum',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Text contrast against its background is below the minimum',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        const color = w.text_info?.color;
+        if (!color) continue;
+        const bg = backgroundColorOf(ctx, w);
+        if (!bg) continue;
+        const ratio = contrastRatio(color, bg);
+        if (ratio >= ctx.thresholds.minContrastRatio) continue;
+        out.push(
+          finding(
+            { id: 'ui_text_contrast_below_minimum', category: 'ui', severity: 'warning' },
+            `"${w.name}" has a contrast ratio of ${round(ratio)}:1 against its background (minimum ${ctx.thresholds.minContrastRatio}:1).`,
+            `WCAG 2.1 asks for 4.5:1 for body text and 3:1 for large text; AAA asks for 7:1. Darken the background or lighten the text. Measured against the nearest opaque ancestor fill — translucent panels are skipped because the real backdrop is unknown.`,
+            w.name,
+            { ratio: round(ratio), required: ctx.thresholds.minContrastRatio, text_color: color, background: bg },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_invisible_but_present',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'standard',
+    title: 'Widget is fully transparent',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        const reasons: string[] = [];
+        if (w.render_opacity <= 0.001) reasons.push('render opacity is 0');
+        const tintAlpha = w.brush_info?.tint?.[3];
+        if (tintAlpha !== undefined && tintAlpha <= 0.001) reasons.push('brush tint alpha is 0');
+        const textAlpha = w.text_info?.color?.[3];
+        if (textAlpha !== undefined && textAlpha <= 0.001) reasons.push('text alpha is 0');
+        if (reasons.length === 0) continue;
+        out.push(
+          finding(
+            { id: 'ui_invisible_but_present', category: 'ui', severity: 'info' },
+            `"${w.name}" cannot be seen (${reasons.join(', ')}) but still lays out and still takes input.`,
+            'If it is meant to fade in at runtime this is correct. If it is meant to be gone, set Visibility to Collapsed so it also stops consuming layout space and hit tests.',
+            w.name,
+            { reasons },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_image_without_resource',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Image widget has no texture or material assigned',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (w.class !== 'Image') continue;
+        if (w.brush_info?.has_resource) continue;
+        out.push(
+          finding(
+            { id: 'ui_image_without_resource', category: 'ui', severity: 'warning' },
+            `"${w.name}" is an Image with no resource assigned.`,
+            'It renders as a flat tinted rectangle. Assign a Texture2D or material with ui_set_brush, or use a Border if a solid fill is what you wanted.',
+            w.name,
+          ),
+        );
+      }
+      return out;
+    },
+  },
+
+  // ══ Input and focus ═══════════════════════════════════════════════════════
+  {
+    id: 'ui_interactive_not_focusable',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Interactive widget cannot receive focus',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (!w.is_interactive || w.is_focusable) continue;
+        out.push(
+          finding(
+            { id: 'ui_interactive_not_focusable', category: 'ui', severity: 'warning' },
+            `"${w.name}" is interactive but not focusable.`,
+            'Gamepad and keyboard navigation move focus between focusable widgets. A control that cannot take focus is unreachable without a mouse — on console that means unreachable, full stop.',
+            w.name,
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_no_focusable_widget',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Screen has interactive content but nothing focusable',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const interactive = ctx.snapshot.widgets.filter((w) => w.is_interactive);
+      if (interactive.length === 0) return [];
+      if (interactive.some((w) => w.is_focusable)) return [];
+      return [
+        finding(
+          { id: 'ui_no_focusable_widget', category: 'ui', severity: 'warning' },
+          `This screen has ${interactive.length} interactive widget(s) and none of them can take focus.`,
+          'Gamepad users will land on this screen with no focus target and no way to move. Make at least one control focusable and set it as the initial focus in the widget graph.',
+          undefined,
+          { interactive_count: interactive.length },
+        ),
+      ];
+    },
+  },
+  {
+    id: 'ui_interactive_hit_test_invisible',
+    category: 'ui',
+    severity: 'error',
+    minStrictness: 'relaxed',
+    title: 'Interactive widget has input disabled by its visibility setting',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (!w.is_interactive) continue;
+        const v = w.visibility;
+        if (!v.includes('HitTestInvisible')) continue;
+        out.push(
+          finding(
+            { id: 'ui_interactive_hit_test_invisible', category: 'ui', severity: 'error' },
+            `"${w.name}" is a control with visibility ${v.split('::').pop()}.`,
+            'HitTestInvisible and SelfHitTestInvisible make a widget ignore the mouse entirely, so this control is visible but cannot be clicked. Set it to Visible.',
+            w.name,
+            { visibility: v },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_button_without_content',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Button has no label or icon',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (w.class !== 'Button') continue;
+        if ((w.child_count ?? 0) > 0) continue;
+        out.push(
+          finding(
+            { id: 'ui_button_without_content', category: 'ui', severity: 'warning' },
+            `"${w.name}" is an empty Button.`,
+            'A button with no child renders as a bare box with nothing to tell the player what it does. Add a TextBlock or Image child.',
+            w.name,
+          ),
+        );
+      }
+      return out;
+    },
+  },
+
+  // ══ Structure and hygiene ═════════════════════════════════════════════════
+  {
+    id: 'ui_empty_panel',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'standard',
+    title: 'Panel has no children',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (!w.is_panel) continue;
+        if ((w.child_count ?? 0) > 0) continue;
+        // A NamedSlot is a deliberate hole for a caller to fill.
+        if (w.class === 'NamedSlot') continue;
+        out.push(
+          finding(
+            { id: 'ui_empty_panel', category: 'ui', severity: 'info' },
+            `"${w.name}" (${w.class}) has no children.`,
+            'Either it is scaffolding that was never filled in, or it is dead. Empty panels still cost a layout pass.',
+            w.name,
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_redundant_single_child_panel',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'strict',
+    title: 'Panel wraps a single child for no layout reason',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      // These wrap one child ON PURPOSE — sizing, scaling, clipping, padding.
+      const purposeful = new Set([
+        'SizeBox',
+        'ScaleBox',
+        'Border',
+        'RetainerBox',
+        'InvalidationBox',
+        'SafeZone',
+        'BackgroundBlur',
+        'NamedSlot',
+        'WidgetSwitcher',
+      ]);
+      for (const w of ctx.snapshot.widgets) {
+        if (!w.is_panel || purposeful.has(w.class)) continue;
+        if ((w.child_count ?? 0) !== 1) continue;
+        out.push(
+          finding(
+            { id: 'ui_redundant_single_child_panel', category: 'ui', severity: 'info' },
+            `"${w.name}" (${w.class}) contains exactly one child.`,
+            'A box or canvas around a single widget usually adds a layout pass without changing the result. Consider removing it (ui_reparent_element the child, then ui_remove_element the panel).',
+            w.name,
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_nesting_too_deep',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Widget hierarchy is deeper than the recommended limit',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      const max = ctx.thresholds.maxNestingDepth;
+      const deepest = laidOut(ctx).reduce<UiWidget | null>(
+        (acc, w) => ((w.depth ?? 0) > (acc?.depth ?? -1) ? w : acc),
+        null,
+      );
+      if (!deepest || (deepest.depth ?? 0) <= max) return out;
+      out.push(
+        finding(
+          { id: 'ui_nesting_too_deep', category: 'ui', severity: 'warning' },
+          `The tree is ${deepest.depth} levels deep at "${deepest.name}" (recommended maximum ${max}).`,
+          'Every level is another layout and paint pass for each child beneath it. Flatten with a Grid or an Overlay where the nesting is only there to position things.',
+          deepest.name,
+          { depth: deepest.depth, maximum: max },
+        ),
+      );
+      return out;
+    },
+  },
+  {
+    id: 'ui_too_many_widgets',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Blueprint contains a lot of widgets',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const max = ctx.thresholds.maxWidgetCount;
+      if (ctx.snapshot.widget_count <= max) return [];
+      return [
+        finding(
+          { id: 'ui_too_many_widgets', category: 'ui', severity: 'warning' },
+          `This blueprint has ${ctx.snapshot.widget_count} widgets (soft limit ${max}).`,
+          'Large static trees are the usual cause of UI frame cost. Split reusable chunks into their own Widget Blueprints, use a ListView with an entry widget for repeated rows, and wrap static regions in an InvalidationBox.',
+          undefined,
+          { widget_count: ctx.snapshot.widget_count, maximum: max },
+        ),
+      ];
+    },
+  },
+  {
+    id: 'ui_default_widget_name',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'strict',
+    title: 'Widget still has its auto-generated name',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (!DEFAULT_NAME_RE.test(w.name)) continue;
+        out.push(
+          finding(
+            { id: 'ui_default_widget_name', category: 'ui', severity: 'info' },
+            `"${w.name}" is an auto-generated name.`,
+            'The widget name is the variable name the graph and C++ BindWidget resolve against, so it is API. Rename it with ui_rename_element.',
+            w.name,
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_named_widget_not_variable',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'strict',
+    title: 'Deliberately named widget is not exposed as a variable',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (w.is_variable) continue;
+        if (DEFAULT_NAME_RE.test(w.name)) continue; // not deliberately named
+        // Only content widgets — nobody binds to a spacer.
+        if (!isTextWidget(w) && !w.is_interactive && w.class !== 'Image') continue;
+        out.push(
+          finding(
+            { id: 'ui_named_widget_not_variable', category: 'ui', severity: 'info' },
+            `"${w.name}" has a deliberate name but is not exposed as a variable.`,
+            'Someone named this widget on purpose, which usually means code is meant to reach it. Without Is Variable set, the graph and BindWidget cannot. Fix with ui_set_variable.',
+            w.name,
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_no_root_widget',
+    category: 'ui',
+    severity: 'error',
+    minStrictness: 'relaxed',
+    title: 'Widget blueprint has no root widget',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      if (ctx.snapshot.widgets.length > 0) return [];
+      return [
+        finding(
+          { id: 'ui_no_root_widget', category: 'ui', severity: 'error' },
+          'This Widget Blueprint has an empty widget tree.',
+          'Nothing will render. Add a root panel with ui_add_element (a CanvasPanel is the usual choice) before adding content.',
+        ),
+      ];
+    },
+  },
+  {
+    id: 'ui_disabled_interactive',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'standard',
+    title: 'Control is authored in the disabled state',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (!w.is_interactive || w.is_enabled) continue;
+        out.push(
+          finding(
+            { id: 'ui_disabled_interactive', category: 'ui', severity: 'info' },
+            `"${w.name}" is authored with Is Enabled off.`,
+            'Fine if the graph enables it later. If not, it ships greyed out — and players cannot tell a deliberately-disabled control from a broken one unless the disabled state is visually distinct.',
+            w.name,
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_backgroundblur_overuse',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Several BackgroundBlur widgets on one screen',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const blurs = ctx.snapshot.widgets.filter((w) => w.class === 'BackgroundBlur');
+      if (blurs.length <= 1) return [];
+      return [
+        finding(
+          { id: 'ui_backgroundblur_overuse', category: 'ui', severity: 'warning' },
+          `${blurs.length} BackgroundBlur widgets on one screen (${blurs.map((b) => b.name).join(', ')}).`,
+          'Each blur is a separate full-resolution render-target pass and they are one of the most expensive things a UMG screen can do — especially on handheld and mobile. Use one blur behind the whole panel instead of one per element.',
+          blurs[0]?.name,
+          { count: blurs.length, widgets: blurs.map((b) => b.name) },
+        ),
+      ];
+    },
+  },
+  {
+    id: 'ui_retainerbox_with_dynamic_content',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'strict',
+    title: 'RetainerBox wraps content that looks dynamic',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (w.class !== 'RetainerBox') continue;
+        // Interactive descendants imply content that changes every frame,
+        // which is exactly what a retainer is bad at.
+        const dynamicChild = ctx.snapshot.widgets.find((c) => c.is_interactive && isAncestor(ctx, w.name, c));
+        if (!dynamicChild) continue;
+        out.push(
+          finding(
+            { id: 'ui_retainerbox_with_dynamic_content', category: 'ui', severity: 'info' },
+            `"${w.name}" is a RetainerBox containing interactive content ("${dynamicChild.name}").`,
+            'A RetainerBox pays for a render target to avoid re-drawing static content. Content that changes on hover or focus invalidates it constantly, so it costs more than it saves. Retain static art instead.',
+            w.name,
+            { dynamic_child: dynamicChild.name },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_widgetswitcher_empty',
+    category: 'ui',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'WidgetSwitcher has fewer than two children',
+    needsLayout: false,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of ctx.snapshot.widgets) {
+        if (w.class !== 'WidgetSwitcher') continue;
+        const count = w.child_count ?? 0;
+        if (count >= 2) continue;
+        out.push(
+          finding(
+            { id: 'ui_widgetswitcher_empty', category: 'ui', severity: 'warning' },
+            `"${w.name}" is a WidgetSwitcher with ${count} child(ren).`,
+            'A switcher exists to swap between alternatives. With fewer than two it adds a layout level for nothing.',
+            w.name,
+            { child_count: count },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'ui_image_oversized_texture',
+    category: 'ui',
+    severity: 'info',
+    minStrictness: 'standard',
+    title: 'Image is drawn much smaller than its source art',
+    needsLayout: true,
+    evaluate: (ctx) => {
+      const out: UiFinding[] = [];
+      for (const w of laidOut(ctx)) {
+        const b = w.brush_info;
+        if (!b?.has_resource || !b.image_size_x || !b.image_size_y) continue;
+        const r = rect(w);
+        if (r.w <= 0 || r.h <= 0) continue;
+        const ratio = Math.min(b.image_size_x / r.w, b.image_size_y / r.h);
+        if (ratio < 2) continue;
+        out.push(
+          finding(
+            { id: 'ui_image_oversized_texture', category: 'ui', severity: 'info' },
+            `"${w.name}" draws at ${Math.round(r.w)}x${Math.round(r.h)}px from ${b.image_size_x}x${b.image_size_y} source art (${round(ratio)}x oversized).`,
+            'The full texture still occupies memory. Downsize the source or set a smaller max texture size in the asset — UI textures are usually not mip-mapped, so the whole thing stays resident.',
+            w.name,
+            { drawn: { w: Math.round(r.w), h: Math.round(r.h) }, source: { w: b.image_size_x, h: b.image_size_y } },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+];
+
+/** Rules keyed by id. */
+export function uiRulesById(): Map<string, UiRule> {
+  const m = new Map<string, UiRule>();
+  for (const r of UI_RULES) m.set(r.id, r);
+  return m;
+}

--- a/mcp-tools/hayba-mcp/src/validator/ui/thresholds.ts
+++ b/mcp-tools/hayba-mcp/src/validator/ui/thresholds.ts
@@ -1,0 +1,175 @@
+// Numeric thresholds the UI rules judge against.
+//
+// Every number here has a source, cited on the line, because "the validator
+// says 44px" is only useful if you can find out why 44. They are expressed at
+// the blueprint's DESIGN resolution and scaled to the actual design size, so a
+// 720p-authored menu is judged by 720p numbers rather than 1080p ones.
+
+import type { Strictness } from '../config.js';
+import type { UiPlatform, UiThresholds } from './types.js';
+
+/** The resolution the base numbers are expressed at. */
+export const REFERENCE_HEIGHT = 1080;
+
+interface PlatformBase {
+  titleSafeFraction: number;
+  actionSafeFraction: number;
+  minTouchTargetPx: number;
+  minInteractiveGapPx: number;
+  minFontPx: number;
+  comfortableFontPx: number;
+}
+
+const PLATFORM_BASE: Record<UiPlatform, PlatformBase> = {
+  // Desktop: mouse pointer, ~60cm viewing distance, no broadcast safe area.
+  pc: {
+    titleSafeFraction: 0.0,
+    actionSafeFraction: 0.0,
+    // A 24px target is the practical floor for comfortable mouse clicking;
+    // WCAG 2.2 AA (2.5.8) sets 24x24 CSS px as the minimum target size.
+    minTouchTargetPx: 24,
+    minInteractiveGapPx: 8,
+    // 12px is the smallest reliably legible UI text on desktop; below that,
+    // hinting breaks down at 100% scaling.
+    minFontPx: 12,
+    comfortableFontPx: 16,
+  },
+  // Console on a TV: ~3m viewing distance, overscan still exists on some sets.
+  console: {
+    // Title safe = inner 90% (5% per edge); action safe = inner 93% (3.5% per
+    // edge). These are the long-standing broadcast/console cert numbers, and
+    // both Xbox and PlayStation TRC/XR checklists still use them.
+    titleSafeFraction: 0.05,
+    actionSafeFraction: 0.035,
+    // Focus-driven, not pointer-driven, but a target still has to be visible
+    // and distinguishable from 3m.
+    minTouchTargetPx: 40,
+    minInteractiveGapPx: 12,
+    // The widely used console floor is 28px at 1080p for body copy; smaller
+    // text is unreadable at couch distance.
+    minFontPx: 28,
+    comfortableFontPx: 32,
+  },
+  // Handheld (Steam Deck / Switch): small screen, close, often touch as well.
+  handheld: {
+    titleSafeFraction: 0.02,
+    actionSafeFraction: 0.015,
+    minTouchTargetPx: 40,
+    minInteractiveGapPx: 8,
+    // Steam Deck's own UI guidance lands around 20px at 800p; scaled to the
+    // 1080p reference that is ~24.
+    minFontPx: 20,
+    comfortableFontPx: 24,
+  },
+  // Touch: finger, not pointer.
+  mobile: {
+    // Notches and gesture bars, not overscan.
+    titleSafeFraction: 0.03,
+    actionSafeFraction: 0.02,
+    // Apple HIG says 44x44pt; Material says 48x48dp. 44 is the lower of the two
+    // and therefore the one that flags only genuine violations.
+    minTouchTargetPx: 44,
+    minInteractiveGapPx: 8,
+    minFontPx: 16,
+    comfortableFontPx: 18,
+  },
+};
+
+/** Strictness scales the discretionary numbers. Hard floors (safe areas, touch
+ *  targets) do NOT get more lenient in relaxed mode — they are either met or
+ *  not; relaxed mode drops the rules that report them at low severity instead. */
+interface StrictnessTuning {
+  spacingGridPx: number;
+  localizationHeadroom: number;
+  textFillWarnRatio: number;
+  minContrastRatio: number;
+  maxNestingDepth: number;
+  maxWidgetCount: number;
+}
+
+const STRICTNESS_TUNING: Record<Strictness, StrictnessTuning> = {
+  relaxed: {
+    spacingGridPx: 4,
+    // Only flag labels with no room for growth at all.
+    localizationHeadroom: 1.0,
+    textFillWarnRatio: 0.98,
+    // WCAG AA for large text.
+    minContrastRatio: 3.0,
+    maxNestingDepth: 16,
+    maxWidgetCount: 500,
+  },
+  standard: {
+    spacingGridPx: 4,
+    // English -> German/Russian commonly grows 30% for short UI strings.
+    localizationHeadroom: 1.3,
+    textFillWarnRatio: 0.9,
+    // WCAG 2.1 AA for body text.
+    minContrastRatio: 4.5,
+    maxNestingDepth: 12,
+    maxWidgetCount: 300,
+  },
+  strict: {
+    // 8pt grid: the spacing system most UI kits standardise on.
+    spacingGridPx: 8,
+    // Short strings (single words on buttons) can grow far more than 30%;
+    // 1.5 is the figure Microsoft's localisation guidance gives for strings
+    // under 10 characters.
+    localizationHeadroom: 1.5,
+    textFillWarnRatio: 0.8,
+    // WCAG AAA.
+    minContrastRatio: 7.0,
+    maxNestingDepth: 8,
+    maxWidgetCount: 200,
+  },
+};
+
+/** Resolve thresholds for a platform + strictness at a given design height.
+ *  Pixel numbers scale with the design resolution; fractions do not. */
+export function resolveThresholds(
+  platform: UiPlatform,
+  strictness: Strictness,
+  designHeight: number = REFERENCE_HEIGHT,
+): UiThresholds {
+  const base = PLATFORM_BASE[platform];
+  const tuning = STRICTNESS_TUNING[strictness];
+
+  // A menu authored at 720p has smaller pixel numbers for the same physical
+  // size; judging it with 1080p pixels would flag every font in the file.
+  const scale = designHeight > 0 ? designHeight / REFERENCE_HEIGHT : 1;
+  const px = (v: number) => Math.round(v * scale);
+
+  return {
+    titleSafeFraction: base.titleSafeFraction,
+    actionSafeFraction: base.actionSafeFraction,
+    minTouchTargetPx: px(base.minTouchTargetPx),
+    minInteractiveGapPx: px(base.minInteractiveGapPx),
+    minFontPx: px(base.minFontPx),
+    comfortableFontPx: px(base.comfortableFontPx),
+    spacingGridPx: tuning.spacingGridPx,
+    localizationHeadroom: tuning.localizationHeadroom,
+    textFillWarnRatio: tuning.textFillWarnRatio,
+    minContrastRatio: tuning.minContrastRatio,
+    maxNestingDepth: tuning.maxNestingDepth,
+    maxWidgetCount: tuning.maxWidgetCount,
+  };
+}
+
+/** Relative luminance per WCAG 2.1, from linear 0-1 RGB.
+ *  UMG colours are already linear, so the sRGB companding step the WCAG
+ *  formula starts with has effectively been done for us. */
+export function relativeLuminance(r: number, g: number, b: number): number {
+  const clamp = (v: number) => Math.min(1, Math.max(0, v));
+  return 0.2126 * clamp(r) + 0.7152 * clamp(g) + 0.0722 * clamp(b);
+}
+
+/** WCAG contrast ratio between two linear colours; 1.0 (identical) to 21.0. */
+export function contrastRatio(
+  a: [number, number, number, number],
+  b: [number, number, number, number],
+): number {
+  const la = relativeLuminance(a[0], a[1], a[2]);
+  const lb = relativeLuminance(b[0], b[1], b[2]);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/mcp-tools/hayba-mcp/src/validator/ui/types.ts
+++ b/mcp-tools/hayba-mcp/src/validator/ui/types.ts
@@ -1,0 +1,186 @@
+// Types for the UI validation pass.
+//
+// The snapshot is produced by the UE command `ui_layout_snapshot`, which does
+// the one job that cannot be done here: a real Slate prepass plus font
+// measurement. Everything in this directory is pure judgement over that data,
+// which is why the rules are unit-testable and can be extended without
+// rebuilding the plugin.
+
+import type { RuleCategory, Strictness } from '../config.js';
+
+/** Text facts for a widget that renders text. */
+export interface UiTextInfo {
+  text?: string;
+  font_size?: number;
+  typeface?: string;
+  font_object?: string;
+  /** True when the font asset is a UFontFace rather than a composite UFont.
+   *  Slate renders a raw font face as its glyph-preview tiles, not as text. */
+  font_is_font_face?: boolean;
+  auto_wrap?: boolean;
+  color?: [number, number, number, number];
+  /** Exact rendered width of `text` in this font, in px. */
+  measured_width?: number;
+  measured_height?: number;
+  /** Width the widget's laid-out box gives the text, in px. */
+  available_width?: number;
+  overflows?: boolean;
+  /** Characters of `text` that fit, kerning included. */
+  chars_that_fit?: number;
+  /** Characters of typical mixed-case prose that fit in the box. */
+  typical_chars_that_fit?: number;
+  /** Characters that fit if every glyph were the font's widest. */
+  worst_case_chars_that_fit?: number;
+}
+
+export interface UiBrushInfo {
+  has_resource?: boolean;
+  resource?: string;
+  tint?: [number, number, number, number];
+  image_size_x?: number;
+  image_size_y?: number;
+}
+
+export interface UiAnchors {
+  min_x: number;
+  min_y: number;
+  max_x: number;
+  max_y: number;
+}
+
+/** One widget as reported by ui_layout_snapshot. */
+export interface UiWidget {
+  name: string;
+  class: string;
+  parent: string;
+  slot_class: string;
+  is_panel: boolean;
+  is_variable: boolean;
+  visibility: string;
+  render_opacity: number;
+  is_enabled: boolean;
+  is_interactive: boolean;
+  is_focusable: boolean;
+
+  /** Design-space rect. Absent/false `laid_out` means Slate gave this widget no
+   *  box (collapsed, or an inactive switcher slot) — geometry rules must skip
+   *  it rather than treat it as a zero-size violation. */
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  depth?: number;
+  laid_out: boolean;
+
+  anchors?: UiAnchors;
+  z_order?: number;
+  auto_size?: boolean;
+  child_count?: number;
+
+  text_info?: UiTextInfo;
+  brush_info?: UiBrushInfo;
+}
+
+export interface UiSnapshot {
+  widget_blueprint_path: string;
+  screen_width: number;
+  screen_height: number;
+  /** False when the blueprint could not be instantiated for layout. Every
+   *  geometry-dependent rule is SKIPPED in that case and reported as skipped,
+   *  never as passing. */
+  layout_resolved: boolean;
+  layout_error?: string;
+  widget_count: number;
+  widgets: UiWidget[];
+}
+
+export type UiSeverity = 'error' | 'warning' | 'info';
+
+/** A single problem found in a widget blueprint. */
+export interface UiFinding {
+  ruleId: string;
+  category: RuleCategory;
+  severity: UiSeverity;
+  /** Widget the finding is about, when it is about one. */
+  widget?: string;
+  message: string;
+  hint: string;
+  /** Numbers behind the message, so a caller can re-check the maths. */
+  data?: Record<string, unknown>;
+}
+
+/** Which platform's conventions to judge against. Safe areas, minimum touch
+ *  targets and legible font sizes differ enough between a TV at 3m and a phone
+ *  at 30cm that one set of numbers would be wrong for both. */
+export const UI_PLATFORMS = ['pc', 'console', 'handheld', 'mobile'] as const;
+export type UiPlatform = (typeof UI_PLATFORMS)[number];
+
+export interface UiRuleContext {
+  snapshot: UiSnapshot;
+  platform: UiPlatform;
+  strictness: Strictness;
+  /** Resolved numeric thresholds for this platform + strictness. */
+  thresholds: UiThresholds;
+  /** Widgets keyed by name, for parent/child lookups. */
+  byName: Map<string, UiWidget>;
+  /** Direct children of each widget, in tree order. */
+  childrenOf: Map<string, UiWidget[]>;
+}
+
+export interface UiThresholds {
+  /** Fraction of each screen edge that is unsafe for critical content. */
+  titleSafeFraction: number;
+  /** Fraction of each screen edge that is unsafe for anything at all. */
+  actionSafeFraction: number;
+  /** Minimum px for the short side of an interactive widget. */
+  minTouchTargetPx: number;
+  /** Minimum px gap between two interactive widgets. */
+  minInteractiveGapPx: number;
+  /** Minimum legible font size in px at the design resolution. */
+  minFontPx: number;
+  /** Font size below which text is flagged only in strict mode. */
+  comfortableFontPx: number;
+  /** Spacing grid that positions and sizes should land on. */
+  spacingGridPx: number;
+  /** Multiplier of headroom a label needs for localisation growth. */
+  localizationHeadroom: number;
+  /** Fraction of the box at which text is "close enough to overflowing". */
+  textFillWarnRatio: number;
+  /** Minimum contrast ratio for body text against its background. */
+  minContrastRatio: number;
+  /** Widget-tree depth beyond which nesting is flagged. */
+  maxNestingDepth: number;
+  /** Widget count beyond which the blueprint is flagged as heavy. */
+  maxWidgetCount: number;
+}
+
+/** One rule. `evaluate` returns every finding it produces for the snapshot. */
+export interface UiRule {
+  id: string;
+  category: RuleCategory;
+  severity: UiSeverity;
+  /** Lowest strictness at which this rule fires. */
+  minStrictness: Strictness;
+  /** One-line summary shown in the settings UI. */
+  title: string;
+  /** True when the rule needs resolved geometry — skipped, and reported as
+   *  skipped, when the layout could not be computed. */
+  needsLayout: boolean;
+  evaluate: (ctx: UiRuleContext) => UiFinding[];
+}
+
+export interface UiValidationResult {
+  widget_blueprint_path: string;
+  platform: UiPlatform;
+  strictness: Strictness;
+  layout_resolved: boolean;
+  layout_error?: string;
+  findings: UiFinding[];
+  /** Rules that ran, were disabled, or were skipped for want of geometry.
+   *  Reported explicitly so "no findings" is never confused with "no checks". */
+  rules_evaluated: number;
+  rules_skipped_no_layout: string[];
+  rules_disabled: string[];
+  rules_below_strictness: string[];
+  counts: Record<UiSeverity, number>;
+}

--- a/mcp-tools/hayba-mcp/src/validator/ui/ui-rules.test.ts
+++ b/mcp-tools/hayba-mcp/src/validator/ui/ui-rules.test.ts
@@ -323,6 +323,27 @@ describe('contrast', () => {
     expect(findingsFor(result, 'ui_text_contrast_below_minimum')).toHaveLength(1);
   });
 
+  it('skips contrast when the background brush has a texture', () => {
+    // A tint over art is a multiplier, not a colour. Reading the default
+    // [1,1,1,1] tint as "white" is how a live HUD reported 1.1:1 against a
+    // background that is actually a dark panel texture.
+    const panel = widget({
+      name: 'Card',
+      class: 'Border',
+      parent: 'Root',
+      is_panel: true,
+      child_count: 1,
+      brush_info: { tint: [1, 1, 1, 1], has_resource: true, resource: '/Game/UI/T_DarkPanel' },
+    });
+    const label = widget({
+      name: 'Caption',
+      parent: 'Card',
+      text_info: { text: 'Hello', font_size: 20, color: [1, 0.9, 0.61, 1] },
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, panel, label]), { strictness: 'standard' });
+    expect(findingsFor(result, 'ui_text_contrast_below_minimum')).toHaveLength(0);
+  });
+
   it('skips contrast when the backdrop is translucent and therefore unknown', () => {
     const panel = widget({
       name: 'Card',

--- a/mcp-tools/hayba-mcp/src/validator/ui/ui-rules.test.ts
+++ b/mcp-tools/hayba-mcp/src/validator/ui/ui-rules.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { validateUiSnapshot, UI_RULES } from './index.js';
+import { contrastRatio, resolveThresholds } from './thresholds.js';
+import { setConfigPath, setRuleDisabled, setStrictness } from '../config.js';
+import type { UiSnapshot, UiWidget } from './types.js';
+
+// Each test gets its own config file so strictness/disable state never leaks
+// between cases (the config is read from disk on every call, by design).
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'hayba-ui-validator-'));
+  setConfigPath(join(tmp, 'validator-config.json'));
+});
+afterEach(() => {
+  setConfigPath(null);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function widget(partial: Partial<UiWidget> & { name: string }): UiWidget {
+  return {
+    class: 'TextBlock',
+    parent: 'Root',
+    slot_class: 'CanvasPanelSlot',
+    is_panel: false,
+    is_variable: true,
+    visibility: 'ESlateVisibility::Visible',
+    render_opacity: 1,
+    is_enabled: true,
+    is_interactive: false,
+    is_focusable: false,
+    laid_out: true,
+    x: 100,
+    y: 100,
+    width: 200,
+    height: 40,
+    depth: 1,
+    ...partial,
+  };
+}
+
+function snapshot(widgets: UiWidget[], overrides: Partial<UiSnapshot> = {}): UiSnapshot {
+  return {
+    widget_blueprint_path: '/Game/UI/WBP_Test',
+    screen_width: 1920,
+    screen_height: 1080,
+    layout_resolved: true,
+    widget_count: widgets.length,
+    widgets,
+    ...overrides,
+  };
+}
+
+const rootPanel = widget({
+  name: 'Root',
+  class: 'CanvasPanel',
+  parent: '',
+  is_panel: true,
+  child_count: 1,
+  depth: 0,
+  x: 0,
+  y: 0,
+  width: 1920,
+  height: 1080,
+});
+
+function findingsFor(result: ReturnType<typeof validateUiSnapshot>, ruleId: string) {
+  return result.findings.filter((f) => f.ruleId === ruleId);
+}
+
+describe('text fit rules', () => {
+  it('reports overflow with the exact character count that fits', () => {
+    const label = widget({
+      name: 'PlayerName',
+      text_info: {
+        text: 'Bartholomew Ravensworth III',
+        font_size: 24,
+        auto_wrap: false,
+        measured_width: 320,
+        available_width: 200,
+        overflows: true,
+        chars_that_fit: 17,
+        typical_chars_that_fit: 18,
+        worst_case_chars_that_fit: 11,
+      },
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, label]), { strictness: 'standard' });
+    const found = findingsFor(result, 'ui_text_overflows_box');
+    expect(found).toHaveLength(1);
+    expect(found[0]!.severity).toBe('error');
+    // The hint must name the exact cut-off point, not a vague "too long".
+    expect(found[0]!.hint).toContain('only the first 17 fit');
+    expect(found[0]!.data).toMatchObject({ chars_that_fit: 17, overflow_px: 120 });
+  });
+
+  it('warns before overflow and states the character budget for variable text', () => {
+    const label = widget({
+      name: 'ItemName',
+      text_info: {
+        text: 'Iron Sword',
+        font_size: 24,
+        auto_wrap: false,
+        measured_width: 190,
+        available_width: 200,
+        overflows: false,
+        chars_that_fit: 10,
+        typical_chars_that_fit: 21,
+        worst_case_chars_that_fit: 13,
+      },
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, label]), { strictness: 'standard' });
+    const found = findingsFor(result, 'ui_text_near_overflow');
+    expect(found).toHaveLength(1);
+    expect(found[0]!.hint).toContain('at most 13 characters');
+    expect(found[0]!.data).toMatchObject({ worst_case_chars_that_fit: 13 });
+  });
+
+  it('does not flag wrapping text as overflowing', () => {
+    const paragraph = widget({
+      name: 'Body',
+      text_info: {
+        text: 'A long paragraph of body copy that is meant to wrap onto several lines.',
+        font_size: 20,
+        auto_wrap: true,
+        measured_width: 900,
+        available_width: 300,
+        overflows: true,
+        chars_that_fit: 20,
+      },
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, paragraph]), { strictness: 'standard' });
+    expect(findingsFor(result, 'ui_text_overflows_box')).toHaveLength(0);
+  });
+
+  it('flags a label that fits in English but not after translation growth', () => {
+    const label = widget({
+      name: 'SettingsLabel',
+      text_info: {
+        text: 'Settings',
+        font_size: 24,
+        auto_wrap: false,
+        measured_width: 100,
+        available_width: 120, // 100 * 1.3 = 130 > 120
+        overflows: false,
+        chars_that_fit: 8,
+        typical_chars_that_fit: 12,
+        worst_case_chars_that_fit: 8,
+      },
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, label]), { strictness: 'standard' });
+    const found = findingsFor(result, 'ui_text_no_localization_headroom');
+    expect(found).toHaveLength(1);
+    expect(found[0]!.data).toMatchObject({ required_width: 130, headroom: 1.3 });
+  });
+
+  it('applies a larger localisation margin in strict mode', () => {
+    const label = widget({
+      name: 'SettingsLabel',
+      text_info: {
+        text: 'Settings',
+        font_size: 24,
+        auto_wrap: false,
+        measured_width: 100,
+        available_width: 140, // survives 1.3x, fails 1.5x
+        overflows: false,
+        chars_that_fit: 8,
+      },
+    });
+    const snap = snapshot([rootPanel, label]);
+    expect(findingsFor(validateUiSnapshot(snap, { strictness: 'standard' }), 'ui_text_no_localization_headroom')).toHaveLength(0);
+    expect(findingsFor(validateUiSnapshot(snap, { strictness: 'strict' }), 'ui_text_no_localization_headroom')).toHaveLength(1);
+  });
+
+  it('catches a UFontFace assigned where a UFont is required', () => {
+    const label = widget({
+      name: 'Title',
+      text_info: { text: 'Play', font_size: 48, font_object: '/Game/UI/Fonts/Cormorant_Font', font_is_font_face: true },
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, label]), { strictness: 'relaxed' });
+    const found = findingsFor(result, 'ui_font_is_font_face');
+    expect(found).toHaveLength(1);
+    expect(found[0]!.severity).toBe('error');
+  });
+});
+
+describe('platform-sensitive thresholds', () => {
+  it('accepts a 16px font on PC and rejects it on console', () => {
+    const label = widget({ name: 'Hint', text_info: { text: 'Press A', font_size: 16 } });
+    const snap = snapshot([rootPanel, label]);
+    expect(findingsFor(validateUiSnapshot(snap, { platform: 'pc' }), 'ui_font_too_small')).toHaveLength(0);
+    const console = findingsFor(validateUiSnapshot(snap, { platform: 'console' }), 'ui_font_too_small');
+    expect(console).toHaveLength(1);
+    expect(console[0]!.hint).toContain('3m');
+  });
+
+  it('applies the 44px touch target minimum only on mobile', () => {
+    const button = widget({
+      name: 'CloseButton',
+      class: 'Button',
+      is_interactive: true,
+      is_focusable: true,
+      width: 32,
+      height: 32,
+    });
+    const snap = snapshot([rootPanel, button]);
+    expect(findingsFor(validateUiSnapshot(snap, { platform: 'pc' }), 'ui_interactive_targets_touch')).toHaveLength(0);
+    expect(findingsFor(validateUiSnapshot(snap, { platform: 'mobile' }), 'ui_interactive_targets_touch')).toHaveLength(1);
+  });
+
+  it('scales pixel thresholds to the design resolution', () => {
+    const at1080 = resolveThresholds('console', 'standard', 1080);
+    const at720 = resolveThresholds('console', 'standard', 720);
+    expect(at1080.minFontPx).toBe(28);
+    // A 720p-authored screen is judged with proportionally smaller pixels.
+    expect(at720.minFontPx).toBe(19);
+    // Fractions are resolution-independent.
+    expect(at720.titleSafeFraction).toBe(at1080.titleSafeFraction);
+  });
+});
+
+describe('safe areas', () => {
+  it('flags console content inside the action-safe margin', () => {
+    const label = widget({ name: 'Score', x: 10, y: 10, width: 200, height: 40, text_info: { text: '0', font_size: 32 } });
+    const result = validateUiSnapshot(snapshot([rootPanel, label]), { platform: 'console' });
+    expect(findingsFor(result, 'ui_outside_action_safe')).toHaveLength(1);
+  });
+
+  it('does not apply TV safe areas on PC', () => {
+    const label = widget({ name: 'Score', x: 10, y: 10, width: 200, height: 40, text_info: { text: '0', font_size: 32 } });
+    const result = validateUiSnapshot(snapshot([rootPanel, label]), { platform: 'pc' });
+    expect(findingsFor(result, 'ui_outside_action_safe')).toHaveLength(0);
+    expect(findingsFor(result, 'ui_outside_title_safe')).toHaveLength(0);
+  });
+
+  it('reports a widget hanging off the screen', () => {
+    const label = widget({ name: 'Offscreen', x: 1850, y: 100, width: 300, height: 40 });
+    const result = validateUiSnapshot(snapshot([rootPanel, label]), { strictness: 'relaxed' });
+    expect(findingsFor(result, 'ui_outside_screen')).toHaveLength(1);
+  });
+});
+
+describe('overlap', () => {
+  it('reports overlapping siblings and names the ambiguity when z-order ties', () => {
+    const a = widget({
+      name: 'Label',
+      x: 100,
+      y: 100,
+      width: 200,
+      height: 40,
+      z_order: 0,
+      text_info: { text: 'Health', font_size: 24 },
+    });
+    const b = widget({ name: 'Icon', class: 'Image', x: 250, y: 110, width: 100, height: 20, z_order: 0 });
+    const result = validateUiSnapshot(snapshot([rootPanel, a, b]), { strictness: 'relaxed' });
+    const found = findingsFor(result, 'ui_widgets_overlap');
+    expect(found).toHaveLength(1);
+    expect(found[0]!.hint).toContain('decided by child order');
+  });
+
+  it('treats stacking inside an Overlay as intentional', () => {
+    const overlay = widget({ name: 'Stack', class: 'Overlay', parent: 'Root', is_panel: true, child_count: 2 });
+    const a = widget({ name: 'Label', parent: 'Stack', x: 100, y: 100, width: 200, height: 40 });
+    const b = widget({ name: 'Badge', parent: 'Stack', x: 120, y: 100, width: 100, height: 40 });
+    const result = validateUiSnapshot(snapshot([rootPanel, overlay, a, b]), { strictness: 'relaxed' });
+    expect(findingsFor(result, 'ui_widgets_overlap')).toHaveLength(0);
+  });
+});
+
+describe('focus and input', () => {
+  it('reports an interactive widget that visibility makes unclickable', () => {
+    const button = widget({
+      name: 'PlayButton',
+      class: 'Button',
+      is_interactive: true,
+      is_focusable: true,
+      visibility: 'ESlateVisibility::HitTestInvisible',
+      width: 200,
+      height: 60,
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, button]), { strictness: 'relaxed' });
+    expect(findingsFor(result, 'ui_interactive_hit_test_invisible')).toHaveLength(1);
+  });
+
+  it('reports a screen where gamepad focus has nowhere to land', () => {
+    const button = widget({
+      name: 'PlayButton',
+      class: 'Button',
+      is_interactive: true,
+      is_focusable: false,
+      width: 200,
+      height: 60,
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, button]), { strictness: 'standard' });
+    expect(findingsFor(result, 'ui_no_focusable_widget')).toHaveLength(1);
+  });
+});
+
+describe('contrast', () => {
+  it('computes WCAG ratios correctly', () => {
+    // Black on white is the canonical 21:1.
+    expect(contrastRatio([0, 0, 0, 1], [1, 1, 1, 1])).toBeCloseTo(21, 5);
+    expect(contrastRatio([1, 1, 1, 1], [1, 1, 1, 1])).toBeCloseTo(1, 5);
+  });
+
+  it('flags low-contrast text over an opaque background', () => {
+    const panel = widget({
+      name: 'Card',
+      class: 'Border',
+      parent: 'Root',
+      is_panel: true,
+      child_count: 1,
+      brush_info: { tint: [0.5, 0.5, 0.5, 1] },
+    });
+    const label = widget({
+      name: 'Caption',
+      parent: 'Card',
+      text_info: { text: 'Hello', font_size: 20, color: [0.6, 0.6, 0.6, 1] },
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, panel, label]), { strictness: 'standard' });
+    expect(findingsFor(result, 'ui_text_contrast_below_minimum')).toHaveLength(1);
+  });
+
+  it('skips contrast when the backdrop is translucent and therefore unknown', () => {
+    const panel = widget({
+      name: 'Card',
+      class: 'Border',
+      parent: 'Root',
+      is_panel: true,
+      child_count: 1,
+      brush_info: { tint: [0.5, 0.5, 0.5, 0.4] },
+    });
+    const label = widget({
+      name: 'Caption',
+      parent: 'Card',
+      text_info: { text: 'Hello', font_size: 20, color: [0.6, 0.6, 0.6, 1] },
+    });
+    const result = validateUiSnapshot(snapshot([rootPanel, panel, label]), { strictness: 'standard' });
+    expect(findingsFor(result, 'ui_text_contrast_below_minimum')).toHaveLength(0);
+  });
+});
+
+describe('strictness and configuration', () => {
+  it('raising strictness only ever adds findings', () => {
+    const widgets = [
+      rootPanel,
+      widget({ name: 'TextBlock_12', x: 101, y: 103, text_info: { text: 'Hi', font_size: 20 } }),
+      widget({ name: 'Panel_3', class: 'VerticalBox', is_panel: true, child_count: 1 }),
+    ];
+    const snap = snapshot(widgets);
+    const relaxed = validateUiSnapshot(snap, { strictness: 'relaxed' }).findings.map((f) => f.ruleId);
+    const standard = validateUiSnapshot(snap, { strictness: 'standard' }).findings.map((f) => f.ruleId);
+    const strict = validateUiSnapshot(snap, { strictness: 'strict' }).findings.map((f) => f.ruleId);
+
+    for (const id of relaxed) expect(standard).toContain(id);
+    for (const id of standard) expect(strict).toContain(id);
+    expect(strict.length).toBeGreaterThan(relaxed.length);
+  });
+
+  it('honours the persisted per-category strictness', () => {
+    setStrictness('strict', 'ui');
+    const widgets = [rootPanel, widget({ name: 'TextBlock_12', text_info: { text: 'Hi', font_size: 20 } })];
+    const result = validateUiSnapshot(snapshot(widgets));
+    expect(result.strictness).toBe('strict');
+    expect(findingsFor(result, 'ui_default_widget_name')).toHaveLength(1);
+  });
+
+  it('respects a disabled rule and reports it as disabled rather than passing', () => {
+    setRuleDisabled('ui_font_too_small', true);
+    const label = widget({ name: 'Tiny', text_info: { text: 'x', font_size: 4 } });
+    const result = validateUiSnapshot(snapshot([rootPanel, label]), { platform: 'console' });
+    expect(findingsFor(result, 'ui_font_too_small')).toHaveLength(0);
+    expect(result.rules_disabled).toContain('ui_font_too_small');
+  });
+});
+
+describe('missing layout is reported, never assumed to pass', () => {
+  it('skips geometry rules and lists them when the layout could not be resolved', () => {
+    const label = widget({ name: 'Label', laid_out: false });
+    const result = validateUiSnapshot(
+      snapshot([rootPanel, label], { layout_resolved: false, layout_error: 'needs compiling' }),
+      { strictness: 'standard' },
+    );
+    expect(result.layout_resolved).toBe(false);
+    expect(result.layout_error).toBe('needs compiling');
+    expect(result.rules_skipped_no_layout).toContain('ui_text_overflows_box');
+    expect(result.rules_skipped_no_layout).toContain('ui_interactive_targets_touch');
+    // Non-geometry rules still run.
+    expect(result.rules_evaluated).toBeGreaterThan(0);
+  });
+});
+
+describe('catalogue integrity', () => {
+  it('has unique rule ids', () => {
+    const ids = UI_RULES.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every rule id is namespaced to the ui category', () => {
+    for (const r of UI_RULES) {
+      expect(r.id.startsWith('ui_')).toBe(true);
+      expect(r.category).toBe('ui');
+    }
+  });
+
+  it('no rule throws on an empty snapshot', () => {
+    const result = validateUiSnapshot(snapshot([]), { strictness: 'strict' });
+    const threw = result.findings.filter((f) => f.hint.includes('threw'));
+    expect(threw).toHaveLength(0);
+  });
+
+  it('no rule throws on a snapshot with a cyclic parent reference', () => {
+    // Defensive: a malformed snapshot must not hang or crash the pass.
+    const a = widget({ name: 'A', parent: 'B', is_panel: true, child_count: 1 });
+    const b = widget({ name: 'B', parent: 'A', is_panel: true, child_count: 1 });
+    const result = validateUiSnapshot(snapshot([a, b]), { strictness: 'strict' });
+    expect(result.findings.filter((f) => f.hint.includes('threw'))).toHaveLength(0);
+  });
+});

--- a/mcp-tools/hayba-mcp/tests/routing-integration.test.ts
+++ b/mcp-tools/hayba-mcp/tests/routing-integration.test.ts
@@ -30,6 +30,7 @@ function fixtureCaptured(): Map<string, CapturedTool> {
     ['validator_clear',             'validator'],
     ['validator_rules',             'validator'],
     ['validator_set_rule_enabled',  'validator'],
+    ['validator_strictness',        'validator'],
     // PLUMB constraint subsystem — captured under the plumb dir, re-registered
     // as always-on via passthrough.
     ['plumb_primitives',            'plumb'],

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
@@ -112,6 +112,9 @@ static bool IsDestructiveCommand(const FString& Cmd)
         TEXT("gas_create_ability"),
         TEXT("gas_create_effect"),
         TEXT("ui_create_widget"),
+        TEXT("ui_set_widget_properties"),
+        TEXT("ui_mutate_tree"),
+        TEXT("ui_save_widget"),
         TEXT("input_create_action"),
         TEXT("input_create_mapping"),
         // Memory

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
@@ -228,6 +228,64 @@ static void PushSceneGraphToPanel(const TSharedPtr<FJsonObject>& Data)
     });
 }
 
+/** Push findings produced OUTSIDE the editor into the Validation panel.
+ *  The panel is push-only from in here, so MCP-side validators (ui_validate
+ *  and anything else that judges a snapshot rather than the live world) have
+ *  no other way to surface. Without this their findings only ever exist in a
+ *  tool response the user never opens.
+ *
+ *  Params: { findings: [{ rule_id, severity, message, hint?, widget? }],
+ *            append?: bool }  — append keeps earlier findings on screen. */
+static void PushExternalFindingsToPanel(const TSharedPtr<FJsonObject>& Data)
+{
+    if (!Data.IsValid()) return;
+
+    TArray<FHaybaValidationIssue> Issues;
+    const TArray<TSharedPtr<FJsonValue>>* FindingsArr = nullptr;
+    if (Data->TryGetArrayField(TEXT("findings"), FindingsArr) && FindingsArr)
+    {
+        for (const auto& V : *FindingsArr)
+        {
+            const TSharedPtr<FJsonObject> F = V->AsObject();
+            if (!F.IsValid()) continue;
+
+            FHaybaValidationIssue I;
+            F->TryGetStringField(TEXT("rule_id"), I.IssueType);
+            F->TryGetStringField(TEXT("widget"), I.ActorLabel);
+
+            FString Message, Hint;
+            F->TryGetStringField(TEXT("message"), Message);
+            F->TryGetStringField(TEXT("hint"), Hint);
+            // The hint is the actionable half of a finding; keeping it out of
+            // the panel would strip the part that says what to actually do.
+            I.Description = Hint.IsEmpty() ? Message : FString::Printf(TEXT("%s — %s"), *Message, *Hint);
+
+            FString Severity;
+            F->TryGetStringField(TEXT("severity"), Severity);
+            if (Severity.Equals(TEXT("error"), ESearchCase::IgnoreCase))        I.Severity = EHaybaSeverity::Error;
+            else if (Severity.Equals(TEXT("warning"), ESearchCase::IgnoreCase)) I.Severity = EHaybaSeverity::Warning;
+            else                                                                I.Severity = EHaybaSeverity::Info;
+
+            Issues.Add(MoveTemp(I));
+        }
+    }
+
+    bool bAppend = false;
+    Data->TryGetBoolField(TEXT("append"), bAppend);
+
+    AsyncTask(ENamedThreads::GameThread, [Issues = MoveTemp(Issues), bAppend]()
+    {
+        if (FHaybaMCPModule* M = FModuleManager::GetModulePtr<FHaybaMCPModule>("HaybaMCPToolkit"))
+        {
+            if (TSharedPtr<SHaybaMCPValidationPanel> Panel = M->ValidationPanel.Pin())
+            {
+                if (!bAppend) Panel->Clear();
+                for (const auto& I : Issues) Panel->AddIssue(I);
+            }
+        }
+    });
+}
+
 static void PushPhysicsResultsToPanel(const TSharedPtr<FJsonObject>& Data)
 {
     if (!Data.IsValid()) return;
@@ -947,6 +1005,9 @@ FString FHaybaMCPCommandHandler::ProcessCommand(const FString& CommandJson)
         if (Cmd == TEXT("scene_get_graph"))           PushSceneGraphToPanel(Result.Data);
         else if (Cmd == TEXT("scene_validate_physics")) PushPhysicsResultsToPanel(Result.Data);
         else if (Cmd == TEXT("memory_query"))           PushMemoryResultsToPanel(Result.Data);
+        // ui_report_findings carries its payload in the REQUEST, not the
+        // response, because the findings were judged MCP-side.
+        else if (Cmd == TEXT("ui_report_findings"))      PushExternalFindingsToPanel(Params);
     }
     // Log destructive ops to the Diff panel with true Before / requested After.
     if (Result.bOk)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
@@ -864,8 +864,15 @@ FString FHaybaMCPCommandHandler::ProcessCommand(const FString& CommandJson)
     // Initiative #1: wrap every destructive op in a native editor transaction
     // so the user can revert AI mutations with Ctrl+Z. Read-only commands
     // skip this for zero overhead.
+    //
+    // Skipped entirely during an active PIE session: the global transaction
+    // buffer (GEditor->Trans) can end up retaining a reference into the PIE
+    // world/GameInstance, which crashes the editor on PIE stop with
+    // "Object 'GameInstance ...' from PIE level still referenced". AI-driven
+    // edits made mid-PIE don't need undo support badly enough to risk that.
     const bool bDestructive = IsDestructiveCommand(Cmd);
-    if (bDestructive && GEditor)
+    const bool bInPIE = GEditor && GEditor->PlayWorld != nullptr;
+    if (bDestructive && GEditor && !bInPIE)
     {
         const FText TxText = FText::FromString(FString::Printf(TEXT("Hayba: %s"), *Cmd));
         GEditor->BeginTransaction(TxText);
@@ -921,7 +928,7 @@ FString FHaybaMCPCommandHandler::ProcessCommand(const FString& CommandJson)
 
     const int64 DurMs = (int64)((FPlatformTime::Seconds() - Start) * 1000.0);
 
-    if (bDestructive && GEditor)
+    if (bDestructive && GEditor && !bInPIE)
     {
         // Cancel the transaction if the handler reported failure — leaves no
         // empty undo entry. Otherwise end normally so Ctrl+Z reverts the op.

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPUIHandlerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPUIHandlerTest.cpp
@@ -1,0 +1,59 @@
+#include "Misc/AutomationTest.h"
+
+#if WITH_EDITOR
+#include "EditorAssetLibrary.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "WidgetBlueprint.h"
+#include "handlers/HaybaMCPUIHandler.h"
+#endif
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaMCPUIWidgetGuidTest,
+    "Hayba.MCP.UI.WidgetGuidRegistration",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaMCPUIWidgetGuidTest::RunTest(const FString& Parameters)
+{
+#if WITH_EDITOR
+    const FString AssetName = FString::Printf(TEXT("WBP_WidgetGuid_%s"), *FGuid::NewGuid().ToString(EGuidFormats::Digits));
+    const FString PackagePath = TEXT("/Game/HaybaMCPAutomation");
+    const FString AssetPath = FString::Printf(TEXT("%s/%s"), *PackagePath, *AssetName);
+
+    FHaybaMCPUIHandler Handler;
+
+    TSharedPtr<FJsonObject> CreateParams = MakeShared<FJsonObject>();
+    CreateParams->SetStringField(TEXT("path"), PackagePath);
+    CreateParams->SetStringField(TEXT("name"), AssetName);
+    CreateParams->SetStringField(TEXT("parent_class"), TEXT("UserWidget"));
+    const FHaybaHandlerResult CreateResult = Handler.Handle(TEXT("ui_create_widget"), CreateParams);
+    TestTrue(TEXT("ui_create_widget succeeds"), CreateResult.bOk);
+
+    FString ObjectPath;
+    if (CreateResult.bOk && CreateResult.Data.IsValid())
+    {
+        CreateResult.Data->TryGetStringField(TEXT("path"), ObjectPath);
+    }
+
+    TSharedPtr<FJsonObject> AddParams = MakeShared<FJsonObject>();
+    AddParams->SetStringField(TEXT("widget_blueprint_path"), ObjectPath);
+    AddParams->SetStringField(TEXT("child_class"), TEXT("Button"));
+    AddParams->SetStringField(TEXT("name"), TEXT("TestButton"));
+    const FHaybaHandlerResult AddResult = Handler.Handle(TEXT("ui_add_element"), AddParams);
+    TestTrue(TEXT("ui_add_element succeeds"), AddResult.bOk);
+
+    UWidgetBlueprint* WidgetBlueprint = LoadObject<UWidgetBlueprint>(nullptr, *ObjectPath);
+    if (TestNotNull(TEXT("created widget blueprint loads"), WidgetBlueprint))
+    {
+        const FGuid* RootGuid = WidgetBlueprint->WidgetVariableNameToGuidMap.Find(TEXT("RootCanvas"));
+        const FGuid* ButtonGuid = WidgetBlueprint->WidgetVariableNameToGuidMap.Find(TEXT("TestButton"));
+        TestTrue(TEXT("root widget has a valid variable GUID"), RootGuid && RootGuid->IsValid());
+        TestTrue(TEXT("added widget has a valid variable GUID"), ButtonGuid && ButtonGuid->IsValid());
+
+        FKismetEditorUtilities::CompileBlueprint(WidgetBlueprint);
+        TestEqual(TEXT("widget blueprint compiles successfully"), WidgetBlueprint->Status, BS_UpToDate);
+    }
+
+    TestTrue(TEXT("temporary widget blueprint is deleted"), UEditorAssetLibrary::DeleteAsset(AssetPath));
+#endif
+    return true;
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -902,8 +902,10 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
     int32 Failed = 0;
     TArray<FString> FailedProps;
     {
-        FScopedTransaction Transaction(NSLOCTEXT("HaybaMCPUI", "SetWidgetProperties", "Set Widget Properties"));
-
+        // No FScopedTransaction: these are automation-tool edits with no undo/redo
+        // requirement, and the global editor transaction buffer (GEditor->Trans) can
+        // end up retaining a reference into a PIE session, crashing the editor on PIE
+        // stop with "Object 'GameInstance ...' from PIE level still referenced".
         WBP->Modify();
         Widget->Modify();
 
@@ -1027,7 +1029,8 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
         int32 OldChildIndex = -1;
 
         {
-            FScopedTransaction Transaction(NSLOCTEXT("HaybaMCPUI", "MutateTreeRemove", "Remove Widget"));
+            // No FScopedTransaction — see comment in ui_set_widget_properties above:
+            // avoids pinning a PIE GameInstance reference in the editor undo buffer.
             WBP->Modify();
             Widget->Modify();
 
@@ -1110,7 +1113,8 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
         FString OldParentName = OldParent->GetName();
 
         {
-            FScopedTransaction Transaction(NSLOCTEXT("HaybaMCPUI", "MutateTreeReparent", "Reparent Widget"));
+            // No FScopedTransaction — see comment in ui_set_widget_properties above:
+            // avoids pinning a PIE GameInstance reference in the editor undo buffer.
             WBP->Modify();
             Widget->Modify();
             OldParent->Modify();
@@ -1160,7 +1164,8 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
         FString OldClass = Widget->GetClass()->GetName();
 
         {
-            FScopedTransaction Transaction(NSLOCTEXT("HaybaMCPUI", "MutateTreeReplace", "Replace Widget"));
+            // No FScopedTransaction — see comment in ui_set_widget_properties above:
+            // avoids pinning a PIE GameInstance reference in the editor undo buffer.
             WBP->Modify();
             Widget->Modify();
             Parent->Modify();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -1,5 +1,6 @@
 #include "HaybaMCPUIHandler.h"
 #include "Json.h"
+#include "Editor.h"
 
 #if WITH_EDITOR
 #include "WidgetBlueprint.h"
@@ -15,27 +16,57 @@
 #include "Components/VerticalBox.h"
 #include "Components/HorizontalBoxSlot.h"
 #include "Components/VerticalBoxSlot.h"
+#include "Components/Overlay.h"
+#include "Components/OverlaySlot.h"
+#include "Components/ScrollBox.h"
+#include "Components/ScrollBoxSlot.h"
+#include "Components/Border.h"
+#include "Components/BorderSlot.h"
+#include "Components/GridPanel.h"
+#include "Components/GridSlot.h"
+#include "Components/UniformGridPanel.h"
+#include "Components/UniformGridSlot.h"
+#include "Components/SizeBox.h"
+#include "Components/SizeBoxSlot.h"
 #include "Components/Button.h"
 #include "Components/TextBlock.h"
 #include "Components/Image.h"
-#include "Components/Overlay.h"
-#include "Components/ScrollBox.h"
-#include "Components/Border.h"
-#include "Components/GridPanel.h"
-#include "Components/UniformGridPanel.h"
-#include "Components/SizeBox.h"
 #include "Components/Spacer.h"
 #include "Components/CheckBox.h"
 #include "Components/EditableTextBox.h"
 #include "Components/ProgressBar.h"
 #include "Components/Slider.h"
+#include "Components/MultiLineEditableTextBox.h"
+#include "Components/Throbber.h"
+#include "Components/SpinBox.h"
+#include "Components/ComboBoxString.h"
+#include "Components/ListView.h"
+#include "Components/TreeView.h"
+#include "Components/TileView.h"
+#include "Components/MenuAnchor.h"
+#include "Components/NativeWidgetHost.h"
+#include "Components/RetainerBox.h"
+#include "Components/ScaleBox.h"
+#include "Components/WidgetSwitcher.h"
+#include "Components/WidgetSwitcherSlot.h"
+#include "Components/WrapBox.h"
+#include "Components/WrapBoxSlot.h"
+#include "Components/NamedSlot.h"
+#include "Components/BackgroundBlur.h"
+#include "Components/ExpandableArea.h"
 #include "AssetToolsModule.h"
 #include "IAssetTools.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "Kismet2/CompilerResultsLog.h"
+#include "Logging/TokenizedMessage.h"
 #include "UObject/Package.h"
+#include "UObject/SavePackage.h"
 #include "Misc/PackageName.h"
 #include "Layout/Margin.h"
+#include "HaybaMCPReflection.h"
+#include "HaybaMCPParams.h"
 #endif
 
 DEFINE_LOG_CATEGORY_STATIC(LogHaybaMCPUI, Log, All);
@@ -45,7 +76,12 @@ TArray<FString> FHaybaMCPUIHandler::GetCommands() const
     return {
         TEXT("ui_create_widget"),
         TEXT("ui_add_element"),
-        TEXT("ui_query")
+        TEXT("ui_set_widget_properties"),
+        TEXT("ui_query"),
+        TEXT("ui_mutate_tree"),
+        TEXT("ui_compile_widget"),
+        TEXT("ui_save_widget"),
+        TEXT("ui_list_widget_types"),
     };
 }
 
@@ -69,32 +105,44 @@ namespace
 
     UClass* ResolveWidgetClass(const FString& Name)
     {
-        // Try common UMG widget classes by short name first.
         static const TMap<FString, UClass*> Known = []
         {
             TMap<FString, UClass*> M;
-            M.Add(TEXT("Button"),           UButton::StaticClass());
-            M.Add(TEXT("TextBlock"),        UTextBlock::StaticClass());
-            M.Add(TEXT("Image"),            UImage::StaticClass());
-            M.Add(TEXT("CanvasPanel"),      UCanvasPanel::StaticClass());
-            M.Add(TEXT("HorizontalBox"),    UHorizontalBox::StaticClass());
-            M.Add(TEXT("VerticalBox"),      UVerticalBox::StaticClass());
-            M.Add(TEXT("Overlay"),          UOverlay::StaticClass());
-            M.Add(TEXT("ScrollBox"),        UScrollBox::StaticClass());
-            M.Add(TEXT("Border"),           UBorder::StaticClass());
-            M.Add(TEXT("GridPanel"),        UGridPanel::StaticClass());
-            M.Add(TEXT("UniformGridPanel"), UUniformGridPanel::StaticClass());
-            M.Add(TEXT("SizeBox"),          USizeBox::StaticClass());
-            M.Add(TEXT("Spacer"),           USpacer::StaticClass());
-            M.Add(TEXT("CheckBox"),         UCheckBox::StaticClass());
-            M.Add(TEXT("EditableTextBox"),  UEditableTextBox::StaticClass());
-            M.Add(TEXT("ProgressBar"),      UProgressBar::StaticClass());
-            M.Add(TEXT("Slider"),           USlider::StaticClass());
+            M.Add(TEXT("Button"),             UButton::StaticClass());
+            M.Add(TEXT("TextBlock"),          UTextBlock::StaticClass());
+            M.Add(TEXT("Image"),              UImage::StaticClass());
+            M.Add(TEXT("CanvasPanel"),        UCanvasPanel::StaticClass());
+            M.Add(TEXT("HorizontalBox"),      UHorizontalBox::StaticClass());
+            M.Add(TEXT("VerticalBox"),        UVerticalBox::StaticClass());
+            M.Add(TEXT("Overlay"),            UOverlay::StaticClass());
+            M.Add(TEXT("ScrollBox"),          UScrollBox::StaticClass());
+            M.Add(TEXT("Border"),             UBorder::StaticClass());
+            M.Add(TEXT("GridPanel"),          UGridPanel::StaticClass());
+            M.Add(TEXT("UniformGridPanel"),   UUniformGridPanel::StaticClass());
+            M.Add(TEXT("SizeBox"),            USizeBox::StaticClass());
+            M.Add(TEXT("Spacer"),             USpacer::StaticClass());
+            M.Add(TEXT("CheckBox"),           UCheckBox::StaticClass());
+            M.Add(TEXT("EditableTextBox"),    UEditableTextBox::StaticClass());
+            M.Add(TEXT("MultiLineEditableTextBox"), UMultiLineEditableTextBox::StaticClass());
+            M.Add(TEXT("ProgressBar"),        UProgressBar::StaticClass());
+            M.Add(TEXT("Slider"),             USlider::StaticClass());
+            M.Add(TEXT("SpinBox"),            USpinBox::StaticClass());
+            M.Add(TEXT("ComboBoxString"),     UComboBoxString::StaticClass());
+            M.Add(TEXT("Throbber"),           UThrobber::StaticClass());
+            M.Add(TEXT("ListView"),           UListView::StaticClass());
+            M.Add(TEXT("TreeView"),           UTreeView::StaticClass());
+            M.Add(TEXT("TileView"),           UTileView::StaticClass());
+            M.Add(TEXT("WidgetSwitcher"),     UWidgetSwitcher::StaticClass());
+            M.Add(TEXT("WrapBox"),            UWrapBox::StaticClass());
+            M.Add(TEXT("ScaleBox"),           UScaleBox::StaticClass());
+            M.Add(TEXT("RetainerBox"),        URetainerBox::StaticClass());
+            M.Add(TEXT("BackgroundBlur"),     UBackgroundBlur::StaticClass());
+            M.Add(TEXT("ExpandableArea"),     UExpandableArea::StaticClass());
+            M.Add(TEXT("MenuAnchor"),         UMenuAnchor::StaticClass());
             return M;
         }();
         if (UClass* const* Found = Known.Find(Name)) return *Found;
 
-        // Allow full class paths / "UMyWidget" / "MyWidget" lookups.
         if (UClass* C = LoadClass<UWidget>(nullptr, *Name)) return C;
         if (UClass* C = FindFirstObjectSafe<UClass>(*Name)) return C;
         if (!Name.StartsWith(TEXT("U")))
@@ -116,125 +164,575 @@ namespace
         return Hit;
     }
 
-    void TrySetByReflection(UObject* Obj, const FString& PropName, const TSharedPtr<FJsonValue>& Val)
+    FString ResolveSlotType(UWidget* W)
     {
-        if (!Obj || !Val.IsValid()) return;
-        FProperty* Prop = Obj->GetClass()->FindPropertyByName(FName(*PropName));
-        if (!Prop) return;
-        FString Text;
-        switch (Val->Type)
+        if (!W || !W->Slot) return TEXT("None");
+        UPanelSlot* S = W->Slot;
+        if (Cast<UCanvasPanelSlot>(S))      return TEXT("CanvasPanelSlot");
+        if (Cast<UHorizontalBoxSlot>(S))    return TEXT("HorizontalBoxSlot");
+        if (Cast<UVerticalBoxSlot>(S))      return TEXT("VerticalBoxSlot");
+        if (Cast<UOverlaySlot>(S))          return TEXT("OverlaySlot");
+        if (Cast<UGridSlot>(S))             return TEXT("GridSlot");
+        if (Cast<UUniformGridSlot>(S))      return TEXT("UniformGridSlot");
+        if (Cast<UScrollBoxSlot>(S))        return TEXT("ScrollBoxSlot");
+        if (Cast<UBorderSlot>(S))           return TEXT("BorderSlot");
+        if (Cast<USizeBoxSlot>(S))          return TEXT("SizeBoxSlot");
+        if (Cast<UWidgetSwitcherSlot>(S))   return TEXT("WidgetSwitcherSlot");
+        if (Cast<UWrapBoxSlot>(S))          return TEXT("WrapBoxSlot");
+        return S->GetClass()->GetName();
+    }
+
+    bool ValidateWidgetName(UWidgetTree* Tree, const FString& Name)
+    {
+        if (!Tree || Name.IsEmpty()) return false;
+        UWidget* Existing = nullptr;
+        Tree->ForEachWidget([&](UWidget* W)
         {
-        case EJson::Number:  Text = FString::SanitizeFloat(Val->AsNumber()); break;
-        case EJson::Boolean: Text = Val->AsBool() ? TEXT("True") : TEXT("False"); break;
-        case EJson::String:  Val->TryGetString(Text); break;
-        default: return;
+            if (Existing) return;
+            if (W && W->GetName() == Name) Existing = W;
+        });
+        return Existing == nullptr;
+    }
+
+    static EHorizontalAlignment ParseHAlign(const FString& S)
+    {
+        const FString Low = S.ToLower();
+        if (Low == TEXT("fill"))   return HAlign_Fill;
+        if (Low == TEXT("left"))   return HAlign_Left;
+        if (Low == TEXT("center")) return HAlign_Center;
+        if (Low == TEXT("right"))  return HAlign_Right;
+        return HAlign_Fill;
+    }
+
+    static EVerticalAlignment ParseVAlign(const FString& S)
+    {
+        const FString Low = S.ToLower();
+        if (Low == TEXT("fill"))   return VAlign_Fill;
+        if (Low == TEXT("top"))    return VAlign_Top;
+        if (Low == TEXT("center")) return VAlign_Center;
+        if (Low == TEXT("bottom")) return VAlign_Bottom;
+        return VAlign_Fill;
+    }
+
+    static FMargin ParseMargin(const TSharedPtr<FJsonObject>& Props, const FString& Key)
+    {
+        const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+        if (Props->TryGetArrayField(Key, Arr) && Arr && Arr->Num() >= 4)
+        {
+            return FMargin(
+                (float)(*Arr)[0]->AsNumber(),
+                (float)(*Arr)[1]->AsNumber(),
+                (float)(*Arr)[2]->AsNumber(),
+                (float)(*Arr)[3]->AsNumber()
+            );
         }
-        Prop->ImportText_Direct(*Text, Prop->ContainerPtrToValuePtr<void>(Obj), Obj, PPF_None);
+        double Single = 0.0;
+        if (Props->TryGetNumberField(Key, Single))
+        {
+            return FMargin((float)Single);
+        }
+        // MCP callers naturally send named edges ({left, top, right, bottom});
+        // support that form alongside the original positional array.
+        const TSharedPtr<FJsonObject>* Obj = nullptr;
+        if (Props->TryGetObjectField(Key, Obj) && Obj && Obj->IsValid())
+        {
+            double Left = 0.0, Top = 0.0, Right = 0.0, Bottom = 0.0;
+            (*Obj)->TryGetNumberField(TEXT("left"), Left);
+            (*Obj)->TryGetNumberField(TEXT("top"), Top);
+            (*Obj)->TryGetNumberField(TEXT("right"), Right);
+            (*Obj)->TryGetNumberField(TEXT("bottom"), Bottom);
+            return FMargin((float)Left, (float)Top, (float)Right, (float)Bottom);
+        }
+        return FMargin(0.0f);
+    }
+
+    static FVector2D ParseVec2(const TSharedPtr<FJsonObject>& Props, const FString& Key)
+    {
+        const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+        if (Props->TryGetArrayField(Key, Arr) && Arr && Arr->Num() >= 2)
+        {
+            return FVector2D(
+                (float)(*Arr)[0]->AsNumber(),
+                (float)(*Arr)[1]->AsNumber()
+            );
+        }
+        const TSharedPtr<FJsonObject>* Obj = nullptr;
+        if (Props->TryGetObjectField(Key, Obj) && Obj && Obj->IsValid())
+        {
+            double X = 0.0, Y = 0.0;
+            (*Obj)->TryGetNumberField(TEXT("x"), X);
+            (*Obj)->TryGetNumberField(TEXT("y"), Y);
+            return FVector2D((float)X, (float)Y);
+        }
+        return FVector2D::ZeroVector;
     }
 
     void ApplySlotProps(UPanelSlot* Slot, const TSharedPtr<FJsonObject>& Props)
     {
         if (!Slot || !Props.IsValid()) return;
 
-        // CanvasPanelSlot — x/y/w/h → Offsets, anchors defaulted to top-left.
+        // CanvasPanelSlot
         if (UCanvasPanelSlot* CSlot = Cast<UCanvasPanelSlot>(Slot))
         {
-            FAnchors Anchors(0.f, 0.f, 0.f, 0.f);
-            CSlot->SetAnchors(Anchors);
-            FMargin Offsets = CSlot->GetOffsets();
-            double X, Y, W, H;
-            if (Props->TryGetNumberField(TEXT("x"), X)) Offsets.Left = X;
-            if (Props->TryGetNumberField(TEXT("y"), Y)) Offsets.Top  = Y;
-            if (Props->TryGetNumberField(TEXT("w"), W)) Offsets.Right  = W;
-            if (Props->TryGetNumberField(TEXT("h"), H)) Offsets.Bottom = H;
-            CSlot->SetOffsets(Offsets);
-            CSlot->SetAutoSize(false);
+            double AnchorMinX, AnchorMinY, AnchorMaxX, AnchorMaxY;
+            if (Props->TryGetNumberField(TEXT("anchor_min_x"), AnchorMinX) ||
+                Props->TryGetNumberField(TEXT("anchor_min_y"), AnchorMinY) ||
+                Props->TryGetNumberField(TEXT("anchor_max_x"), AnchorMaxX) ||
+                Props->TryGetNumberField(TEXT("anchor_max_y"), AnchorMaxY))
+            {
+                FAnchors Anchors = CSlot->GetAnchors();
+                if (Props->TryGetNumberField(TEXT("anchor_min_x"), AnchorMinX)) Anchors.Minimum.X = AnchorMinX;
+                if (Props->TryGetNumberField(TEXT("anchor_min_y"), AnchorMinY)) Anchors.Minimum.Y = AnchorMinY;
+                if (Props->TryGetNumberField(TEXT("anchor_max_x"), AnchorMaxX)) Anchors.Maximum.X = AnchorMaxX;
+                if (Props->TryGetNumberField(TEXT("anchor_max_y"), AnchorMaxY)) Anchors.Maximum.Y = AnchorMaxY;
+                CSlot->SetAnchors(Anchors);
+            }
+            const TSharedPtr<FJsonObject>* AnchorsObj = nullptr;
+            if (Props->TryGetObjectField(TEXT("anchors"), AnchorsObj) && AnchorsObj && AnchorsObj->IsValid())
+            {
+                FAnchors A;
+                double MinX = 0.0, MinY = 0.0, MaxX = 0.0, MaxY = 0.0;
+                (*AnchorsObj)->TryGetNumberField(TEXT("min_x"), MinX);
+                (*AnchorsObj)->TryGetNumberField(TEXT("min_y"), MinY);
+                (*AnchorsObj)->TryGetNumberField(TEXT("max_x"), MaxX);
+                (*AnchorsObj)->TryGetNumberField(TEXT("max_y"), MaxY);
+                A.Minimum = FVector2D(MinX, MinY);
+                A.Maximum = FVector2D(MaxX, MaxY);
+                CSlot->SetAnchors(A);
+            }
+
+            double OffX, OffY, OffW, OffH;
+            const bool bHasOffX = Props->TryGetNumberField(TEXT("x"), OffX);
+            const bool bHasOffY = Props->TryGetNumberField(TEXT("y"), OffY);
+            const bool bHasOffW = Props->TryGetNumberField(TEXT("w"), OffW);
+            const bool bHasOffH = Props->TryGetNumberField(TEXT("h"), OffH);
+            if (bHasOffX || bHasOffY || bHasOffW || bHasOffH)
+            {
+                FMargin Offsets = CSlot->GetOffsets();
+                if (bHasOffX) Offsets.Left   = OffX;
+                if (bHasOffY) Offsets.Top    = OffY;
+                if (bHasOffW) Offsets.Right  = OffW;
+                if (bHasOffH) Offsets.Bottom = OffH;
+                CSlot->SetOffsets(Offsets);
+            }
+
+            FVector2D Position = ParseVec2(Props, TEXT("position"));
+            if (!Position.IsZero() || Props->HasField(TEXT("position")))
+                CSlot->SetPosition(Position);
+
+            FVector2D Size = ParseVec2(Props, TEXT("size"));
+            if (!Size.IsZero() || Props->HasField(TEXT("size")))
+                CSlot->SetSize(Size);
+
+            FVector2D Alignment = ParseVec2(Props, TEXT("alignment"));
+            if (!Alignment.IsZero() || Props->HasField(TEXT("alignment")))
+                CSlot->SetAlignment(Alignment);
+
+            bool bAutoSize = false;
+            if (Props->TryGetBoolField(TEXT("auto_size"), bAutoSize))
+                CSlot->SetAutoSize(bAutoSize);
+
+            int32 ZOrder = 0;
+            if (Props->TryGetNumberField(TEXT("z_order"), ZOrder))
+                CSlot->SetZOrder(ZOrder);
         }
 
-        // HorizontalBoxSlot / VerticalBoxSlot — fill + padding.
-        double Fill = 0.0;
-        const bool bHaveFill = Props->TryGetNumberField(TEXT("fill"), Fill);
-        double Pad = 0.0;
-        const bool bHavePad = Props->TryGetNumberField(TEXT("padding"), Pad);
-
+        // HorizontalBoxSlot
         if (UHorizontalBoxSlot* HSlot = Cast<UHorizontalBoxSlot>(Slot))
         {
-            if (bHaveFill)
+            double Fill = 0.0;
+            if (Props->TryGetNumberField(TEXT("fill"), Fill))
             {
                 FSlateChildSize Sz;
-                Sz.Value = Fill;
+                Sz.Value = (float)Fill;
                 Sz.SizeRule = Fill > 0.0 ? ESlateSizeRule::Fill : ESlateSizeRule::Automatic;
                 HSlot->SetSize(Sz);
             }
-            if (bHavePad) HSlot->SetPadding(FMargin(Pad));
+            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
+            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
+                HSlot->SetPadding(Pad);
+
+            FString HAlign, VAlign;
+            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
+                HSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
+            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
+                HSlot->SetVerticalAlignment(ParseVAlign(VAlign));
         }
-        else if (UVerticalBoxSlot* VSlot = Cast<UVerticalBoxSlot>(Slot))
+
+        // VerticalBoxSlot
+        if (UVerticalBoxSlot* VSlot = Cast<UVerticalBoxSlot>(Slot))
         {
-            if (bHaveFill)
+            double Fill = 0.0;
+            if (Props->TryGetNumberField(TEXT("fill"), Fill))
             {
                 FSlateChildSize Sz;
-                Sz.Value = Fill;
+                Sz.Value = (float)Fill;
                 Sz.SizeRule = Fill > 0.0 ? ESlateSizeRule::Fill : ESlateSizeRule::Automatic;
                 VSlot->SetSize(Sz);
             }
-            if (bHavePad) VSlot->SetPadding(FMargin(Pad));
+            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
+            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
+                VSlot->SetPadding(Pad);
+
+            FString HAlign, VAlign;
+            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
+                VSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
+            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
+                VSlot->SetVerticalAlignment(ParseVAlign(VAlign));
         }
 
-        // Generic reflection fall-through for any other documented slot prop.
-        for (const auto& Pair : Props->Values)
+        // OverlaySlot
+        if (UOverlaySlot* OSlot = Cast<UOverlaySlot>(Slot))
         {
-            const FString Key = FString(*Pair.Key);
-            if (Key == TEXT("x") || Key == TEXT("y") || Key == TEXT("w") || Key == TEXT("h")
-                || Key == TEXT("fill") || Key == TEXT("padding")) continue;
-            TrySetByReflection(Slot, Key, Pair.Value);
+            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
+            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
+                OSlot->SetPadding(Pad);
+
+            FString HAlign, VAlign;
+            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
+                OSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
+            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
+                OSlot->SetVerticalAlignment(ParseVAlign(VAlign));
+        }
+
+        // GridSlot
+        if (UGridSlot* GSlot = Cast<UGridSlot>(Slot))
+        {
+            int32 Row, Column, RowSpan, ColSpan, Layer;
+            if (Props->TryGetNumberField(TEXT("row"), Row))      GSlot->SetRow(Row);
+            if (Props->TryGetNumberField(TEXT("column"), Column)) GSlot->SetColumn(Column);
+            if (Props->TryGetNumberField(TEXT("row_span"), RowSpan))  GSlot->SetRowSpan(RowSpan);
+            if (Props->TryGetNumberField(TEXT("column_span"), ColSpan)) GSlot->SetColumnSpan(ColSpan);
+            if (Props->TryGetNumberField(TEXT("layer"), Layer))   GSlot->SetLayer(Layer);
+
+            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
+            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
+                GSlot->SetPadding(Pad);
+
+            FString HAlign, VAlign;
+            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
+                GSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
+            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
+                GSlot->SetVerticalAlignment(ParseVAlign(VAlign));
+
+            FVector2D Nudge = ParseVec2(Props, TEXT("nudge"));
+            if (!Nudge.IsZero() || Props->HasField(TEXT("nudge")))
+                GSlot->SetNudge(Nudge);
+        }
+
+        // UniformGridSlot
+        if (UUniformGridSlot* USlot = Cast<UUniformGridSlot>(Slot))
+        {
+            int32 Row, Column;
+            if (Props->TryGetNumberField(TEXT("row"), Row))      USlot->SetRow(Row);
+            if (Props->TryGetNumberField(TEXT("column"), Column)) USlot->SetColumn(Column);
+
+            FString HAlign, VAlign;
+            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
+                USlot->SetHorizontalAlignment(ParseHAlign(HAlign));
+            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
+                USlot->SetVerticalAlignment(ParseVAlign(VAlign));
+        }
+
+        // ScrollBoxSlot
+        if (UScrollBoxSlot* ScSlot = Cast<UScrollBoxSlot>(Slot))
+        {
+            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
+            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
+                ScSlot->SetPadding(Pad);
+
+            FString HAlign, VAlign;
+            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
+                ScSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
+            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
+                ScSlot->SetVerticalAlignment(ParseVAlign(VAlign));
+        }
+
+        // BorderSlot
+        if (UBorderSlot* BSlot = Cast<UBorderSlot>(Slot))
+        {
+            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
+            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
+                BSlot->SetPadding(Pad);
+
+            FString HAlign, VAlign;
+            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
+                BSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
+            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
+                BSlot->SetVerticalAlignment(ParseVAlign(VAlign));
+        }
+
+        // SizeBoxSlot
+        if (USizeBoxSlot* SbSlot = Cast<USizeBoxSlot>(Slot))
+        {
+            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
+            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
+                SbSlot->SetPadding(Pad);
+
+            FString HAlign, VAlign;
+            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
+                SbSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
+            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
+                SbSlot->SetVerticalAlignment(ParseVAlign(VAlign));
         }
     }
 
-    TSharedPtr<FJsonObject> WidgetToJson(UWidget* W)
+    TSharedPtr<FJsonObject> ExtractWidgetProperties(UWidget* W)
     {
         TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
         if (!W) return Out;
+
+        // Visibility
+        Out->SetStringField(TEXT("visibility"), UEnum::GetValueAsString(W->GetVisibility()));
+        Out->SetNumberField(TEXT("render_opacity"), W->GetRenderOpacity());
+        Out->SetBoolField(TEXT("is_enabled"), W->GetIsEnabled());
+        Out->SetStringField(TEXT("tool_tip_text"), W->GetToolTipText().ToString());
+
+        // TextBlock
+        if (UTextBlock* TB = Cast<UTextBlock>(W))
+        {
+            Out->SetStringField(TEXT("text"), TB->GetText().ToString());
+            const FSlateFontInfo& Font = TB->GetFont();
+            TSharedPtr<FJsonObject> FontObj = MakeShared<FJsonObject>();
+            FontObj->SetNumberField(TEXT("size"), Font.Size);
+            FontObj->SetStringField(TEXT("typeface_font_name"), Font.TypefaceFontName.ToString());
+            if (Font.FontObject)
+                FontObj->SetStringField(TEXT("font_object"), Font.FontObject->GetPathName());
+            Out->SetObjectField(TEXT("font"), FontObj);
+
+            if (FByteProperty* JustificationProperty = CastField<FByteProperty>(TB->GetClass()->FindPropertyByName(TEXT("Justification"))))
+            {
+                if (JustificationProperty->Enum)
+                {
+                    const uint8 Value = JustificationProperty->GetPropertyValue_InContainer(TB);
+                    Out->SetStringField(TEXT("justification"), JustificationProperty->Enum->GetNameStringByValue(Value));
+                }
+            }
+        }
+
+        // EditableTextBox
+        if (UEditableTextBox* ETB = Cast<UEditableTextBox>(W))
+        {
+            Out->SetStringField(TEXT("text"), ETB->GetText().ToString());
+            Out->SetStringField(TEXT("hint_text"), ETB->GetHintText().ToString());
+        }
+
+        // MultiLineEditableTextBox
+        if (UMultiLineEditableTextBox* MLTB = Cast<UMultiLineEditableTextBox>(W))
+        {
+            Out->SetStringField(TEXT("text"), MLTB->GetText().ToString());
+        }
+
+        // Button
+        if (UButton* Btn = Cast<UButton>(W))
+        {
+            if (Btn->GetChildrenCount() > 0)
+            {
+                if (UTextBlock* ChildText = Cast<UTextBlock>(Btn->GetChildAt(0)))
+                    Out->SetStringField(TEXT("text"), ChildText->GetText().ToString());
+            }
+        }
+
+        // Image
+        if (UImage* Img = Cast<UImage>(W))
+        {
+            const FLinearColor Color = Img->GetColorAndOpacity();
+            TArray<TSharedPtr<FJsonValue>> ColorArr;
+            ColorArr.Add(MakeShared<FJsonValueNumber>(Color.R));
+            ColorArr.Add(MakeShared<FJsonValueNumber>(Color.G));
+            ColorArr.Add(MakeShared<FJsonValueNumber>(Color.B));
+            ColorArr.Add(MakeShared<FJsonValueNumber>(Color.A));
+            Out->SetArrayField(TEXT("color_and_opacity"), ColorArr);
+        }
+
+        // ProgressBar
+        if (UProgressBar* PB = Cast<UProgressBar>(W))
+        {
+            Out->SetNumberField(TEXT("percent"), PB->GetPercent());
+        }
+
+        // Slider
+        if (USlider* Sld = Cast<USlider>(W))
+        {
+            Out->SetNumberField(TEXT("value"), Sld->GetValue());
+            Out->SetNumberField(TEXT("min_value"), Sld->GetMinValue());
+            Out->SetNumberField(TEXT("max_value"), Sld->GetMaxValue());
+        }
+
+        // CheckBox
+        if (UCheckBox* CB = Cast<UCheckBox>(W))
+        {
+            Out->SetBoolField(TEXT("is_checked"), CB->IsChecked());
+        }
+
+        // SpinBox
+        if (USpinBox* SB = Cast<USpinBox>(W))
+        {
+            Out->SetNumberField(TEXT("value"), SB->GetValue());
+            Out->SetNumberField(TEXT("min_value"), SB->GetMinValue());
+            Out->SetNumberField(TEXT("max_value"), SB->GetMaxValue());
+            Out->SetNumberField(TEXT("delta"), SB->GetDelta());
+        }
+
+        return Out;
+    }
+
+    void WidgetToJsonRecursive(UWidget* W, UWidgetBlueprint* WBP, TSharedPtr<FJsonObject>& Out,
+        bool bIncludeSlot, bool bIncludeGuid, bool bIncludeProperties)
+    {
+        if (!W) return;
         Out->SetStringField(TEXT("name"), W->GetName());
         Out->SetStringField(TEXT("class"), W->GetClass()->GetName());
 
-        TSharedPtr<FJsonObject> SlotObj = MakeShared<FJsonObject>();
-        if (UPanelSlot* PS = W->Slot)
+        if (bIncludeGuid && WBP)
         {
-            SlotObj->SetStringField(TEXT("class"), PS->GetClass()->GetName());
-            if (UCanvasPanelSlot* CSlot = Cast<UCanvasPanelSlot>(PS))
+            const FGuid* Found = WBP->WidgetVariableNameToGuidMap.Find(W->GetFName());
+            if (Found && Found->IsValid())
+            {
+                Out->SetStringField(TEXT("guid"), Found->ToString());
+            }
+        }
+
+        if (bIncludeSlot && W->Slot)
+        {
+            TSharedPtr<FJsonObject> SlotObj = MakeShared<FJsonObject>();
+            SlotObj->SetStringField(TEXT("class"), ResolveSlotType(W));
+            UCanvasPanelSlot* CSlot = Cast<UCanvasPanelSlot>(W->Slot);
+            if (CSlot)
             {
                 const FMargin Off = CSlot->GetOffsets();
                 SlotObj->SetNumberField(TEXT("x"), Off.Left);
                 SlotObj->SetNumberField(TEXT("y"), Off.Top);
                 SlotObj->SetNumberField(TEXT("w"), Off.Right);
                 SlotObj->SetNumberField(TEXT("h"), Off.Bottom);
+                const FAnchors Anch = CSlot->GetAnchors();
+                TSharedPtr<FJsonObject> AnchObj = MakeShared<FJsonObject>();
+                AnchObj->SetNumberField(TEXT("min_x"), Anch.Minimum.X);
+                AnchObj->SetNumberField(TEXT("min_y"), Anch.Minimum.Y);
+                AnchObj->SetNumberField(TEXT("max_x"), Anch.Maximum.X);
+                AnchObj->SetNumberField(TEXT("max_y"), Anch.Maximum.Y);
+                SlotObj->SetObjectField(TEXT("anchors"), AnchObj);
+                const FVector2D Pos = CSlot->GetPosition();
+                SlotObj->SetNumberField(TEXT("position_x"), Pos.X);
+                SlotObj->SetNumberField(TEXT("position_y"), Pos.Y);
+                const FVector2D Sz = CSlot->GetSize();
+                SlotObj->SetNumberField(TEXT("size_width"), Sz.X);
+                SlotObj->SetNumberField(TEXT("size_height"), Sz.Y);
+                const FVector2D Align = CSlot->GetAlignment();
+                SlotObj->SetNumberField(TEXT("alignment_x"), Align.X);
+                SlotObj->SetNumberField(TEXT("alignment_y"), Align.Y);
+                SlotObj->SetNumberField(TEXT("z_order"), CSlot->GetZOrder());
             }
-            else if (UHorizontalBoxSlot* HSlot = Cast<UHorizontalBoxSlot>(PS))
+            else if (UHorizontalBoxSlot* HSlot = Cast<UHorizontalBoxSlot>(W->Slot))
             {
                 SlotObj->SetNumberField(TEXT("fill"), HSlot->GetSize().Value);
-                SlotObj->SetNumberField(TEXT("padding"), HSlot->GetPadding().Left);
+                const FMargin P = HSlot->GetPadding();
+                SlotObj->SetNumberField(TEXT("padding_left"), P.Left);
+                SlotObj->SetNumberField(TEXT("padding_top"), P.Top);
+                SlotObj->SetNumberField(TEXT("padding_right"), P.Right);
+                SlotObj->SetNumberField(TEXT("padding_bottom"), P.Bottom);
             }
-            else if (UVerticalBoxSlot* VSlot = Cast<UVerticalBoxSlot>(PS))
+            else if (UVerticalBoxSlot* VSlot = Cast<UVerticalBoxSlot>(W->Slot))
             {
                 SlotObj->SetNumberField(TEXT("fill"), VSlot->GetSize().Value);
-                SlotObj->SetNumberField(TEXT("padding"), VSlot->GetPadding().Left);
+                const FMargin P = VSlot->GetPadding();
+                SlotObj->SetNumberField(TEXT("padding_left"), P.Left);
+                SlotObj->SetNumberField(TEXT("padding_top"), P.Top);
+                SlotObj->SetNumberField(TEXT("padding_right"), P.Right);
+                SlotObj->SetNumberField(TEXT("padding_bottom"), P.Bottom);
             }
+            else if (UScrollBoxSlot* ScSlot = Cast<UScrollBoxSlot>(W->Slot))
+            {
+                const FMargin P = ScSlot->GetPadding();
+                SlotObj->SetNumberField(TEXT("padding_left"), P.Left);
+                SlotObj->SetNumberField(TEXT("padding_top"), P.Top);
+                SlotObj->SetNumberField(TEXT("padding_right"), P.Right);
+                SlotObj->SetNumberField(TEXT("padding_bottom"), P.Bottom);
+            }
+            else if (UGridSlot* GSlot = Cast<UGridSlot>(W->Slot))
+            {
+                SlotObj->SetNumberField(TEXT("row"), GSlot->GetRow());
+                SlotObj->SetNumberField(TEXT("column"), GSlot->GetColumn());
+                SlotObj->SetNumberField(TEXT("row_span"), GSlot->GetRowSpan());
+                SlotObj->SetNumberField(TEXT("column_span"), GSlot->GetColumnSpan());
+            }
+            Out->SetObjectField(TEXT("slot"), SlotObj);
         }
-        Out->SetObjectField(TEXT("slot"), SlotObj);
 
-        TArray<TSharedPtr<FJsonValue>> Children;
+        if (bIncludeProperties)
+        {
+            Out->SetObjectField(TEXT("properties"), ExtractWidgetProperties(W));
+        }
+
         if (UPanelWidget* Panel = Cast<UPanelWidget>(W))
         {
+            TArray<TSharedPtr<FJsonValue>> Children;
             for (int32 i = 0; i < Panel->GetChildrenCount(); ++i)
             {
                 UWidget* Child = Panel->GetChildAt(i);
                 if (!Child) continue;
-                TSharedPtr<FJsonObject> ChildObj = WidgetToJson(Child);
+                TSharedPtr<FJsonObject> ChildObj = MakeShared<FJsonObject>();
+                WidgetToJsonRecursive(Child, WBP, ChildObj, bIncludeSlot, bIncludeGuid, bIncludeProperties);
                 Children.Add(MakeShared<FJsonValueObject>(ChildObj.ToSharedRef()));
             }
+            Out->SetArrayField(TEXT("children"), Children);
         }
-        Out->SetArrayField(TEXT("children"), Children);
-        return Out;
+    }
+
+    struct FCompileResult
+    {
+        bool bSuccess = false;
+        FString Status;
+        TArray<FString> Warnings;
+        TArray<FString> Errors;
+    };
+
+    FCompileResult CompileWidgetBlueprint(UWidgetBlueprint* WBP)
+    {
+        FCompileResult R;
+        if (!WBP) { R.Status = TEXT("NoBP"); return R; }
+
+        FCompilerResultsLog ResultsLog;
+        ResultsLog.SetSourcePath(WBP->GetPathName());
+        ResultsLog.BeginEvent(TEXT("Compile"));
+        FKismetEditorUtilities::CompileBlueprint(WBP, EBlueprintCompileOptions::None, &ResultsLog);
+        ResultsLog.EndEvent();
+
+        for (const TSharedRef<FTokenizedMessage>& Msg : ResultsLog.Messages)
+        {
+            const EMessageSeverity::Type Sev = Msg->GetSeverity();
+            const FString Text = Msg->ToText().ToString();
+            if (Sev == EMessageSeverity::Error)
+                R.Errors.Add(Text);
+            else if (Sev == EMessageSeverity::Warning)
+                R.Warnings.Add(Text);
+        }
+
+        R.bSuccess = (WBP->Status == BS_UpToDate || WBP->Status == BS_UpToDateWithWarnings);
+
+        if (WBP->Status == BS_UpToDate)               R.Status = TEXT("UpToDate");
+        else if (WBP->Status == BS_UpToDateWithWarnings) R.Status = TEXT("UpToDateWithWarnings");
+        else if (WBP->Status == BS_Error)              R.Status = TEXT("Error");
+        else if (WBP->Status == BS_Dirty)              R.Status = TEXT("Dirty");
+        else                                           R.Status = TEXT("Unknown");
+
+        return R;
+    }
+
+    bool SaveWidgetPackage(UWidgetBlueprint* WBP)
+    {
+        if (!WBP) return false;
+        WBP->MarkPackageDirty();
+        UPackage* Pkg = WBP->GetOutermost();
+        if (!Pkg) return false;
+
+        const FString FileName = FPackageName::LongPackageNameToFilename(
+            Pkg->GetName(), FPackageName::GetAssetPackageExtension());
+
+        FSavePackageArgs Args;
+        Args.TopLevelFlags = RF_Public | RF_Standalone;
+        Args.SaveFlags = SAVE_NoError;
+        return UPackage::SavePackage(Pkg, WBP, *FileName, Args);
     }
 }
 
@@ -247,143 +745,604 @@ FHaybaHandlerResult FHaybaMCPUIHandler::Handle(const FString& Cmd, const TShared
 #else
     if (!P.IsValid()) return FHaybaHandlerResult::Err(TEXT("UIHandler: missing params"));
 
-    // ----- ui_create_widget --------------------------------------------------
-    if (Cmd == TEXT("ui_create_widget"))
-    {
-        FString PkgPath, AssetName, ParentClassName;
-        if (!P->TryGetStringField(TEXT("path"), PkgPath) || PkgPath.IsEmpty())
-            return FHaybaHandlerResult::Err(TEXT("ui_create_widget: missing path"));
-        if (!P->TryGetStringField(TEXT("name"), AssetName) || AssetName.IsEmpty())
-            return FHaybaHandlerResult::Err(TEXT("ui_create_widget: missing name"));
-        if (!P->TryGetStringField(TEXT("parent_class"), ParentClassName) || ParentClassName.IsEmpty())
-            ParentClassName = TEXT("UserWidget");
-
-        UClass* ParentClass = LoadClass<UUserWidget>(nullptr, *ParentClassName);
-        if (!ParentClass) ParentClass = FindFirstObjectSafe<UClass>(*ParentClassName);
-        if (!ParentClass && !ParentClassName.StartsWith(TEXT("U")))
-            ParentClass = FindFirstObjectSafe<UClass>(*(TEXT("U") + ParentClassName));
-        if (!ParentClass) ParentClass = UUserWidget::StaticClass();
-        if (!ParentClass->IsChildOf(UUserWidget::StaticClass()))
-            return FHaybaHandlerResult::Err(TEXT("ui_create_widget: parent_class must derive from UserWidget"));
-
-        FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
-        UWidgetBlueprintFactory* Factory = NewObject<UWidgetBlueprintFactory>();
-        Factory->ParentClass = ParentClass;
-
-        UObject* Asset = AssetToolsModule.Get().CreateAsset(AssetName, PkgPath, UWidgetBlueprint::StaticClass(), Factory);
-        UWidgetBlueprint* WBP = Cast<UWidgetBlueprint>(Asset);
-        if (!WBP)
-            return FHaybaHandlerResult::Err(TEXT("ui_create_widget: CreateAsset failed"));
-
-        // Make sure there is a root panel (CanvasPanel) for usability.
-        if (WBP->WidgetTree && !WBP->WidgetTree->RootWidget)
-        {
-            UCanvasPanel* Root = WBP->WidgetTree->ConstructWidget<UCanvasPanel>(UCanvasPanel::StaticClass(), TEXT("RootCanvas"));
-            WBP->WidgetTree->RootWidget = Root;
-            RegisterWidgetVariable(WBP, Root);
-            FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
-        }
-
-        FAssetRegistryModule::AssetCreated(WBP);
-        WBP->MarkPackageDirty();
-
-        TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-        Out->SetStringField(TEXT("path"), WBP->GetPathName());
-        Out->SetStringField(TEXT("name"), AssetName);
-        Out->SetStringField(TEXT("parent_class"), ParentClass->GetPathName());
-        if (WBP->WidgetTree && WBP->WidgetTree->RootWidget)
-            Out->SetStringField(TEXT("root"), WBP->WidgetTree->RootWidget->GetName());
-        return FHaybaHandlerResult::Ok(Out);
-    }
-
-    // ----- ui_add_element ----------------------------------------------------
-    if (Cmd == TEXT("ui_add_element"))
-    {
-        FString BPPath, ParentName, ChildClassName, ChildName;
-        if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
-            return FHaybaHandlerResult::Err(TEXT("ui_add_element: missing widget_blueprint_path"));
-        if (!P->TryGetStringField(TEXT("child_class"), ChildClassName) || ChildClassName.IsEmpty())
-            return FHaybaHandlerResult::Err(TEXT("ui_add_element: missing child_class"));
-        P->TryGetStringField(TEXT("parent_widget_name"), ParentName);
-        P->TryGetStringField(TEXT("name"), ChildName);
-
-        UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
-        if (!WBP || !WBP->WidgetTree)
-            return FHaybaHandlerResult::Err(TEXT("ui_add_element: widget blueprint not found"));
-
-        UClass* ChildClass = ResolveWidgetClass(ChildClassName);
-        if (!ChildClass || !ChildClass->IsChildOf(UWidget::StaticClass()))
-            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_add_element: unknown child_class '%s'"), *ChildClassName));
-
-        UPanelWidget* Parent = nullptr;
-        if (ParentName.IsEmpty())
-        {
-            Parent = Cast<UPanelWidget>(WBP->WidgetTree->RootWidget);
-            if (!Parent)
-                return FHaybaHandlerResult::Err(TEXT("ui_add_element: root widget is not a panel; specify parent_widget_name"));
-        }
-        else
-        {
-            UWidget* Found = FindWidgetByName(WBP->WidgetTree, ParentName);
-            Parent = Cast<UPanelWidget>(Found);
-            if (!Parent)
-                return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_add_element: parent '%s' not found or not a panel"), *ParentName));
-        }
-
-        const FName ConstructName = ChildName.IsEmpty() ? NAME_None : FName(*ChildName);
-        UWidget* NewChild = WBP->WidgetTree->ConstructWidget<UWidget>(ChildClass, ConstructName);
-        if (!NewChild)
-            return FHaybaHandlerResult::Err(TEXT("ui_add_element: ConstructWidget failed"));
-
-        UPanelSlot* NewSlot = Parent->AddChild(NewChild);
-        if (!NewSlot)
-            return FHaybaHandlerResult::Err(TEXT("ui_add_element: AddChild rejected (panel may be full or incompatible)"));
-
-        // Widget blueprints track every designer widget by a stable GUID. ConstructWidget
-        // does not update that map, and compiling a partially populated map triggers an
-        // ensure in UMGEditor (and leaves references vulnerable to rename breakage).
-        RegisterWidgetVariable(WBP, NewChild);
-
-        const TSharedPtr<FJsonObject>* SlotProps = nullptr;
-        if (P->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid())
-            ApplySlotProps(NewSlot, *SlotProps);
-
-        FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
-        WBP->MarkPackageDirty();
-
-        TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-        Out->SetStringField(TEXT("widget_blueprint_path"), WBP->GetPathName());
-        Out->SetStringField(TEXT("parent"), Parent->GetName());
-        Out->SetStringField(TEXT("name"),   NewChild->GetName());
-        Out->SetStringField(TEXT("class"),  ChildClass->GetName());
-        Out->SetStringField(TEXT("slot_class"), NewSlot->GetClass()->GetName());
-        return FHaybaHandlerResult::Ok(Out);
-    }
-
-    // ----- ui_query ----------------------------------------------------------
-    if (Cmd == TEXT("ui_query"))
-    {
-        FString BPPath;
-        if (!P->TryGetStringField(TEXT("path"), BPPath) || BPPath.IsEmpty())
-            return FHaybaHandlerResult::Err(TEXT("ui_query: missing path"));
-        UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
-        if (!WBP || !WBP->WidgetTree)
-            return FHaybaHandlerResult::Err(TEXT("ui_query: widget blueprint not found"));
-
-        TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-        Out->SetStringField(TEXT("path"), WBP->GetPathName());
-        Out->SetStringField(TEXT("parent_class"), WBP->ParentClass ? WBP->ParentClass->GetPathName() : TEXT(""));
-        if (UWidget* Root = WBP->WidgetTree->RootWidget)
-        {
-            Out->SetObjectField(TEXT("root"), WidgetToJson(Root));
-        }
-        else
-        {
-            Out->SetObjectField(TEXT("root"), MakeShared<FJsonObject>());
-        }
-        return FHaybaHandlerResult::Ok(Out);
-    }
+    if (Cmd == TEXT("ui_create_widget"))       return HandleCreateWidget(P);
+    if (Cmd == TEXT("ui_add_element"))         return HandleAddElement(P);
+    if (Cmd == TEXT("ui_set_widget_properties")) return HandleSetProperties(P);
+    if (Cmd == TEXT("ui_query"))               return HandleQuery(P);
+    if (Cmd == TEXT("ui_mutate_tree"))         return HandleMutateTree(P);
+    if (Cmd == TEXT("ui_compile_widget"))      return HandleCompile(P);
+    if (Cmd == TEXT("ui_save_widget"))         return HandleSave(P);
+    if (Cmd == TEXT("ui_list_widget_types"))   return HandleListTypes(P);
 
     return FHaybaHandlerResult::Err(FString::Printf(TEXT("UIHandler: unknown command %s"), *Cmd));
 #endif
 }
+
+#if WITH_EDITOR
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleCreateWidget(const TSharedPtr<FJsonObject>& P)
+{
+    FString PkgPath, AssetName, ParentClassName;
+    if (!P->TryGetStringField(TEXT("path"), PkgPath) || PkgPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_create_widget: missing path"));
+    if (!P->TryGetStringField(TEXT("name"), AssetName) || AssetName.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_create_widget: missing name"));
+    if (!P->TryGetStringField(TEXT("parent_class"), ParentClassName) || ParentClassName.IsEmpty())
+        ParentClassName = TEXT("UserWidget");
+
+    UClass* ParentClass = LoadClass<UUserWidget>(nullptr, *ParentClassName);
+    if (!ParentClass) ParentClass = FindFirstObjectSafe<UClass>(*ParentClassName);
+    if (!ParentClass && !ParentClassName.StartsWith(TEXT("U")))
+        ParentClass = FindFirstObjectSafe<UClass>(*(TEXT("U") + ParentClassName));
+    if (!ParentClass) ParentClass = UUserWidget::StaticClass();
+    if (!ParentClass->IsChildOf(UUserWidget::StaticClass()))
+        return FHaybaHandlerResult::Err(TEXT("ui_create_widget: parent_class must derive from UserWidget"));
+
+    FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
+    UWidgetBlueprintFactory* Factory = NewObject<UWidgetBlueprintFactory>();
+    Factory->ParentClass = ParentClass;
+
+    UObject* Asset = AssetToolsModule.Get().CreateAsset(AssetName, PkgPath, UWidgetBlueprint::StaticClass(), Factory);
+    UWidgetBlueprint* WBP = Cast<UWidgetBlueprint>(Asset);
+    if (!WBP)
+        return FHaybaHandlerResult::Err(TEXT("ui_create_widget: CreateAsset failed"));
+
+    if (WBP->WidgetTree && !WBP->WidgetTree->RootWidget)
+    {
+        UCanvasPanel* Root = WBP->WidgetTree->ConstructWidget<UCanvasPanel>(UCanvasPanel::StaticClass(), TEXT("RootCanvas"));
+        WBP->WidgetTree->RootWidget = Root;
+        RegisterWidgetVariable(WBP, Root);
+        FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+    }
+
+    FAssetRegistryModule::AssetCreated(WBP);
+    WBP->MarkPackageDirty();
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("path"), WBP->GetPathName());
+    Out->SetStringField(TEXT("name"), AssetName);
+    Out->SetStringField(TEXT("parent_class"), ParentClass->GetPathName());
+    if (WBP->WidgetTree && WBP->WidgetTree->RootWidget)
+        Out->SetStringField(TEXT("root"), WBP->WidgetTree->RootWidget->GetName());
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleAddElement(const TSharedPtr<FJsonObject>& P)
+{
+    FString BPPath, ParentName, ChildClassName, ChildName;
+    if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_add_element: missing widget_blueprint_path"));
+    if (!P->TryGetStringField(TEXT("child_class"), ChildClassName) || ChildClassName.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_add_element: missing child_class"));
+    P->TryGetStringField(TEXT("parent_widget_name"), ParentName);
+    P->TryGetStringField(TEXT("name"), ChildName);
+
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    if (!WBP || !WBP->WidgetTree)
+        return FHaybaHandlerResult::Err(TEXT("ui_add_element: widget blueprint not found"));
+
+    UClass* ChildClass = ResolveWidgetClass(ChildClassName);
+    if (!ChildClass || !ChildClass->IsChildOf(UWidget::StaticClass()))
+        return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_add_element: unknown child_class '%s'"), *ChildClassName));
+
+    UPanelWidget* Parent = nullptr;
+    if (ParentName.IsEmpty())
+    {
+        Parent = Cast<UPanelWidget>(WBP->WidgetTree->RootWidget);
+        if (!Parent)
+            return FHaybaHandlerResult::Err(TEXT("ui_add_element: root widget is not a panel; specify parent_widget_name"));
+    }
+    else
+    {
+        UWidget* Found = FindWidgetByName(WBP->WidgetTree, ParentName);
+        Parent = Cast<UPanelWidget>(Found);
+        if (!Parent)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_add_element: parent '%s' not found or not a panel"), *ParentName));
+    }
+
+    const FName ConstructName = ChildName.IsEmpty() ? NAME_None : FName(*ChildName);
+    UWidget* NewChild = WBP->WidgetTree->ConstructWidget<UWidget>(ChildClass, ConstructName);
+    if (!NewChild)
+        return FHaybaHandlerResult::Err(TEXT("ui_add_element: ConstructWidget failed"));
+
+    UPanelSlot* NewSlot = Parent->AddChild(NewChild);
+    if (!NewSlot)
+        return FHaybaHandlerResult::Err(TEXT("ui_add_element: AddChild rejected (panel may be full or incompatible)"));
+
+    RegisterWidgetVariable(WBP, NewChild);
+
+    const TSharedPtr<FJsonObject>* SlotProps = nullptr;
+    if (P->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid())
+        ApplySlotProps(NewSlot, *SlotProps);
+
+    FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+    WBP->MarkPackageDirty();
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("widget_blueprint_path"), WBP->GetPathName());
+    Out->SetStringField(TEXT("parent"), Parent->GetName());
+    Out->SetStringField(TEXT("name"),   NewChild->GetName());
+    Out->SetStringField(TEXT("class"),  ChildClass->GetName());
+    Out->SetStringField(TEXT("slot_class"), NewSlot->GetClass()->GetName());
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJsonObject>& P)
+{
+    FString BPPath, WidgetName;
+    if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: missing widget_blueprint_path"));
+    if (!P->TryGetStringField(TEXT("widget_name"), WidgetName) || WidgetName.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: missing widget_name"));
+
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    if (!WBP || !WBP->WidgetTree)
+        return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: widget blueprint not found"));
+
+    UWidget* Widget = FindWidgetByName(WBP->WidgetTree, WidgetName);
+    if (!Widget)
+        return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_set_widget_properties: widget '%s' not found"), *WidgetName));
+
+    const TSharedPtr<FJsonObject>* Props = nullptr;
+    const TSharedPtr<FJsonObject>* SlotProps = nullptr;
+    P->TryGetObjectField(TEXT("properties"), Props);
+    // Public MCP schema has always documented `slot_props`, while an earlier
+    // handler revision only read `slot_properties`.  Accept both spellings so
+    // typed UMG calls actually persist margins/layout rather than silently
+    // reporting success for unrelated widget properties.
+    if (!(P->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid()))
+    {
+        P->TryGetObjectField(TEXT("slot_properties"), SlotProps);
+    }
+
+    if ((!Props || !Props->IsValid()) && (!SlotProps || !SlotProps->IsValid()))
+        return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: no properties or slot_props provided"));
+
+    int32 Succeeded = 0;
+    int32 Failed = 0;
+    TArray<FString> FailedProps;
+    {
+        FScopedTransaction Transaction(NSLOCTEXT("HaybaMCPUI", "SetWidgetProperties", "Set Widget Properties"));
+
+        WBP->Modify();
+        Widget->Modify();
+
+        if (Props && Props->IsValid())
+        {
+            for (const auto& Pair : (*Props)->Values)
+            {
+                const FString PropertyName(Pair.Key);
+                if (HaybaReflection::SetProp(Widget, PropertyName, Pair.Value))
+                    ++Succeeded;
+                else
+                {
+                    ++Failed;
+                    FailedProps.Add(PropertyName);
+                }
+            }
+        }
+
+        if (SlotProps && SlotProps->IsValid() && Widget->Slot)
+        {
+            // Slots are distinct UObject instances in a WidgetTree.  Marking
+            // only the child widget dirty made horizontal/vertical padding look
+            // successful in the response but vanish on the next query/reopen.
+            Widget->Slot->Modify();
+            ApplySlotProps(Widget->Slot, *SlotProps);
+            Widget->Slot->PostEditChange();
+            for (const auto& Pair : (*SlotProps)->Values)
+            {
+                ++Succeeded;
+            }
+        }
+
+        Widget->PostEditChange();
+        // Designer-slot layout is serialized as part of the WidgetTree, so use
+        // a structural notification rather than a mere generated-class refresh.
+        FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+        WBP->MarkPackageDirty();
+    }
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetNumberField(TEXT("succeeded"), Succeeded);
+    Out->SetNumberField(TEXT("failed"), Failed);
+    if (FailedProps.Num() > 0)
+    {
+        TArray<TSharedPtr<FJsonValue>> FArr;
+        for (const FString& F : FailedProps)
+            FArr.Add(MakeShared<FJsonValueString>(F));
+        Out->SetArrayField(TEXT("failed_properties"), FArr);
+    }
+
+    if (Succeeded == 0)
+        return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: all properties failed"));
+
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleQuery(const TSharedPtr<FJsonObject>& P)
+{
+    FString BPPath;
+    if (!P->TryGetStringField(TEXT("path"), BPPath) || BPPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_query: missing path"));
+
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    if (!WBP || !WBP->WidgetTree)
+        return FHaybaHandlerResult::Err(TEXT("ui_query: widget blueprint not found"));
+
+    bool bIncludeSlot = true;
+    bool bIncludeGuid = false;
+    bool bIncludeProperties = false;
+    P->TryGetBoolField(TEXT("include_slot"), bIncludeSlot);
+    P->TryGetBoolField(TEXT("include_guid"), bIncludeGuid);
+    P->TryGetBoolField(TEXT("include_properties"), bIncludeProperties);
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("path"), WBP->GetPathName());
+    Out->SetStringField(TEXT("parent_class"), WBP->ParentClass ? WBP->ParentClass->GetPathName() : TEXT(""));
+
+    if (UWidget* Root = WBP->WidgetTree->RootWidget)
+    {
+        TSharedPtr<FJsonObject> RootObj = MakeShared<FJsonObject>();
+        WidgetToJsonRecursive(Root, WBP, RootObj, bIncludeSlot, bIncludeGuid, bIncludeProperties);
+        Out->SetObjectField(TEXT("root"), RootObj);
+    }
+    else
+    {
+        Out->SetObjectField(TEXT("root"), MakeShared<FJsonObject>());
+    }
+
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonObject>& P)
+{
+    FString BPPath, Operation;
+    if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree: missing widget_blueprint_path"));
+    if (!P->TryGetStringField(TEXT("operation"), Operation) || Operation.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree: missing operation"));
+
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    if (!WBP || !WBP->WidgetTree)
+        return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree: widget blueprint not found"));
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("widget_blueprint_path"), WBP->GetPathName());
+    Out->SetStringField(TEXT("operation"), Operation);
+
+    if (Operation == TEXT("remove"))
+    {
+        FString WidgetName, ReplacementRoot;
+        if (!P->TryGetStringField(TEXT("widget_name"), WidgetName) || WidgetName.IsEmpty())
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree remove: missing widget_name"));
+
+        UWidget* Widget = FindWidgetByName(WBP->WidgetTree, WidgetName);
+        if (!Widget)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree remove: widget '%s' not found"), *WidgetName));
+
+        P->TryGetStringField(TEXT("replacement_root"), ReplacementRoot);
+
+        FString OldParentName;
+        int32 OldChildIndex = -1;
+
+        {
+            FScopedTransaction Transaction(NSLOCTEXT("HaybaMCPUI", "MutateTreeRemove", "Remove Widget"));
+            WBP->Modify();
+            Widget->Modify();
+
+            if (Widget == WBP->WidgetTree->RootWidget)
+            {
+                OldParentName = TEXT("(root)");
+
+                if (!ReplacementRoot.IsEmpty())
+                {
+                    UClass* NewRootClass = ResolveWidgetClass(ReplacementRoot);
+                    if (!NewRootClass || !NewRootClass->IsChildOf(UWidget::StaticClass()))
+                        return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree remove: invalid replacement_root class"));
+
+                    UWidget* NewRoot = WBP->WidgetTree->ConstructWidget<UWidget>(NewRootClass);
+                    WBP->WidgetTree->RootWidget = NewRoot;
+                    RegisterWidgetVariable(WBP, NewRoot);
+                }
+                else
+                {
+                    WBP->WidgetTree->RootWidget = nullptr;
+                }
+            }
+            else
+            {
+                UPanelWidget* Parent = Widget->GetParent();
+                if (Parent)
+                {
+                    OldParentName = Parent->GetName();
+                    OldChildIndex = Parent->GetChildIndex(Widget);
+                    Parent->RemoveChild(Widget);
+                }
+            }
+
+            WBP->WidgetVariableNameToGuidMap.Remove(Widget->GetFName());
+            FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+            WBP->MarkPackageDirty();
+        }
+
+        Out->SetStringField(TEXT("widget_name"), WidgetName);
+        Out->SetStringField(TEXT("old_parent"), OldParentName);
+        if (OldChildIndex >= 0)
+            Out->SetNumberField(TEXT("old_child_index"), OldChildIndex);
+
+        return FHaybaHandlerResult::Ok(Out);
+    }
+    else if (Operation == TEXT("reparent"))
+    {
+        FString WidgetName, NewParentName;
+        if (!P->TryGetStringField(TEXT("widget_name"), WidgetName) || WidgetName.IsEmpty())
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree reparent: missing widget_name"));
+        if (!P->TryGetStringField(TEXT("new_parent_name"), NewParentName) || NewParentName.IsEmpty())
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree reparent: missing new_parent_name"));
+
+        UWidget* Widget = FindWidgetByName(WBP->WidgetTree, WidgetName);
+        if (!Widget)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree reparent: widget '%s' not found"), *WidgetName));
+
+        UWidget* NewParentWidget = FindWidgetByName(WBP->WidgetTree, NewParentName);
+        if (!NewParentWidget)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree reparent: new parent '%s' not found"), *NewParentName));
+
+        UPanelWidget* NewParent = Cast<UPanelWidget>(NewParentWidget);
+        if (!NewParent)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree reparent: '%s' is not a panel"), *NewParentName));
+
+        UPanelWidget* OldParent = Widget->GetParent();
+        if (!OldParent)
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree reparent: widget has no parent (root)"));
+
+        // Validate no cycles
+        UWidget* Ancestor = NewParent;
+        while (Ancestor)
+        {
+            if (Ancestor == Widget)
+                return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree reparent: cannot reparent a widget to its own descendant"));
+            Ancestor = Ancestor->GetParent();
+        }
+
+        int32 OldIndex = OldParent->GetChildIndex(Widget);
+        FString OldParentName = OldParent->GetName();
+
+        {
+            FScopedTransaction Transaction(NSLOCTEXT("HaybaMCPUI", "MutateTreeReparent", "Reparent Widget"));
+            WBP->Modify();
+            Widget->Modify();
+            OldParent->Modify();
+            NewParent->Modify();
+
+            OldParent->RemoveChild(Widget);
+            UPanelSlot* NewSlot = NewParent->AddChild(Widget);
+
+            FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+            WBP->MarkPackageDirty();
+        }
+
+        Out->SetStringField(TEXT("widget_name"), WidgetName);
+        Out->SetStringField(TEXT("old_parent"), OldParentName);
+        Out->SetNumberField(TEXT("old_child_index"), OldIndex);
+        Out->SetStringField(TEXT("new_parent"), NewParentName);
+
+        return FHaybaHandlerResult::Ok(Out);
+    }
+    else if (Operation == TEXT("replace"))
+    {
+        FString WidgetName, NewClassName, NewName;
+        if (!P->TryGetStringField(TEXT("widget_name"), WidgetName) || WidgetName.IsEmpty())
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree replace: missing widget_name"));
+        if (!P->TryGetStringField(TEXT("new_class"), NewClassName) || NewClassName.IsEmpty())
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree replace: missing new_class"));
+
+        bool bPreserveGuid = true;
+        bool bPreserveProperties = false;
+        P->TryGetBoolField(TEXT("preserve_guid"), bPreserveGuid);
+        P->TryGetBoolField(TEXT("preserve_properties"), bPreserveProperties);
+        P->TryGetStringField(TEXT("new_name"), NewName);
+
+        UWidget* Widget = FindWidgetByName(WBP->WidgetTree, WidgetName);
+        if (!Widget)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree replace: widget '%s' not found"), *WidgetName));
+
+        UClass* NewClass = ResolveWidgetClass(NewClassName);
+        if (!NewClass || !NewClass->IsChildOf(UWidget::StaticClass()))
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree replace: unknown class '%s'"), *NewClassName));
+
+        UPanelWidget* Parent = Widget->GetParent();
+        if (!Parent)
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree replace: cannot replace root widget"));
+
+        int32 ChildIndex = Parent->GetChildIndex(Widget);
+        FString OldClass = Widget->GetClass()->GetName();
+
+        {
+            FScopedTransaction Transaction(NSLOCTEXT("HaybaMCPUI", "MutateTreeReplace", "Replace Widget"));
+            WBP->Modify();
+            Widget->Modify();
+            Parent->Modify();
+
+            const FName ConstructName = NewName.IsEmpty() ? Widget->GetFName() : FName(*NewName);
+            UWidget* NewWidget = WBP->WidgetTree->ConstructWidget<UWidget>(NewClass, ConstructName);
+            if (!NewWidget)
+                return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree replace: ConstructWidget failed"));
+
+            UPanelSlot* NewSlot = Parent->InsertChildAt(ChildIndex, NewWidget);
+            if (!NewSlot)
+                return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree replace: InsertChildAt failed"));
+
+            Parent->RemoveChild(Widget);
+
+            if (bPreserveGuid)
+            {
+                const FName OldName = Widget->GetFName();
+                FGuid OldGuid;
+                if (WBP->WidgetVariableNameToGuidMap.RemoveAndCopyValue(OldName, OldGuid))
+                {
+                    if (!WBP->WidgetVariableNameToGuidMap.Contains(ConstructName))
+                        WBP->WidgetVariableNameToGuidMap.Add(ConstructName, OldGuid);
+                }
+            }
+            else
+            {
+                WBP->WidgetVariableNameToGuidMap.Remove(Widget->GetFName());
+                RegisterWidgetVariable(WBP, NewWidget);
+            }
+
+            FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+            WBP->MarkPackageDirty();
+        }
+
+        Out->SetStringField(TEXT("widget_name"), WidgetName);
+        Out->SetStringField(TEXT("old_class"), OldClass);
+        Out->SetStringField(TEXT("new_class"), NewClassName);
+        Out->SetStringField(TEXT("new_name"), NewName.IsEmpty() ? WidgetName : NewName);
+        Out->SetNumberField(TEXT("child_index"), ChildIndex);
+
+        return FHaybaHandlerResult::Ok(Out);
+    }
+
+    return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree: unknown operation '%s'"), *Operation));
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleCompile(const TSharedPtr<FJsonObject>& P)
+{
+    FString BPPath;
+    if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_compile_widget: missing widget_blueprint_path"));
+
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    if (!WBP)
+        return FHaybaHandlerResult::Err(TEXT("ui_compile_widget: widget blueprint not found"));
+
+    FCompileResult CR = CompileWidgetBlueprint(WBP);
+
+    bool bSaveOnSuccess = false;
+    P->TryGetBoolField(TEXT("save_on_success"), bSaveOnSuccess);
+
+    if (bSaveOnSuccess && CR.bSuccess)
+    {
+        if (!SaveWidgetPackage(WBP))
+        {
+            return FHaybaHandlerResult::Err(TEXT("ui_compile_widget: compile succeeded but save failed"));
+        }
+    }
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetBoolField(TEXT("success"), CR.bSuccess);
+    Out->SetStringField(TEXT("status"), CR.Status);
+
+    if (CR.Warnings.Num() > 0)
+    {
+        TArray<TSharedPtr<FJsonValue>> WArr;
+        for (const FString& W : CR.Warnings)
+            WArr.Add(MakeShared<FJsonValueString>(W));
+        Out->SetArrayField(TEXT("warnings"), WArr);
+    }
+    else
+    {
+        Out->SetArrayField(TEXT("warnings"), TArray<TSharedPtr<FJsonValue>>());
+    }
+
+    if (CR.Errors.Num() > 0)
+    {
+        TArray<TSharedPtr<FJsonValue>> EArr;
+        for (const FString& E : CR.Errors)
+            EArr.Add(MakeShared<FJsonValueString>(E));
+        Out->SetArrayField(TEXT("errors"), EArr);
+    }
+    else
+    {
+        Out->SetArrayField(TEXT("errors"), TArray<TSharedPtr<FJsonValue>>());
+    }
+
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleSave(const TSharedPtr<FJsonObject>& P)
+{
+    FString BPPath;
+    if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_save_widget: missing widget_blueprint_path"));
+
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    if (!WBP)
+        return FHaybaHandlerResult::Err(TEXT("ui_save_widget: widget blueprint not found"));
+
+    bool bCompileFirst = false;
+    P->TryGetBoolField(TEXT("compile_first"), bCompileFirst);
+
+    if (bCompileFirst)
+    {
+        FCompileResult CR = CompileWidgetBlueprint(WBP);
+        if (!CR.bSuccess)
+        {
+            TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+            Out->SetBoolField(TEXT("success"), false);
+            Out->SetStringField(TEXT("saved_path"), WBP->GetPathName());
+            Out->SetStringField(TEXT("reason"), TEXT("compile_failed"));
+            return FHaybaHandlerResult::Ok(Out);
+        }
+    }
+
+    if (!SaveWidgetPackage(WBP))
+    {
+        return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_save_widget: SavePackage failed for %s"), *WBP->GetPathName()));
+    }
+
+    UPackage* Pkg = WBP->GetOutermost();
+    const bool bDirtyAfter = Pkg ? Pkg->IsDirty() : true;
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("saved_path"), WBP->GetPathName());
+    Out->SetBoolField(TEXT("success"), !bDirtyAfter);
+    Out->SetBoolField(TEXT("package_dirty_after_save"), bDirtyAfter);
+
+    if (bDirtyAfter)
+    {
+        return FHaybaHandlerResult::Ok(Out);
+    }
+
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleListTypes(const TSharedPtr<FJsonObject>& P)
+{
+    FString Filter;
+    P->TryGetStringField(TEXT("filter"), Filter);
+
+    TArray<TSharedPtr<FJsonValue>> Results;
+
+    for (TObjectIterator<UClass> It; It; ++It)
+    {
+        UClass* C = *It;
+        if (!C->IsChildOf(UWidget::StaticClass())) continue;
+        if (C == UWidget::StaticClass()) continue;
+        if (C->HasAnyClassFlags(CLASS_Abstract | CLASS_Deprecated | CLASS_NewerVersionExists)) continue;
+        if (!C->IsNative()) continue;
+
+        const FString Name = C->GetName();
+        if (!Filter.IsEmpty() && !Name.Contains(Filter)) continue;
+
+        TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+        Entry->SetStringField(TEXT("name"), Name);
+        Entry->SetStringField(TEXT("class_path"), C->GetPathName());
+        Entry->SetBoolField(TEXT("is_panel"), C->IsChildOf(UPanelWidget::StaticClass()));
+
+        FString Desc = C->GetMetaData(TEXT("ToolTip"));
+        if (Desc.IsEmpty()) Desc = C->GetMetaData(TEXT("Description"));
+        if (Desc.IsEmpty()) Desc = C->GetMetaData(TEXT("WidgetCategory"));
+        Entry->SetStringField(TEXT("description"), Desc);
+
+        Results.Add(MakeShared<FJsonValueObject>(Entry));
+    }
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetArrayField(TEXT("types"), Results);
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+#endif // WITH_EDITOR

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -100,6 +100,7 @@ TArray<FString> FHaybaMCPUIHandler::GetCommands() const
         TEXT("ui_list_widget_blueprints"),
         TEXT("ui_layout_snapshot"),
         TEXT("ui_measure_text"),
+        TEXT("ui_report_findings"),
     };
 }
 
@@ -901,6 +902,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::Handle(const FString& Cmd, const TShared
     if (Cmd == TEXT("ui_list_widget_blueprints")) return HandleListWidgetBlueprints(P);
     if (Cmd == TEXT("ui_layout_snapshot"))     return HandleLayoutSnapshot(P);
     if (Cmd == TEXT("ui_measure_text"))        return HandleMeasureText(P);
+    if (Cmd == TEXT("ui_report_findings"))     return HandleReportFindings(P);
 
     return FHaybaHandlerResult::Err(FString::Printf(TEXT("UIHandler: unknown command %s"), *Cmd));
 #endif
@@ -2288,6 +2290,37 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMeasureText(const TSharedPtr<FJson
     Out->SetNumberField(TEXT("worst_case_chars_that_fit"), Fit.WorstCaseChars);
     Out->SetNumberField(TEXT("font_size"), Font.Size);
     if (Font.FontObject) Out->SetStringField(TEXT("font_object"), Font.FontObject->GetPathName());
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleReportFindings(const TSharedPtr<FJsonObject>& P)
+{
+    // Deliberately a pass-through that only validates shape: the judging lives
+    // MCP-side so rules can change without a plugin rebuild, and this command
+    // exists purely so those findings can reach the editor's Validation panel.
+    // The actual push happens in the command handler's post-dispatch hook,
+    // which is where every other panel-feeding command is wired.
+    const TArray<TSharedPtr<FJsonValue>>* FindingsArr = nullptr;
+    if (!P->TryGetArrayField(TEXT("findings"), FindingsArr) || !FindingsArr)
+        return FHaybaHandlerResult::Err(TEXT("ui_report_findings: missing findings array"));
+
+    int32 Errors = 0, Warnings = 0, Infos = 0;
+    for (const auto& V : *FindingsArr)
+    {
+        const TSharedPtr<FJsonObject> F = V->AsObject();
+        if (!F.IsValid()) continue;
+        FString Severity;
+        F->TryGetStringField(TEXT("severity"), Severity);
+        if (Severity.Equals(TEXT("error"), ESearchCase::IgnoreCase)) ++Errors;
+        else if (Severity.Equals(TEXT("warning"), ESearchCase::IgnoreCase)) ++Warnings;
+        else ++Infos;
+    }
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetNumberField(TEXT("received"), FindingsArr->Num());
+    Out->SetNumberField(TEXT("errors"), Errors);
+    Out->SetNumberField(TEXT("warnings"), Warnings);
+    Out->SetNumberField(TEXT("infos"), Infos);
     return FHaybaHandlerResult::Ok(Out);
 }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -1565,13 +1565,49 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
 
         // Duplicating into the widget tree copies the whole subtree, which is
         // the point: duplicating a styled row should bring its children along.
-        const FName DupName = NewName.IsEmpty()
-            ? MakeUniqueObjectName(WBP->WidgetTree, Source->GetClass(), Source->GetFName())
-            : FName(*NewName);
+        //
+        // But the copy arrives with EVERY descendant still carrying its source
+        // name, and UMG requires names to be unique across the whole tree. UE
+        // resolves the collision by renaming objects to TRASH_<name>, which
+        // leaves the blueprint with a mangled copy and two widgets answering to
+        // the same name. So duplicate under a scratch name first, then rename
+        // the whole subtree to unique names before anything else sees it.
+        const FName ScratchName = MakeUniqueObjectName(
+            WBP->WidgetTree, Source->GetClass(), TEXT("HaybaMCP_DuplicateScratch"));
 
-        UWidget* Copy = DuplicateObject<UWidget>(Source, WBP->WidgetTree, DupName);
+        UWidget* Copy = DuplicateObject<UWidget>(Source, WBP->WidgetTree, ScratchName);
         if (!Copy)
             return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree duplicate: DuplicateObject failed"));
+
+        // The root of the copy takes the caller's name (or a unique variant of
+        // the source's); every descendant takes a unique variant of its own.
+        {
+            TArray<UWidget*> Copied;
+            CollectSubtree(Copy, Copied);
+            for (UWidget* W : Copied)
+            {
+                if (!W) continue;
+
+                const bool bIsRoot = (W == Copy);
+                FName Desired;
+                if (bIsRoot && !NewName.IsEmpty())
+                {
+                    Desired = FName(*NewName);
+                }
+                else
+                {
+                    // Base the unique name on the SOURCE widget's name, not the
+                    // scratch name, so a duplicated "Row" reads "Row_1".
+                    const FName Base = bIsRoot ? Source->GetFName() : W->GetFName();
+                    Desired = MakeUniqueObjectName(WBP->WidgetTree, W->GetClass(), Base);
+                }
+
+                if (W->GetFName() != Desired)
+                {
+                    W->Rename(*Desired.ToString(), WBP->WidgetTree, REN_DontCreateRedirectors | REN_DoNotDirty);
+                }
+            }
+        }
 
         UPanelSlot* NewSlot = TargetParent->AddChild(Copy);
         if (!NewSlot)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -1,4 +1,5 @@
 #include "HaybaMCPUIHandler.h"
+#include <initializer_list>
 #include "Json.h"
 #include "Editor.h"
 
@@ -54,6 +55,10 @@
 #include "Components/NamedSlot.h"
 #include "Components/BackgroundBlur.h"
 #include "Components/ExpandableArea.h"
+#include "Components/CircularThrobber.h"
+#include "Components/InvalidationBox.h"
+#include "Components/SafeZone.h"
+#include "Components/InputKeySelector.h"
 #include "AssetToolsModule.h"
 #include "IAssetTools.h"
 #include "AssetRegistry/AssetRegistryModule.h"
@@ -65,8 +70,16 @@
 #include "UObject/SavePackage.h"
 #include "Misc/PackageName.h"
 #include "Layout/Margin.h"
+#include "Components/RichTextBlock.h"
+#include "Components/EditableText.h"
+#include "Engine/Font.h"
+#include "Engine/FontFace.h"
+#include "Engine/Blueprint.h"
+#include "Styling/CoreStyle.h"
+#include "AssetRegistry/IAssetRegistry.h"
 #include "HaybaMCPReflection.h"
 #include "HaybaMCPParams.h"
+#include "HaybaMCPUILayout.h"
 #endif
 
 DEFINE_LOG_CATEGORY_STATIC(LogHaybaMCPUI, Log, All);
@@ -82,6 +95,11 @@ TArray<FString> FHaybaMCPUIHandler::GetCommands() const
         TEXT("ui_compile_widget"),
         TEXT("ui_save_widget"),
         TEXT("ui_list_widget_types"),
+        TEXT("ui_build_tree"),
+        TEXT("ui_set_variable"),
+        TEXT("ui_list_widget_blueprints"),
+        TEXT("ui_layout_snapshot"),
+        TEXT("ui_measure_text"),
     };
 }
 
@@ -139,6 +157,15 @@ namespace
             M.Add(TEXT("BackgroundBlur"),     UBackgroundBlur::StaticClass());
             M.Add(TEXT("ExpandableArea"),     UExpandableArea::StaticClass());
             M.Add(TEXT("MenuAnchor"),         UMenuAnchor::StaticClass());
+            // Previously included as headers but never resolvable by short name.
+            M.Add(TEXT("NamedSlot"),          UNamedSlot::StaticClass());
+            M.Add(TEXT("NativeWidgetHost"),   UNativeWidgetHost::StaticClass());
+            M.Add(TEXT("RichTextBlock"),      URichTextBlock::StaticClass());
+            M.Add(TEXT("EditableText"),       UEditableText::StaticClass());
+            M.Add(TEXT("CircularThrobber"),   UCircularThrobber::StaticClass());
+            M.Add(TEXT("InvalidationBox"),    UInvalidationBox::StaticClass());
+            M.Add(TEXT("SafeZone"),           USafeZone::StaticClass());
+            M.Add(TEXT("InputKeySelector"),   UInputKeySelector::StaticClass());
             return M;
         }();
         if (UClass* const* Found = Known.Find(Name)) return *Found;
@@ -150,6 +177,63 @@ namespace
             if (UClass* C = FindFirstObjectSafe<UClass>(*(TEXT("U") + Name))) return C;
         }
         return nullptr;
+    }
+
+    /** Every widget in the subtree rooted at `W`, including `W` itself. */
+    void CollectSubtree(UWidget* W, TArray<UWidget*>& Out)
+    {
+        if (!W) return;
+        Out.Add(W);
+        if (UPanelWidget* Panel = Cast<UPanelWidget>(W))
+        {
+            for (int32 i = 0; i < Panel->GetChildrenCount(); ++i)
+            {
+                CollectSubtree(Panel->GetChildAt(i), Out);
+            }
+        }
+    }
+
+    /** Drop the whole subtree's variable GUIDs, not just the removed widget's.
+     *  Leaving descendants behind orphans entries in
+     *  WidgetVariableNameToGuidMap, which later resurfaces as phantom
+     *  variables on the compiled blueprint. */
+    void PurgeSubtreeGuids(UWidgetBlueprint* WBP, UWidget* Root)
+    {
+        if (!WBP || !Root) return;
+        TArray<UWidget*> Subtree;
+        CollectSubtree(Root, Subtree);
+        for (UWidget* W : Subtree)
+        {
+            if (W) WBP->WidgetVariableNameToGuidMap.Remove(W->GetFName());
+        }
+    }
+
+    /** Copy every property the two widgets share by name and type. Used by
+     *  `replace` with preserve_properties — text, colours, padding and so on
+     *  survive a Button→CheckBox style swap instead of resetting to defaults. */
+    int32 CopyCommonProperties(UObject* From, UObject* To)
+    {
+        if (!From || !To) return 0;
+        int32 Copied = 0;
+        for (TFieldIterator<FProperty> It(From->GetClass()); It; ++It)
+        {
+            FProperty* SrcProp = *It;
+            if (!SrcProp) continue;
+            // Transient/native-only state is not authoring data; copying it
+            // moves runtime junk (cached slate handles, generated names) across.
+            if (SrcProp->HasAnyPropertyFlags(CPF_Transient | CPF_DuplicateTransient | CPF_EditorOnly)) continue;
+
+            const FName PropName = SrcProp->GetFName();
+            if (PropName == TEXT("Slot")) continue;  // owned by the parent panel
+
+            FProperty* DstProp = To->GetClass()->FindPropertyByName(PropName);
+            if (!DstProp) continue;
+            if (!DstProp->SameType(SrcProp)) continue;
+
+            DstProp->CopyCompleteValue_InContainer(To, From);
+            ++Copied;
+        }
+        return Copied;
     }
 
     UWidget* FindWidgetByName(UWidgetTree* Tree, const FString& Name)
@@ -267,39 +351,144 @@ namespace
         return FVector2D::ZeroVector;
     }
 
+    /** Outcome of applying a slot-props object. Callers report these verbatim:
+     *  a key that matched nothing is a caller error worth surfacing, not
+     *  something to swallow while still reporting success. */
+    struct FSlotApplyResult
+    {
+        TArray<FString> Applied;
+        TArray<FString> Unknown;
+    };
+
+    /** Keys the explicit branches below actually consume FOR THIS SLOT TYPE.
+     *  Type-aware on purpose: `z_order` is real on a canvas slot and meaningless
+     *  on a vertical-box slot, and a caller who sends the latter deserves to be
+     *  told rather than shown a success count that includes it. */
+    static TSet<FString> ApplicableSlotKeys(UPanelSlot* Slot)
+    {
+        // Accepted and ignored everywhere: callers routinely echo the slot type back.
+        TSet<FString> Keys = { TEXT("type") };
+
+        auto AddAll = [&Keys](std::initializer_list<const TCHAR*> Names)
+        {
+            for (const TCHAR* N : Names) Keys.Add(FString(N));
+        };
+
+        const bool bHasAlignment =
+            Slot->IsA<UHorizontalBoxSlot>() || Slot->IsA<UVerticalBoxSlot>() || Slot->IsA<UOverlaySlot>() ||
+            Slot->IsA<UScrollBoxSlot>()     || Slot->IsA<UBorderSlot>()      || Slot->IsA<USizeBoxSlot>() ||
+            Slot->IsA<UWrapBoxSlot>()       || Slot->IsA<UWidgetSwitcherSlot>() ||
+            Slot->IsA<UGridSlot>()          || Slot->IsA<UUniformGridSlot>();
+        if (bHasAlignment) AddAll({ TEXT("horizontal_alignment"), TEXT("vertical_alignment") });
+
+        const bool bHasPadding =
+            Slot->IsA<UHorizontalBoxSlot>() || Slot->IsA<UVerticalBoxSlot>() || Slot->IsA<UOverlaySlot>() ||
+            Slot->IsA<UScrollBoxSlot>()     || Slot->IsA<UBorderSlot>()      || Slot->IsA<USizeBoxSlot>() ||
+            Slot->IsA<UWrapBoxSlot>()       || Slot->IsA<UWidgetSwitcherSlot>() || Slot->IsA<UGridSlot>();
+        if (bHasPadding) Keys.Add(TEXT("padding"));
+
+        if (Slot->IsA<UCanvasPanelSlot>())
+        {
+            AddAll({ TEXT("anchor_min_x"), TEXT("anchor_min_y"), TEXT("anchor_max_x"), TEXT("anchor_max_y"),
+                     TEXT("anchors"), TEXT("anchors_min"), TEXT("anchors_max"),
+                     TEXT("x"), TEXT("y"), TEXT("w"), TEXT("h"),
+                     TEXT("position"), TEXT("size"), TEXT("alignment"), TEXT("auto_size"), TEXT("z_order") });
+        }
+        if (Slot->IsA<UHorizontalBoxSlot>() || Slot->IsA<UVerticalBoxSlot>())
+        {
+            Keys.Add(TEXT("fill"));
+        }
+        if (Slot->IsA<UGridSlot>())
+        {
+            AddAll({ TEXT("row"), TEXT("column"), TEXT("row_span"), TEXT("column_span"), TEXT("layer"), TEXT("nudge") });
+        }
+        if (Slot->IsA<UUniformGridSlot>())
+        {
+            AddAll({ TEXT("row"), TEXT("column") });
+        }
+        return Keys;
+    }
+
+    /** Padding is set whenever the key is present, including an explicit zero.
+     *  The previous "only if non-zero" guard made it impossible to clear
+     *  padding — the call reported success and the margin stayed put. */
+    static bool TryApplyPadding(const TSharedPtr<FJsonObject>& Props, const FString& Key, FMargin& Out)
+    {
+        if (!Props->HasField(Key)) return false;
+        Out = ParseMargin(Props, Key);
+        return true;
+    }
+
+    /** Anchors accept every shape a caller might reasonably send:
+     *  flat anchor_min_x/…, an {min_x,…} object, or anchors_min/anchors_max
+     *  as [x,y] pairs (which is what the typed slot-layout tool sends). */
+    static bool TryApplyAnchors(const TSharedPtr<FJsonObject>& Props, UCanvasPanelSlot* CSlot)
+    {
+        bool bChanged = false;
+        FAnchors Anchors = CSlot->GetAnchors();
+
+        double V = 0.0;
+        if (Props->TryGetNumberField(TEXT("anchor_min_x"), V)) { Anchors.Minimum.X = V; bChanged = true; }
+        if (Props->TryGetNumberField(TEXT("anchor_min_y"), V)) { Anchors.Minimum.Y = V; bChanged = true; }
+        if (Props->TryGetNumberField(TEXT("anchor_max_x"), V)) { Anchors.Maximum.X = V; bChanged = true; }
+        if (Props->TryGetNumberField(TEXT("anchor_max_y"), V)) { Anchors.Maximum.Y = V; bChanged = true; }
+
+        const TSharedPtr<FJsonObject>* AnchorsObj = nullptr;
+        if (Props->TryGetObjectField(TEXT("anchors"), AnchorsObj) && AnchorsObj && AnchorsObj->IsValid())
+        {
+            double MinX = Anchors.Minimum.X, MinY = Anchors.Minimum.Y;
+            double MaxX = Anchors.Maximum.X, MaxY = Anchors.Maximum.Y;
+            (*AnchorsObj)->TryGetNumberField(TEXT("min_x"), MinX);
+            (*AnchorsObj)->TryGetNumberField(TEXT("min_y"), MinY);
+            (*AnchorsObj)->TryGetNumberField(TEXT("max_x"), MaxX);
+            (*AnchorsObj)->TryGetNumberField(TEXT("max_y"), MaxY);
+            Anchors.Minimum = FVector2D(MinX, MinY);
+            Anchors.Maximum = FVector2D(MaxX, MaxY);
+            bChanged = true;
+        }
+
+        if (Props->HasField(TEXT("anchors_min"))) { Anchors.Minimum = ParseVec2(Props, TEXT("anchors_min")); bChanged = true; }
+        if (Props->HasField(TEXT("anchors_max"))) { Anchors.Maximum = ParseVec2(Props, TEXT("anchors_max")); bChanged = true; }
+
+        if (bChanged) CSlot->SetAnchors(Anchors);
+        return bChanged;
+    }
+
+    /** Alignment shared by every slot type that exposes H/V alignment. */
+    template <typename TSlot>
+    static void ApplyAlignments(TSlot* S, const TSharedPtr<FJsonObject>& Props)
+    {
+        FString HAlign, VAlign;
+        if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
+            S->SetHorizontalAlignment(ParseHAlign(HAlign));
+        if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
+            S->SetVerticalAlignment(ParseVAlign(VAlign));
+    }
+
+    template <typename TSlot>
+    static void ApplyPaddingAndAlignment(TSlot* S, const TSharedPtr<FJsonObject>& Props)
+    {
+        FMargin Pad;
+        if (TryApplyPadding(Props, TEXT("padding"), Pad)) S->SetPadding(Pad);
+        ApplyAlignments(S, Props);
+    }
+
+    FSlotApplyResult ApplySlotPropsChecked(UPanelSlot* Slot, const TSharedPtr<FJsonObject>& Props);
+
     void ApplySlotProps(UPanelSlot* Slot, const TSharedPtr<FJsonObject>& Props)
     {
-        if (!Slot || !Props.IsValid()) return;
+        ApplySlotPropsChecked(Slot, Props);
+    }
+
+    FSlotApplyResult ApplySlotPropsChecked(UPanelSlot* Slot, const TSharedPtr<FJsonObject>& Props)
+    {
+        FSlotApplyResult Result;
+        if (!Slot || !Props.IsValid()) return Result;
 
         // CanvasPanelSlot
         if (UCanvasPanelSlot* CSlot = Cast<UCanvasPanelSlot>(Slot))
         {
-            double AnchorMinX, AnchorMinY, AnchorMaxX, AnchorMaxY;
-            if (Props->TryGetNumberField(TEXT("anchor_min_x"), AnchorMinX) ||
-                Props->TryGetNumberField(TEXT("anchor_min_y"), AnchorMinY) ||
-                Props->TryGetNumberField(TEXT("anchor_max_x"), AnchorMaxX) ||
-                Props->TryGetNumberField(TEXT("anchor_max_y"), AnchorMaxY))
-            {
-                FAnchors Anchors = CSlot->GetAnchors();
-                if (Props->TryGetNumberField(TEXT("anchor_min_x"), AnchorMinX)) Anchors.Minimum.X = AnchorMinX;
-                if (Props->TryGetNumberField(TEXT("anchor_min_y"), AnchorMinY)) Anchors.Minimum.Y = AnchorMinY;
-                if (Props->TryGetNumberField(TEXT("anchor_max_x"), AnchorMaxX)) Anchors.Maximum.X = AnchorMaxX;
-                if (Props->TryGetNumberField(TEXT("anchor_max_y"), AnchorMaxY)) Anchors.Maximum.Y = AnchorMaxY;
-                CSlot->SetAnchors(Anchors);
-            }
-            const TSharedPtr<FJsonObject>* AnchorsObj = nullptr;
-            if (Props->TryGetObjectField(TEXT("anchors"), AnchorsObj) && AnchorsObj && AnchorsObj->IsValid())
-            {
-                FAnchors A;
-                double MinX = 0.0, MinY = 0.0, MaxX = 0.0, MaxY = 0.0;
-                (*AnchorsObj)->TryGetNumberField(TEXT("min_x"), MinX);
-                (*AnchorsObj)->TryGetNumberField(TEXT("min_y"), MinY);
-                (*AnchorsObj)->TryGetNumberField(TEXT("max_x"), MaxX);
-                (*AnchorsObj)->TryGetNumberField(TEXT("max_y"), MaxY);
-                A.Minimum = FVector2D(MinX, MinY);
-                A.Maximum = FVector2D(MaxX, MaxY);
-                CSlot->SetAnchors(A);
-            }
+            TryApplyAnchors(Props, CSlot);
 
             double OffX, OffY, OffW, OffH;
             const bool bHasOffX = Props->TryGetNumberField(TEXT("x"), OffX);
@@ -316,17 +505,11 @@ namespace
                 CSlot->SetOffsets(Offsets);
             }
 
-            FVector2D Position = ParseVec2(Props, TEXT("position"));
-            if (!Position.IsZero() || Props->HasField(TEXT("position")))
-                CSlot->SetPosition(Position);
-
-            FVector2D Size = ParseVec2(Props, TEXT("size"));
-            if (!Size.IsZero() || Props->HasField(TEXT("size")))
-                CSlot->SetSize(Size);
-
-            FVector2D Alignment = ParseVec2(Props, TEXT("alignment"));
-            if (!Alignment.IsZero() || Props->HasField(TEXT("alignment")))
-                CSlot->SetAlignment(Alignment);
+            // HasField (not "is non-zero") so a caller CAN move a widget back to
+            // the origin or collapse it to zero size.
+            if (Props->HasField(TEXT("position")))  CSlot->SetPosition(ParseVec2(Props, TEXT("position")));
+            if (Props->HasField(TEXT("size")))      CSlot->SetSize(ParseVec2(Props, TEXT("size")));
+            if (Props->HasField(TEXT("alignment"))) CSlot->SetAlignment(ParseVec2(Props, TEXT("alignment")));
 
             bool bAutoSize = false;
             if (Props->TryGetBoolField(TEXT("auto_size"), bAutoSize))
@@ -337,7 +520,7 @@ namespace
                 CSlot->SetZOrder(ZOrder);
         }
 
-        // HorizontalBoxSlot
+        // HorizontalBoxSlot / VerticalBoxSlot share the fill+padding+alignment shape.
         if (UHorizontalBoxSlot* HSlot = Cast<UHorizontalBoxSlot>(Slot))
         {
             double Fill = 0.0;
@@ -348,18 +531,9 @@ namespace
                 Sz.SizeRule = Fill > 0.0 ? ESlateSizeRule::Fill : ESlateSizeRule::Automatic;
                 HSlot->SetSize(Sz);
             }
-            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
-            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
-                HSlot->SetPadding(Pad);
-
-            FString HAlign, VAlign;
-            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
-                HSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
-            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
-                HSlot->SetVerticalAlignment(ParseVAlign(VAlign));
+            ApplyPaddingAndAlignment(HSlot, Props);
         }
 
-        // VerticalBoxSlot
         if (UVerticalBoxSlot* VSlot = Cast<UVerticalBoxSlot>(Slot))
         {
             double Fill = 0.0;
@@ -370,111 +544,58 @@ namespace
                 Sz.SizeRule = Fill > 0.0 ? ESlateSizeRule::Fill : ESlateSizeRule::Automatic;
                 VSlot->SetSize(Sz);
             }
-            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
-            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
-                VSlot->SetPadding(Pad);
-
-            FString HAlign, VAlign;
-            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
-                VSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
-            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
-                VSlot->SetVerticalAlignment(ParseVAlign(VAlign));
+            ApplyPaddingAndAlignment(VSlot, Props);
         }
 
-        // OverlaySlot
-        if (UOverlaySlot* OSlot = Cast<UOverlaySlot>(Slot))
-        {
-            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
-            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
-                OSlot->SetPadding(Pad);
-
-            FString HAlign, VAlign;
-            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
-                OSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
-            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
-                OSlot->SetVerticalAlignment(ParseVAlign(VAlign));
-        }
+        if (UOverlaySlot* OSlot = Cast<UOverlaySlot>(Slot))       ApplyPaddingAndAlignment(OSlot, Props);
+        if (UScrollBoxSlot* ScSlot = Cast<UScrollBoxSlot>(Slot))  ApplyPaddingAndAlignment(ScSlot, Props);
+        if (UBorderSlot* BSlot = Cast<UBorderSlot>(Slot))         ApplyPaddingAndAlignment(BSlot, Props);
+        if (USizeBoxSlot* SbSlot = Cast<USizeBoxSlot>(Slot))      ApplyPaddingAndAlignment(SbSlot, Props);
+        if (UWrapBoxSlot* WSlot = Cast<UWrapBoxSlot>(Slot))       ApplyPaddingAndAlignment(WSlot, Props);
+        if (UWidgetSwitcherSlot* WsSlot = Cast<UWidgetSwitcherSlot>(Slot)) ApplyPaddingAndAlignment(WsSlot, Props);
 
         // GridSlot
         if (UGridSlot* GSlot = Cast<UGridSlot>(Slot))
         {
             int32 Row, Column, RowSpan, ColSpan, Layer;
-            if (Props->TryGetNumberField(TEXT("row"), Row))      GSlot->SetRow(Row);
-            if (Props->TryGetNumberField(TEXT("column"), Column)) GSlot->SetColumn(Column);
-            if (Props->TryGetNumberField(TEXT("row_span"), RowSpan))  GSlot->SetRowSpan(RowSpan);
-            if (Props->TryGetNumberField(TEXT("column_span"), ColSpan)) GSlot->SetColumnSpan(ColSpan);
-            if (Props->TryGetNumberField(TEXT("layer"), Layer))   GSlot->SetLayer(Layer);
+            if (Props->TryGetNumberField(TEXT("row"), Row))              GSlot->SetRow(Row);
+            if (Props->TryGetNumberField(TEXT("column"), Column))        GSlot->SetColumn(Column);
+            if (Props->TryGetNumberField(TEXT("row_span"), RowSpan))     GSlot->SetRowSpan(RowSpan);
+            if (Props->TryGetNumberField(TEXT("column_span"), ColSpan))  GSlot->SetColumnSpan(ColSpan);
+            if (Props->TryGetNumberField(TEXT("layer"), Layer))          GSlot->SetLayer(Layer);
 
-            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
-            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
-                GSlot->SetPadding(Pad);
+            ApplyPaddingAndAlignment(GSlot, Props);
 
-            FString HAlign, VAlign;
-            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
-                GSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
-            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
-                GSlot->SetVerticalAlignment(ParseVAlign(VAlign));
-
-            FVector2D Nudge = ParseVec2(Props, TEXT("nudge"));
-            if (!Nudge.IsZero() || Props->HasField(TEXT("nudge")))
-                GSlot->SetNudge(Nudge);
+            if (Props->HasField(TEXT("nudge"))) GSlot->SetNudge(ParseVec2(Props, TEXT("nudge")));
         }
 
         // UniformGridSlot
         if (UUniformGridSlot* USlot = Cast<UUniformGridSlot>(Slot))
         {
             int32 Row, Column;
-            if (Props->TryGetNumberField(TEXT("row"), Row))      USlot->SetRow(Row);
+            if (Props->TryGetNumberField(TEXT("row"), Row))       USlot->SetRow(Row);
             if (Props->TryGetNumberField(TEXT("column"), Column)) USlot->SetColumn(Column);
-
-            FString HAlign, VAlign;
-            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
-                USlot->SetHorizontalAlignment(ParseHAlign(HAlign));
-            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
-                USlot->SetVerticalAlignment(ParseVAlign(VAlign));
+            ApplyAlignments(USlot, Props);
         }
 
-        // ScrollBoxSlot
-        if (UScrollBoxSlot* ScSlot = Cast<UScrollBoxSlot>(Slot))
+        // Anything not handled above gets one reflection attempt against the
+        // slot's own UPROPERTYs; only then is it reported unknown. Silently
+        // dropping keys is what let ui_set_slot_layout report success while
+        // changing nothing.
+        const TSet<FString> Applicable = ApplicableSlotKeys(Slot);
+        for (const auto& Pair : Props->Values)
         {
-            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
-            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
-                ScSlot->SetPadding(Pad);
-
-            FString HAlign, VAlign;
-            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
-                ScSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
-            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
-                ScSlot->SetVerticalAlignment(ParseVAlign(VAlign));
+            const FString& Key = Pair.Key;
+            if (Applicable.Contains(Key))
+            {
+                Result.Applied.Add(Key);
+                continue;
+            }
+            if (HaybaReflection::SetProp(Slot, Key, Pair.Value)) Result.Applied.Add(Key);
+            else Result.Unknown.Add(Key);
         }
 
-        // BorderSlot
-        if (UBorderSlot* BSlot = Cast<UBorderSlot>(Slot))
-        {
-            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
-            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
-                BSlot->SetPadding(Pad);
-
-            FString HAlign, VAlign;
-            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
-                BSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
-            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
-                BSlot->SetVerticalAlignment(ParseVAlign(VAlign));
-        }
-
-        // SizeBoxSlot
-        if (USizeBoxSlot* SbSlot = Cast<USizeBoxSlot>(Slot))
-        {
-            const FMargin Pad = ParseMargin(Props, TEXT("padding"));
-            if (Pad.Left != 0.0 || Pad.Top != 0.0 || Pad.Right != 0.0 || Pad.Bottom != 0.0)
-                SbSlot->SetPadding(Pad);
-
-            FString HAlign, VAlign;
-            if (Props->TryGetStringField(TEXT("horizontal_alignment"), HAlign))
-                SbSlot->SetHorizontalAlignment(ParseHAlign(HAlign));
-            if (Props->TryGetStringField(TEXT("vertical_alignment"), VAlign))
-                SbSlot->SetVerticalAlignment(ParseVAlign(VAlign));
-        }
+        return Result;
     }
 
     TSharedPtr<FJsonObject> ExtractWidgetProperties(UWidget* W)
@@ -753,6 +874,11 @@ FHaybaHandlerResult FHaybaMCPUIHandler::Handle(const FString& Cmd, const TShared
     if (Cmd == TEXT("ui_compile_widget"))      return HandleCompile(P);
     if (Cmd == TEXT("ui_save_widget"))         return HandleSave(P);
     if (Cmd == TEXT("ui_list_widget_types"))   return HandleListTypes(P);
+    if (Cmd == TEXT("ui_build_tree"))          return HandleBuildTree(P);
+    if (Cmd == TEXT("ui_set_variable"))        return HandleSetVariable(P);
+    if (Cmd == TEXT("ui_list_widget_blueprints")) return HandleListWidgetBlueprints(P);
+    if (Cmd == TEXT("ui_layout_snapshot"))     return HandleLayoutSnapshot(P);
+    if (Cmd == TEXT("ui_measure_text"))        return HandleMeasureText(P);
 
     return FHaybaHandlerResult::Err(FString::Printf(TEXT("UIHandler: unknown command %s"), *Cmd));
 #endif
@@ -886,13 +1012,17 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
     const TSharedPtr<FJsonObject>* Props = nullptr;
     const TSharedPtr<FJsonObject>* SlotProps = nullptr;
     P->TryGetObjectField(TEXT("properties"), Props);
-    // Public MCP schema has always documented `slot_props`, while an earlier
-    // handler revision only read `slot_properties`.  Accept both spellings so
-    // typed UMG calls actually persist margins/layout rather than silently
-    // reporting success for unrelated widget properties.
+    // Three spellings have shipped in different layers: `slot_props` (public
+    // schema), `slot_properties` (an early handler revision) and `slot_layout`
+    // (the typed slot tool). Only the first was ever read, so the typed tool's
+    // payload fell on the floor and the call failed with "no properties
+    // provided" no matter how well-formed it was. Accept all three.
     if (!(P->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid()))
     {
-        P->TryGetObjectField(TEXT("slot_properties"), SlotProps);
+        if (!(P->TryGetObjectField(TEXT("slot_properties"), SlotProps) && SlotProps && SlotProps->IsValid()))
+        {
+            P->TryGetObjectField(TEXT("slot_layout"), SlotProps);
+        }
     }
 
     if ((!Props || !Props->IsValid()) && (!SlotProps || !SlotProps->IsValid()))
@@ -901,6 +1031,8 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
     int32 Succeeded = 0;
     int32 Failed = 0;
     TArray<FString> FailedProps;
+    TArray<FString> UnknownSlotProps;
+    TArray<FString> Warnings;
     {
         // No FScopedTransaction: these are automation-tool edits with no undo/redo
         // requirement, and the global editor transaction buffer (GEditor->Trans) can
@@ -924,17 +1056,63 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
             }
         }
 
-        if (SlotProps && SlotProps->IsValid() && Widget->Slot)
+        if (SlotProps && SlotProps->IsValid())
         {
-            // Slots are distinct UObject instances in a WidgetTree.  Marking
-            // only the child widget dirty made horizontal/vertical padding look
-            // successful in the response but vanish on the next query/reopen.
-            Widget->Slot->Modify();
-            ApplySlotProps(Widget->Slot, *SlotProps);
-            Widget->Slot->PostEditChange();
-            for (const auto& Pair : (*SlotProps)->Values)
+            if (!Widget->Slot)
             {
-                ++Succeeded;
+                // The root widget has no slot at all. Reporting the keys as
+                // applied here would be a flat lie.
+                for (const auto& Pair : (*SlotProps)->Values)
+                {
+                    ++Failed;
+                    FailedProps.Add(FString::Printf(TEXT("slot.%s"), *Pair.Key));
+                }
+                Warnings.Add(FString::Printf(
+                    TEXT("'%s' has no panel slot (it is the root widget, or its parent is not a panel), so slot layout was not applied."),
+                    *WidgetName));
+            }
+            else
+            {
+                // Slots are distinct UObject instances in a WidgetTree.  Marking
+                // only the child widget dirty made horizontal/vertical padding look
+                // successful in the response but vanish on the next query/reopen.
+                Widget->Slot->Modify();
+                const FSlotApplyResult SlotResult = ApplySlotPropsChecked(Widget->Slot, *SlotProps);
+                Widget->Slot->PostEditChange();
+
+                // Count what actually landed. The previous code incremented the
+                // success counter once per submitted key regardless of whether
+                // the slot understood it.
+                Succeeded += SlotResult.Applied.Num();
+                Failed += SlotResult.Unknown.Num();
+                for (const FString& Key : SlotResult.Unknown)
+                {
+                    UnknownSlotProps.Add(Key);
+                    FailedProps.Add(FString::Printf(TEXT("slot.%s"), *Key));
+                }
+                if (SlotResult.Unknown.Num() > 0)
+                {
+                    Warnings.Add(FString::Printf(
+                        TEXT("Slot is a %s; keys %s are not valid for that slot type. Query the widget to see its real slot class."),
+                        *Widget->Slot->GetClass()->GetName(),
+                        *FString::Join(SlotResult.Unknown, TEXT(", "))));
+                }
+            }
+        }
+
+        // The single most expensive UMG trap to debug: assigning a UFontFace to
+        // a Slate font renders the font's glyph-preview atlas ("BASIC LATIN /
+        // A / 0000-007F" tiles) instead of text. Slate needs a composite UFont.
+        {
+            FSlateFontInfo WidgetFont;
+            if (HaybaUILayout::GetWidgetFont(Widget, WidgetFont) && WidgetFont.FontObject)
+            {
+                if (WidgetFont.FontObject->IsA<UFontFace>())
+                {
+                    Warnings.Add(FString::Printf(
+                        TEXT("Font object '%s' is a UFontFace, not a UFont. Slate renders a UFontFace as its glyph-preview tiles rather than as text. Assign the composite UFont asset instead."),
+                        *WidgetFont.FontObject->GetPathName()));
+                }
             }
         }
 
@@ -945,19 +1123,27 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
         WBP->MarkPackageDirty();
     }
 
+    auto ToJsonArray = [](const TArray<FString>& In)
+    {
+        TArray<TSharedPtr<FJsonValue>> Arr;
+        for (const FString& S : In) Arr.Add(MakeShared<FJsonValueString>(S));
+        return Arr;
+    };
+
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("widget_name"), WidgetName);
     Out->SetNumberField(TEXT("succeeded"), Succeeded);
     Out->SetNumberField(TEXT("failed"), Failed);
-    if (FailedProps.Num() > 0)
-    {
-        TArray<TSharedPtr<FJsonValue>> FArr;
-        for (const FString& F : FailedProps)
-            FArr.Add(MakeShared<FJsonValueString>(F));
-        Out->SetArrayField(TEXT("failed_properties"), FArr);
-    }
+    if (FailedProps.Num() > 0)      Out->SetArrayField(TEXT("failed_properties"), ToJsonArray(FailedProps));
+    if (UnknownSlotProps.Num() > 0) Out->SetArrayField(TEXT("unknown_slot_props"), ToJsonArray(UnknownSlotProps));
+    if (Warnings.Num() > 0)         Out->SetArrayField(TEXT("warnings"), ToJsonArray(Warnings));
 
     if (Succeeded == 0)
-        return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: all properties failed"));
+    {
+        return FHaybaHandlerResult::Err(FString::Printf(
+            TEXT("ui_set_widget_properties: nothing applied to '%s'. Rejected: %s"),
+            *WidgetName, *FString::Join(FailedProps, TEXT(", "))));
+    }
 
     return FHaybaHandlerResult::Ok(Out);
 }
@@ -982,6 +1168,60 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleQuery(const TSharedPtr<FJsonObject
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("path"), WBP->GetPathName());
     Out->SetStringField(TEXT("parent_class"), WBP->ParentClass ? WBP->ParentClass->GetPathName() : TEXT(""));
+
+    // Filtered mode: return a flat list of matching widgets rather than the
+    // whole tree. Without this a "search" can only be done by shipping the
+    // entire tree to the caller and filtering there, which is what made the
+    // search tool a full-tree dump wearing a search tool's schema.
+    FString NamePattern, ClassFilter;
+    const bool bHasNameFilter  = P->TryGetStringField(TEXT("name_pattern"), NamePattern) && !NamePattern.IsEmpty();
+    const bool bHasClassFilter = P->TryGetStringField(TEXT("class_filter"), ClassFilter) && !ClassFilter.IsEmpty();
+    bool bFlatten = false;
+    P->TryGetBoolField(TEXT("flatten"), bFlatten);
+
+    if (bHasNameFilter || bHasClassFilter || bFlatten)
+    {
+        TArray<TSharedPtr<FJsonValue>> Matches;
+        WBP->WidgetTree->ForEachWidget([&](UWidget* Widget)
+        {
+            if (!Widget) return;
+            if (bHasNameFilter && !Widget->GetName().Contains(NamePattern)) return;
+            if (bHasClassFilter)
+            {
+                // Match on the exact class name or anywhere in the inheritance
+                // chain, so class_filter:"PanelWidget" finds every panel.
+                bool bClassMatch = false;
+                for (UClass* C = Widget->GetClass(); C; C = C->GetSuperClass())
+                {
+                    if (C->GetName() == ClassFilter || C->GetName() == (TEXT("U") + ClassFilter))
+                    {
+                        bClassMatch = true;
+                        break;
+                    }
+                }
+                if (!bClassMatch) return;
+            }
+
+            TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+            Entry->SetStringField(TEXT("name"), Widget->GetName());
+            Entry->SetStringField(TEXT("class"), Widget->GetClass()->GetName());
+            Entry->SetStringField(TEXT("parent"), Widget->GetParent() ? Widget->GetParent()->GetName() : FString());
+            if (bIncludeSlot) Entry->SetStringField(TEXT("slot_class"), ResolveSlotType(Widget));
+            if (bIncludeGuid)
+            {
+                if (const FGuid* Found = WBP->WidgetVariableNameToGuidMap.Find(Widget->GetFName()))
+                    Entry->SetStringField(TEXT("guid"), Found->ToString());
+            }
+            if (bIncludeProperties) Entry->SetObjectField(TEXT("properties"), ExtractWidgetProperties(Widget));
+            Matches.Add(MakeShared<FJsonValueObject>(Entry));
+        });
+
+        Out->SetArrayField(TEXT("matches"), Matches);
+        Out->SetNumberField(TEXT("match_count"), Matches.Num());
+        if (bHasNameFilter)  Out->SetStringField(TEXT("name_pattern"), NamePattern);
+        if (bHasClassFilter) Out->SetStringField(TEXT("class_filter"), ClassFilter);
+        return FHaybaHandlerResult::Ok(Out);
+    }
 
     if (UWidget* Root = WBP->WidgetTree->RootWidget)
     {
@@ -1064,7 +1304,10 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
                 }
             }
 
-            WBP->WidgetVariableNameToGuidMap.Remove(Widget->GetFName());
+            PurgeSubtreeGuids(WBP, Widget);
+            // Detach the widget objects from the tree as well; RemoveChild only
+            // unlinks from the panel, leaving the widgets owned by the tree.
+            WBP->WidgetTree->RemoveWidget(Widget);
             FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
             WBP->MarkPackageDirty();
         }
@@ -1112,6 +1355,9 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
         int32 OldIndex = OldParent->GetChildIndex(Widget);
         FString OldParentName = OldParent->GetName();
 
+        int32 InsertIndex = -1;
+        P->TryGetNumberField(TEXT("index"), InsertIndex);
+
         {
             // No FScopedTransaction — see comment in ui_set_widget_properties above:
             // avoids pinning a PIE GameInstance reference in the editor undo buffer.
@@ -1121,7 +1367,41 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
             NewParent->Modify();
 
             OldParent->RemoveChild(Widget);
-            UPanelSlot* NewSlot = NewParent->AddChild(Widget);
+
+            UPanelSlot* NewSlot = (InsertIndex >= 0 && InsertIndex <= NewParent->GetChildrenCount())
+                ? NewParent->InsertChildAt(InsertIndex, Widget)
+                : NewParent->AddChild(Widget);
+
+            if (!NewSlot)
+            {
+                // Put it back rather than leaving the widget orphaned: full
+                // panels (SizeBox, Border, ScaleBox hold exactly one child)
+                // reject the add and the caller's tree would silently lose a
+                // whole subtree.
+                OldParent->InsertChildAt(FMath::Clamp(OldIndex, 0, OldParent->GetChildrenCount()), Widget);
+                return FHaybaHandlerResult::Err(FString::Printf(
+                    TEXT("ui_mutate_tree reparent: '%s' refused the child (a %s holds a limited number of children). Widget left under '%s'."),
+                    *NewParentName, *NewParent->GetClass()->GetName(), *OldParentName));
+            }
+
+            // Slot layout for the NEW parent, since the old slot's type is
+            // usually not even the same class.
+            const TSharedPtr<FJsonObject>* SlotProps = nullptr;
+            if (P->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid())
+            {
+                NewSlot->Modify();
+                const FSlotApplyResult SlotResult = ApplySlotPropsChecked(NewSlot, *SlotProps);
+                NewSlot->PostEditChange();
+                if (SlotResult.Unknown.Num() > 0)
+                {
+                    TArray<TSharedPtr<FJsonValue>> UArr;
+                    for (const FString& K : SlotResult.Unknown) UArr.Add(MakeShared<FJsonValueString>(K));
+                    Out->SetArrayField(TEXT("unknown_slot_props"), UArr);
+                }
+            }
+
+            Out->SetStringField(TEXT("new_slot_class"), NewSlot->GetClass()->GetName());
+            Out->SetNumberField(TEXT("new_child_index"), NewParent->GetChildIndex(Widget));
 
             FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
             WBP->MarkPackageDirty();
@@ -1132,6 +1412,175 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
         Out->SetNumberField(TEXT("old_child_index"), OldIndex);
         Out->SetStringField(TEXT("new_parent"), NewParentName);
 
+        return FHaybaHandlerResult::Ok(Out);
+    }
+    else if (Operation == TEXT("move"))
+    {
+        // Reorder within the current parent. Draw/tab order in a box panel is
+        // child order, so this is the only way to change it without a
+        // remove+re-add round trip that loses the slot layout.
+        FString WidgetName;
+        int32 NewIndex = 0;
+        if (!P->TryGetStringField(TEXT("widget_name"), WidgetName) || WidgetName.IsEmpty())
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree move: missing widget_name"));
+        if (!P->TryGetNumberField(TEXT("index"), NewIndex))
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree move: missing index"));
+
+        UWidget* Widget = FindWidgetByName(WBP->WidgetTree, WidgetName);
+        if (!Widget)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree move: widget '%s' not found"), *WidgetName));
+
+        UPanelWidget* Parent = Widget->GetParent();
+        if (!Parent)
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree move: widget is the root and has no siblings"));
+
+        const int32 OldIndex = Parent->GetChildIndex(Widget);
+        const int32 LastIndex = Parent->GetChildrenCount() - 1;
+        if (NewIndex < 0 || NewIndex > LastIndex)
+        {
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("ui_mutate_tree move: index %d out of range (parent '%s' has %d children, valid 0..%d)"),
+                NewIndex, *Parent->GetName(), Parent->GetChildrenCount(), LastIndex));
+        }
+
+        if (NewIndex != OldIndex)
+        {
+            WBP->Modify();
+            Parent->Modify();
+            Widget->Modify();
+
+            // Preserve the slot: shifting order must not reset padding/fill, so
+            // copy the old slot's values onto whatever slot the re-insert makes.
+            UPanelSlot* const OldSlot = Widget->Slot;
+            UObject* SlotSnapshot = nullptr;
+            if (OldSlot)
+            {
+                SlotSnapshot = NewObject<UObject>(GetTransientPackage(), OldSlot->GetClass());
+                CopyCommonProperties(OldSlot, SlotSnapshot);
+            }
+
+            Parent->RemoveChild(Widget);
+            UPanelSlot* NewSlot = Parent->InsertChildAt(NewIndex, Widget);
+            if (!NewSlot)
+            {
+                Parent->InsertChildAt(FMath::Clamp(OldIndex, 0, Parent->GetChildrenCount()), Widget);
+                return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree move: re-insert failed; widget restored to its original index"));
+            }
+            if (SlotSnapshot)
+            {
+                CopyCommonProperties(SlotSnapshot, NewSlot);
+                NewSlot->SynchronizeProperties();
+            }
+
+            FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+            WBP->MarkPackageDirty();
+        }
+
+        Out->SetStringField(TEXT("widget_name"), WidgetName);
+        Out->SetStringField(TEXT("parent"), Parent->GetName());
+        Out->SetNumberField(TEXT("old_index"), OldIndex);
+        Out->SetNumberField(TEXT("new_index"), NewIndex);
+        return FHaybaHandlerResult::Ok(Out);
+    }
+    else if (Operation == TEXT("rename"))
+    {
+        FString WidgetName, NewName;
+        if (!P->TryGetStringField(TEXT("widget_name"), WidgetName) || WidgetName.IsEmpty())
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree rename: missing widget_name"));
+        if (!P->TryGetStringField(TEXT("new_name"), NewName) || NewName.IsEmpty())
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree rename: missing new_name"));
+
+        UWidget* Widget = FindWidgetByName(WBP->WidgetTree, WidgetName);
+        if (!Widget)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree rename: widget '%s' not found"), *WidgetName));
+        if (!ValidateWidgetName(WBP->WidgetTree, NewName))
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree rename: '%s' is already taken in this widget tree"), *NewName));
+
+        WBP->Modify();
+        Widget->Modify();
+
+        // Carry the variable GUID across so existing bindings and any graph
+        // references keep resolving to this widget.
+        FGuid Guid;
+        const bool bHadGuid = WBP->WidgetVariableNameToGuidMap.RemoveAndCopyValue(FName(*WidgetName), Guid);
+
+        Widget->Rename(*NewName, Widget->GetOuter(), REN_DontCreateRedirectors);
+
+        if (bHadGuid) WBP->WidgetVariableNameToGuidMap.Add(FName(*NewName), Guid);
+        else RegisterWidgetVariable(WBP, Widget);
+
+        FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+        WBP->MarkPackageDirty();
+
+        Out->SetStringField(TEXT("old_name"), WidgetName);
+        Out->SetStringField(TEXT("new_name"), Widget->GetName());
+        Out->SetBoolField(TEXT("guid_preserved"), bHadGuid);
+        return FHaybaHandlerResult::Ok(Out);
+    }
+    else if (Operation == TEXT("duplicate"))
+    {
+        FString WidgetName, NewName, TargetParentName;
+        if (!P->TryGetStringField(TEXT("widget_name"), WidgetName) || WidgetName.IsEmpty())
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree duplicate: missing widget_name"));
+        P->TryGetStringField(TEXT("new_name"), NewName);
+        P->TryGetStringField(TEXT("parent_widget_name"), TargetParentName);
+
+        UWidget* Source = FindWidgetByName(WBP->WidgetTree, WidgetName);
+        if (!Source)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree duplicate: widget '%s' not found"), *WidgetName));
+
+        UPanelWidget* TargetParent = TargetParentName.IsEmpty()
+            ? Source->GetParent()
+            : Cast<UPanelWidget>(FindWidgetByName(WBP->WidgetTree, TargetParentName));
+        if (!TargetParent)
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree duplicate: no target panel (source is the root — pass parent_widget_name)"));
+
+        if (!NewName.IsEmpty() && !ValidateWidgetName(WBP->WidgetTree, NewName))
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree duplicate: '%s' is already taken"), *NewName));
+
+        WBP->Modify();
+        TargetParent->Modify();
+
+        // Duplicating into the widget tree copies the whole subtree, which is
+        // the point: duplicating a styled row should bring its children along.
+        const FName DupName = NewName.IsEmpty()
+            ? MakeUniqueObjectName(WBP->WidgetTree, Source->GetClass(), Source->GetFName())
+            : FName(*NewName);
+
+        UWidget* Copy = DuplicateObject<UWidget>(Source, WBP->WidgetTree, DupName);
+        if (!Copy)
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree duplicate: DuplicateObject failed"));
+
+        UPanelSlot* NewSlot = TargetParent->AddChild(Copy);
+        if (!NewSlot)
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("ui_mutate_tree duplicate: '%s' refused the child (panel is full)"), *TargetParent->GetName()));
+
+        if (Source->Slot && NewSlot->GetClass() == Source->Slot->GetClass())
+        {
+            CopyCommonProperties(Source->Slot, NewSlot);
+            NewSlot->SynchronizeProperties();
+        }
+
+        // Register the copy and every duplicated descendant as variables so
+        // they behave like hand-placed widgets in the designer.
+        TArray<UWidget*> Subtree;
+        CollectSubtree(Copy, Subtree);
+        for (UWidget* W : Subtree) RegisterWidgetVariable(WBP, W);
+
+        const TSharedPtr<FJsonObject>* SlotProps = nullptr;
+        if (P->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid())
+        {
+            ApplySlotPropsChecked(NewSlot, *SlotProps);
+        }
+
+        FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+        WBP->MarkPackageDirty();
+
+        Out->SetStringField(TEXT("source"), WidgetName);
+        Out->SetStringField(TEXT("name"), Copy->GetName());
+        Out->SetStringField(TEXT("parent"), TargetParent->GetName());
+        Out->SetNumberField(TEXT("widgets_duplicated"), Subtree.Num());
         return FHaybaHandlerResult::Ok(Out);
     }
     else if (Operation == TEXT("replace"))
@@ -1171,19 +1620,50 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
             Parent->Modify();
 
             const FName ConstructName = NewName.IsEmpty() ? Widget->GetFName() : FName(*NewName);
+
+            // Free the name before reusing it. Constructing a widget with a name
+            // the outgoing widget still holds makes UE silently uniquify the new
+            // one ("Title_1"), which then breaks every binding that referenced
+            // the original name.
+            UPanelSlot* const OldSlot = Widget->Slot;
+            if (ConstructName == Widget->GetFName())
+            {
+                Widget->Rename(*MakeUniqueObjectName(Widget->GetOuter(), Widget->GetClass(), TEXT("HaybaMCP_Replaced")).ToString(),
+                    Widget->GetOuter(), REN_DontCreateRedirectors | REN_DoNotDirty);
+            }
+
             UWidget* NewWidget = WBP->WidgetTree->ConstructWidget<UWidget>(NewClass, ConstructName);
             if (!NewWidget)
                 return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree replace: ConstructWidget failed"));
+
+            int32 PropertiesCopied = 0;
+            if (bPreserveProperties)
+            {
+                PropertiesCopied = CopyCommonProperties(Widget, NewWidget);
+            }
 
             UPanelSlot* NewSlot = Parent->InsertChildAt(ChildIndex, NewWidget);
             if (!NewSlot)
                 return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree replace: InsertChildAt failed"));
 
+            // Slot layout describes the widget's place in its parent, not the
+            // widget's own identity, so it survives a class swap whenever the
+            // parent hands out the same slot type (it always does — the slot
+            // class is a property of the panel).
+            if (OldSlot && NewSlot->GetClass() == OldSlot->GetClass())
+            {
+                CopyCommonProperties(OldSlot, NewSlot);
+                NewSlot->SynchronizeProperties();
+            }
+
+            Out->SetNumberField(TEXT("properties_copied"), PropertiesCopied);
             Parent->RemoveChild(Widget);
 
             if (bPreserveGuid)
             {
-                const FName OldName = Widget->GetFName();
+                // The outgoing widget may have been renamed to a scratch name
+                // just above, so key off the name the caller asked for.
+                const FName OldName(*WidgetName);
                 FGuid OldGuid;
                 if (WBP->WidgetVariableNameToGuidMap.RemoveAndCopyValue(OldName, OldGuid))
                 {
@@ -1193,9 +1673,10 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
             }
             else
             {
-                WBP->WidgetVariableNameToGuidMap.Remove(Widget->GetFName());
+                WBP->WidgetVariableNameToGuidMap.Remove(FName(*WidgetName));
                 RegisterWidgetVariable(WBP, NewWidget);
             }
+            WBP->WidgetTree->RemoveWidget(Widget);
 
             FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
             WBP->MarkPackageDirty();
@@ -1210,7 +1691,9 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
         return FHaybaHandlerResult::Ok(Out);
     }
 
-    return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_mutate_tree: unknown operation '%s'"), *Operation));
+    return FHaybaHandlerResult::Err(FString::Printf(
+        TEXT("ui_mutate_tree: unknown operation '%s' (expected one of: remove, reparent, replace, move, rename, duplicate)"),
+        *Operation));
 }
 
 FHaybaHandlerResult FHaybaMCPUIHandler::HandleCompile(const TSharedPtr<FJsonObject>& P)
@@ -1319,6 +1802,12 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleListTypes(const TSharedPtr<FJsonOb
     FString Filter;
     P->TryGetStringField(TEXT("filter"), Filter);
 
+    bool bIncludeBlueprints = false;
+    P->TryGetBoolField(TEXT("include_blueprints"), bIncludeBlueprints);
+
+    bool bPanelsOnly = false;
+    P->TryGetBoolField(TEXT("panels_only"), bPanelsOnly);
+
     TArray<TSharedPtr<FJsonValue>> Results;
 
     for (TObjectIterator<UClass> It; It; ++It)
@@ -1327,15 +1816,22 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleListTypes(const TSharedPtr<FJsonOb
         if (!C->IsChildOf(UWidget::StaticClass())) continue;
         if (C == UWidget::StaticClass()) continue;
         if (C->HasAnyClassFlags(CLASS_Abstract | CLASS_Deprecated | CLASS_NewerVersionExists)) continue;
-        if (!C->IsNative()) continue;
+        // Blueprint widget classes (your own reusable WBP_* components) are
+        // legitimate children — ui_add_element accepts them by class path — so
+        // they are only excluded when the caller asks for native types only.
+        if (!C->IsNative() && !bIncludeBlueprints) continue;
 
         const FString Name = C->GetName();
         if (!Filter.IsEmpty() && !Name.Contains(Filter)) continue;
 
+        const bool bIsPanel = C->IsChildOf(UPanelWidget::StaticClass());
+        if (bPanelsOnly && !bIsPanel) continue;
+
         TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
         Entry->SetStringField(TEXT("name"), Name);
         Entry->SetStringField(TEXT("class_path"), C->GetPathName());
-        Entry->SetBoolField(TEXT("is_panel"), C->IsChildOf(UPanelWidget::StaticClass()));
+        Entry->SetBoolField(TEXT("is_panel"), bIsPanel);
+        Entry->SetBoolField(TEXT("is_native"), C->IsNative());
 
         FString Desc = C->GetMetaData(TEXT("ToolTip"));
         if (Desc.IsEmpty()) Desc = C->GetMetaData(TEXT("Description"));
@@ -1347,6 +1843,591 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleListTypes(const TSharedPtr<FJsonOb
 
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetArrayField(TEXT("types"), Results);
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+// ── Batch authoring ─────────────────────────────────────────────────────────
+//
+// One ui_add_element per widget costs a round trip each and leaves the
+// blueprint half-built when a call in the middle fails. ui_build_tree takes the
+// whole subtree as a nested spec, so a screen is one call and the response
+// names every widget it created.
+
+namespace
+{
+    struct FBuildTreeStats
+    {
+        int32 Created = 0;
+        TArray<FString> Names;
+        TArray<FString> Warnings;
+    };
+
+    /** Recursively realise one spec node under `Parent`.
+     *  Spec: { class, name?, properties?, slot_props?, children?[] } */
+    FString BuildTreeNode(UWidgetBlueprint* WBP, UPanelWidget* Parent,
+        const TSharedPtr<FJsonObject>& Spec, FBuildTreeStats& Stats, int32 Depth)
+    {
+        if (Depth > 64) return TEXT("ui_build_tree: spec nested deeper than 64 levels");
+        if (!Spec.IsValid()) return TEXT("ui_build_tree: empty node in children");
+
+        FString ClassName;
+        if (!Spec->TryGetStringField(TEXT("class"), ClassName) || ClassName.IsEmpty())
+            return TEXT("ui_build_tree: every node needs a 'class'");
+
+        UClass* Class = ResolveWidgetClass(ClassName);
+        if (!Class || !Class->IsChildOf(UWidget::StaticClass()))
+            return FString::Printf(TEXT("ui_build_tree: unknown class '%s'"), *ClassName);
+
+        FString Name;
+        Spec->TryGetStringField(TEXT("name"), Name);
+        if (!Name.IsEmpty() && !ValidateWidgetName(WBP->WidgetTree, Name))
+            return FString::Printf(TEXT("ui_build_tree: widget name '%s' is already taken"), *Name);
+
+        const FName ConstructName = Name.IsEmpty() ? NAME_None : FName(*Name);
+        UWidget* New = WBP->WidgetTree->ConstructWidget<UWidget>(Class, ConstructName);
+        if (!New) return FString::Printf(TEXT("ui_build_tree: could not construct '%s'"), *ClassName);
+
+        UPanelSlot* Slot = Parent->AddChild(New);
+        if (!Slot)
+            return FString::Printf(TEXT("ui_build_tree: '%s' (a %s) refused another child"),
+                *Parent->GetName(), *Parent->GetClass()->GetName());
+
+        RegisterWidgetVariable(WBP, New);
+        Stats.Created++;
+        Stats.Names.Add(New->GetName());
+
+        const TSharedPtr<FJsonObject>* SlotProps = nullptr;
+        if (Spec->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid())
+        {
+            const FSlotApplyResult R = ApplySlotPropsChecked(Slot, *SlotProps);
+            for (const FString& K : R.Unknown)
+            {
+                Stats.Warnings.Add(FString::Printf(TEXT("%s: slot key '%s' is not valid for a %s"),
+                    *New->GetName(), *K, *Slot->GetClass()->GetName()));
+            }
+        }
+
+        const TSharedPtr<FJsonObject>* Props = nullptr;
+        if (Spec->TryGetObjectField(TEXT("properties"), Props) && Props && Props->IsValid())
+        {
+            for (const auto& Pair : (*Props)->Values)
+            {
+                if (!HaybaReflection::SetProp(New, Pair.Key, Pair.Value))
+                {
+                    Stats.Warnings.Add(FString::Printf(TEXT("%s: property '%s' was rejected by %s"),
+                        *New->GetName(), *Pair.Key, *Class->GetName()));
+                }
+            }
+        }
+
+        const TArray<TSharedPtr<FJsonValue>>* Children = nullptr;
+        if (Spec->TryGetArrayField(TEXT("children"), Children) && Children && Children->Num() > 0)
+        {
+            UPanelWidget* AsPanel = Cast<UPanelWidget>(New);
+            if (!AsPanel)
+            {
+                return FString::Printf(TEXT("ui_build_tree: '%s' is a %s, which is not a panel and cannot take children"),
+                    *New->GetName(), *Class->GetName());
+            }
+            for (const TSharedPtr<FJsonValue>& ChildVal : *Children)
+            {
+                if (!ChildVal.IsValid() || ChildVal->Type != EJson::Object)
+                    return TEXT("ui_build_tree: every entry of 'children' must be an object");
+                const FString Err = BuildTreeNode(WBP, AsPanel, ChildVal->AsObject(), Stats, Depth + 1);
+                if (!Err.IsEmpty()) return Err;
+            }
+        }
+
+        return FString();
+    }
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleBuildTree(const TSharedPtr<FJsonObject>& P)
+{
+    FString BPPath, ParentName;
+    if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_build_tree: missing widget_blueprint_path"));
+    P->TryGetStringField(TEXT("parent_widget_name"), ParentName);
+
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    if (!WBP || !WBP->WidgetTree)
+        return FHaybaHandlerResult::Err(TEXT("ui_build_tree: widget blueprint not found"));
+
+    UPanelWidget* Parent = nullptr;
+    if (ParentName.IsEmpty())
+    {
+        Parent = Cast<UPanelWidget>(WBP->WidgetTree->RootWidget);
+        if (!Parent)
+            return FHaybaHandlerResult::Err(TEXT("ui_build_tree: root widget is not a panel; pass parent_widget_name"));
+    }
+    else
+    {
+        Parent = Cast<UPanelWidget>(FindWidgetByName(WBP->WidgetTree, ParentName));
+        if (!Parent)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_build_tree: parent '%s' not found or not a panel"), *ParentName));
+    }
+
+    // Accept either a single root node or an array of siblings.
+    TArray<TSharedPtr<FJsonValue>> Nodes;
+    const TSharedPtr<FJsonObject>* SingleNode = nullptr;
+    const TArray<TSharedPtr<FJsonValue>>* NodeArray = nullptr;
+    if (P->TryGetObjectField(TEXT("tree"), SingleNode) && SingleNode && SingleNode->IsValid())
+    {
+        Nodes.Add(MakeShared<FJsonValueObject>(SingleNode->ToSharedRef()));
+    }
+    else if (P->TryGetArrayField(TEXT("tree"), NodeArray) && NodeArray)
+    {
+        Nodes = *NodeArray;
+    }
+    else
+    {
+        return FHaybaHandlerResult::Err(TEXT("ui_build_tree: missing 'tree' (an object, or an array of objects, each {class, name?, properties?, slot_props?, children?})"));
+    }
+
+    WBP->Modify();
+
+    FBuildTreeStats Stats;
+    FString Error;
+    for (const TSharedPtr<FJsonValue>& Node : Nodes)
+    {
+        if (!Node.IsValid() || Node->Type != EJson::Object)
+        {
+            Error = TEXT("ui_build_tree: every entry of 'tree' must be an object");
+            break;
+        }
+        Error = BuildTreeNode(WBP, Parent, Node->AsObject(), Stats, 0);
+        if (!Error.IsEmpty()) break;
+    }
+
+    FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+    WBP->MarkPackageDirty();
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("widget_blueprint_path"), WBP->GetPathName());
+    Out->SetStringField(TEXT("parent"), Parent->GetName());
+    Out->SetNumberField(TEXT("created"), Stats.Created);
+
+    TArray<TSharedPtr<FJsonValue>> NameArr;
+    for (const FString& N : Stats.Names) NameArr.Add(MakeShared<FJsonValueString>(N));
+    Out->SetArrayField(TEXT("names"), NameArr);
+
+    if (Stats.Warnings.Num() > 0)
+    {
+        TArray<TSharedPtr<FJsonValue>> WArr;
+        for (const FString& W : Stats.Warnings) WArr.Add(MakeShared<FJsonValueString>(W));
+        Out->SetArrayField(TEXT("warnings"), WArr);
+    }
+
+    if (!Error.IsEmpty())
+    {
+        // Partial builds are kept, not rolled back — the widgets that landed are
+        // usually the ones the caller wanted, and silently discarding them would
+        // hide how far the spec got. The error names where it stopped and the
+        // response lists exactly what exists now.
+        Out->SetStringField(TEXT("error"), Error);
+        Out->SetBoolField(TEXT("partial"), true);
+        return FHaybaHandlerResult::Err(FString::Printf(
+            TEXT("%s — %d widget(s) were created before the failure: %s"),
+            *Error, Stats.Created, *FString::Join(Stats.Names, TEXT(", "))));
+    }
+
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetVariable(const TSharedPtr<FJsonObject>& P)
+{
+    FString BPPath, WidgetName;
+    if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_set_variable: missing widget_blueprint_path"));
+    if (!P->TryGetStringField(TEXT("widget_name"), WidgetName) || WidgetName.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_set_variable: missing widget_name"));
+
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    if (!WBP || !WBP->WidgetTree)
+        return FHaybaHandlerResult::Err(TEXT("ui_set_variable: widget blueprint not found"));
+
+    UWidget* Widget = FindWidgetByName(WBP->WidgetTree, WidgetName);
+    if (!Widget)
+        return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_set_variable: widget '%s' not found"), *WidgetName));
+
+    bool bIsVariable = true;
+    P->TryGetBoolField(TEXT("is_variable"), bIsVariable);
+
+    WBP->Modify();
+    Widget->Modify();
+    Widget->bIsVariable = bIsVariable;
+
+    if (bIsVariable) RegisterWidgetVariable(WBP, Widget);
+    else WBP->WidgetVariableNameToGuidMap.Remove(Widget->GetFName());
+
+    FString Category;
+    if (P->TryGetStringField(TEXT("category"), Category) && !Category.IsEmpty())
+    {
+        Widget->SetCategoryName(Category);
+    }
+
+    FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
+    WBP->MarkPackageDirty();
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("widget_name"), Widget->GetName());
+    Out->SetBoolField(TEXT("is_variable"), bIsVariable);
+    if (!Category.IsEmpty()) Out->SetStringField(TEXT("category"), Category);
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleListWidgetBlueprints(const TSharedPtr<FJsonObject>& P)
+{
+    FString PathFilter, NameFilter;
+    P->TryGetStringField(TEXT("path"), PathFilter);
+    P->TryGetStringField(TEXT("filter"), NameFilter);
+
+    IAssetRegistry& Registry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
+
+    FARFilter Filter;
+    Filter.ClassPaths.Add(UWidgetBlueprint::StaticClass()->GetClassPathName());
+    Filter.bRecursiveClasses = true;
+    if (!PathFilter.IsEmpty())
+    {
+        Filter.PackagePaths.Add(FName(*PathFilter));
+        Filter.bRecursivePaths = true;
+    }
+
+    TArray<FAssetData> Assets;
+    Registry.GetAssets(Filter, Assets);
+
+    TArray<TSharedPtr<FJsonValue>> Results;
+    for (const FAssetData& Asset : Assets)
+    {
+        const FString AssetName = Asset.AssetName.ToString();
+        if (!NameFilter.IsEmpty() && !AssetName.Contains(NameFilter)) continue;
+
+        TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+        Entry->SetStringField(TEXT("name"), AssetName);
+        Entry->SetStringField(TEXT("path"), Asset.GetObjectPathString());
+        Entry->SetStringField(TEXT("package"), Asset.PackageName.ToString());
+
+        // The parent class comes from asset-registry tags, so this stays cheap:
+        // no blueprint is loaded just to list it.
+        FString ParentClass;
+        if (Asset.GetTagValue(FBlueprintTags::ParentClassPath, ParentClass))
+        {
+            Entry->SetStringField(TEXT("parent_class"), ParentClass);
+        }
+        // The `_C` suffix form is what ui_add_element / ui_create_widget need to
+        // reference this blueprint as a class, so hand it over directly.
+        Entry->SetStringField(TEXT("class_path"), Asset.GetObjectPathString() + TEXT("_C"));
+
+        Results.Add(MakeShared<FJsonValueObject>(Entry));
+    }
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetArrayField(TEXT("widget_blueprints"), Results);
+    Out->SetNumberField(TEXT("count"), Results.Num());
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+// ── Measurement ─────────────────────────────────────────────────────────────
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleMeasureText(const TSharedPtr<FJsonObject>& P)
+{
+    FString Text;
+    if (!P->TryGetStringField(TEXT("text"), Text))
+        return FHaybaHandlerResult::Err(TEXT("ui_measure_text: missing text"));
+
+    double AvailableWidth = 0.0;
+    P->TryGetNumberField(TEXT("available_width"), AvailableWidth);
+
+    double FontScale = 1.0;
+    P->TryGetNumberField(TEXT("font_scale"), FontScale);
+
+    FSlateFontInfo Font;
+    bool bHaveFont = false;
+
+    // Either measure against a live widget's real font, or against an explicit
+    // font/size pair. The former is what validation uses — measuring with a
+    // guessed font would defeat the entire point of measuring.
+    FString BPPath, WidgetName;
+    if (P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) && !BPPath.IsEmpty() &&
+        P->TryGetStringField(TEXT("widget_name"), WidgetName) && !WidgetName.IsEmpty())
+    {
+        UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+        if (!WBP || !WBP->WidgetTree)
+            return FHaybaHandlerResult::Err(TEXT("ui_measure_text: widget blueprint not found"));
+        UWidget* Widget = FindWidgetByName(WBP->WidgetTree, WidgetName);
+        if (!Widget)
+            return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_measure_text: widget '%s' not found"), *WidgetName));
+        if (!HaybaUILayout::GetWidgetFont(Widget, Font))
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("ui_measure_text: '%s' is a %s, which renders no text and has no font"),
+                *WidgetName, *Widget->GetClass()->GetName()));
+        bHaveFont = true;
+
+        // Default the available width to the widget's own laid-out box so the
+        // common call needs nothing but the blueprint, the widget and the text.
+        if (AvailableWidth <= 0.0)
+        {
+            TMap<FString, FHaybaUIWidgetGeom> Geoms;
+            FString LayoutError;
+            if (HaybaUILayout::ComputeGeometry(WBP, HaybaUILayout::GetDesignSize(WBP), Geoms, LayoutError))
+            {
+                if (const FHaybaUIWidgetGeom* G = Geoms.Find(WidgetName))
+                {
+                    AvailableWidth = G->Size.X;
+                }
+            }
+        }
+    }
+    else
+    {
+        FString FontPath;
+        double Size = 0.0;
+        if (!P->TryGetNumberField(TEXT("font_size"), Size) || Size <= 0.0)
+            return FHaybaHandlerResult::Err(TEXT("ui_measure_text: pass either (widget_blueprint_path + widget_name) or (font_size [+ font_asset])"));
+
+        if (P->TryGetStringField(TEXT("font_asset"), FontPath) && !FontPath.IsEmpty())
+        {
+            UObject* FontObj = LoadObject<UObject>(nullptr, *FontPath);
+            if (!FontObj)
+                return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_measure_text: font asset '%s' could not be loaded"), *FontPath));
+            if (FontObj->IsA<UFontFace>())
+                return FHaybaHandlerResult::Err(FString::Printf(
+                    TEXT("ui_measure_text: '%s' is a UFontFace. Slate measures (and renders) text through a composite UFont — pass the UFont asset."),
+                    *FontPath));
+            Font.FontObject = FontObj;
+        }
+        else
+        {
+            // No font given: fall back to the editor's own UI font so the answer
+            // is still a real measurement rather than an invented average.
+            Font = FCoreStyle::GetDefaultFontStyle("Regular", (int32)Size);
+        }
+        Font.Size = (float)Size;
+
+        FString Typeface;
+        if (P->TryGetStringField(TEXT("typeface"), Typeface) && !Typeface.IsEmpty())
+            Font.TypefaceFontName = FName(*Typeface);
+
+        bHaveFont = true;
+    }
+
+    if (!bHaveFont)
+        return FHaybaHandlerResult::Err(TEXT("ui_measure_text: no font resolved"));
+
+    const FHaybaUITextFit Fit = HaybaUILayout::AnalyzeTextFit(Text, Font, (float)AvailableWidth, (float)FontScale);
+    if (!Fit.bValid)
+        return FHaybaHandlerResult::Err(TEXT("ui_measure_text: the Slate font measure service is unavailable (headless editor?)"));
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("text"), Text);
+    Out->SetNumberField(TEXT("width_px"), Fit.MeasuredWidth);
+    Out->SetNumberField(TEXT("height_px"), Fit.MeasuredHeight);
+    Out->SetNumberField(TEXT("available_width_px"), Fit.AvailableWidth);
+    Out->SetBoolField(TEXT("overflows"), Fit.bOverflows);
+    Out->SetNumberField(TEXT("chars_that_fit"), Fit.CharsThatFit);
+    Out->SetNumberField(TEXT("typical_chars_that_fit"), Fit.TypicalChars);
+    Out->SetNumberField(TEXT("worst_case_chars_that_fit"), Fit.WorstCaseChars);
+    Out->SetNumberField(TEXT("font_size"), Font.Size);
+    if (Font.FontObject) Out->SetStringField(TEXT("font_object"), Font.FontObject->GetPathName());
+    return FHaybaHandlerResult::Ok(Out);
+}
+
+FHaybaHandlerResult FHaybaMCPUIHandler::HandleLayoutSnapshot(const TSharedPtr<FJsonObject>& P)
+{
+    FString BPPath;
+    if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("ui_layout_snapshot: missing widget_blueprint_path"));
+
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    if (!WBP || !WBP->WidgetTree)
+        return FHaybaHandlerResult::Err(TEXT("ui_layout_snapshot: widget blueprint not found"));
+
+    FVector2D ScreenSize = HaybaUILayout::GetDesignSize(WBP);
+    double W = 0.0, H = 0.0;
+    if (P->TryGetNumberField(TEXT("screen_width"), W) && W > 0.0)  ScreenSize.X = W;
+    if (P->TryGetNumberField(TEXT("screen_height"), H) && H > 0.0) ScreenSize.Y = H;
+
+    TMap<FString, FHaybaUIWidgetGeom> Geoms;
+    FString LayoutError;
+    const bool bHaveLayout = HaybaUILayout::ComputeGeometry(WBP, ScreenSize, Geoms, LayoutError);
+
+    TArray<TSharedPtr<FJsonValue>> Widgets;
+
+    WBP->WidgetTree->ForEachWidget([&](UWidget* Widget)
+    {
+        if (!Widget) return;
+
+        TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+        Entry->SetStringField(TEXT("name"), Widget->GetName());
+        Entry->SetStringField(TEXT("class"), Widget->GetClass()->GetName());
+        Entry->SetStringField(TEXT("parent"), Widget->GetParent() ? Widget->GetParent()->GetName() : FString());
+        Entry->SetStringField(TEXT("slot_class"), ResolveSlotType(Widget));
+        Entry->SetBoolField(TEXT("is_panel"), Widget->IsA<UPanelWidget>());
+        Entry->SetBoolField(TEXT("is_variable"), Widget->bIsVariable);
+        Entry->SetStringField(TEXT("visibility"), UEnum::GetValueAsString(Widget->GetVisibility()));
+        Entry->SetNumberField(TEXT("render_opacity"), Widget->GetRenderOpacity());
+        Entry->SetBoolField(TEXT("is_enabled"), Widget->GetIsEnabled());
+
+        // Interactivity is what most input/accessibility rules key off, and it
+        // is not derivable from the class name alone on the MCP side.
+        const bool bInteractive =
+            Widget->IsA<UButton>() || Widget->IsA<UCheckBox>() || Widget->IsA<USlider>() ||
+            Widget->IsA<USpinBox>() || Widget->IsA<UComboBoxString>() || Widget->IsA<UEditableText>() ||
+            Widget->IsA<UEditableTextBox>() || Widget->IsA<UMultiLineEditableTextBox>();
+        Entry->SetBoolField(TEXT("is_interactive"), bInteractive);
+        Entry->SetBoolField(TEXT("is_focusable"), Widget->IsFocusable());
+
+        if (const FHaybaUIWidgetGeom* G = Geoms.Find(Widget->GetName()))
+        {
+            Entry->SetNumberField(TEXT("x"), G->Position.X);
+            Entry->SetNumberField(TEXT("y"), G->Position.Y);
+            Entry->SetNumberField(TEXT("width"), G->Size.X);
+            Entry->SetNumberField(TEXT("height"), G->Size.Y);
+            Entry->SetNumberField(TEXT("depth"), G->Depth);
+            Entry->SetBoolField(TEXT("laid_out"), !G->IsDegenerate());
+        }
+        else
+        {
+            Entry->SetBoolField(TEXT("laid_out"), false);
+        }
+
+        if (UCanvasPanelSlot* CSlot = Cast<UCanvasPanelSlot>(Widget->Slot))
+        {
+            const FAnchors A = CSlot->GetAnchors();
+            TSharedPtr<FJsonObject> Anch = MakeShared<FJsonObject>();
+            Anch->SetNumberField(TEXT("min_x"), A.Minimum.X);
+            Anch->SetNumberField(TEXT("min_y"), A.Minimum.Y);
+            Anch->SetNumberField(TEXT("max_x"), A.Maximum.X);
+            Anch->SetNumberField(TEXT("max_y"), A.Maximum.Y);
+            Entry->SetObjectField(TEXT("anchors"), Anch);
+            Entry->SetNumberField(TEXT("z_order"), CSlot->GetZOrder());
+            Entry->SetBoolField(TEXT("auto_size"), CSlot->GetAutoSize());
+        }
+
+        // Text facts, including the measurement that only Slate can do.
+        FString Text;
+        FSlateFontInfo Font;
+        const bool bHasText = HaybaUILayout::GetWidgetText(Widget, Text);
+        const bool bHasFont = HaybaUILayout::GetWidgetFont(Widget, Font);
+
+        if (bHasText || bHasFont)
+        {
+            TSharedPtr<FJsonObject> TextObj = MakeShared<FJsonObject>();
+            if (bHasText) TextObj->SetStringField(TEXT("text"), Text);
+            if (bHasFont)
+            {
+                TextObj->SetNumberField(TEXT("font_size"), Font.Size);
+                TextObj->SetStringField(TEXT("typeface"), Font.TypefaceFontName.ToString());
+                if (Font.FontObject)
+                {
+                    TextObj->SetStringField(TEXT("font_object"), Font.FontObject->GetPathName());
+                    TextObj->SetBoolField(TEXT("font_is_font_face"), Font.FontObject->IsA<UFontFace>());
+                }
+                else
+                {
+                    TextObj->SetBoolField(TEXT("font_is_font_face"), false);
+                }
+
+                float AvailableWidth = 0.f;
+                if (const FHaybaUIWidgetGeom* G = Geoms.Find(Widget->GetName()))
+                {
+                    AvailableWidth = (float)G->Size.X;
+                }
+                if (bHasText && AvailableWidth > 0.f)
+                {
+                    const FHaybaUITextFit Fit = HaybaUILayout::AnalyzeTextFit(Text, Font, AvailableWidth);
+                    if (Fit.bValid)
+                    {
+                        TextObj->SetNumberField(TEXT("measured_width"), Fit.MeasuredWidth);
+                        TextObj->SetNumberField(TEXT("measured_height"), Fit.MeasuredHeight);
+                        TextObj->SetNumberField(TEXT("available_width"), Fit.AvailableWidth);
+                        TextObj->SetBoolField(TEXT("overflows"), Fit.bOverflows);
+                        TextObj->SetNumberField(TEXT("chars_that_fit"), Fit.CharsThatFit);
+                        TextObj->SetNumberField(TEXT("typical_chars_that_fit"), Fit.TypicalChars);
+                        TextObj->SetNumberField(TEXT("worst_case_chars_that_fit"), Fit.WorstCaseChars);
+                    }
+                }
+            }
+
+            if (UTextBlock* TB = Cast<UTextBlock>(Widget))
+            {
+                TextObj->SetBoolField(TEXT("auto_wrap"), TB->GetAutoWrapText());
+                const FLinearColor C = TB->GetColorAndOpacity().GetSpecifiedColor();
+                TArray<TSharedPtr<FJsonValue>> ColorArr;
+                ColorArr.Add(MakeShared<FJsonValueNumber>(C.R));
+                ColorArr.Add(MakeShared<FJsonValueNumber>(C.G));
+                ColorArr.Add(MakeShared<FJsonValueNumber>(C.B));
+                ColorArr.Add(MakeShared<FJsonValueNumber>(C.A));
+                TextObj->SetArrayField(TEXT("color"), ColorArr);
+            }
+            Entry->SetObjectField(TEXT("text_info"), TextObj);
+        }
+
+        // Brush facts for the fill/contrast rules.
+        if (UImage* Img = Cast<UImage>(Widget))
+        {
+            TSharedPtr<FJsonObject> BrushObj = MakeShared<FJsonObject>();
+            const FSlateBrush& B = Img->GetBrush();
+            BrushObj->SetBoolField(TEXT("has_resource"), B.GetResourceObject() != nullptr);
+            if (B.GetResourceObject()) BrushObj->SetStringField(TEXT("resource"), B.GetResourceObject()->GetPathName());
+            const FLinearColor Tint = Img->GetColorAndOpacity();
+            TArray<TSharedPtr<FJsonValue>> TintArr;
+            TintArr.Add(MakeShared<FJsonValueNumber>(Tint.R));
+            TintArr.Add(MakeShared<FJsonValueNumber>(Tint.G));
+            TintArr.Add(MakeShared<FJsonValueNumber>(Tint.B));
+            TintArr.Add(MakeShared<FJsonValueNumber>(Tint.A));
+            BrushObj->SetArrayField(TEXT("tint"), TintArr);
+            BrushObj->SetNumberField(TEXT("image_size_x"), B.ImageSize.X);
+            BrushObj->SetNumberField(TEXT("image_size_y"), B.ImageSize.Y);
+            Entry->SetObjectField(TEXT("brush_info"), BrushObj);
+        }
+        if (UBorder* Bd = Cast<UBorder>(Widget))
+        {
+            TSharedPtr<FJsonObject> BrushObj = MakeShared<FJsonObject>();
+            const FLinearColor Tint = Bd->GetBrushColor();
+            TArray<TSharedPtr<FJsonValue>> TintArr;
+            TintArr.Add(MakeShared<FJsonValueNumber>(Tint.R));
+            TintArr.Add(MakeShared<FJsonValueNumber>(Tint.G));
+            TintArr.Add(MakeShared<FJsonValueNumber>(Tint.B));
+            TintArr.Add(MakeShared<FJsonValueNumber>(Tint.A));
+            BrushObj->SetArrayField(TEXT("tint"), TintArr);
+            // A Border's own brush is reached through the reflection system
+            // rather than the member: UMG moved these properties behind
+            // accessors, and the member is not public in current engine
+            // versions. The contrast rules only need the tint, so a missing
+            // brush here degrades to "no resource" rather than failing.
+            bool bHasResource = false;
+            if (FStructProperty* BgProp = CastField<FStructProperty>(Bd->GetClass()->FindPropertyByName(TEXT("Background"))))
+            {
+                if (BgProp->Struct == TBaseStructure<FSlateBrush>::Get() ||
+                    BgProp->Struct->GetName() == TEXT("SlateBrush"))
+                {
+                    const FSlateBrush* Brush = BgProp->ContainerPtrToValuePtr<FSlateBrush>(Bd);
+                    bHasResource = Brush && Brush->GetResourceObject() != nullptr;
+                }
+            }
+            BrushObj->SetBoolField(TEXT("has_resource"), bHasResource);
+            Entry->SetObjectField(TEXT("brush_info"), BrushObj);
+        }
+
+        if (UPanelWidget* Panel = Cast<UPanelWidget>(Widget))
+        {
+            Entry->SetNumberField(TEXT("child_count"), Panel->GetChildrenCount());
+        }
+
+        Widgets.Add(MakeShared<FJsonValueObject>(Entry));
+    });
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetStringField(TEXT("widget_blueprint_path"), WBP->GetPathName());
+    Out->SetNumberField(TEXT("screen_width"), ScreenSize.X);
+    Out->SetNumberField(TEXT("screen_height"), ScreenSize.Y);
+    Out->SetBoolField(TEXT("layout_resolved"), bHaveLayout);
+    // Callers MUST be able to tell "no problems found" from "could not measure".
+    // Rules that depend on geometry are skipped, not passed, when this is set.
+    if (!bHaveLayout) Out->SetStringField(TEXT("layout_error"), LayoutError);
+    Out->SetNumberField(TEXT("widget_count"), Widgets.Num());
+    Out->SetArrayField(TEXT("widgets"), Widgets);
     return FHaybaHandlerResult::Ok(Out);
 }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -53,6 +53,20 @@ TArray<FString> FHaybaMCPUIHandler::GetCommands() const
 
 namespace
 {
+    void RegisterWidgetVariable(UWidgetBlueprint* WidgetBlueprint, UWidget* Widget)
+    {
+        if (!WidgetBlueprint || !Widget)
+        {
+            return;
+        }
+
+        const FName WidgetName = Widget->GetFName();
+        if (!WidgetBlueprint->WidgetVariableNameToGuidMap.Contains(WidgetName))
+        {
+            WidgetBlueprint->OnVariableAdded(WidgetName);
+        }
+    }
+
     UClass* ResolveWidgetClass(const FString& Name)
     {
         // Try common UMG widget classes by short name first.
@@ -266,6 +280,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::Handle(const FString& Cmd, const TShared
         {
             UCanvasPanel* Root = WBP->WidgetTree->ConstructWidget<UCanvasPanel>(UCanvasPanel::StaticClass(), TEXT("RootCanvas"));
             WBP->WidgetTree->RootWidget = Root;
+            RegisterWidgetVariable(WBP, Root);
             FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
         }
 
@@ -323,6 +338,11 @@ FHaybaHandlerResult FHaybaMCPUIHandler::Handle(const FString& Cmd, const TShared
         UPanelSlot* NewSlot = Parent->AddChild(NewChild);
         if (!NewSlot)
             return FHaybaHandlerResult::Err(TEXT("ui_add_element: AddChild rejected (panel may be full or incompatible)"));
+
+        // Widget blueprints track every designer widget by a stable GUID. ConstructWidget
+        // does not update that map, and compiling a partially populated map triggers an
+        // ensure in UMGEditor (and leaves references vulnerable to rename breakage).
+        RegisterWidgetVariable(WBP, NewChild);
 
         const TSharedPtr<FJsonObject>* SlotProps = nullptr;
         if (P->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid())

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -236,6 +236,28 @@ namespace
         return Copied;
     }
 
+    /** Whether a widget can take keyboard/gamepad focus.
+     *  There is no UWidget-level accessor: each focusable widget class declares
+     *  its own `IsFocusable` / `bIsFocusable` property, so read it reflectively
+     *  rather than casting to a hand-maintained list of classes. Text entry
+     *  widgets do not declare the flag at all — they are always focusable. */
+    bool ResolveIsFocusable(UWidget* W)
+    {
+        if (!W) return false;
+
+        static const FName Names[] = { TEXT("IsFocusable"), TEXT("bIsFocusable") };
+        for (const FName& PropName : Names)
+        {
+            if (FBoolProperty* Prop = CastField<FBoolProperty>(W->GetClass()->FindPropertyByName(PropName)))
+            {
+                return Prop->GetPropertyValue_InContainer(W);
+            }
+        }
+
+        return W->IsA<UEditableText>() || W->IsA<UEditableTextBox>() ||
+               W->IsA<UMultiLineEditableTextBox>() || W->IsA<USpinBox>() || W->IsA<USlider>();
+    }
+
     UWidget* FindWidgetByName(UWidgetTree* Tree, const FString& Name)
     {
         if (!Tree) return nullptr;
@@ -585,7 +607,7 @@ namespace
         const TSet<FString> Applicable = ApplicableSlotKeys(Slot);
         for (const auto& Pair : Props->Values)
         {
-            const FString& Key = Pair.Key;
+            const FString Key(Pair.Key);
             if (Applicable.Contains(Key))
             {
                 Result.Applied.Add(Key);
@@ -1065,7 +1087,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
                 for (const auto& Pair : (*SlotProps)->Values)
                 {
                     ++Failed;
-                    FailedProps.Add(FString::Printf(TEXT("slot.%s"), *Pair.Key));
+                    FailedProps.Add(FString::Printf(TEXT("slot.%s"), *FString(Pair.Key)));
                 }
                 Warnings.Add(FString::Printf(
                     TEXT("'%s' has no panel slot (it is the root widget, or its parent is not a panel), so slot layout was not applied."),
@@ -1912,10 +1934,11 @@ namespace
         {
             for (const auto& Pair : (*Props)->Values)
             {
-                if (!HaybaReflection::SetProp(New, Pair.Key, Pair.Value))
+                const FString PropName(Pair.Key);
+                if (!HaybaReflection::SetProp(New, PropName, Pair.Value))
                 {
                     Stats.Warnings.Add(FString::Printf(TEXT("%s: property '%s' was rejected by %s"),
-                        *New->GetName(), *Pair.Key, *Class->GetName()));
+                        *New->GetName(), *PropName, *Class->GetName()));
                 }
             }
         }
@@ -2275,7 +2298,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleLayoutSnapshot(const TSharedPtr<FJ
             Widget->IsA<USpinBox>() || Widget->IsA<UComboBoxString>() || Widget->IsA<UEditableText>() ||
             Widget->IsA<UEditableTextBox>() || Widget->IsA<UMultiLineEditableTextBox>();
         Entry->SetBoolField(TEXT("is_interactive"), bInteractive);
-        Entry->SetBoolField(TEXT("is_focusable"), Widget->IsFocusable());
+        Entry->SetBoolField(TEXT("is_focusable"), ResolveIsFocusable(Widget));
 
         if (const FHaybaUIWidgetGeom* G = Geoms.Find(Widget->GetName()))
         {

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.h
@@ -16,4 +16,15 @@ private:
     FHaybaHandlerResult HandleCompile(const TSharedPtr<FJsonObject>& P);
     FHaybaHandlerResult HandleSave(const TSharedPtr<FJsonObject>& P);
     FHaybaHandlerResult HandleListTypes(const TSharedPtr<FJsonObject>& P);
+
+    // Authoring additions
+    FHaybaHandlerResult HandleBuildTree(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleSetVariable(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleListWidgetBlueprints(const TSharedPtr<FJsonObject>& P);
+
+    // Measurement — facts only the engine can produce. The validation rules
+    // themselves live MCP-side so they can be extended and configured without
+    // a plugin rebuild; these two commands feed them.
+    FHaybaHandlerResult HandleLayoutSnapshot(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleMeasureText(const TSharedPtr<FJsonObject>& P);
 };

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.h
@@ -7,4 +7,13 @@ public:
     virtual FString GetDomain() const override { return TEXT("ui"); }
     virtual TArray<FString> GetCommands() const override;
     virtual FHaybaHandlerResult Handle(const FString& Cmd, const TSharedPtr<FJsonObject>& Params) override;
+private:
+    FHaybaHandlerResult HandleCreateWidget(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleAddElement(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleSetProperties(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleQuery(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleMutateTree(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleCompile(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleSave(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult HandleListTypes(const TSharedPtr<FJsonObject>& P);
 };

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.h
@@ -27,4 +27,6 @@ private:
     // a plugin rebuild; these two commands feed them.
     FHaybaHandlerResult HandleLayoutSnapshot(const TSharedPtr<FJsonObject>& P);
     FHaybaHandlerResult HandleMeasureText(const TSharedPtr<FJsonObject>& P);
+    /** Accepts findings judged MCP-side so they can reach the Validation panel. */
+    FHaybaHandlerResult HandleReportFindings(const TSharedPtr<FJsonObject>& P);
 };

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUILayout.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUILayout.cpp
@@ -1,0 +1,339 @@
+#include "HaybaMCPUILayout.h"
+
+#if WITH_EDITOR
+
+#include "Editor.h"
+#include "WidgetBlueprint.h"
+#include "Blueprint/UserWidget.h"
+#include "Blueprint/WidgetTree.h"
+#include "Components/Widget.h"
+#include "Components/PanelWidget.h"
+#include "Components/TextBlock.h"
+#include "Components/RichTextBlock.h"
+#include "Components/EditableText.h"
+#include "Components/EditableTextBox.h"
+#include "Components/MultiLineEditableTextBox.h"
+#include "Components/Button.h"
+#include "Components/CheckBox.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Fonts/FontMeasure.h"
+#include "Layout/ArrangedChildren.h"
+#include "Layout/Geometry.h"
+#include "Widgets/SWidget.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogHaybaMCPUILayout, Log, All);
+
+namespace
+{
+    /** Reference strings for the statistical bounds. Deliberately fixed so the
+     *  same font+size always reports the same numbers run to run. */
+    const TCHAR* const kTypicalProse = TEXT("the quick brown fox jumps over a lazy dog and then rests");
+    /** Characters a Latin UI realistically has to survive. The worst case for a
+     *  variable-length field (player names, item names, localized strings) is a
+     *  run of the widest of these, not the average. */
+    const TCHAR* const kGlyphSample = TEXT("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@#%&WM_");
+
+    TSharedPtr<FSlateFontMeasure> GetMeasureService()
+    {
+        if (!FSlateApplication::IsInitialized()) return nullptr;
+        FSlateRenderer* Renderer = FSlateApplication::Get().GetRenderer();
+        if (!Renderer) return nullptr;
+        return Renderer->GetFontMeasureService();
+    }
+
+    void ArrangeRecursive(const TSharedRef<SWidget>& Widget, const FGeometry& Geom,
+        TMap<const SWidget*, FGeometry>& Out, int32 Depth)
+    {
+        // Deep trees are legal but a runaway recursion here would take the
+        // editor down; 128 is far past any hand-authored UMG hierarchy.
+        if (Depth > 128) return;
+
+        Out.Add(&Widget.Get(), Geom);
+
+        FArrangedChildren Arranged(EVisibility::All);
+        Widget->ArrangeChildren(Geom, Arranged);
+        for (int32 i = 0; i < Arranged.Num(); ++i)
+        {
+            const FArrangedWidget& Child = Arranged[i];
+            ArrangeRecursive(Child.Widget, Child.Geometry, Out, Depth + 1);
+        }
+    }
+}
+
+namespace HaybaUILayout
+{
+
+FVector2D GetDesignSize(UWidgetBlueprint* WBP)
+{
+    if (!WBP) return FVector2D(1920.0, 1080.0);
+
+    const FVector2D Declared(WBP->DesignTimeSize.X, WBP->DesignTimeSize.Y);
+    if (Declared.X > 1.0 && Declared.Y > 1.0)
+    {
+        return Declared;
+    }
+    // A blueprint authored in "Fill Screen" / "Desired" mode has no meaningful
+    // DesignTimeSize; 1080p is the honest default to reason about because it is
+    // what the designer canvas shows by default.
+    return FVector2D(1920.0, 1080.0);
+}
+
+bool ComputeGeometry(UWidgetBlueprint* WBP, const FVector2D& ScreenSize,
+    TMap<FString, FHaybaUIWidgetGeom>& Out, FString& OutError)
+{
+    Out.Reset();
+
+    if (!WBP)
+    {
+        OutError = TEXT("no widget blueprint");
+        return false;
+    }
+    if (!FSlateApplication::IsInitialized())
+    {
+        OutError = TEXT("Slate is not initialized (running headless?) — layout-dependent checks are unavailable");
+        return false;
+    }
+    if (!WBP->GeneratedClass)
+    {
+        OutError = TEXT("widget blueprint has no GeneratedClass — compile it first (ui_compile_widget)");
+        return false;
+    }
+    if (WBP->GeneratedClass->HasAnyClassFlags(CLASS_Abstract))
+    {
+        OutError = TEXT("widget blueprint class is abstract and cannot be instantiated for layout");
+        return false;
+    }
+    if (ScreenSize.X <= 1.0 || ScreenSize.Y <= 1.0)
+    {
+        OutError = TEXT("screen size must be at least 1x1");
+        return false;
+    }
+
+    // Outer to the editor world when there is one (that is what the designer
+    // preview uses). Never a PIE world — a retained reference into a PIE
+    // GameInstance is what crashes the editor on PIE stop.
+    UWorld* World = nullptr;
+    if (GEditor)
+    {
+        UWorld* EditorWorld = GEditor->GetEditorWorldContext().World();
+        if (EditorWorld && !EditorWorld->IsPlayInEditor())
+        {
+            World = EditorWorld;
+        }
+    }
+
+    UUserWidget* Instance = World
+        ? NewObject<UUserWidget>(World, WBP->GeneratedClass)
+        : NewObject<UUserWidget>(GetTransientPackage(), WBP->GeneratedClass);
+    if (!Instance)
+    {
+        OutError = TEXT("failed to instantiate the widget class");
+        return false;
+    }
+
+    // Designing flag keeps the instance from running BeginPlay-style logic and
+    // matches how the UMG designer evaluates layout.
+    Instance->SetDesignerFlags(EWidgetDesignFlags::Designing);
+
+    bool bOk = false;
+    {
+        TSharedPtr<SWidget> SlateWidget;
+        SlateWidget = Instance->TakeWidget();
+        if (SlateWidget.IsValid())
+        {
+            const TSharedRef<SWidget> SlateRef = SlateWidget.ToSharedRef();
+            SlateRef->SlatePrepass(1.0f);
+
+            const FGeometry Root = FGeometry::MakeRoot(ScreenSize, FSlateLayoutTransform());
+
+            TMap<const SWidget*, FGeometry> BySlate;
+            ArrangeRecursive(SlateRef, Root, BySlate, 0);
+
+            // Map the arranged Slate widgets back to the UMG widgets by identity
+            // of the cached SWidget each UWidget produced during TakeWidget.
+            if (Instance->WidgetTree)
+            {
+                Instance->WidgetTree->ForEachWidget([&](UWidget* W)
+                {
+                    if (!W) return;
+
+                    FHaybaUIWidgetGeom G;
+                    G.Name = W->GetName();
+                    G.ClassName = W->GetClass()->GetName();
+
+                    int32 Depth = 0;
+                    for (UPanelWidget* P = W->GetParent(); P; P = P->GetParent()) ++Depth;
+                    G.Depth = Depth;
+                    G.ParentName = W->GetParent() ? W->GetParent()->GetName() : FString();
+
+                    const TSharedPtr<SWidget> Cached = W->GetCachedWidget();
+                    if (Cached.IsValid())
+                    {
+                        if (const FGeometry* Found = BySlate.Find(&Cached.Get()))
+                        {
+                            const FVector2D Min(Found->GetAbsolutePosition());
+                            const FVector2D Max(Found->GetAbsolutePositionAtCoordinates(FVector2D(1.0, 1.0)));
+                            G.Position = Min;
+                            G.Size = Max - Min;
+                        }
+                    }
+                    // A widget with no arranged entry is genuinely not laid out
+                    // (collapsed, or in an inactive WidgetSwitcher slot). It is
+                    // reported with a zero size rather than omitted, so callers
+                    // can tell "not laid out" from "absent from the tree".
+                    Out.Add(G.Name, G);
+                });
+            }
+
+            bOk = Out.Num() > 0;
+            if (!bOk) OutError = TEXT("layout produced no widgets (empty widget tree?)");
+        }
+        else
+        {
+            OutError = TEXT("TakeWidget() returned no Slate widget");
+        }
+
+        // Drop Slate resources before the instance goes out of scope so nothing
+        // retains a live SWidget for a UObject that is about to be collected.
+        Instance->ReleaseSlateResources(true);
+    }
+
+    Instance->MarkAsGarbage();
+    return bOk;
+}
+
+FVector2D MeasureText(const FString& Text, const FSlateFontInfo& Font, float FontScale)
+{
+    const TSharedPtr<FSlateFontMeasure> Measure = GetMeasureService();
+    if (!Measure.IsValid()) return FVector2D::ZeroVector;
+    return FVector2D(Measure->Measure(Text, Font, FontScale));
+}
+
+int32 CharsThatFit(const FString& Text, const FSlateFontInfo& Font, float MaxWidthPx, float FontScale)
+{
+    if (Text.IsEmpty()) return 0;
+    if (MaxWidthPx <= 0.f) return 0;
+
+    const TSharedPtr<FSlateFontMeasure> Measure = GetMeasureService();
+    if (!Measure.IsValid()) return 0;
+
+    // Whole string already fits — report its real length rather than a clipped
+    // index, so callers can say "fits with N characters of headroom".
+    if (FVector2D(Measure->Measure(Text, Font, FontScale)).X <= MaxWidthPx)
+    {
+        return Text.Len();
+    }
+
+    const int32 LastIndex = Measure->FindLastWholeCharacterIndexBeforeOffset(
+        Text, Font, FMath::FloorToInt(MaxWidthPx), FontScale);
+    return FMath::Max(0, LastIndex + 1);
+}
+
+float WidestGlyphWidth(const FSlateFontInfo& Font, float FontScale)
+{
+    const TSharedPtr<FSlateFontMeasure> Measure = GetMeasureService();
+    if (!Measure.IsValid()) return 0.f;
+
+    const FString Sample(kGlyphSample);
+    float Widest = 0.f;
+    for (int32 i = 0; i < Sample.Len(); ++i)
+    {
+        const float W = (float)FVector2D(Measure->Measure(Sample.Mid(i, 1), Font, FontScale)).X;
+        Widest = FMath::Max(Widest, W);
+    }
+    return Widest;
+}
+
+float TypicalGlyphWidth(const FSlateFontInfo& Font, float FontScale)
+{
+    const TSharedPtr<FSlateFontMeasure> Measure = GetMeasureService();
+    if (!Measure.IsValid()) return 0.f;
+
+    const FString Sample(kTypicalProse);
+    if (Sample.Len() == 0) return 0.f;
+    // Measured as one run so kerning and inter-character advance are included,
+    // then averaged — a per-character sum would overstate the width.
+    const float Total = (float)FVector2D(Measure->Measure(Sample, Font, FontScale)).X;
+    return Total / (float)Sample.Len();
+}
+
+FHaybaUITextFit AnalyzeTextFit(const FString& Text, const FSlateFontInfo& Font, float AvailableWidth, float FontScale)
+{
+    FHaybaUITextFit Fit;
+    const TSharedPtr<FSlateFontMeasure> Measure = GetMeasureService();
+    if (!Measure.IsValid()) return Fit;
+
+    Fit.bValid = true;
+    Fit.AvailableWidth = AvailableWidth;
+
+    const FVector2D Measured = FVector2D(Measure->Measure(Text, Font, FontScale));
+    Fit.MeasuredWidth = (float)Measured.X;
+    Fit.MeasuredHeight = (float)Measured.Y;
+    Fit.bOverflows = AvailableWidth > 0.f && Fit.MeasuredWidth > AvailableWidth;
+    Fit.CharsThatFit = CharsThatFit(Text, Font, AvailableWidth, FontScale);
+
+    const float Widest = WidestGlyphWidth(Font, FontScale);
+    const float Typical = TypicalGlyphWidth(Font, FontScale);
+    Fit.WorstCaseChars = Widest > 0.f ? FMath::FloorToInt(AvailableWidth / Widest) : 0;
+    Fit.TypicalChars = Typical > 0.f ? FMath::FloorToInt(AvailableWidth / Typical) : 0;
+
+    return Fit;
+}
+
+bool GetWidgetFont(UWidget* W, FSlateFontInfo& OutFont)
+{
+    if (!W) return false;
+
+    if (UTextBlock* TB = Cast<UTextBlock>(W))                    { OutFont = TB->GetFont(); return true; }
+    if (UEditableText* ET = Cast<UEditableText>(W))              { OutFont = ET->GetFont(); return true; }
+    if (UEditableTextBox* ETB = Cast<UEditableTextBox>(W))       { OutFont = ETB->GetWidgetStyle().TextStyle.Font; return true; }
+    if (UMultiLineEditableTextBox* ML = Cast<UMultiLineEditableTextBox>(W)) { OutFont = ML->GetWidgetStyle().TextStyle.Font; return true; }
+    if (URichTextBlock* RT = Cast<URichTextBlock>(W))
+    {
+        // RichTextBlock resolves its font per text-run from a style set, so
+        // there is no single authoritative font. The default style is the
+        // honest answer for a whole-widget estimate.
+        OutFont = RT->GetDefaultTextStyle().Font;
+        return true;
+    }
+    // A Button's label lives in its child; fall through to that child's font.
+    if (UButton* Btn = Cast<UButton>(W))
+    {
+        if (Btn->GetChildrenCount() > 0)
+        {
+            return GetWidgetFont(Btn->GetChildAt(0), OutFont);
+        }
+    }
+    if (UCheckBox* CB = Cast<UCheckBox>(W))
+    {
+        if (CB->GetChildrenCount() > 0)
+        {
+            return GetWidgetFont(CB->GetChildAt(0), OutFont);
+        }
+    }
+    return false;
+}
+
+bool GetWidgetText(UWidget* W, FString& OutText)
+{
+    if (!W) return false;
+
+    if (UTextBlock* TB = Cast<UTextBlock>(W))               { OutText = TB->GetText().ToString(); return true; }
+    if (URichTextBlock* RT = Cast<URichTextBlock>(W))       { OutText = RT->GetText().ToString(); return true; }
+    if (UEditableText* ET = Cast<UEditableText>(W))         { OutText = ET->GetText().ToString(); return true; }
+    if (UEditableTextBox* ETB = Cast<UEditableTextBox>(W))  { OutText = ETB->GetText().ToString(); return true; }
+    if (UMultiLineEditableTextBox* ML = Cast<UMultiLineEditableTextBox>(W)) { OutText = ML->GetText().ToString(); return true; }
+    if (UButton* Btn = Cast<UButton>(W))
+    {
+        if (Btn->GetChildrenCount() > 0) return GetWidgetText(Btn->GetChildAt(0), OutText);
+    }
+    if (UCheckBox* CB = Cast<UCheckBox>(W))
+    {
+        if (CB->GetChildrenCount() > 0) return GetWidgetText(CB->GetChildAt(0), OutText);
+    }
+    return false;
+}
+
+} // namespace HaybaUILayout
+
+#endif // WITH_EDITOR

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUILayout.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUILayout.cpp
@@ -67,14 +67,34 @@ FVector2D GetDesignSize(UWidgetBlueprint* WBP)
 {
     if (!WBP) return FVector2D(1920.0, 1080.0);
 
-    const FVector2D Declared(WBP->DesignTimeSize.X, WBP->DesignTimeSize.Y);
-    if (Declared.X > 1.0 && Declared.Y > 1.0)
+#if WITH_EDITORONLY_DATA
+    // The authored design size is stored on the generated widget class's CDO,
+    // not on the blueprint asset — and it is only a real screen size when the
+    // designer is in one of the Custom modes.
+    //
+    // In FillScreen / Desired mode DesignTimeSize keeps its (100,100)
+    // placeholder. Treating that as the screen makes every widget on a normal
+    // screen look wildly off-canvas, which would fire the safe-area and
+    // off-screen rules on essentially every blueprint.
+    if (WBP->GeneratedClass)
     {
-        return Declared;
+        if (const UUserWidget* CDO = Cast<UUserWidget>(WBP->GeneratedClass->GetDefaultObject()))
+        {
+            const bool bCustomSize =
+                CDO->DesignSizeMode == EDesignPreviewSizeMode::Custom ||
+                CDO->DesignSizeMode == EDesignPreviewSizeMode::CustomOnScreen;
+
+            const FVector2D Declared(CDO->DesignTimeSize.X, CDO->DesignTimeSize.Y);
+            if (bCustomSize && Declared.X > 1.0 && Declared.Y > 1.0)
+            {
+                return Declared;
+            }
+        }
     }
-    // A blueprint authored in "Fill Screen" / "Desired" mode has no meaningful
-    // DesignTimeSize; 1080p is the honest default to reason about because it is
-    // what the designer canvas shows by default.
+#endif
+    // Fill-screen and desired-size blueprints are authored against the whole
+    // viewport, so 1080p is the honest default to reason about. Callers that
+    // care about a different target pass screen_width/screen_height.
     return FVector2D(1920.0, 1080.0);
 }
 
@@ -169,7 +189,7 @@ bool ComputeGeometry(UWidgetBlueprint* WBP, const FVector2D& ScreenSize,
                     const TSharedPtr<SWidget> Cached = W->GetCachedWidget();
                     if (Cached.IsValid())
                     {
-                        if (const FGeometry* Found = BySlate.Find(&Cached.Get()))
+                        if (const FGeometry* Found = BySlate.Find(Cached.Get()))
                         {
                             const FVector2D Min(Found->GetAbsolutePosition());
                             const FVector2D Max(Found->GetAbsolutePositionAtCoordinates(FVector2D(1.0, 1.0)));
@@ -287,7 +307,7 @@ bool GetWidgetFont(UWidget* W, FSlateFontInfo& OutFont)
     if (UTextBlock* TB = Cast<UTextBlock>(W))                    { OutFont = TB->GetFont(); return true; }
     if (UEditableText* ET = Cast<UEditableText>(W))              { OutFont = ET->GetFont(); return true; }
     if (UEditableTextBox* ETB = Cast<UEditableTextBox>(W))       { OutFont = ETB->GetWidgetStyle().TextStyle.Font; return true; }
-    if (UMultiLineEditableTextBox* ML = Cast<UMultiLineEditableTextBox>(W)) { OutFont = ML->GetWidgetStyle().TextStyle.Font; return true; }
+    if (UMultiLineEditableTextBox* ML = Cast<UMultiLineEditableTextBox>(W)) { OutFont = ML->WidgetStyle.TextStyle.Font; return true; }
     if (URichTextBlock* RT = Cast<URichTextBlock>(W))
     {
         // RichTextBlock resolves its font per text-run from a style set, so

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUILayout.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUILayout.h
@@ -1,0 +1,113 @@
+#pragma once
+
+// Design-time layout resolution and text metrics for Widget Blueprints.
+//
+// Everything here answers questions that CANNOT be answered from the widget
+// tree alone: how wide is this text in this font, how big is the box Slate
+// actually gives this widget, and therefore at exactly which character does
+// the label stop fitting. The tree says "TextBlock with Font size 24"; only a
+// real Slate prepass + the font measure service can say "that label overflows
+// its 220px box after 17 characters".
+//
+// The approach is the one the UMG designer itself uses: instantiate the
+// generated widget class, take its Slate widget, prepass it, then arrange it
+// inside a root geometry of the blueprint's design-time screen size and walk
+// the arranged children. That yields the same rectangles the designer draws.
+
+#include "CoreMinimal.h"
+
+#if WITH_EDITOR
+
+#include "Fonts/SlateFontInfo.h"
+
+class UWidgetBlueprint;
+class UWidget;
+
+/** Resolved design-time geometry for one widget in the tree. */
+struct FHaybaUIWidgetGeom
+{
+    FString Name;
+    FString ClassName;
+    /** Top-left in design space (px), origin at the root widget's top-left. */
+    FVector2D Position = FVector2D::ZeroVector;
+    /** Rendered size in design space (px). */
+    FVector2D Size = FVector2D::ZeroVector;
+    /** Depth in the widget tree (root = 0). */
+    int32 Depth = 0;
+    /** Name of the parent widget, empty for the root. */
+    FString ParentName;
+
+    FORCEINLINE FVector2D GetMax() const { return Position + Size; }
+    FORCEINLINE bool IsDegenerate() const { return Size.X <= KINDA_SMALL_NUMBER || Size.Y <= KINDA_SMALL_NUMBER; }
+
+    /** Overlap rectangle with another widget's box; zero-size when disjoint. */
+    FVector2D OverlapExtent(const FHaybaUIWidgetGeom& Other) const
+    {
+        const float OverlapX = FMath::Min(GetMax().X, Other.GetMax().X) - FMath::Max(Position.X, Other.Position.X);
+        const float OverlapY = FMath::Min(GetMax().Y, Other.GetMax().Y) - FMath::Max(Position.Y, Other.Position.Y);
+        if (OverlapX <= 0.f || OverlapY <= 0.f) return FVector2D::ZeroVector;
+        return FVector2D(OverlapX, OverlapY);
+    }
+};
+
+/** Result of asking "how much of this text fits in this many pixels". */
+struct FHaybaUITextFit
+{
+    /** Measured width of the full string, in px, at the widget's real font. */
+    float MeasuredWidth = 0.f;
+    float MeasuredHeight = 0.f;
+    /** Width the widget actually has available for text (box minus padding). */
+    float AvailableWidth = 0.f;
+    /** True when MeasuredWidth already exceeds AvailableWidth. */
+    bool bOverflows = false;
+    /** Characters of the measured string that fit before the box runs out.
+     *  Exact — computed by the Slate font measure service, kerning included. */
+    int32 CharsThatFit = 0;
+    /** Characters that fit assuming the WIDEST glyph in the font repeats
+     *  (worst case for variable-length runtime text, e.g. a long player name). */
+    int32 WorstCaseChars = 0;
+    /** Characters that fit for typical mixed-case prose in this font. */
+    int32 TypicalChars = 0;
+    bool bValid = false;
+};
+
+namespace HaybaUILayout
+{
+    /** Design-time screen size the blueprint is authored against. */
+    FVector2D GetDesignSize(UWidgetBlueprint* WBP);
+
+    /** Instantiate + prepass + arrange the blueprint at `ScreenSize`, filling
+     *  `Out` keyed by widget name. Returns false with a reason in `OutError`
+     *  when the blueprint cannot be instantiated (uncompiled, abstract parent,
+     *  no editor world). Callers must degrade to tree-only checks in that case
+     *  rather than reporting a clean bill of health. */
+    bool ComputeGeometry(UWidgetBlueprint* WBP, const FVector2D& ScreenSize,
+        TMap<FString, FHaybaUIWidgetGeom>& Out, FString& OutError);
+
+    /** Exact rendered size of `Text` in `Font`, via the Slate font measure service. */
+    FVector2D MeasureText(const FString& Text, const FSlateFontInfo& Font, float FontScale = 1.0f);
+
+    /** Largest prefix length of `Text` that fits within `MaxWidthPx`. Uses
+     *  FindLastWholeCharacterIndexBeforeOffset, so it accounts for kerning and
+     *  variable glyph advance rather than assuming a monospace average. */
+    int32 CharsThatFit(const FString& Text, const FSlateFontInfo& Font, float MaxWidthPx, float FontScale = 1.0f);
+
+    /** Width of the single widest glyph the font renders for the characters a
+     *  caller is likely to see (used for the worst-case bound). */
+    float WidestGlyphWidth(const FSlateFontInfo& Font, float FontScale = 1.0f);
+
+    /** Average advance for typical mixed-case prose in this font. */
+    float TypicalGlyphWidth(const FSlateFontInfo& Font, float FontScale = 1.0f);
+
+    /** Full fit analysis for a string in a box of `AvailableWidth` px. */
+    FHaybaUITextFit AnalyzeTextFit(const FString& Text, const FSlateFontInfo& Font, float AvailableWidth, float FontScale = 1.0f);
+
+    /** The font a widget renders text with, if it renders text at all.
+     *  Covers TextBlock / RichTextBlock / EditableText(Box) / Button-with-text. */
+    bool GetWidgetFont(UWidget* W, FSlateFontInfo& OutFont);
+
+    /** The text a widget currently displays, if any. */
+    bool GetWidgetText(UWidget* W, FString& OutText);
+}
+
+#endif // WITH_EDITOR

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPReflection.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPReflection.h
@@ -84,8 +84,11 @@ namespace HaybaReflection
         int32 Applied = 0;
         for (const auto& Pair : Obj->Values)
         {
-            if (SetStructField(Struct, StructPtr, Pair.Key, Pair.Value)) ++Applied;
-            else if (OutUnknown) OutUnknown->Add(Pair.Key);
+            // FJsonObject keys are a storage type, not FString, so they need an
+            // explicit conversion before anything takes them by const FString&.
+            const FString Key(Pair.Key);
+            if (SetStructField(Struct, StructPtr, Key, Pair.Value)) ++Applied;
+            else if (OutUnknown) OutUnknown->Add(Key);
         }
         return Applied;
     }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPReflection.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPReflection.h
@@ -94,6 +94,12 @@ namespace HaybaReflection
         }
         if (FNameProperty* Nm = CastField<FNameProperty>(Prop)) { Nm->SetPropertyValue_InContainer(Owner, FName(*V->AsString())); return true; }
         if (FStrProperty* S = CastField<FStrProperty>(Prop)) { S->SetPropertyValue_InContainer(Owner, V->AsString()); return true; }
+        if (FTextProperty* T = CastField<FTextProperty>(Prop))
+        {
+            if (V->Type != EJson::String) return false;
+            T->SetPropertyValue_InContainer(Owner, FText::FromString(V->AsString()));
+            return true;
+        }
         if (FObjectProperty* O = CastField<FObjectProperty>(Prop))
         {
             if (V->Type == EJson::String)
@@ -103,6 +109,12 @@ namespace HaybaReflection
         }
         if (FStructProperty* St = CastField<FStructProperty>(Prop))
         {
+            if (V->Type == EJson::String)
+            {
+                void* Ptr = St->ContainerPtrToValuePtr<void>(Owner);
+                const TCHAR* End = St->ImportText_Direct(*V->AsString(), Ptr, Target, PPF_None);
+                return End != nullptr;
+            }
             if (V->Type == EJson::Array)
             {
                 const TArray<TSharedPtr<FJsonValue>>& A = V->AsArray();
@@ -114,8 +126,9 @@ namespace HaybaReflection
                 else if (SN == TEXT("Vector4") || SN == TEXT("Vector4f")) *(FVector4f*)Ptr = FVector4f(Num(0), Num(1), Num(2), Num(3));
                 else if (SN == TEXT("Vector2D"))                      *(FVector2D*)Ptr    = FVector2D(Num(0), Num(1));
                 else if (SN == TEXT("Color"))                         *(FColor*)Ptr       = FColor((uint8)Num(0), (uint8)Num(1), (uint8)Num(2), A.Num() > 3 ? (uint8)Num(3) : 255);
+                return true;
             }
-            return true;
+            return false;
         }
         // TArray support — each element is a JSON object whose keys are set
         // via SetStructField. Primary use: MaterialExpressionCustom.Inputs

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPReflection.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPReflection.h
@@ -1,59 +1,117 @@
 #pragma once
 
-// Generic, UObject-agnostic reflection setters lifted VERBATIM from the
-// material handler so other handlers CAN adopt them later. No material-specific
-// logic lives here. Behavior must remain identical to the original inline copies.
+// Generic, UObject-agnostic reflection setters, originally lifted from the
+// material handler so other handlers could adopt them. No material-specific
+// logic lives here.
+//
+// The type switch lives in ONE place (SetValueFromJson) and both public entry
+// points delegate to it, so struct fields and object properties support the
+// same JSON shapes at every nesting depth. That recursion is what makes nested
+// UMG styling work: FSlateBrush / FSlateFontInfo / FSlateColor are structs
+// whose fields are themselves structs and object refs, e.g.
+//
+//   { "Brush": { "ResourceObject": "/Game/UI/T_Panel",
+//                "TintColor": { "SpecifiedColor": [1,1,1,1] },
+//                "ImageSize": { "X": 64, "Y": 64 },
+//                "DrawAs": "RoundedBox" } }
+//
+// Before the recursion existed, a JSON object handed to a struct property was
+// rejected outright (returned false), so every nested style edit reported
+// "property failed" no matter how well-formed it was.
+
 #include "CoreMinimal.h"
 #include "Dom/JsonObject.h"
 #include "UObject/Object.h"
 #include "UObject/UnrealType.h"
 #include "UObject/EnumProperty.h"
+// FMargin / FSlateColor are handled explicitly in the numeric-array form because
+// they are the two Slate layout structs MCP callers send most often.
+#include "Layout/Margin.h"
+#include "Styling/SlateColor.h"
 
 namespace HaybaReflection
 {
-    // Set a single named field on an arbitrary struct instance by reflection.
-    // Covers the subset of field types needed for FCustomInput
-    // (FName/FString/bool/numeric).
+    // Set one already-resolved property inside `Container` from a JSON value.
+    // `Outer` is the owning UObject when there is one (used as the import outer
+    // for ImportText_Direct); it may be null for free-standing struct memory.
+    inline bool SetValueFromJson(FProperty* Prop, void* Container, const TSharedPtr<FJsonValue>& V, UObject* Outer);
+
+    /** Resolve a UObject reference from either a bare path string or an object
+     *  wrapper such as {"ObjectPath": "/Game/..."} — MCP clients naturally send
+     *  the latter when mirroring UE's own JSON export shape. */
+    inline UObject* ResolveObjectRef(const TSharedPtr<FJsonValue>& V)
+    {
+        if (!V.IsValid()) return nullptr;
+        if (V->Type == EJson::String)
+        {
+            const FString Path = V->AsString();
+            if (Path.IsEmpty() || Path == TEXT("None")) return nullptr;
+            return LoadObject<UObject>(nullptr, *Path);
+        }
+        if (V->Type == EJson::Object)
+        {
+            const TSharedPtr<FJsonObject>& Obj = V->AsObject();
+            static const TCHAR* Keys[] = { TEXT("ObjectPath"), TEXT("object_path"), TEXT("AssetPath"), TEXT("asset_path"), TEXT("Path"), TEXT("path") };
+            for (const TCHAR* Key : Keys)
+            {
+                FString Path;
+                if (Obj->TryGetStringField(Key, Path) && !Path.IsEmpty() && Path != TEXT("None"))
+                {
+                    return LoadObject<UObject>(nullptr, *Path);
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    /** Set a single named field on an arbitrary struct instance by reflection.
+     *  Handles every type SetProp does, including nested structs. */
     inline bool SetStructField(UScriptStruct* Struct, void* StructPtr, const FString& FieldName, const TSharedPtr<FJsonValue>& V)
     {
         if (!Struct || !StructPtr || !V.IsValid()) return false;
         FProperty* Prop = Struct->FindPropertyByName(FName(*FieldName));
         if (!Prop) return false;
-
-        if (FNameProperty* Nm = CastField<FNameProperty>(Prop)) { Nm->SetPropertyValue_InContainer(StructPtr, FName(*V->AsString())); return true; }
-        if (FStrProperty* S = CastField<FStrProperty>(Prop)) { S->SetPropertyValue_InContainer(StructPtr, V->AsString()); return true; }
-        if (FBoolProperty* B = CastField<FBoolProperty>(Prop))
-        {
-            const bool bVal = (V->Type == EJson::Boolean) ? V->AsBool() : (V->AsNumber() != 0.0);
-            B->SetPropertyValue_InContainer(StructPtr, bVal);
-            return true;
-        }
-        if (FNumericProperty* N = CastField<FNumericProperty>(Prop))
-        {
-            void* Ptr = N->ContainerPtrToValuePtr<void>(StructPtr);
-            if (N->IsFloatingPoint()) N->SetFloatingPointPropertyValue(Ptr, V->AsNumber());
-            else N->SetIntPropertyValue(Ptr, (int64)V->AsNumber());
-            return true;
-        }
-        return false;
+        return SetValueFromJson(Prop, StructPtr, V, nullptr);
     }
 
-    // Generic reflection setter: set ANY UPROPERTY on the target by its real
-    // name, coercing from the JSON value by property type. Covers enums-by-string
-    // (e.g. InputType="FunctionInput_Scalar"), bool bitfields (ComponentMask R/G/B/A),
-    // numerics, FName/FString, struct-from-array (LinearColor/Vector/Vector4f/Vector2D/Color),
-    // and object refs by asset path. Returns true if the property existed.
+    /** Set every key of a JSON object onto a struct instance. Returns the
+     *  number of fields that applied and, when `OutUnknown` is provided,
+     *  collects the keys that matched no property so callers can report them
+     *  instead of silently dropping them. */
+    inline int32 ApplyStructFields(UScriptStruct* Struct, void* StructPtr, const TSharedPtr<FJsonObject>& Obj, TArray<FString>* OutUnknown = nullptr)
+    {
+        if (!Struct || !StructPtr || !Obj.IsValid()) return 0;
+        int32 Applied = 0;
+        for (const auto& Pair : Obj->Values)
+        {
+            if (SetStructField(Struct, StructPtr, Pair.Key, Pair.Value)) ++Applied;
+            else if (OutUnknown) OutUnknown->Add(Pair.Key);
+        }
+        return Applied;
+    }
+
+    /** Generic reflection setter: set ANY UPROPERTY on the target by its real
+     *  name, coercing from the JSON value by property type. Covers enums-by-string
+     *  (e.g. InputType="FunctionInput_Scalar"), bool bitfields (ComponentMask R/G/B/A),
+     *  numerics, FName/FString/FText, structs (from string, numeric array, or
+     *  nested JSON object), object refs by asset path, and arrays.
+     *  Returns true if the property existed and the value was applied. */
     inline bool SetProp(UObject* Target, const FString& Name, const TSharedPtr<FJsonValue>& V)
     {
         if (!Target || !V.IsValid()) return false;
         FProperty* Prop = Target->GetClass()->FindPropertyByName(FName(*Name));
         if (!Prop) return false;
-        void* Owner = Target;
+        return SetValueFromJson(Prop, Target, V, Target);
+    }
+
+    inline bool SetValueFromJson(FProperty* Prop, void* Container, const TSharedPtr<FJsonValue>& V, UObject* Outer)
+    {
+        if (!Prop || !Container || !V.IsValid()) return false;
 
         if (FBoolProperty* B = CastField<FBoolProperty>(Prop))
         {
             const bool bVal = (V->Type == EJson::Boolean) ? V->AsBool() : (V->AsNumber() != 0.0);
-            B->SetPropertyValue_InContainer(Owner, bVal);
+            B->SetPropertyValue_InContainer(Container, bVal);
             return true;
         }
         if (FByteProperty* By = CastField<FByteProperty>(Prop))
@@ -63,14 +121,18 @@ namespace HaybaReflection
                 int64 E = By->Enum->GetValueByNameString(V->AsString());
                 if (E == INDEX_NONE)
                 {
+                    // Accept the bare tail of a prefixed enumerator, e.g. "Center"
+                    // for ETextJustify::Center or HAlign_Center.
                     const FString First = By->Enum->GetNameStringByIndex(0);
                     int32 Underscore;
                     if (First.FindChar('_', Underscore))
                         E = By->Enum->GetValueByNameString(First.Left(Underscore) + TEXT("_") + V->AsString());
                 }
-                if (E != INDEX_NONE) By->SetIntPropertyValue(By->ContainerPtrToValuePtr<void>(Owner), E);
+                if (E == INDEX_NONE) return false;
+                By->SetIntPropertyValue(By->ContainerPtrToValuePtr<void>(Container), E);
+                return true;
             }
-            else By->SetIntPropertyValue(By->ContainerPtrToValuePtr<void>(Owner), (int64)V->AsNumber());
+            By->SetIntPropertyValue(By->ContainerPtrToValuePtr<void>(Container), (int64)V->AsNumber());
             return true;
         }
         if (FEnumProperty* En = CastField<FEnumProperty>(Prop))
@@ -79,80 +141,110 @@ namespace HaybaReflection
             if (V->Type == EJson::String && En->GetEnum())
             {
                 Val = En->GetEnum()->GetValueByNameString(V->AsString());
-                if (Val == INDEX_NONE) Val = 0;
+                if (Val == INDEX_NONE)
+                {
+                    const FString Qualified = En->GetEnum()->GetName() + TEXT("::") + V->AsString();
+                    Val = En->GetEnum()->GetValueByNameString(Qualified);
+                }
+                if (Val == INDEX_NONE) return false;
             }
             else Val = (int64)V->AsNumber();
-            En->GetUnderlyingProperty()->SetIntPropertyValue(En->ContainerPtrToValuePtr<void>(Owner), Val);
+            En->GetUnderlyingProperty()->SetIntPropertyValue(En->ContainerPtrToValuePtr<void>(Container), Val);
             return true;
         }
         if (FNumericProperty* N = CastField<FNumericProperty>(Prop))
         {
-            void* Ptr = N->ContainerPtrToValuePtr<void>(Owner);
+            void* Ptr = N->ContainerPtrToValuePtr<void>(Container);
             if (N->IsFloatingPoint()) N->SetFloatingPointPropertyValue(Ptr, V->AsNumber());
             else N->SetIntPropertyValue(Ptr, (int64)V->AsNumber());
             return true;
         }
-        if (FNameProperty* Nm = CastField<FNameProperty>(Prop)) { Nm->SetPropertyValue_InContainer(Owner, FName(*V->AsString())); return true; }
-        if (FStrProperty* S = CastField<FStrProperty>(Prop)) { S->SetPropertyValue_InContainer(Owner, V->AsString()); return true; }
+        if (FNameProperty* Nm = CastField<FNameProperty>(Prop)) { Nm->SetPropertyValue_InContainer(Container, FName(*V->AsString())); return true; }
+        if (FStrProperty* S = CastField<FStrProperty>(Prop)) { S->SetPropertyValue_InContainer(Container, V->AsString()); return true; }
         if (FTextProperty* T = CastField<FTextProperty>(Prop))
         {
             if (V->Type != EJson::String) return false;
-            T->SetPropertyValue_InContainer(Owner, FText::FromString(V->AsString()));
+            T->SetPropertyValue_InContainer(Container, FText::FromString(V->AsString()));
             return true;
         }
         if (FObjectProperty* O = CastField<FObjectProperty>(Prop))
         {
-            if (V->Type == EJson::String)
-                if (UObject* Obj = LoadObject<UObject>(nullptr, *V->AsString()))
-                    if (Obj->IsA(O->PropertyClass)) O->SetObjectPropertyValue_InContainer(Owner, Obj);
+            // An explicit null clears the reference; anything else must both
+            // resolve and be type-compatible, otherwise this is a failure the
+            // caller needs to hear about rather than a silent no-op.
+            if (V->Type == EJson::Null)
+            {
+                O->SetObjectPropertyValue_InContainer(Container, nullptr);
+                return true;
+            }
+            UObject* Obj = ResolveObjectRef(V);
+            if (!Obj || !Obj->IsA(O->PropertyClass)) return false;
+            O->SetObjectPropertyValue_InContainer(Container, Obj);
             return true;
         }
         if (FStructProperty* St = CastField<FStructProperty>(Prop))
         {
+            void* Ptr = St->ContainerPtrToValuePtr<void>(Container);
+
             if (V->Type == EJson::String)
             {
-                void* Ptr = St->ContainerPtrToValuePtr<void>(Owner);
-                const TCHAR* End = St->ImportText_Direct(*V->AsString(), Ptr, Target, PPF_None);
+                const TCHAR* End = St->ImportText_Direct(*V->AsString(), Ptr, Outer, PPF_None);
                 return End != nullptr;
+            }
+            if (V->Type == EJson::Object)
+            {
+                // Nested struct: recurse field by field. Partial application is
+                // still success — callers merge onto the existing value, so
+                // {"Size": 32} on a font leaves the typeface untouched.
+                return ApplyStructFields(St->Struct, Ptr, V->AsObject()) > 0;
             }
             if (V->Type == EJson::Array)
             {
                 const TArray<TSharedPtr<FJsonValue>>& A = V->AsArray();
                 auto Num = [&A](int32 i) { return A.IsValidIndex(i) ? (float)A[i]->AsNumber() : 0.f; };
-                void* Ptr = St->ContainerPtrToValuePtr<void>(Owner);
                 const FString SN = St->Struct->GetName();
                 if (SN == TEXT("LinearColor"))                        *(FLinearColor*)Ptr = FLinearColor(Num(0), Num(1), Num(2), A.Num() > 3 ? Num(3) : 1.f);
                 else if (SN == TEXT("Vector"))                        *(FVector*)Ptr      = FVector(Num(0), Num(1), Num(2));
                 else if (SN == TEXT("Vector4") || SN == TEXT("Vector4f")) *(FVector4f*)Ptr = FVector4f(Num(0), Num(1), Num(2), Num(3));
                 else if (SN == TEXT("Vector2D"))                      *(FVector2D*)Ptr    = FVector2D(Num(0), Num(1));
                 else if (SN == TEXT("Color"))                         *(FColor*)Ptr       = FColor((uint8)Num(0), (uint8)Num(1), (uint8)Num(2), A.Num() > 3 ? (uint8)Num(3) : 255);
+                // Slate layout structs are the common UMG case: a 4-number
+                // array is a margin, a 2-number array is a 2D size/offset.
+                else if (SN == TEXT("Margin"))                        *(FMargin*)Ptr      = A.Num() >= 4 ? FMargin(Num(0), Num(1), Num(2), Num(3))
+                                                                                          : A.Num() == 2 ? FMargin(Num(0), Num(1), Num(0), Num(1))
+                                                                                                         : FMargin(Num(0));
+                else if (SN == TEXT("SlateColor"))                    *(FSlateColor*)Ptr  = FSlateColor(FLinearColor(Num(0), Num(1), Num(2), A.Num() > 3 ? Num(3) : 1.f));
+                else return false;
                 return true;
             }
             return false;
         }
-        // TArray support — each element is a JSON object whose keys are set
-        // via SetStructField. Primary use: MaterialExpressionCustom.Inputs
-        // where each element is an FCustomInput struct with an InputName FName field.
+        // TArray support — each element is a JSON value applied through the same
+        // switch, so arrays of primitives, structs and object refs all work.
+        // Primary original use: MaterialExpressionCustom.Inputs (FCustomInput).
         if (FArrayProperty* Arr = CastField<FArrayProperty>(Prop))
         {
             if (V->Type != EJson::Array) return false;  // don't claim success on a non-array value
+            FScriptArrayHelper Helper(Arr, Arr->ContainerPtrToValuePtr<void>(Container));
+            const TArray<TSharedPtr<FJsonValue>>& JArr = V->AsArray();
+            Helper.Resize(JArr.Num());
+            for (int32 i = 0; i < JArr.Num(); ++i)
             {
-                FScriptArrayHelper Helper(Arr, Arr->ContainerPtrToValuePtr<void>(Owner));
-                const TArray<TSharedPtr<FJsonValue>>& JArr = V->AsArray();
-                Helper.Resize(JArr.Num());
+                void* ElemPtr = Helper.GetRawPtr(i);
                 if (FStructProperty* InnerSt = CastField<FStructProperty>(Arr->Inner))
                 {
-                    for (int32 i = 0; i < JArr.Num(); ++i)
+                    InnerSt->Struct->InitializeStruct(ElemPtr);
+                    if (JArr[i].IsValid() && JArr[i]->Type == EJson::Object)
                     {
-                        void* ElemPtr = Helper.GetRawPtr(i);
-                        InnerSt->Struct->InitializeStruct(ElemPtr);
-                        if (JArr[i].IsValid() && JArr[i]->Type == EJson::Object)
-                        {
-                            const TSharedPtr<FJsonObject>& ElemObj = JArr[i]->AsObject();
-                            for (const auto& F : ElemObj->Values)
-                                SetStructField(InnerSt->Struct, ElemPtr, FString(*F.Key), F.Value);
-                        }
+                        ApplyStructFields(InnerSt->Struct, ElemPtr, JArr[i]->AsObject());
                     }
+                }
+                else
+                {
+                    // Inner properties address the element directly rather than
+                    // through a container offset, so hand the element pointer in
+                    // as the container with the inner property's own zero offset.
+                    SetValueFromJson(Arr->Inner, ElemPtr, JArr[i], Outer);
                 }
             }
             return true;


### PR DESCRIPTION
Fixes a set of UMG authoring paths that reported success while doing nothing, extends the toolset, and adds a UI validation engine built on real Slate measurement.

## Architecture: UE measures, MCP judges

The plugin gained three read commands — `ui_layout_snapshot` (a real Slate prepass on the compiled widget class), `ui_measure_text` (font measure service), and `ui_report_findings` (the route into the editor's Validation panel). Every rule that *interprets* those numbers lives in TypeScript.

That split is deliberate and worth keeping: rules are unit-tested without an editor, extend without a plugin rebuild, and adding one means appending a single array entry.

## Bugs fixed — all of them silent

| What | Symptom |
|---|---|
| `ui_search_widgets` never sent `path` | every call failed `ui_query: missing path` |
| `ui_set_slot_layout` sent `slot_layout` | no handler revision ever read that key |
| `HaybaReflection::SetProp` rejected JSON objects for structs | `ui_set_brush` / `ui_set_text_style` could not set a brush or font **at all** |
| `ui_set_text_style` sent `Typeface: {FontName}` | the field is `TypefaceFontName` |
| `ui_set_brush` sent `Brush` to Borders | Borders expose theirs as `Background` |
| slot props counted as succeeded unconditionally | success counts included keys the slot never accepted |
| padding only applied when non-zero | padding could never be cleared |
| `preserve_properties` on replace | parsed, then never used |
| `remove` purged only the named widget's GUID | descendants left phantom variable entries |
| `replace` reused a name the old widget still held | UE uniquified to `Name_1`, breaking bindings |
| `reparent` discarded slot layout | and orphaned the widget if the new panel refused it |
| `duplicate` kept every descendant's name | UE trashed the collisions; two widgets answered to one name |
| `ui_validate` findings never reached the Validation panel | the panel is push-only; nothing routed them |

Descriptor text is corrected too — it claimed `FScopedTransaction` undo that c071a59 deliberately removed, and several `returns:` strings named fields the handlers never emitted.

## New

`ui_build_tree` (a whole subtree from one nested spec), `ui_duplicate_element`, `ui_move_element`, `ui_rename_element`, `ui_set_variable`, `ui_list_widget_blueprints`, `ui_layout_snapshot`, `ui_measure_text`, `ui_validate`, `validator_strictness`, plus `name_pattern`/`class_filter`/`flatten` on `ui_query`.

Validation strictness is three modes — relaxed/standard/strict — global or per category. A rule declares the lowest mode at which it fires, so raising strictness only ever adds findings.

## Verified against a live UE 5.8 editor

- **Text measurement is exact at the boundary**: 12 chars = 199px fits, 13 = 219px overflows, in a 200px box.
- `ui_build_tree` — 13 widgets across two calls, canvas and box/grid slots, all three padding shapes, zero rejected keys.
- Every seeded defect caught on a probe blueprint, `rules_skipped_no_layout` empty.
- Platform gate holds: pc 24px vs console 40px targets, safe areas console-only.
- Contrast measured 6:1 — silent at standard (4.5:1), fires at strict (7:1).
- Previously-broken paths now persist, confirmed by re-query.

Calibrated against a real HUD (`WBP_MapHUD`), which cut 58 findings to 10 and exposed three genuine issues in the process: a `DesignTimeSize` placeholder being read as a 100×100 screen, two rules that fired on nearly every widget, and a contrast check reading a textured brush's tint as its colour.

## Reporting contract

A rule that needs geometry and has none is reported in `rules_skipped_no_layout` — never counted as a pass. Same principle as per-key `unknown_slot_props` on the authoring side. The whole point of this change is that silence was being read as success.

## Verification

TypeScript typecheck + `lint:legacy-wrappers` clean; 72 UI/rule tests green. Plugin compiles and links against 5.8.

**Known caveats:** the last two C++ fixes (duplicate naming, panel routing) are committed but need a plugin rebuild to take effect in a running editor. `ui_remove_element`, `ui_reparent_element`, `ui_get_widget_info`, `ui_list_widget_types` and the strictness round-trip are untested live. `ui_bind_event` and animation authoring were out of scope. All recorded in `docs/HANDOFF-umg-validation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUbaP2TVPqkSzUL18h2NCc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Unreal UMG authoring tools for creating, editing, organizing, compiling, saving, and inspecting Widget Blueprints.
  * Added UI layout snapshots and text measurement to support responsive design checks.
  * Added configurable UI validation with rules for sizing, overflow, safe areas, contrast, focus, overlap, and accessibility.
  * Added validator strictness controls and editor validation-panel reporting.
* **Bug Fixes**
  * Improved widget property, slot layout, styling, object reference, and enum handling with clearer failure reporting.
* **Documentation**
  * Added handoff guides and runbooks for UMG workflows, validation, connectivity, and demo production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->