### PR TITLE
Lean first-install surface, working vector search, and an honest PCG property path

### DIFF
--- a/docs/HANDOFF-umg-validation.md
+++ b/docs/HANDOFF-umg-validation.md
@@ -96,11 +96,8 @@ fails on a clean tree too (pre-existing, unrelated).
 
 Two C++ fixes are committed but **not yet compiled into the running editor**:
 
-1. `ui_duplicate_element` corrupted the tree — `DuplicateObject` keeps every
-   descendant's name and UMG requires tree-wide uniqueness, so UE renamed the
-   collisions to `TRASH_<name>` and left two widgets answering to `Card`. Until
-   the rebuild lands, **do not use this tool**.
-2. `ui_report_findings` — the route that puts findings in the Validation panel.
+1. `ui_report_findings` — the route that puts findings in the Validation panel.
+   Compiled and verified present in the DLL.
 
 ### Still untested
 
@@ -146,6 +143,46 @@ the rebuild.
 5. **Not built:** `ui_bind_event` (widget delegate → blueprint event graph) and
    widget-animation authoring. Both need Kismet graph / MovieScene work that was
    out of scope here.
+
+## ui_duplicate_element — partially fixed, still not right
+
+Worth reading before touching it, because two plausible fixes failed here.
+
+**Root cause.** A `UPanelSlot`'s `Content` is a plain pointer to a widget owned by
+the `WidgetTree`, not a subobject of the panel. `DuplicateObject` therefore copies
+the POINTER: the "copy" shares the original's children. Renaming "the copy's"
+subtree renames the ORIGINAL's widgets. Observed as `RowLabel` silently becoming
+`RowLabel_0` on the source after duplicating its parent.
+
+**What did not work.**
+- Giving the copy's root a scratch name before renaming. The collisions are among
+  the descendants, so the root was never the problem.
+- Duplicating into a transient package first. Same outcome — the shared-children
+  problem is in what `DuplicateObject` produces, not in where it is put.
+
+**What did work.** `DeepCloneWidget` rebuilds the subtree node by node —
+`ConstructWidget` per node, copy properties, recurse, re-parent, copy slot layout.
+`CopyCommonProperties` now also skips the `Slots` array, since copying it is what
+makes two widgets claim the same children. **Verified: the source subtree is no
+longer corrupted.**
+
+**What is still wrong.** The copy itself can come back named `TRASH_<name>_0`, and
+the tree can show two widgets reporting the same name. The remaining suspect is
+`FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified`, which triggers a
+recompile between the clone and the point where the name is read — but that is
+unconfirmed. Note `ui_query` reads names via `GetChildAt`, so two entries showing
+one name may mean two slots pointing at one widget rather than two widgets.
+
+**Current behaviour.** The handler checks its own post-condition and returns a hard
+error when the copy is trashed or any name is duplicated, instead of reporting
+success on a bad tree. The blueprint is not saved on that path. `ui_build_tree` is
+the dependable way to produce a repeated structure.
+
+**Next step if picking this up:** the cheap win is visibility — add the object path
+name to `ui_query` output so distinct widgets can be told apart, and capture
+`Copy->GetName()` immediately after the clone, after `AddChild`, and after
+`MarkBlueprintAsStructurallyModified`. That pins which call trashes it in one
+build cycle instead of guessing.
 
 ## Rule catalogue shape
 

--- a/docs/HANDOFF-umg-validation.md
+++ b/docs/HANDOFF-umg-validation.md
@@ -144,47 +144,62 @@ the rebuild.
    widget-animation authoring. Both need Kismet graph / MovieScene work that was
    out of scope here.
 
-## ui_duplicate_element — partially fixed, still not right
+## ui_duplicate_element and ui_replace_element — fixed, one root cause
 
-Worth reading before touching it, because two plausible fixes failed here.
+Both were corrupting the widget tree, and it was the same bug. Worth reading,
+because three plausible fixes failed before the real one, and two of the failures
+looked like progress.
 
-**Root cause.** A `UPanelSlot`'s `Content` is a plain pointer to a widget owned by
-the `WidgetTree`, not a subobject of the panel. `DuplicateObject` therefore copies
-the POINTER: the "copy" shares the original's children. Renaming "the copy's"
-subtree renames the ORIGINAL's widgets. Observed as `RowLabel` silently becoming
-`RowLabel_0` on the source after duplicating its parent.
+**Root cause.** `CopyCommonProperties(SourceSlot, NewSlot)` copied the slot's
+`Content` pointer. `UPanelSlot::Content` points at the child widget, so the new
+slot adopted the SOURCE's child. The tree then held one widget reached through
+two slots — which reads as two widgets with the same name, and is why the first
+diagnosis was wrong. Adding the object path to `ui_query` is what settled it:
+both entries had the identical path.
 
-**What did not work.**
-- Giving the copy's root a scratch name before renaming. The collisions are among
-  the descendants, so the root was never the problem.
-- Duplicating into a transient package first. Same outcome — the shared-children
-  problem is in what `DuplicateObject` produces, not in where it is put.
+The knock-on effect explains the rest. Because the copy's own child pointer was
+overwritten, the copy was ORPHANED — nothing referenced it — so the next
+recompile collected it and renamed it `TRASH_<name>_0`.
 
-**What did work.** `DeepCloneWidget` rebuilds the subtree node by node —
-`ConstructWidget` per node, copy properties, recurse, re-parent, copy slot layout.
-`CopyCommonProperties` now also skips the `Slots` array, since copying it is what
-makes two widgets claim the same children. **Verified: the source subtree is no
-longer corrupted.**
+**Dead ends, and why they looked right.**
+- *Scratch name for the copy's root.* The collisions were among descendants.
+- *Duplicating into a transient package.* The problem is in what
+  `DuplicateObject` produces, not where it is put — a slot's `Content` is a plain
+  pointer, not a subobject, so the copy shares the original's children either way.
+- *Deferring compilation with `MarkBlueprintAsModified`.* A stage trace showed the
+  name correct before `MarkBlueprintAsStructurallyModified` and `TRASH_` after,
+  which made the recompile look guilty. It was innocent: it was collecting an
+  orphan. This change was reverted once the slot pointers were fixed — every
+  other tree mutation uses the structural notification, and diverging for this
+  one would have hidden the real defect.
 
-**What is still wrong.** The copy itself can come back named `TRASH_<name>_0`, and
-the tree can show two widgets reporting the same name. The remaining suspect is
-`FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified`, which triggers a
-recompile between the clone and the point where the name is read — but that is
-unconfirmed. Note `ui_query` reads names via `GetChildAt`, so two entries showing
-one name may mean two slots pointing at one widget rather than two widgets.
+**The fix.** `CopyCommonProperties` now skips `Content` and `Parent` alongside
+`Slot` and `Slots`. Layout values are the only thing worth copying between slots;
+who they point at belongs to `AddChild`. `DeepCloneWidget` rebuilds the subtree
+node by node rather than calling `DuplicateObject`.
 
-**Current behaviour.** The handler checks its own post-condition and returns a hard
-error when the copy is trashed or any name is duplicated, instead of reporting
-success on a bad tree. The blueprint is not saved on that path. `ui_build_tree` is
-the dependable way to produce a repeated structure.
+**Verified live:** duplicate produces distinct object paths, unique names
+(`RowLabel` / `RowLabel_0`), and carries properties and slot layout across.
+Replace swaps class in place, keeps the name and index, and leaves no orphan —
+the `HaybaMCP_Replaced_0` leak seen earlier is gone.
 
-**Next step if picking this up:** the cheap win is visibility — add the object path
-name to `ui_query` output so distinct widgets can be told apart, and capture
-`Copy->GetName()` immediately after the clone, after `AddChild`, and after
-`MarkBlueprintAsStructurallyModified`. That pins which call trashes it in one
-build cycle instead of guessing.
+**Kept:** the handler still checks its own post-condition (trashed copy, or any
+name shared by two widgets) and returns a hard error rather than reporting
+success on a malformed tree.
 
-## Rule catalogue shape
+## ui_create_widget could hang the whole MCP connection
+
+`AssetTools::CreateAsset` raises a modal "Overwrite Existing Object" dialog on a
+name collision. Handlers run on the game thread, so that dialog blocks the thread
+that would service the reply: the command never completes, the caller times out,
+and every later request queues behind it until a human clicks the box. Nothing in
+the log says why.
+
+The handler now checks the asset registry AND memory (an asset created earlier in
+the session is absent from the registry but still collides) and returns a plain
+error instead of prompting. See `[[no-modal-dialogs-from-handlers]]`.
+
+## Rule catalogue shape## Rule catalogue shape
 
 ```
 src/validator/ui/

--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -1,35 +1,122 @@
 {
   "$schema": "./sidecar.schema.json",
-  "_doc": "Hand-authored sidecar for UE-side commands routed through HaybaMCPLegacyHandler::Handle (see unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp). This file is the single source of truth for: (a) the parameter docs surfaced by get_tool_signature for legacy commands that have no TS Zod registration, and (b) the allowlist that hayba_invoke consults when called with via:'ue_legacy'. INVARIANTS (enforced by scripts/check-legacy-wrappers.ts and CI): every dispatch-table command in the .cpp MUST have an entry here (including aliases); every entry with has_ts_wrapper:true MUST have a corresponding executeCommand('<name>', ...) or dispatch('<name>', ...) call somewhere under src/tools/**; every entry with has_ts_wrapper:false MUST NOT have such a call. To add a new legacy command: register it in the .cpp dispatch table, add an entry here (with aliases array if any), set has_ts_wrapper to whatever's true, run `npm run lint:legacy-wrappers`. Marking agent_callable:false hides it from hayba_invoke via:'ue_legacy' while still letting get_tool_signature document it (e.g. ping, wizard_chat — internal/diagnostic).",
+  "_doc": "Hand-authored sidecar for UE-side commands routed through HaybaMCPLegacyHandler::Handle (see unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp). This file is the single source of truth for: (a) the parameter docs surfaced by get_tool_signature for legacy commands that have no TS Zod registration, and (b) the allowlist that hayba_invoke consults when called with via:'ue_legacy'. INVARIANTS (enforced by scripts/check-legacy-wrappers.ts and CI): every dispatch-table command in the .cpp MUST have an entry here (including aliases); every entry with has_ts_wrapper:true MUST have a corresponding executeCommand('<name>', ...) or dispatch('<name>', ...) call somewhere under src/tools/**; every entry with has_ts_wrapper:false MUST NOT have such a call. To add a new legacy command: register it in the .cpp dispatch table, add an entry here (with aliases array if any), set has_ts_wrapper to whatever's true, run `npm run lint:legacy-wrappers`. Marking agent_callable:false hides it from hayba_invoke via:'ue_legacy' while still letting get_tool_signature document it (e.g. ping, wizard_chat \u2014 internal/diagnostic).",
   "version": 1,
   "commands": {
     "mesh_extract": {
       "aliases": [],
       "handler_cpp": "FHaybaMCPStaticMeshHandler::MeshExtract",
       "params": [
-        { "name": "actor_label", "type": "string", "required": false, "description": "Editor actor label; reads its UDynamicMeshComponent (primary source for PCG dynamic-mesh output). Provide this OR path, not both." },
-        { "name": "component_index", "type": "number", "required": false, "description": "Which UDynamicMeshComponent on the actor (default 0)" },
-        { "name": "component_name", "type": "string", "required": false, "description": "Match the dynamic mesh component by name instead of index" },
-        { "name": "path", "type": "string", "required": false, "description": "UStaticMesh asset path (/Game/...) — alternative source (render data: counts + bounds + optional arrays)" },
-        { "name": "lod", "type": "number", "required": false, "description": "StaticMesh LOD to read (default 0); ignored for dynamic mesh" },
-        { "name": "include_triangles", "type": "boolean", "required": false, "description": "Include the triangles index array [[i,j,k],...] (bounded by max_elements)" },
-        { "name": "include_positions", "type": "boolean", "required": false, "description": "Include the vertices array [[x,y,z],...] (bounded by max_elements)" },
-        { "name": "include_normals", "type": "boolean", "required": false, "description": "Include computed per-triangle face normals (dynamic mesh only)" },
-        { "name": "max_elements", "type": "number", "required": false, "description": "Hard cap on emitted array elements (default 2000); stats are always over the whole mesh" },
-        { "name": "bbox_min", "type": "array", "required": false, "description": "[x,y,z] local-space AABB min; with arrays requested, only emit triangles whose centroid is inside the box" },
-        { "name": "bbox_max", "type": "array", "required": false, "description": "[x,y,z] local-space AABB max" }
+        {
+          "name": "actor_label",
+          "type": "string",
+          "required": false,
+          "description": "Editor actor label; reads its UDynamicMeshComponent (primary source for PCG dynamic-mesh output). Provide this OR path, not both."
+        },
+        {
+          "name": "component_index",
+          "type": "number",
+          "required": false,
+          "description": "Which UDynamicMeshComponent on the actor (default 0)"
+        },
+        {
+          "name": "component_name",
+          "type": "string",
+          "required": false,
+          "description": "Match the dynamic mesh component by name instead of index"
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "UStaticMesh asset path (/Game/...) \u2014 alternative source (render data: counts + bounds + optional arrays)"
+        },
+        {
+          "name": "lod",
+          "type": "number",
+          "required": false,
+          "description": "StaticMesh LOD to read (default 0); ignored for dynamic mesh"
+        },
+        {
+          "name": "include_triangles",
+          "type": "boolean",
+          "required": false,
+          "description": "Include the triangles index array [[i,j,k],...] (bounded by max_elements)"
+        },
+        {
+          "name": "include_positions",
+          "type": "boolean",
+          "required": false,
+          "description": "Include the vertices array [[x,y,z],...] (bounded by max_elements)"
+        },
+        {
+          "name": "include_normals",
+          "type": "boolean",
+          "required": false,
+          "description": "Include computed per-triangle face normals (dynamic mesh only)"
+        },
+        {
+          "name": "max_elements",
+          "type": "number",
+          "required": false,
+          "description": "Hard cap on emitted array elements (default 2000); stats are always over the whole mesh"
+        },
+        {
+          "name": "bbox_min",
+          "type": "array",
+          "required": false,
+          "description": "[x,y,z] local-space AABB min; with arrays requested, only emit triangles whose centroid is inside the box"
+        },
+        {
+          "name": "bbox_max",
+          "type": "array",
+          "required": false,
+          "description": "[x,y,z] local-space AABB max"
+        }
       ],
       "returns": {
         "shape": "object",
         "fields": [
-          { "name": "source", "type": "string", "description": "'dynamic_mesh_component' | 'static_mesh'" },
-          { "name": "counts", "type": "object", "description": "{triangles, vertices, edges}" },
-          { "name": "topology", "type": "object", "description": "Both dynamic AND static sources (static is welded from the render LOD first): {boundary_edges, boundary_loops (hole count), non_manifold_vertices (bowties), degenerate_triangles, connected_components, component_triangle_counts[], has_open_boundaries, is_closed, is_valid, surface_area, volume, euler_characteristic, genus (only when single closed manifold)}" },
-          { "name": "bounds", "type": "object", "description": "{min,max,extents}" },
-          { "name": "triangles", "type": "array", "description": "present only when include_triangles" },
-          { "name": "vertices", "type": "array", "description": "present only when include_positions" },
-          { "name": "face_normals", "type": "array", "description": "present only when include_normals (dynamic mesh)" },
-          { "name": "truncated", "type": "boolean", "description": "true if arrays were capped by max_elements/bbox" }
+          {
+            "name": "source",
+            "type": "string",
+            "description": "'dynamic_mesh_component' | 'static_mesh'"
+          },
+          {
+            "name": "counts",
+            "type": "object",
+            "description": "{triangles, vertices, edges}"
+          },
+          {
+            "name": "topology",
+            "type": "object",
+            "description": "Both dynamic AND static sources (static is welded from the render LOD first): {boundary_edges, boundary_loops (hole count), non_manifold_vertices (bowties), degenerate_triangles, connected_components, component_triangle_counts[], has_open_boundaries, is_closed, is_valid, surface_area, volume, euler_characteristic, genus (only when single closed manifold)}"
+          },
+          {
+            "name": "bounds",
+            "type": "object",
+            "description": "{min,max,extents}"
+          },
+          {
+            "name": "triangles",
+            "type": "array",
+            "description": "present only when include_triangles"
+          },
+          {
+            "name": "vertices",
+            "type": "array",
+            "description": "present only when include_positions"
+          },
+          {
+            "name": "face_normals",
+            "type": "array",
+            "description": "present only when include_normals (dynamic mesh)"
+          },
+          {
+            "name": "truncated",
+            "type": "boolean",
+            "description": "true if arrays were capped by max_elements/bbox"
+          }
         ]
       },
       "agent_callable": true,
@@ -40,18 +127,54 @@
       "aliases": [],
       "handler_cpp": "FHaybaMCPStaticMeshHandler::MeshExtract",
       "params": [
-        { "name": "actor_label", "type": "string", "required": false, "description": "Editor actor label; reads its UDynamicMeshComponent" },
-        { "name": "component_index", "type": "number", "required": false, "description": "Which UDynamicMeshComponent (default 0)" },
-        { "name": "component_name", "type": "string", "required": false, "description": "Match component by name instead of index" },
-        { "name": "path", "type": "string", "required": false, "description": "UStaticMesh asset path (alternative source)" },
-        { "name": "lod", "type": "number", "required": false, "description": "StaticMesh LOD (default 0)" }
+        {
+          "name": "actor_label",
+          "type": "string",
+          "required": false,
+          "description": "Editor actor label; reads its UDynamicMeshComponent"
+        },
+        {
+          "name": "component_index",
+          "type": "number",
+          "required": false,
+          "description": "Which UDynamicMeshComponent (default 0)"
+        },
+        {
+          "name": "component_name",
+          "type": "string",
+          "required": false,
+          "description": "Match component by name instead of index"
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "required": false,
+          "description": "UStaticMesh asset path (alternative source)"
+        },
+        {
+          "name": "lod",
+          "type": "number",
+          "required": false,
+          "description": "StaticMesh LOD (default 0)"
+        }
       ],
       "returns": {
         "shape": "object",
         "fields": [
-          { "name": "counts", "type": "object", "description": "{triangles, vertices, edges}" },
-          { "name": "topology", "type": "object", "description": "{boundary_edges, boundary_loops, non_manifold_vertices, degenerate_triangles, connected_components, component_triangle_counts[], has_open_boundaries, is_closed, is_valid, surface_area, volume, euler_characteristic, genus}" },
-          { "name": "bounds", "type": "object" }
+          {
+            "name": "counts",
+            "type": "object",
+            "description": "{triangles, vertices, edges}"
+          },
+          {
+            "name": "topology",
+            "type": "object",
+            "description": "{boundary_edges, boundary_loops, non_manifold_vertices, degenerate_triangles, connected_components, component_triangle_counts[], has_open_boundaries, is_closed, is_valid, surface_area, volume, euler_characteristic, genus}"
+          },
+          {
+            "name": "bounds",
+            "type": "object"
+          }
         ]
       },
       "agent_callable": true,
@@ -62,62 +185,152 @@
       "aliases": [],
       "handler_cpp": "FHaybaMCPStaticMeshHandler::MeshListDynamic",
       "params": [
-        { "name": "label_contains", "type": "string", "required": false, "description": "Only list components on actors whose label contains this substring" }
+        {
+          "name": "label_contains",
+          "type": "string",
+          "required": false,
+          "description": "Only list components on actors whose label contains this substring"
+        }
       ],
-      "returns": { "shape": "object", "fields": [
-        { "name": "dynamic_meshes", "type": "array", "description": "[{actor_label, component, triangles, vertices, num_materials, empty}]" },
-        { "name": "count", "type": "number" },
-        { "name": "total_triangles", "type": "number" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "dynamic_meshes",
+            "type": "array",
+            "description": "[{actor_label, component, triangles, vertices, num_materials, empty}]"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          },
+          {
+            "name": "total_triangles",
+            "type": "number"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Enumerate every UDynamicMeshComponent in the editor level with tri/vert/material counts — replaces the hand-rolled 'loop all actors -> DynamicMeshComponent -> tris' python_run for inspecting PCG/grammar output. Pair with mesh_topology_stats(actor_label=...) for a full weld/manifold verdict on a specific one."
+      "notes": "Enumerate every UDynamicMeshComponent in the editor level with tri/vert/material counts \u2014 replaces the hand-rolled 'loop all actors -> DynamicMeshComponent -> tris' python_run for inspecting PCG/grammar output. Pair with mesh_topology_stats(actor_label=...) for a full weld/manifold verdict on a specific one."
     },
     "object_get_property": {
       "aliases": [],
       "handler_cpp": "FHaybaMCPAssetHandler::ObjectGetProperty",
       "params": [
-        { "name": "path", "type": "string", "required": true, "description": "Object/asset path, e.g. /Game/Foo/MyAsset or a sub-object path" },
-        { "name": "names", "type": "array", "required": false, "description": "Optional list of property names to read; omit to dump all editable (CPF_Edit) properties" }
+        {
+          "name": "path",
+          "type": "string",
+          "required": true,
+          "description": "Object/asset path, e.g. /Game/Foo/MyAsset or a sub-object path"
+        },
+        {
+          "name": "names",
+          "type": "array",
+          "required": false,
+          "description": "Optional list of property names to read; omit to dump all editable (CPF_Edit) properties"
+        }
       ],
-      "returns": { "shape": "object", "fields": [
-        { "name": "path", "type": "string" },
-        { "name": "class", "type": "string" },
-        { "name": "properties", "type": "object", "description": "name -> ExportText string value" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "path",
+            "type": "string"
+          },
+          {
+            "name": "class",
+            "type": "string"
+          },
+          {
+            "name": "properties",
+            "type": "object",
+            "description": "name -> ExportText string value"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Generic reflection read on any loadable UObject — replaces get_editor_property python_run pokes. Values are UE ExportText strings."
+      "notes": "Generic reflection read on any loadable UObject \u2014 replaces get_editor_property python_run pokes. Values are UE ExportText strings."
     },
     "object_set_property": {
       "aliases": [],
       "handler_cpp": "FHaybaMCPAssetHandler::ObjectSetProperty",
       "params": [
-        { "name": "path", "type": "string", "required": true, "description": "Object/asset path" },
-        { "name": "properties", "type": "object", "required": true, "description": "name -> value map (numbers/strings/bools/arrays); set via reflection (HaybaReflection::SetProp)" }
+        {
+          "name": "path",
+          "type": "string",
+          "required": true,
+          "description": "Object/asset path"
+        },
+        {
+          "name": "properties",
+          "type": "object",
+          "required": true,
+          "description": "name -> value map (numbers/strings/bools/arrays); set via reflection (HaybaReflection::SetProp)"
+        }
       ],
-      "returns": { "shape": "object", "fields": [
-        { "name": "path", "type": "string" },
-        { "name": "applied", "type": "array" },
-        { "name": "failed", "type": "array", "description": "property names that did not resolve" },
-        { "name": "ok", "type": "boolean" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "path",
+            "type": "string"
+          },
+          {
+            "name": "applied",
+            "type": "array"
+          },
+          {
+            "name": "failed",
+            "type": "array",
+            "description": "property names that did not resolve"
+          },
+          {
+            "name": "ok",
+            "type": "boolean"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Generic reflection write on any loadable UObject (Modify + PostEditChange + MarkPackageDirty) — replaces set_editor_property python_run pokes. For textures prefer texture_set_settings; for material nodes prefer the material_* tools."
+      "notes": "Generic reflection write on any loadable UObject (Modify + PostEditChange + MarkPackageDirty) \u2014 replaces set_editor_property python_run pokes. For textures prefer texture_set_settings; for material nodes prefer the material_* tools."
     },
     "test_list": {
       "aliases": [],
       "handler_cpp": "FHaybaMCPTestHandler::Handle",
       "params": [
-        { "name": "filter_pattern", "type": "string", "required": false, "description": "Substring filter on display name or full path" },
-        { "name": "category", "type": "string", "required": false, "description": "Full-path prefix filter, e.g. 'Hayba.Socket'" }
+        {
+          "name": "filter_pattern",
+          "type": "string",
+          "required": false,
+          "description": "Substring filter on display name or full path"
+        },
+        {
+          "name": "category",
+          "type": "string",
+          "required": false,
+          "description": "Full-path prefix filter, e.g. 'Hayba.Socket'"
+        }
       ],
-      "returns": { "shape": "object", "fields": [
-        { "name": "tests", "type": "array", "description": "[{name, full_test_path, file_name, line_number}]" },
-        { "name": "count", "type": "number" },
-        { "name": "total_discovered", "type": "number" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "tests",
+            "type": "array",
+            "description": "[{name, full_test_path, file_name, line_number}]"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          },
+          {
+            "name": "total_discovered",
+            "type": "number"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": "Enumerate registered automation tests via FAutomationTestFramework directly (no controller/session-frontend needed)."
@@ -126,16 +339,49 @@
       "aliases": [],
       "handler_cpp": "FHaybaMCPTestHandler::Handle",
       "params": [
-        { "name": "test_names", "type": "array", "required": false, "description": "Test names/full-paths to run, or the single string 'all'. Accepts a string or array." },
-        { "name": "smoke_only", "type": "boolean", "required": false, "description": "Restrict to SmokeFilter-tagged tests" },
-        { "name": "timeout_seconds", "type": "number", "required": false, "description": "Per-test latent-command drain timeout (default 120)" }
+        {
+          "name": "test_names",
+          "type": "array",
+          "required": false,
+          "description": "Test names/full-paths to run, or the single string 'all'. Accepts a string or array."
+        },
+        {
+          "name": "smoke_only",
+          "type": "boolean",
+          "required": false,
+          "description": "Restrict to SmokeFilter-tagged tests"
+        },
+        {
+          "name": "timeout_seconds",
+          "type": "number",
+          "required": false,
+          "description": "Per-test latent-command drain timeout (default 120)"
+        }
       ],
-      "returns": { "shape": "object", "fields": [
-        { "name": "job_id", "type": "string", "description": "Poll build_status { job_id } for the result" },
-        { "name": "status", "type": "string", "description": "'running' immediately; 'busy' if another run is already in flight" },
-        { "name": "total", "type": "number", "description": "Number of tests queued for this run" },
-        { "name": "note", "type": "string" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "job_id",
+            "type": "string",
+            "description": "Poll build_status { job_id } for the result"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "description": "'running' immediately; 'busy' if another run is already in flight"
+          },
+          {
+            "name": "total",
+            "type": "number",
+            "description": "Number of tests queued for this run"
+          },
+          {
+            "name": "note",
+            "type": "string"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": "JOB ENVELOPE (async, non-freezing): returns { job_id, status:'running' } IMMEDIATELY and runs the tests on the editor's game-thread core ticker (one step/frame), so the editor stays responsive. Poll build_status { job_id } for the result { passed, failed, skipped, elapsed_seconds, total } (delivered as a JSON string in build_status.output), or call test_get_log for the last run's detailed errors/warnings. Only one test_run job at a time (status:'busy' otherwise). Drives FAutomationTestFramework::StartTestByName -> ExecuteLatentCommands -> StopTest directly, bypassing the controller/worker session queue, so it works in a normal GUI editor without the Session Frontend. Replaces the old INLINE busy-sleep that froze the game thread up to 120s/test."
@@ -144,10 +390,20 @@
       "aliases": [],
       "handler_cpp": "FHaybaMCPTestHandler::Handle",
       "params": [],
-      "returns": { "shape": "object", "fields": [
-        { "name": "tests", "type": "array", "description": "[{name, success, duration_seconds, errors[], warnings[]}] from the most recent test_run" },
-        { "name": "count", "type": "number" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "tests",
+            "type": "array",
+            "description": "[{name, success, duration_seconds, errors[], warnings[]}] from the most recent test_run"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": "Full entries (errors + warnings) from the last test_run."
@@ -156,36 +412,106 @@
       "aliases": [],
       "handler_cpp": "FHaybaMCPBuildHandler::Handle",
       "params": [
-        { "name": "target", "type": "string", "required": false, "description": "'Editor' (default) -> <Project>Editor, or 'Game' -> <Project>" },
-        { "name": "configuration", "type": "string", "required": false, "description": "Development (default) | DebugGame | Shipping | Test" },
-        { "name": "platform", "type": "string", "required": false, "description": "Win64 (default) | Linux | Mac" }
+        {
+          "name": "target",
+          "type": "string",
+          "required": false,
+          "description": "'Editor' (default) -> <Project>Editor, or 'Game' -> <Project>"
+        },
+        {
+          "name": "configuration",
+          "type": "string",
+          "required": false,
+          "description": "Development (default) | DebugGame | Shipping | Test"
+        },
+        {
+          "name": "platform",
+          "type": "string",
+          "required": false,
+          "description": "Win64 (default) | Linux | Mac"
+        }
       ],
-      "returns": { "shape": "object", "fields": [
-        { "name": "job_id", "type": "string", "description": "Poll build_status { job_id } for the result" },
-        { "name": "status", "type": "string", "description": "'running' (returned immediately)" },
-        { "name": "command", "type": "string" },
-        { "name": "ok", "type": "boolean" },
-        { "name": "note", "type": "string" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "job_id",
+            "type": "string",
+            "description": "Poll build_status { job_id } for the result"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "description": "'running' (returned immediately)"
+          },
+          {
+            "name": "command",
+            "type": "string"
+          },
+          {
+            "name": "ok",
+            "type": "boolean"
+          },
+          {
+            "name": "note",
+            "type": "string"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "JOB ENVELOPE (async, non-freezing): invokes UnrealBuildTool.exe on a background thread and returns { job_id, status:'running' } IMMEDIATELY — never blocks the editor (the old version blocked the game thread up to 5min). Poll build_status { job_id } for { status:'done', exit_code, output (log tail) }, or watch hayba_journal_tail for live build_job:<id> progress."
+      "notes": "JOB ENVELOPE (async, non-freezing): invokes UnrealBuildTool.exe on a background thread and returns { job_id, status:'running' } IMMEDIATELY \u2014 never blocks the editor (the old version blocked the game thread up to 5min). Poll build_status { job_id } for { status:'done', exit_code, output (log tail) }, or watch hayba_journal_tail for live build_job:<id> progress."
     },
     "build_cook": {
       "aliases": [],
       "handler_cpp": "FHaybaMCPBuildHandler::Handle",
       "params": [
-        { "name": "platform", "type": "string", "required": false, "description": "Cook target platform (default WindowsNoEditor)" },
-        { "name": "iterate", "type": "boolean", "required": false, "description": "Iterative cook (default true)" },
-        { "name": "unversioned", "type": "boolean", "required": false, "description": "Cook unversioned packages (default false)" }
+        {
+          "name": "platform",
+          "type": "string",
+          "required": false,
+          "description": "Cook target platform (default WindowsNoEditor)"
+        },
+        {
+          "name": "iterate",
+          "type": "boolean",
+          "required": false,
+          "description": "Iterative cook (default true)"
+        },
+        {
+          "name": "unversioned",
+          "type": "boolean",
+          "required": false,
+          "description": "Cook unversioned packages (default false)"
+        }
       ],
-      "returns": { "shape": "object", "fields": [
-        { "name": "job_id", "type": "string", "description": "Poll build_status { job_id } for the result" },
-        { "name": "status", "type": "string", "description": "'running' (returned immediately)" },
-        { "name": "command", "type": "string" },
-        { "name": "ok", "type": "boolean" },
-        { "name": "note", "type": "string" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "job_id",
+            "type": "string",
+            "description": "Poll build_status { job_id } for the result"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "description": "'running' (returned immediately)"
+          },
+          {
+            "name": "command",
+            "type": "string"
+          },
+          {
+            "name": "ok",
+            "type": "boolean"
+          },
+          {
+            "name": "note",
+            "type": "string"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": "JOB ENVELOPE (async, non-freezing): runs UnrealEditor-Cmd -run=cook on a background thread and returns { job_id, status:'running' } IMMEDIATELY. Poll build_status { job_id } for { status:'done', exit_code, output }, or watch hayba_journal_tail."
@@ -194,13 +520,33 @@
       "aliases": [],
       "handler_cpp": "FHaybaMCPBuildHandler::Handle",
       "params": [],
-      "returns": { "shape": "object", "fields": [
-        { "name": "job_id", "type": "string", "description": "Poll build_status { job_id } for the result" },
-        { "name": "status", "type": "string", "description": "'running' (returned immediately)" },
-        { "name": "command", "type": "string" },
-        { "name": "ok", "type": "boolean" },
-        { "name": "note", "type": "string" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "job_id",
+            "type": "string",
+            "description": "Poll build_status { job_id } for the result"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "description": "'running' (returned immediately)"
+          },
+          {
+            "name": "command",
+            "type": "string"
+          },
+          {
+            "name": "ok",
+            "type": "boolean"
+          },
+          {
+            "name": "note",
+            "type": "string"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": "JOB ENVELOPE (async, non-freezing): runs RunUAT GenerateProjectFiles on a background thread and returns { job_id, status:'running' } IMMEDIATELY. Poll build_status { job_id } for { status:'done', exit_code, output }."
@@ -209,16 +555,47 @@
       "aliases": [],
       "handler_cpp": "FHaybaMCPBuildHandler::Handle",
       "params": [
-        { "name": "job_id", "type": "string", "required": true, "description": "Id returned by a build_* or test_run job envelope" }
+        {
+          "name": "job_id",
+          "type": "string",
+          "required": true,
+          "description": "Id returned by a build_* or test_run job envelope"
+        }
       ],
-      "returns": { "shape": "object", "fields": [
-        { "name": "job_id", "type": "string" },
-        { "name": "command", "type": "string", "description": "Originating command, e.g. 'build_project' or 'test_run'" },
-        { "name": "status", "type": "string", "description": "'running' | 'done' | 'unknown'" },
-        { "name": "ok", "type": "boolean", "description": "When done: exit_code == 0" },
-        { "name": "exit_code", "type": "number", "description": "When done: process exit code (build) or failure count (test_run)" },
-        { "name": "output", "type": "string", "description": "When done: log tail (build) or a JSON string of { passed, failed, skipped, elapsed_seconds, total } (test_run)" }
-      ] },
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "job_id",
+            "type": "string"
+          },
+          {
+            "name": "command",
+            "type": "string",
+            "description": "Originating command, e.g. 'build_project' or 'test_run'"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "description": "'running' | 'done' | 'unknown'"
+          },
+          {
+            "name": "ok",
+            "type": "boolean",
+            "description": "When done: exit_code == 0"
+          },
+          {
+            "name": "exit_code",
+            "type": "number",
+            "description": "When done: process exit code (build) or failure count (test_run)"
+          },
+          {
+            "name": "output",
+            "type": "string",
+            "description": "When done: log tail (build) or a JSON string of { passed, failed, skipped, elapsed_seconds, total } (test_run)"
+          }
+        ]
+      },
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": "Reader for the async job registry shared by build_project / build_cook / build_generate_project_files / test_run. Reads the job entry under its lock by job_id and returns its current status/result. Poll this after a build_* / test_run call returns { job_id, status:'running' }."
@@ -254,7 +631,7 @@
       },
       "agent_callable": false,
       "has_ts_wrapper": false,
-      "notes": "Diagnostic ping used by sidecar discovery handshake. Not exposed to agents via hayba_invoke — call check_ue_status instead."
+      "notes": "Diagnostic ping used by sidecar discovery handshake. Not exposed to agents via hayba_invoke \u2014 call check_ue_status instead."
     },
     "list_node_classes": {
       "aliases": [
@@ -547,7 +924,7 @@
           {
             "name": "errors",
             "type": "array",
-            "description": "Present when created:false — same shape as validate_graph errors"
+            "description": "Present when created:false \u2014 same shape as validate_graph errors"
           }
         ]
       },
@@ -630,7 +1007,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Wrapped by hayba_validate_pcg_graph (src/tools/validate-pcg-graph.ts). Pure validation — does not touch UE world state."
+      "notes": "Wrapped by hayba_validate_pcg_graph (src/tools/validate-pcg-graph.ts). Pure validation \u2014 does not touch UE world state."
     },
     "pcg_validate_graph": {
       "aliases": [
@@ -688,7 +1065,7 @@
           {
             "name": "componentsExecuted",
             "type": "number",
-            "description": "Count of PCGComponents in the world that reference this graph and were triggered. ZERO means the graph runs no instances — verify HISM counts before claiming success (see verify-by-viewport skill)."
+            "description": "Count of PCGComponents in the world that reference this graph and were triggered. ZERO means the graph runs no instances \u2014 verify HISM counts before claiming success (see verify-by-viewport skill)."
           },
           {
             "name": "note",
@@ -699,7 +1076,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Wrapped by hayba_execute_pcg_graph (src/tools/execute-pcg-graph.ts). Game-thread marshaled. Returning success:true with componentsExecuted>0 is NOT proof that instances were placed — see the 2026-05-23 PCG/landscape postmortem."
+      "notes": "Wrapped by hayba_execute_pcg_graph (src/tools/execute-pcg-graph.ts). Game-thread marshaled. Returning success:true with componentsExecuted>0 is NOT proof that instances were placed \u2014 see the 2026-05-23 PCG/landscape postmortem."
     },
     "pcg_execute_graph": {
       "aliases": [
@@ -774,7 +1151,7 @@
       },
       "agent_callable": false,
       "has_ts_wrapper": false,
-      "notes": "Hardcoded wizard-style chat for the in-editor panel. Not useful from agents — use hayba_initiate_infrastructure_brainstorm instead."
+      "notes": "Hardcoded wizard-style chat for the in-editor panel. Not useful from agents \u2014 use hayba_initiate_infrastructure_brainstorm instead."
     },
     "import_landscape": {
       "aliases": [
@@ -899,7 +1276,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Alias of import_landscape — the name discoverable in list_tool_categories under the 'pcg' domain. Wrapped by hayba_import_landscape (src/tools/index.ts uses this exact name as the dispatch target). See PR #229 for the game-thread marshal fix."
+      "notes": "Alias of import_landscape \u2014 the name discoverable in list_tool_categories under the 'pcg' domain. Wrapped by hayba_import_landscape (src/tools/index.ts uses this exact name as the dispatch target). See PR #229 for the game-thread marshal fix."
     },
     "read_node_output": {
       "aliases": [
@@ -946,7 +1323,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "STALE-READ WARNING: reads a possibly-STALE inspection CACHE, not live post-cook data. point_count can report 0 (or a prior run's numbers) while the cook actually produced real instances — do NOT treat point_count:0 here as ground truth. GROUND TRUTH for instance counts is `pcg_cook_and_wait` result.ism[] (with result.freshness.changed proving this cook). Returns zero counts if the graph has not been executed. FOLLOW-UP (C++): make this read live post-cook data or return an explicit {stale:true} flag."
+      "notes": "STALE-READ WARNING: reads a possibly-STALE inspection CACHE, not live post-cook data. point_count can report 0 (or a prior run's numbers) while the cook actually produced real instances \u2014 do NOT treat point_count:0 here as ground truth. GROUND TRUTH for instance counts is `pcg_cook_and_wait` result.ism[] (with result.freshness.changed proving this cook). Returns zero counts if the graph has not been executed. FOLLOW-UP (C++): make this read live post-cook data or return an explicit {stale:true} flag."
     },
     "pcg_read_node_output": {
       "aliases": [
@@ -988,7 +1365,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Alias of read_node_output. STALE-READ WARNING: reads a possibly-STALE inspection cache, not live post-cook data — point_count:0 here is NOT ground truth. Use `pcg_cook_and_wait` result.ism[] for authoritative instance counts."
+      "notes": "Alias of read_node_output. STALE-READ WARNING: reads a possibly-STALE inspection cache, not live post-cook data \u2014 point_count:0 here is NOT ground truth. Use `pcg_cook_and_wait` result.ism[] for authoritative instance counts."
     },
     "describe_assets": {
       "aliases": [
@@ -1125,7 +1502,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Alias of describe_assets — the agent-friendly name surfaced as the hayba_asset_browse routing tool."
+      "notes": "Alias of describe_assets \u2014 the agent-friendly name surfaced as the hayba_asset_browse routing tool."
     },
     "actor_get_properties": {
       "aliases": [],
@@ -2171,20 +2548,28 @@
           "name": "look_at",
           "type": "array",
           "required": false,
-          "description": "BEST way to aim the camera: a world point [x,y,z] to face. The orientation is computed in C++ (correct pitch+yaw, roll always 0 — the horizon never tilts). Use this instead of rotation whenever you know what you want the camera pointed at; you do NOT compute any angles yourself. Takes precedence over rotation."
+          "description": "BEST way to aim the camera: a world point [x,y,z] to face. The orientation is computed in C++ (correct pitch+yaw, roll always 0 \u2014 the horizon never tilts). Use this instead of rotation whenever you know what you want the camera pointed at; you do NOT compute any angles yourself. Takes precedence over rotation."
         },
         {
           "name": "rotation",
           "type": "object",
           "required": false,
-          "description": "Manual orientation (only if you are not using look_at). PREFERRED form: object {pitch, yaw, roll} in degrees — unambiguous. yaw = heading (about the vertical/Z axis, the value you usually want); pitch = look up(+)/down(-); roll = horizon tilt and defaults to 0 (omit it — a non-zero roll is what makes the viewport 'look angled'). Array form is accepted as [pitch, yaw, roll] but its 3rd element (roll) is IGNORED so the camera never tilts by accident — do NOT pass [x,y,z] euler here, index 2 is roll, not yaw."
+          "description": "Manual orientation (only if you are not using look_at). PREFERRED form: object {pitch, yaw, roll} in degrees \u2014 unambiguous. yaw = heading (about the vertical/Z axis, the value you usually want); pitch = look up(+)/down(-); roll = horizon tilt and defaults to 0 (omit it \u2014 a non-zero roll is what makes the viewport 'look angled'). Array form is accepted as [pitch, yaw, roll] but its 3rd element (roll) is IGNORED so the camera never tilts by accident \u2014 do NOT pass [x,y,z] euler here, index 2 is roll, not yaw."
         }
       ],
       "returns": {
         "shape": "object",
         "fields": [
-          { "name": "location", "type": "array", "description": "Applied [x,y,z]" },
-          { "name": "rotation", "type": "array", "description": "Applied [pitch, yaw, roll]" }
+          {
+            "name": "location",
+            "type": "array",
+            "description": "Applied [x,y,z]"
+          },
+          {
+            "name": "rotation",
+            "type": "array",
+            "description": "Applied [pitch, yaw, roll]"
+          }
         ]
       },
       "agent_callable": true,
@@ -2195,21 +2580,47 @@
       "aliases": [],
       "handler_cpp": "FHaybaMCPEditorHandler::Handle",
       "params": [
-        { "name": "actor_label", "type": "string", "required": true, "description": "Label of the actor to frame in the viewport." },
-        { "name": "distance_scale", "type": "number", "required": false, "description": "How far back to sit, as a multiple of the actor's bounds radius (default 2.5; larger = further/more padding)." },
-        { "name": "direction", "type": "array", "required": false, "description": "Optional [x,y,z] view direction (camera→actor). Default is a 3/4 front-right-above view. Need not be normalized." }
+        {
+          "name": "actor_label",
+          "type": "string",
+          "required": true,
+          "description": "Label of the actor to frame in the viewport."
+        },
+        {
+          "name": "distance_scale",
+          "type": "number",
+          "required": false,
+          "description": "How far back to sit, as a multiple of the actor's bounds radius (default 2.5; larger = further/more padding)."
+        },
+        {
+          "name": "direction",
+          "type": "array",
+          "required": false,
+          "description": "Optional [x,y,z] view direction (camera\u2192actor). Default is a 3/4 front-right-above view. Need not be normalized."
+        }
       ],
       "returns": {
         "shape": "object",
         "fields": [
-          { "name": "actor_label", "type": "string" },
-          { "name": "location", "type": "array", "description": "Resulting camera [x,y,z]" },
-          { "name": "rotation", "type": "array", "description": "Resulting [pitch, yaw, roll] (roll always 0)" }
+          {
+            "name": "actor_label",
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "type": "array",
+            "description": "Resulting camera [x,y,z]"
+          },
+          {
+            "name": "rotation",
+            "type": "array",
+            "description": "Resulting [pitch, yaw, roll] (roll always 0)"
+          }
         ]
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Frame an actor in the editor viewport by label — computes camera position from the actor's bounds and aims at its centre, entirely in C++. Roll is always 0 so the view never tilts. This is the correct 'framing tool'; do NOT hand-compute camera angles in python_run."
+      "notes": "Frame an actor in the editor viewport by label \u2014 computes camera position from the actor's bounds and aims at its centre, entirely in C++. Roll is always 0 so the view never tilts. This is the correct 'framing tool'; do NOT hand-compute camera angles in python_run."
     },
     "editor_run_console_command": {
       "aliases": [],
@@ -2288,20 +2699,58 @@
       "aliases": [],
       "handler_cpp": "FHaybaMCPUIHandler::Handle",
       "params": [
-        { "name": "widget_blueprint_path", "type": "string", "required": true, "description": "Widget Blueprint asset path, for example /Game/UI/WBP_HUD" },
-        { "name": "widget_name", "type": "string", "required": true, "description": "Exact widget name in the authoritative designer WidgetTree" },
-        { "name": "properties", "type": "object", "required": true, "description": "Widget UPROPERTY names mapped to reflection-compatible values" },
-        { "name": "slot_props", "type": "object", "required": false, "description": "Optional typed slot values such as x, y, w, h, padding, and fill" }
+        {
+          "name": "widget_blueprint_path",
+          "type": "string",
+          "required": true,
+          "description": "Widget Blueprint asset path, for example /Game/UI/WBP_HUD"
+        },
+        {
+          "name": "widget_name",
+          "type": "string",
+          "required": true,
+          "description": "Exact widget name in the authoritative designer WidgetTree"
+        },
+        {
+          "name": "properties",
+          "type": "object",
+          "required": true,
+          "description": "Widget UPROPERTY names mapped to reflection-compatible values"
+        },
+        {
+          "name": "slot_props",
+          "type": "object",
+          "required": false,
+          "description": "Optional typed slot values such as x, y, w, h, padding, and fill"
+        }
       ],
       "returns": {
         "shape": "object",
         "fields": [
-          { "name": "widget_name", "type": "string" },
-          { "name": "succeeded", "type": "number" },
-          { "name": "failed", "type": "number" },
-          { "name": "failed_properties", "type": "array" },
-          { "name": "unknown_slot_props", "type": "array" },
-          { "name": "warnings", "type": "array" }
+          {
+            "name": "widget_name",
+            "type": "string"
+          },
+          {
+            "name": "succeeded",
+            "type": "number"
+          },
+          {
+            "name": "failed",
+            "type": "number"
+          },
+          {
+            "name": "failed_properties",
+            "type": "array"
+          },
+          {
+            "name": "unknown_slot_props",
+            "type": "array"
+          },
+          {
+            "name": "warnings",
+            "type": "array"
+          }
         ]
       },
       "agent_callable": true,
@@ -2330,6 +2779,67 @@
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": ""
+    },
+    "editor_pie_screenshot": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPIEHandler::PIEScreenshot",
+      "params": [
+        {
+          "name": "filename",
+          "type": "string",
+          "required": false,
+          "description": "Absolute PNG output path; defaults to Saved/Screenshots/HaybaPIE_<timestamp>.png. Captures the composited PIE viewport INCLUDING UMG (unlike HighResShot)."
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "filename",
+            "type": "string",
+            "description": "path written"
+          },
+          {
+            "name": "captured",
+            "type": "boolean",
+            "description": "true if the file exists after capture"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Requests a capture and returns immediately; the engine writes the file a frame or two later. Poll with check_only:true. Previously pumped the core ticker for up to 3s from the game thread, which crashed the editor."
+    },
+    "editor_pie_press_key": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPIEHandler::PIEPressKey",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "required": true,
+          "description": "FKey name, e.g. 'A','Enter','Tab','SpaceBar','LeftMouseButton'"
+        },
+        {
+          "name": "event",
+          "type": "string",
+          "required": false,
+          "description": "'Pressed' (default), 'Released', or a down+up click depending on handler"
+        },
+        {
+          "name": "held_ms",
+          "type": "number",
+          "required": false,
+          "description": "Hold duration in ms before release"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": []
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Dispatches the press and schedules the release on a later tick, returning immediately. Previously spun the core ticker while holding raw viewport pointers, which tore down PIE underneath itself and crashed."
     }
   }
 }

--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./sidecar.schema.json",
-  "_doc": "Hand-authored sidecar for UE-side commands routed through HaybaMCPLegacyHandler::Handle (see unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp). This file is the single source of truth for: (a) the parameter docs surfaced by get_tool_signature for legacy commands that have no TS Zod registration, and (b) the allowlist that hayba_invoke consults when called with via:'ue_legacy'. INVARIANTS (enforced by scripts/check-legacy-wrappers.ts and CI): every dispatch-table command in the .cpp MUST have an entry here (including aliases); every entry with has_ts_wrapper:true MUST have a corresponding executeCommand('<name>', ...) or dispatch('<name>', ...) call somewhere under src/tools/**; every entry with has_ts_wrapper:false MUST NOT have such a call. To add a new legacy command: register it in the .cpp dispatch table, add an entry here (with aliases array if any), set has_ts_wrapper to whatever's true, run `npm run lint:legacy-wrappers`. Marking agent_callable:false hides it from hayba_invoke via:'ue_legacy' while still letting get_tool_signature document it (e.g. ping, wizard_chat — internal/diagnostic).",
+  "_doc": "Hand-authored sidecar for UE-side commands routed through HaybaMCPLegacyHandler::Handle (see unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp). This file is the single source of truth for: (a) the parameter docs surfaced by get_tool_signature for legacy commands that have no TS Zod registration, and (b) the allowlist that hayba_invoke consults when called with via:'ue_legacy'. INVARIANTS (enforced by scripts/check-legacy-wrappers.ts and CI): every dispatch-table command in the .cpp MUST have an entry here (including aliases); every entry with has_ts_wrapper:true MUST have a corresponding executeCommand('<name>', ...) or dispatch('<name>', ...) call somewhere under src/tools/**; every entry with has_ts_wrapper:false MUST NOT have such a call. To add a new legacy command: register it in the .cpp dispatch table, add an entry here (with aliases array if any), set has_ts_wrapper to whatever's true, run `npm run lint:legacy-wrappers`. Marking agent_callable:false hides it from hayba_invoke via:'ue_legacy' while still letting get_tool_signature document it (e.g. ping, wizard_chat \u2014 internal/diagnostic).",
   "version": 1,
   "commands": {
     "mesh_extract": {
@@ -29,7 +29,7 @@
           "name": "path",
           "type": "string",
           "required": false,
-          "description": "UStaticMesh asset path (/Game/...) — alternative source (render data: counts + bounds + optional arrays)"
+          "description": "UStaticMesh asset path (/Game/...) \u2014 alternative source (render data: counts + bounds + optional arrays)"
         },
         {
           "name": "lod",
@@ -212,7 +212,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Enumerate every UDynamicMeshComponent in the editor level with tri/vert/material counts — replaces the hand-rolled 'loop all actors -> DynamicMeshComponent -> tris' python_run for inspecting PCG/grammar output. Pair with mesh_topology_stats(actor_label=...) for a full weld/manifold verdict on a specific one."
+      "notes": "Enumerate every UDynamicMeshComponent in the editor level with tri/vert/material counts \u2014 replaces the hand-rolled 'loop all actors -> DynamicMeshComponent -> tris' python_run for inspecting PCG/grammar output. Pair with mesh_topology_stats(actor_label=...) for a full weld/manifold verdict on a specific one."
     },
     "object_get_property": {
       "aliases": [],
@@ -251,7 +251,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Generic reflection read on any loadable UObject — replaces get_editor_property python_run pokes. Values are UE ExportText strings."
+      "notes": "Generic reflection read on any loadable UObject \u2014 replaces get_editor_property python_run pokes. Values are UE ExportText strings."
     },
     "object_set_property": {
       "aliases": [],
@@ -294,7 +294,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Generic reflection write on any loadable UObject (Modify + PostEditChange + MarkPackageDirty) — replaces set_editor_property python_run pokes. For textures prefer texture_set_settings; for material nodes prefer the material_* tools."
+      "notes": "Generic reflection write on any loadable UObject (Modify + PostEditChange + MarkPackageDirty) \u2014 replaces set_editor_property python_run pokes. For textures prefer texture_set_settings; for material nodes prefer the material_* tools."
     },
     "test_list": {
       "aliases": [],
@@ -460,7 +460,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "JOB ENVELOPE (async, non-freezing): invokes UnrealBuildTool.exe on a background thread and returns { job_id, status:'running' } IMMEDIATELY — never blocks the editor (the old version blocked the game thread up to 5min). Poll build_status { job_id } for { status:'done', exit_code, output (log tail) }, or watch hayba_journal_tail for live build_job:<id> progress."
+      "notes": "JOB ENVELOPE (async, non-freezing): invokes UnrealBuildTool.exe on a background thread and returns { job_id, status:'running' } IMMEDIATELY \u2014 never blocks the editor (the old version blocked the game thread up to 5min). Poll build_status { job_id } for { status:'done', exit_code, output (log tail) }, or watch hayba_journal_tail for live build_job:<id> progress."
     },
     "build_cook": {
       "aliases": [],
@@ -631,7 +631,7 @@
       },
       "agent_callable": false,
       "has_ts_wrapper": false,
-      "notes": "Diagnostic ping used by sidecar discovery handshake. Not exposed to agents via hayba_invoke — call check_ue_status instead."
+      "notes": "Diagnostic ping used by sidecar discovery handshake. Not exposed to agents via hayba_invoke \u2014 call check_ue_status instead."
     },
     "list_node_classes": {
       "aliases": [
@@ -924,7 +924,7 @@
           {
             "name": "errors",
             "type": "array",
-            "description": "Present when created:false — same shape as validate_graph errors"
+            "description": "Present when created:false \u2014 same shape as validate_graph errors"
           }
         ]
       },
@@ -1007,7 +1007,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Wrapped by hayba_validate_pcg_graph (src/tools/validate-pcg-graph.ts). Pure validation — does not touch UE world state."
+      "notes": "Wrapped by hayba_validate_pcg_graph (src/tools/validate-pcg-graph.ts). Pure validation \u2014 does not touch UE world state."
     },
     "pcg_validate_graph": {
       "aliases": [
@@ -1065,7 +1065,7 @@
           {
             "name": "componentsExecuted",
             "type": "number",
-            "description": "Count of PCGComponents in the world that reference this graph and were triggered. ZERO means the graph runs no instances — verify HISM counts before claiming success (see verify-by-viewport skill)."
+            "description": "Count of PCGComponents in the world that reference this graph and were triggered. ZERO means the graph runs no instances \u2014 verify HISM counts before claiming success (see verify-by-viewport skill)."
           },
           {
             "name": "note",
@@ -1076,7 +1076,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Wrapped by hayba_execute_pcg_graph (src/tools/execute-pcg-graph.ts). Game-thread marshaled. Returning success:true with componentsExecuted>0 is NOT proof that instances were placed — see the 2026-05-23 PCG/landscape postmortem."
+      "notes": "Wrapped by hayba_execute_pcg_graph (src/tools/execute-pcg-graph.ts). Game-thread marshaled. Returning success:true with componentsExecuted>0 is NOT proof that instances were placed \u2014 see the 2026-05-23 PCG/landscape postmortem."
     },
     "pcg_execute_graph": {
       "aliases": [
@@ -1151,7 +1151,7 @@
       },
       "agent_callable": false,
       "has_ts_wrapper": false,
-      "notes": "Hardcoded wizard-style chat for the in-editor panel. Not useful from agents — use hayba_initiate_infrastructure_brainstorm instead."
+      "notes": "Hardcoded wizard-style chat for the in-editor panel. Not useful from agents \u2014 use hayba_initiate_infrastructure_brainstorm instead."
     },
     "import_landscape": {
       "aliases": [
@@ -1276,7 +1276,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Alias of import_landscape — the name discoverable in list_tool_categories under the 'pcg' domain. Wrapped by hayba_import_landscape (src/tools/index.ts uses this exact name as the dispatch target). See PR #229 for the game-thread marshal fix."
+      "notes": "Alias of import_landscape \u2014 the name discoverable in list_tool_categories under the 'pcg' domain. Wrapped by hayba_import_landscape (src/tools/index.ts uses this exact name as the dispatch target). See PR #229 for the game-thread marshal fix."
     },
     "read_node_output": {
       "aliases": [
@@ -1323,7 +1323,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "STALE-READ WARNING: reads a possibly-STALE inspection CACHE, not live post-cook data. point_count can report 0 (or a prior run's numbers) while the cook actually produced real instances — do NOT treat point_count:0 here as ground truth. GROUND TRUTH for instance counts is `pcg_cook_and_wait` result.ism[] (with result.freshness.changed proving this cook). Returns zero counts if the graph has not been executed. FOLLOW-UP (C++): make this read live post-cook data or return an explicit {stale:true} flag."
+      "notes": "STALE-READ WARNING: reads a possibly-STALE inspection CACHE, not live post-cook data. point_count can report 0 (or a prior run's numbers) while the cook actually produced real instances \u2014 do NOT treat point_count:0 here as ground truth. GROUND TRUTH for instance counts is `pcg_cook_and_wait` result.ism[] (with result.freshness.changed proving this cook). Returns zero counts if the graph has not been executed. FOLLOW-UP (C++): make this read live post-cook data or return an explicit {stale:true} flag."
     },
     "pcg_read_node_output": {
       "aliases": [
@@ -1365,7 +1365,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Alias of read_node_output. STALE-READ WARNING: reads a possibly-STALE inspection cache, not live post-cook data — point_count:0 here is NOT ground truth. Use `pcg_cook_and_wait` result.ism[] for authoritative instance counts."
+      "notes": "Alias of read_node_output. STALE-READ WARNING: reads a possibly-STALE inspection cache, not live post-cook data \u2014 point_count:0 here is NOT ground truth. Use `pcg_cook_and_wait` result.ism[] for authoritative instance counts."
     },
     "describe_assets": {
       "aliases": [
@@ -1502,7 +1502,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Alias of describe_assets — the agent-friendly name surfaced as the hayba_asset_browse routing tool."
+      "notes": "Alias of describe_assets \u2014 the agent-friendly name surfaced as the hayba_asset_browse routing tool."
     },
     "actor_get_properties": {
       "aliases": [],
@@ -2548,13 +2548,13 @@
           "name": "look_at",
           "type": "array",
           "required": false,
-          "description": "BEST way to aim the camera: a world point [x,y,z] to face. The orientation is computed in C++ (correct pitch+yaw, roll always 0 — the horizon never tilts). Use this instead of rotation whenever you know what you want the camera pointed at; you do NOT compute any angles yourself. Takes precedence over rotation."
+          "description": "BEST way to aim the camera: a world point [x,y,z] to face. The orientation is computed in C++ (correct pitch+yaw, roll always 0 \u2014 the horizon never tilts). Use this instead of rotation whenever you know what you want the camera pointed at; you do NOT compute any angles yourself. Takes precedence over rotation."
         },
         {
           "name": "rotation",
           "type": "object",
           "required": false,
-          "description": "Manual orientation (only if you are not using look_at). PREFERRED form: object {pitch, yaw, roll} in degrees — unambiguous. yaw = heading (about the vertical/Z axis, the value you usually want); pitch = look up(+)/down(-); roll = horizon tilt and defaults to 0 (omit it — a non-zero roll is what makes the viewport 'look angled'). Array form is accepted as [pitch, yaw, roll] but its 3rd element (roll) is IGNORED so the camera never tilts by accident — do NOT pass [x,y,z] euler here, index 2 is roll, not yaw."
+          "description": "Manual orientation (only if you are not using look_at). PREFERRED form: object {pitch, yaw, roll} in degrees \u2014 unambiguous. yaw = heading (about the vertical/Z axis, the value you usually want); pitch = look up(+)/down(-); roll = horizon tilt and defaults to 0 (omit it \u2014 a non-zero roll is what makes the viewport 'look angled'). Array form is accepted as [pitch, yaw, roll] but its 3rd element (roll) is IGNORED so the camera never tilts by accident \u2014 do NOT pass [x,y,z] euler here, index 2 is roll, not yaw."
         }
       ],
       "returns": {
@@ -2596,7 +2596,7 @@
           "name": "direction",
           "type": "array",
           "required": false,
-          "description": "Optional [x,y,z] view direction (camera→actor). Default is a 3/4 front-right-above view. Need not be normalized."
+          "description": "Optional [x,y,z] view direction (camera\u2192actor). Default is a 3/4 front-right-above view. Need not be normalized."
         }
       ],
       "returns": {
@@ -2620,7 +2620,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Frame an actor in the editor viewport by label — computes camera position from the actor's bounds and aims at its centre, entirely in C++. Roll is always 0 so the view never tilts. This is the correct 'framing tool'; do NOT hand-compute camera angles in python_run."
+      "notes": "Frame an actor in the editor viewport by label \u2014 computes camera position from the actor's bounds and aims at its centre, entirely in C++. Roll is always 0 so the view never tilts. This is the correct 'framing tool'; do NOT hand-compute camera angles in python_run."
     },
     "editor_run_console_command": {
       "aliases": [],
@@ -2893,8 +2893,8 @@
         "fields": []
       },
       "agent_callable": true,
-      "has_ts_wrapper": false,
-      "notes": "Inject a mouse action into PIE (drag interpolates so delta-tracking widgets react)."
+      "has_ts_wrapper": true,
+      "notes": "Move, click, double_click, press, release, drag or scroll in the running game. Drag interpolates intermediate positions because widgets tracking deltas ignore a single jump."
     },
     "editor_pie_type_text": {
       "aliases": [],
@@ -2912,8 +2912,8 @@
         "fields": []
       },
       "agent_callable": true,
-      "has_ts_wrapper": false,
-      "notes": "Type text into the focused PIE widget via character events."
+      "has_ts_wrapper": true,
+      "notes": "Sends character events, which is what text fields consume. Goes to whatever holds keyboard focus."
     },
     "editor_pie_click_widget": {
       "aliases": [],
@@ -2931,8 +2931,8 @@
         "fields": []
       },
       "agent_callable": true,
-      "has_ts_wrapper": false,
-      "notes": "Click a widget by visible text instead of coordinates; reports candidate count so ambiguous picks aren't silent."
+      "has_ts_wrapper": true,
+      "notes": "Clicks a control by its visible text, tag or type, preferring the interactive widget. Reports candidate count so an ambiguous pick is visible."
     },
     "editor_pie_widget_tree": {
       "aliases": [],
@@ -2956,8 +2956,8 @@
         "fields": []
       },
       "agent_callable": true,
-      "has_ts_wrapper": false,
-      "notes": "List every visible PIE widget with its on-screen rect (read the screen before clicking)."
+      "has_ts_wrapper": true,
+      "notes": "Every visible Slate/UMG widget in the running game with its on-screen rectangle. The input to click-by-name."
     },
     "editor_pie_axis": {
       "aliases": [],
@@ -2981,8 +2981,8 @@
         "fields": []
       },
       "agent_callable": true,
-      "has_ts_wrapper": false,
-      "notes": "Inject an analog axis (sticks/triggers) into PIE."
+      "has_ts_wrapper": true,
+      "notes": "Analog input for sticks, triggers and mouse axes. Applies for one frame; resend per step for sustained movement."
     }
   }
 }

--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./sidecar.schema.json",
-  "_doc": "Hand-authored sidecar for UE-side commands routed through HaybaMCPLegacyHandler::Handle (see unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp). This file is the single source of truth for: (a) the parameter docs surfaced by get_tool_signature for legacy commands that have no TS Zod registration, and (b) the allowlist that hayba_invoke consults when called with via:'ue_legacy'. INVARIANTS (enforced by scripts/check-legacy-wrappers.ts and CI): every dispatch-table command in the .cpp MUST have an entry here (including aliases); every entry with has_ts_wrapper:true MUST have a corresponding executeCommand('<name>', ...) or dispatch('<name>', ...) call somewhere under src/tools/**; every entry with has_ts_wrapper:false MUST NOT have such a call. To add a new legacy command: register it in the .cpp dispatch table, add an entry here (with aliases array if any), set has_ts_wrapper to whatever's true, run `npm run lint:legacy-wrappers`. Marking agent_callable:false hides it from hayba_invoke via:'ue_legacy' while still letting get_tool_signature document it (e.g. ping, wizard_chat \u2014 internal/diagnostic).",
+  "_doc": "Hand-authored sidecar for UE-side commands routed through HaybaMCPLegacyHandler::Handle (see unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp). This file is the single source of truth for: (a) the parameter docs surfaced by get_tool_signature for legacy commands that have no TS Zod registration, and (b) the allowlist that hayba_invoke consults when called with via:'ue_legacy'. INVARIANTS (enforced by scripts/check-legacy-wrappers.ts and CI): every dispatch-table command in the .cpp MUST have an entry here (including aliases); every entry with has_ts_wrapper:true MUST have a corresponding executeCommand('<name>', ...) or dispatch('<name>', ...) call somewhere under src/tools/**; every entry with has_ts_wrapper:false MUST NOT have such a call. To add a new legacy command: register it in the .cpp dispatch table, add an entry here (with aliases array if any), set has_ts_wrapper to whatever's true, run `npm run lint:legacy-wrappers`. Marking agent_callable:false hides it from hayba_invoke via:'ue_legacy' while still letting get_tool_signature document it (e.g. ping, wizard_chat — internal/diagnostic).",
   "version": 1,
   "commands": {
     "mesh_extract": {
@@ -29,7 +29,7 @@
           "name": "path",
           "type": "string",
           "required": false,
-          "description": "UStaticMesh asset path (/Game/...) \u2014 alternative source (render data: counts + bounds + optional arrays)"
+          "description": "UStaticMesh asset path (/Game/...) — alternative source (render data: counts + bounds + optional arrays)"
         },
         {
           "name": "lod",
@@ -212,7 +212,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Enumerate every UDynamicMeshComponent in the editor level with tri/vert/material counts \u2014 replaces the hand-rolled 'loop all actors -> DynamicMeshComponent -> tris' python_run for inspecting PCG/grammar output. Pair with mesh_topology_stats(actor_label=...) for a full weld/manifold verdict on a specific one."
+      "notes": "Enumerate every UDynamicMeshComponent in the editor level with tri/vert/material counts — replaces the hand-rolled 'loop all actors -> DynamicMeshComponent -> tris' python_run for inspecting PCG/grammar output. Pair with mesh_topology_stats(actor_label=...) for a full weld/manifold verdict on a specific one."
     },
     "object_get_property": {
       "aliases": [],
@@ -251,7 +251,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Generic reflection read on any loadable UObject \u2014 replaces get_editor_property python_run pokes. Values are UE ExportText strings."
+      "notes": "Generic reflection read on any loadable UObject — replaces get_editor_property python_run pokes. Values are UE ExportText strings."
     },
     "object_set_property": {
       "aliases": [],
@@ -294,7 +294,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Generic reflection write on any loadable UObject (Modify + PostEditChange + MarkPackageDirty) \u2014 replaces set_editor_property python_run pokes. For textures prefer texture_set_settings; for material nodes prefer the material_* tools."
+      "notes": "Generic reflection write on any loadable UObject (Modify + PostEditChange + MarkPackageDirty) — replaces set_editor_property python_run pokes. For textures prefer texture_set_settings; for material nodes prefer the material_* tools."
     },
     "test_list": {
       "aliases": [],
@@ -460,7 +460,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "JOB ENVELOPE (async, non-freezing): invokes UnrealBuildTool.exe on a background thread and returns { job_id, status:'running' } IMMEDIATELY \u2014 never blocks the editor (the old version blocked the game thread up to 5min). Poll build_status { job_id } for { status:'done', exit_code, output (log tail) }, or watch hayba_journal_tail for live build_job:<id> progress."
+      "notes": "JOB ENVELOPE (async, non-freezing): invokes UnrealBuildTool.exe on a background thread and returns { job_id, status:'running' } IMMEDIATELY — never blocks the editor (the old version blocked the game thread up to 5min). Poll build_status { job_id } for { status:'done', exit_code, output (log tail) }, or watch hayba_journal_tail for live build_job:<id> progress."
     },
     "build_cook": {
       "aliases": [],
@@ -631,7 +631,7 @@
       },
       "agent_callable": false,
       "has_ts_wrapper": false,
-      "notes": "Diagnostic ping used by sidecar discovery handshake. Not exposed to agents via hayba_invoke \u2014 call check_ue_status instead."
+      "notes": "Diagnostic ping used by sidecar discovery handshake. Not exposed to agents via hayba_invoke — call check_ue_status instead."
     },
     "list_node_classes": {
       "aliases": [
@@ -924,7 +924,7 @@
           {
             "name": "errors",
             "type": "array",
-            "description": "Present when created:false \u2014 same shape as validate_graph errors"
+            "description": "Present when created:false — same shape as validate_graph errors"
           }
         ]
       },
@@ -1007,7 +1007,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Wrapped by hayba_validate_pcg_graph (src/tools/validate-pcg-graph.ts). Pure validation \u2014 does not touch UE world state."
+      "notes": "Wrapped by hayba_validate_pcg_graph (src/tools/validate-pcg-graph.ts). Pure validation — does not touch UE world state."
     },
     "pcg_validate_graph": {
       "aliases": [
@@ -1065,7 +1065,7 @@
           {
             "name": "componentsExecuted",
             "type": "number",
-            "description": "Count of PCGComponents in the world that reference this graph and were triggered. ZERO means the graph runs no instances \u2014 verify HISM counts before claiming success (see verify-by-viewport skill)."
+            "description": "Count of PCGComponents in the world that reference this graph and were triggered. ZERO means the graph runs no instances — verify HISM counts before claiming success (see verify-by-viewport skill)."
           },
           {
             "name": "note",
@@ -1076,7 +1076,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Wrapped by hayba_execute_pcg_graph (src/tools/execute-pcg-graph.ts). Game-thread marshaled. Returning success:true with componentsExecuted>0 is NOT proof that instances were placed \u2014 see the 2026-05-23 PCG/landscape postmortem."
+      "notes": "Wrapped by hayba_execute_pcg_graph (src/tools/execute-pcg-graph.ts). Game-thread marshaled. Returning success:true with componentsExecuted>0 is NOT proof that instances were placed — see the 2026-05-23 PCG/landscape postmortem."
     },
     "pcg_execute_graph": {
       "aliases": [
@@ -1151,7 +1151,7 @@
       },
       "agent_callable": false,
       "has_ts_wrapper": false,
-      "notes": "Hardcoded wizard-style chat for the in-editor panel. Not useful from agents \u2014 use hayba_initiate_infrastructure_brainstorm instead."
+      "notes": "Hardcoded wizard-style chat for the in-editor panel. Not useful from agents — use hayba_initiate_infrastructure_brainstorm instead."
     },
     "import_landscape": {
       "aliases": [
@@ -1276,7 +1276,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Alias of import_landscape \u2014 the name discoverable in list_tool_categories under the 'pcg' domain. Wrapped by hayba_import_landscape (src/tools/index.ts uses this exact name as the dispatch target). See PR #229 for the game-thread marshal fix."
+      "notes": "Alias of import_landscape — the name discoverable in list_tool_categories under the 'pcg' domain. Wrapped by hayba_import_landscape (src/tools/index.ts uses this exact name as the dispatch target). See PR #229 for the game-thread marshal fix."
     },
     "read_node_output": {
       "aliases": [
@@ -1323,7 +1323,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "STALE-READ WARNING: reads a possibly-STALE inspection CACHE, not live post-cook data. point_count can report 0 (or a prior run's numbers) while the cook actually produced real instances \u2014 do NOT treat point_count:0 here as ground truth. GROUND TRUTH for instance counts is `pcg_cook_and_wait` result.ism[] (with result.freshness.changed proving this cook). Returns zero counts if the graph has not been executed. FOLLOW-UP (C++): make this read live post-cook data or return an explicit {stale:true} flag."
+      "notes": "STALE-READ WARNING: reads a possibly-STALE inspection CACHE, not live post-cook data. point_count can report 0 (or a prior run's numbers) while the cook actually produced real instances — do NOT treat point_count:0 here as ground truth. GROUND TRUTH for instance counts is `pcg_cook_and_wait` result.ism[] (with result.freshness.changed proving this cook). Returns zero counts if the graph has not been executed. FOLLOW-UP (C++): make this read live post-cook data or return an explicit {stale:true} flag."
     },
     "pcg_read_node_output": {
       "aliases": [
@@ -1365,7 +1365,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Alias of read_node_output. STALE-READ WARNING: reads a possibly-STALE inspection cache, not live post-cook data \u2014 point_count:0 here is NOT ground truth. Use `pcg_cook_and_wait` result.ism[] for authoritative instance counts."
+      "notes": "Alias of read_node_output. STALE-READ WARNING: reads a possibly-STALE inspection cache, not live post-cook data — point_count:0 here is NOT ground truth. Use `pcg_cook_and_wait` result.ism[] for authoritative instance counts."
     },
     "describe_assets": {
       "aliases": [
@@ -1502,7 +1502,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": true,
-      "notes": "Alias of describe_assets \u2014 the agent-friendly name surfaced as the hayba_asset_browse routing tool."
+      "notes": "Alias of describe_assets — the agent-friendly name surfaced as the hayba_asset_browse routing tool."
     },
     "actor_get_properties": {
       "aliases": [],
@@ -2548,13 +2548,13 @@
           "name": "look_at",
           "type": "array",
           "required": false,
-          "description": "BEST way to aim the camera: a world point [x,y,z] to face. The orientation is computed in C++ (correct pitch+yaw, roll always 0 \u2014 the horizon never tilts). Use this instead of rotation whenever you know what you want the camera pointed at; you do NOT compute any angles yourself. Takes precedence over rotation."
+          "description": "BEST way to aim the camera: a world point [x,y,z] to face. The orientation is computed in C++ (correct pitch+yaw, roll always 0 — the horizon never tilts). Use this instead of rotation whenever you know what you want the camera pointed at; you do NOT compute any angles yourself. Takes precedence over rotation."
         },
         {
           "name": "rotation",
           "type": "object",
           "required": false,
-          "description": "Manual orientation (only if you are not using look_at). PREFERRED form: object {pitch, yaw, roll} in degrees \u2014 unambiguous. yaw = heading (about the vertical/Z axis, the value you usually want); pitch = look up(+)/down(-); roll = horizon tilt and defaults to 0 (omit it \u2014 a non-zero roll is what makes the viewport 'look angled'). Array form is accepted as [pitch, yaw, roll] but its 3rd element (roll) is IGNORED so the camera never tilts by accident \u2014 do NOT pass [x,y,z] euler here, index 2 is roll, not yaw."
+          "description": "Manual orientation (only if you are not using look_at). PREFERRED form: object {pitch, yaw, roll} in degrees — unambiguous. yaw = heading (about the vertical/Z axis, the value you usually want); pitch = look up(+)/down(-); roll = horizon tilt and defaults to 0 (omit it — a non-zero roll is what makes the viewport 'look angled'). Array form is accepted as [pitch, yaw, roll] but its 3rd element (roll) is IGNORED so the camera never tilts by accident — do NOT pass [x,y,z] euler here, index 2 is roll, not yaw."
         }
       ],
       "returns": {
@@ -2596,7 +2596,7 @@
           "name": "direction",
           "type": "array",
           "required": false,
-          "description": "Optional [x,y,z] view direction (camera\u2192actor). Default is a 3/4 front-right-above view. Need not be normalized."
+          "description": "Optional [x,y,z] view direction (camera→actor). Default is a 3/4 front-right-above view. Need not be normalized."
         }
       ],
       "returns": {
@@ -2620,7 +2620,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Frame an actor in the editor viewport by label \u2014 computes camera position from the actor's bounds and aims at its centre, entirely in C++. Roll is always 0 so the view never tilts. This is the correct 'framing tool'; do NOT hand-compute camera angles in python_run."
+      "notes": "Frame an actor in the editor viewport by label — computes camera position from the actor's bounds and aims at its centre, entirely in C++. Roll is always 0 so the view never tilts. This is the correct 'framing tool'; do NOT hand-compute camera angles in python_run."
     },
     "editor_run_console_command": {
       "aliases": [],
@@ -2840,6 +2840,149 @@
       "agent_callable": true,
       "has_ts_wrapper": true,
       "notes": "Dispatches the press and schedules the release on a later tick, returning immediately. Previously spun the core ticker while holding raw viewport pointers, which tore down PIE underneath itself and crashed."
+    },
+    "editor_pie_mouse": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPIEHandler::PIEMouse",
+      "params": [
+        {
+          "name": "action",
+          "type": "string",
+          "required": true,
+          "description": "move|click|double|press|release|drag|scroll"
+        },
+        {
+          "name": "x",
+          "type": "number",
+          "required": false,
+          "description": "target x in viewport px"
+        },
+        {
+          "name": "y",
+          "type": "number",
+          "required": false,
+          "description": "target y in viewport px"
+        },
+        {
+          "name": "button",
+          "type": "string",
+          "required": false,
+          "description": "Left|Right|Middle (default Left)"
+        },
+        {
+          "name": "to_x",
+          "type": "number",
+          "required": false,
+          "description": "drag end x"
+        },
+        {
+          "name": "to_y",
+          "type": "number",
+          "required": false,
+          "description": "drag end y"
+        },
+        {
+          "name": "delta",
+          "type": "number",
+          "required": false,
+          "description": "scroll delta"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": []
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Inject a mouse action into PIE (drag interpolates so delta-tracking widgets react)."
+    },
+    "editor_pie_type_text": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPIEHandler::PIETypeText",
+      "params": [
+        {
+          "name": "text",
+          "type": "string",
+          "required": true,
+          "description": "text to type as character events (what text fields consume)"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": []
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Type text into the focused PIE widget via character events."
+    },
+    "editor_pie_click_widget": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPIEHandler::PIEClickWidget",
+      "params": [
+        {
+          "name": "match",
+          "type": "string",
+          "required": true,
+          "description": "visible text/label of the widget to click; prefers the interactive widget"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": []
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Click a widget by visible text instead of coordinates; reports candidate count so ambiguous picks aren't silent."
+    },
+    "editor_pie_widget_tree": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPIEHandler::PIEWidgetTree",
+      "params": [
+        {
+          "name": "max_depth",
+          "type": "number",
+          "required": false,
+          "description": "limit tree depth"
+        },
+        {
+          "name": "filter",
+          "type": "string",
+          "required": false,
+          "description": "substring filter on text/type/tag"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": []
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "List every visible PIE widget with its on-screen rect (read the screen before clicking)."
+    },
+    "editor_pie_axis": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPIEHandler::PIEAxis",
+      "params": [
+        {
+          "name": "key",
+          "type": "string",
+          "required": true,
+          "description": "axis FKey, e.g. Gamepad_LeftX"
+        },
+        {
+          "name": "value",
+          "type": "number",
+          "required": false,
+          "description": "axis value -1..1"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": []
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Inject an analog axis (sticks/triggers) into PIE."
     }
   }
 }

--- a/mcp-tools/hayba-mcp/src/plumb/__fixtures__/room-grammar.json
+++ b/mcp-tools/hayba-mcp/src/plumb/__fixtures__/room-grammar.json
@@ -1,0 +1,52 @@
+{
+  "P_tunnel_native": {
+    "id": "P_tunnel_native",
+    "lhs": { "kind": "tunnel", "when": { "builder": "native" } },
+    "rhs": [
+      { "emit": "shell", "role": "wall", "profile_curve": "arch", "thickness_by": "importance" },
+      { "emit": "asset", "role": "column", "along": "floor_edge", "spacing_m": 2.5, "alternate": true },
+      { "emit": "asset", "role": "vent", "at": "wall_mid" },
+      { "emit": "symbol", "kind": "shaft", "len": 5 },
+      { "emit": "scatter", "tag": "rubble" },
+      { "emit": "decal", "role": "crack", "along": "arch_crown" },
+      { "emit": "fill", "role": "sand", "at": "floor_low" }
+    ],
+    "guards": ["clearance_min_1p2", "count_per_m2", "grounded", "upright"],
+    "priority": 100
+  },
+  "P_shaft_straight": {
+    "id": "P_shaft_straight",
+    "lhs": { "kind": "shaft" },
+    "rhs": [ { "emit": "shell", "role": "vent" } ],
+    "guards": ["no_straight_air_over_6m"],
+    "priority": 60
+  },
+  "P_shaft_bend": {
+    "id": "P_shaft_bend",
+    "lhs": { "kind": "shaft" },
+    "rhs": [ { "emit": "shell", "role": "vent", "bend_at_m": 5 } ],
+    "guards": [],
+    "priority": 10
+  },
+  "P_room_imperial": {
+    "id": "P_room_imperial",
+    "lhs": { "kind": "room", "when": { "builder": "imperial" } },
+    "rhs": [
+      { "emit": "shell", "role": "room", "profile_curve": "box", "thickness_by": "importance" },
+      { "emit": "scatter", "tag": "debris" },
+      { "emit": "fill", "role": "floor_detail", "at": "floor_low" }
+    ],
+    "guards": ["grounded", "upright"],
+    "priority": 100
+  },
+  "P_room_native": {
+    "id": "P_room_native",
+    "lhs": { "kind": "room", "when": { "builder": "native" } },
+    "rhs": [
+      { "emit": "shell", "role": "room", "profile_curve": "cavern", "thickness_by": "importance" },
+      { "emit": "scatter", "tag": "rubble" }
+    ],
+    "guards": ["grounded"],
+    "priority": 90
+  }
+}

--- a/mcp-tools/hayba-mcp/src/plumb/room-grammar.test.ts
+++ b/mcp-tools/hayba-mcp/src/plumb/room-grammar.test.ts
@@ -2,7 +2,22 @@ import { describe, it, expect } from 'vitest';
 import { matchProductions, expandGrammar } from './grammar.js';
 import type { Production, Symbol } from './contracts.js';
 import { readFileSync } from 'node:fs';
-const roomProds = JSON.parse(readFileSync('D:/UnrealEngine/template/.scratch/grammar.json', 'utf8'));
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The productions used to be read from D:/UnrealEngine/template/.scratch/grammar.json
+// — an absolute path on one developer's machine. That made this suite pass
+// locally and fail on every CI runner with ENOENT, permanently, which is worse
+// than having no test: a red check everyone learns to ignore stops reporting
+// anything at all.
+//
+// The fixture is committed instead. It is 5 productions and under 2KB, and it
+// is the input the assertions below are written against, so it belongs with
+// them rather than in a scratch directory that can be cleared at any time.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const roomProds = JSON.parse(
+  readFileSync(join(__dirname, '__fixtures__', 'room-grammar.json'), 'utf8'),
+) as Record<string, Production>;
 
 const prods = Object.values(roomProds) as Production[];
 const noGuards = () => ({ hardFail: false, softFails: [] });

--- a/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-fix-redirectors.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-fix-redirectors.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'cleaning up the redirector stubs left behind by renames and moves',
+  not_when: 'you have not renamed or moved anything — there will be nothing to fix',
+};
+
+export const schema = z.object({
+  path: z
+    .string()
+    .optional()
+    .describe('Folder to scan, e.g. "/Game/UI". Omit to scan the whole project.'),
+});
+
+export const assetFixRedirectorsHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_fix_redirectors', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-get-dependencies.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-get-dependencies.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'finding out what an asset pulls in — what must exist for it to load',
+  not_when: 'you want what depends ON it (use asset_get_referencers)',
+};
+
+export const schema = z.object({
+  path: z.string().min(1).describe('Asset path whose dependencies to list'),
+});
+
+export const assetGetDependenciesHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_get_dependencies', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-get-referencers.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-get-referencers.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'finding out what would break if you deleted, renamed or moved an asset',
+  not_when: 'you want what the asset itself needs (use asset_get_dependencies)',
+};
+
+export const schema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe('Asset path to look up, e.g. "/Game/UI/T_Panel" or "/Game/UI/T_Panel.T_Panel"'),
+});
+
+export const assetGetReferencersHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_get_referencers', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-get-references.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-get-references.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'you want both directions of an asset reference graph in one call',
+  not_when: 'you only need one direction — the single-direction tools return an exact count rather than a capped list',
+};
+
+export const schema = z.object({
+  path: z.string().min(1).describe('Asset path to inspect'),
+});
+
+export const assetGetReferencesHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_get_references', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-move.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-move.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'moving an asset to another folder while keeping references working',
+  not_when: 'only changing the name (use asset_rename)',
+};
+
+export const schema = z.object({
+  path: z.string().min(1).describe('Current asset path'),
+  target_dir: z
+    .string()
+    .min(1)
+    .describe('Destination folder, e.g. "/Game/UI/Icons". The asset keeps its name.'),
+});
+
+export const assetMoveHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_move', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-rename.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-rename.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_asset'],
+  when: 'renaming an asset in place, with references fixed up rather than broken',
+  not_when: 'moving it to a different folder (use asset_move)',
+};
+
+export const schema = z.object({
+  path: z.string().min(1).describe('Current asset path'),
+  new_name: z
+    .string()
+    .min(1)
+    .describe('New asset name only — not a path. The asset stays in its current folder.'),
+});
+
+export const assetRenameHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_rename', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-validate.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-graph/asset-validate.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'running the editor data-validation rules over an asset before relying on it',
+  not_when: 'checking UI layout specifically (use ui_validate)',
+};
+
+export const schema = z.object({
+  path: z.string().min(1).describe('Asset or folder path to validate'),
+});
+
+export const assetValidateHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('asset_validate', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/code-mode/list-tool-categories.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/code-mode/list-tool-categories.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { z } from 'zod';
 import { listToolCategoriesHandler } from './list-tool-categories.js';
+import { recordSchema } from '../schema-registry.js';
+import { STANDARD_DESCRIPTORS } from '../index.js';
 
 // Stubs that always return not_implemented_in_v1 from C++ and must not be
 // advertised — even in the "unavailable" bucket — so agents are never misled
@@ -44,5 +47,97 @@ describe('list_tool_categories — catalog honesty', () => {
     const allBpCommands = [...(bp?.callable ?? []), ...(bp?.unavailable ?? [])];
     expect(allBpCommands).toContain('blueprint_compile');
     expect(allBpCommands).toContain('blueprint_create');
+  });
+});
+
+// ── Coverage ────────────────────────────────────────────────────────────────
+//
+// A gap in this catalogue is not cosmetic: it is the tool an agent consults to
+// learn what the system can do, so an omission reads as "that capability does
+// not exist" and the agent stops looking.
+//
+// The domain list used to be written by hand and had drifted badly — by the time
+// these tests were added, 176 of 245 registered tools were missing, including
+// every UI tool after the first three. The callable half is now generated from
+// the schema registry; these tests exist so it stays generated. Reintroduce a
+// hand-maintained list and the first assertion fails as soon as it falls behind.
+
+interface CatalogDomain {
+  domain: string;
+  command_count: number;
+  callable_count: number;
+  callable: string[];
+  unavailable: string[];
+}
+
+async function catalog(): Promise<{ _legend: string; domains: CatalogDomain[]; total_commands: number; total_callable: number }> {
+  const out = await parsedOutput();
+  return out as unknown as { _legend: string; domains: CatalogDomain[]; total_commands: number; total_callable: number };
+}
+
+describe('list_tool_categories — coverage', () => {
+  beforeAll(() => {
+    // Mirror what the server does at startup; without it the registry is empty
+    // and the catalogue has nothing legitimate to report.
+    for (const d of STANDARD_DESCRIPTORS) {
+      recordSchema(d.name, { shape: (d.schema ?? {}) as z.ZodRawShape, cost: 'low', returns: 'any' });
+    }
+  });
+
+  it('reports every registered tool as callable', async () => {
+    const c = await catalog();
+    const listed = new Set(c.domains.flatMap((d) => d.callable));
+    const missing = STANDARD_DESCRIPTORS.map((d) => d.name).filter((n) => !listed.has(n));
+
+    expect(
+      missing.length,
+      `${missing.length} registered tools are absent from the catalogue, so an agent reading it ` +
+        `would conclude they do not exist:\n  ${missing.slice(0, 25).join('\n  ')}` +
+        (missing.length > 25 ? `\n  ...and ${missing.length - 25} more` : ''),
+    ).toBe(0);
+  });
+
+  it('surfaces the whole UI toolset, not the first three tools', async () => {
+    // The specific regression that prompted this: the catalogue reported ui as
+    // three commands long after the toolset had grown past twenty.
+    const c = await catalog();
+    const ui = c.domains.find((d) => d.domain === 'ui');
+    expect(ui, 'ui domain should be present').toBeDefined();
+    expect(ui!.callable_count).toBeGreaterThan(15);
+    for (const expected of ['ui_validate', 'ui_build_tree', 'ui_measure_text', 'ui_layout_snapshot']) {
+      expect(ui!.callable, `${expected} missing from the ui domain`).toContain(expected);
+    }
+  });
+
+  it('groups tools under the domain their name implies', async () => {
+    const c = await catalog();
+    const domainOf = new Map<string, string>();
+    for (const d of c.domains) for (const t of d.callable) domainOf.set(t, d.domain);
+    expect(domainOf.get('ui_validate')).toBe('ui');
+    expect(domainOf.get('actor_spawn')).toBe('actor');
+    expect(domainOf.get('material_compile')).toBe('material');
+  });
+
+  it('never reports the same command as both callable and unavailable', async () => {
+    const c = await catalog();
+    for (const d of c.domains) {
+      const overlap = d.callable.filter((n) => d.unavailable.includes(n));
+      expect(overlap, `${d.domain} reports contradictory availability for: ${overlap.join(', ')}`).toEqual([]);
+    }
+  });
+
+  it('counts add up to the per-domain totals', async () => {
+    const c = await catalog();
+    for (const d of c.domains) {
+      expect(d.callable_count).toBe(d.callable.length);
+      expect(d.command_count).toBe(d.callable.length + d.unavailable.length);
+    }
+    expect(c.total_callable).toBe(c.domains.reduce((n, d) => n + d.callable_count, 0));
+  });
+
+  it('says in the legend that the callable list is generated', async () => {
+    // The legend is what tells an agent how much to trust the list.
+    const c = await catalog();
+    expect(c._legend).toMatch(/generated|live/i);
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/code-mode/list-tool-categories.ts
+++ b/mcp-tools/hayba-mcp/src/tools/code-mode/list-tool-categories.ts
@@ -11,7 +11,23 @@ export const meta: HaybaToolMeta = {
   not_when: 'you already know the exact tool name',
 };
 
-// TODO(v1.1): wire to C++ meta_list_domains when the handler exists
+// The plugin's capability surface, hand-maintained.
+//
+// This list used to be the WHOLE catalogue, and it had drifted badly: 176 of the
+// 245 registered tools were absent from it, including every UI tool added after
+// the first three. The tool an agent consults to learn what the system can do
+// was understating it by 72%, and its own legend framed the omission as "does
+// not exist" rather than "not listed here".
+//
+// It is no longer the source of truth for anything callable. The callable half
+// is derived from the schema registry below, so it cannot drift. What stays here
+// is the one thing the registry genuinely cannot know: commands the C++ plugin
+// dispatches but no agent wrapper reaches yet. Those are worth naming — an agent
+// that knows the capability exists can ask the user or reach for python_run
+// instead of concluding it is impossible.
+//
+// A guard test asserts every registered tool appears in the generated output, so
+// this file falling behind is a test failure rather than a silent lie.
 const DOMAINS: ReadonlyArray<{ domain: string; command_count: number; commands: string[] }> = [
   { domain: 'actor', command_count: 14, commands: ['actor_spawn','actor_delete','actor_transform','actor_list','actor_get_properties','actor_set_properties','actor_tag','actor_snap_to_socket','actor_duplicate','actor_set_visibility','actor_get_components','actor_call_function','actor_batch_spawn','placement_validate'] },
   { domain: 'level', command_count: 8, commands: ['level_load','level_save','level_list','level_get_info','level_get_spatial_index','level_create','level_set_bookmark','level_goto_bookmark'] },
@@ -49,6 +65,25 @@ const DOMAINS: ReadonlyArray<{ domain: string; command_count: number; commands: 
   { domain: 'test', command_count: 3, commands: ['test_list','test_run','test_get_log'] },
 ];
 
+/** Domain for a command name. Mirrors inferDir() in ../index.ts, duplicated
+ *  deliberately: index.ts imports this module, so importing it back would close
+ *  a cycle. Falls back to the prefix before the first underscore, which is the
+ *  convention every domain follows. */
+function domainOf(name: string): string {
+  if (name.startsWith('hayba_fab_')) return 'fab';
+  if (name.startsWith('hayba_polyhaven_') || name.startsWith('hayba_ambientcg_') || name.startsWith('hayba_sketchfab_')) {
+    return 'asset-sources';
+  }
+  if (name === 'list_tool_categories' || name === 'get_tool_signature') return 'code-mode';
+  if (name.startsWith('hayba_')) {
+    const rest = name.slice('hayba_'.length);
+    const head = rest.split('_')[0];
+    return head || 'hayba';
+  }
+  const head = name.split('_')[0];
+  return head || 'misc';
+}
+
 /**
  * A command is *agent-callable right now* iff it has a TS wrapper in the schema
  * registry OR it is allow-listed for the ue_legacy route. The DOMAINS array
@@ -67,36 +102,50 @@ function callableCommandSet(): ReadonlySet<string> {
 export const listToolCategoriesHandler: ToolHandler = async () => {
   const callable = callableCommandSet();
 
-  // Filter out tools the user has disabled in the MCP panel, then annotate each
-  // remaining command with whether it is callable now. Drop categories that end
-  // up empty so the agent doesn't see "actor: 0 commands" noise.
-  const domains = DOMAINS
-    .map(d => ({
-      domain: d.domain,
-      commands: d.commands.filter(c => !isToolDisabled(c)),
+  // Everything callable, grouped by domain, straight from the registry. This is
+  // the half that must never be stale, so it is never written down.
+  const byDomain = new Map<string, { callable: string[]; unavailable: string[] }>();
+  const bucket = (d: string) => {
+    let b = byDomain.get(d);
+    if (!b) { b = { callable: [], unavailable: [] }; byDomain.set(d, b); }
+    return b;
+  };
+
+  for (const name of callable) {
+    if (isToolDisabled(name)) continue;
+    bucket(domainOf(name)).callable.push(name);
+  }
+
+  // Plugin commands with no wrapper. Anything here that HAS since gained a
+  // wrapper is already in the callable set above, so skip it rather than
+  // reporting the same command twice with contradictory availability.
+  for (const d of DOMAINS) {
+    for (const name of d.commands) {
+      if (callable.has(name) || isToolDisabled(name)) continue;
+      bucket(d.domain).unavailable.push(name);
+    }
+  }
+
+  const domains = Array.from(byDomain.entries())
+    .map(([domain, b]) => ({
+      domain,
+      command_count: b.callable.length + b.unavailable.length,
+      callable_count: b.callable.length,
+      callable: b.callable.slice().sort(),
+      // Advertised by the plugin but not yet wrapped for agents — calling these
+      // returns unknown_tool. Listed so the agent knows the capability exists
+      // (e.g. to ask the user / use python_run) without trying to invoke them.
+      unavailable: b.unavailable.slice().sort(),
     }))
-    .filter(d => d.commands.length > 0)
-    .map(d => {
-      const callableNames = d.commands.filter(c => callable.has(c));
-      const unavailableNames = d.commands.filter(c => !callable.has(c));
-      return {
-        domain: d.domain,
-        command_count: d.commands.length,
-        callable_count: callableNames.length,
-        callable: callableNames,
-        // Advertised by the plugin but not yet wrapped for agents — calling these
-        // returns unknown_tool. Listed so the agent knows the capability exists
-        // (e.g. to ask the user / use python_run) without trying to invoke them.
-        unavailable: unavailableNames,
-      };
-    });
+    .filter(d => d.command_count > 0)
+    .sort((a, b) => b.callable_count - a.callable_count || a.domain.localeCompare(b.domain));
 
   const totalAdvertised = domains.reduce((n, d) => n + d.command_count, 0);
   const totalCallable = domains.reduce((n, d) => n + d.callable_count, 0);
 
   return {
     content: [{ type: 'text', text: JSON.stringify({
-      _legend: 'callable = invokable now via hayba_invoke. unavailable = plugin supports it but no agent wrapper exists yet (calling it errors).',
+      _legend: 'callable = invokable now via hayba_invoke, no pack load needed. unavailable = the plugin supports it but no agent wrapper exists yet (calling it errors). The callable list is generated from the live tool registry, so it reflects what is actually there.',
       domains,
       total_commands: totalAdvertised,
       total_callable: totalCallable,

--- a/mcp-tools/hayba-mcp/src/tools/content/content-validate.ts
+++ b/mcp-tools/hayba-mcp/src/tools/content/content-validate.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { validateContentSnapshot, type ContentSnapshot } from '../../validator/content/index.js';
+import { STRICTNESS_MODES } from '../../validator/config.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'checking project content for memory and performance problems — oversized textures, wrong compression, meshes with no LODs',
+  not_when: 'checking a UI screen (use ui_validate) or one specific asset (texture_get_info)',
+};
+
+export const schema = z.object({
+  strictness: z
+    .enum(STRICTNESS_MODES)
+    .optional()
+    .describe(
+      'Override the configured asset strictness. relaxed = only the extreme; standard = normal budgets; strict = tight budgets plus hygiene notes.',
+    ),
+  top_n: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      'How many of the heaviest assets to judge, per type. Default 25. Anything outside this window is NOT examined, and the response says so.',
+    ),
+  include: z
+    .array(z.enum(['textures', 'meshes']))
+    .optional()
+    .describe('Which audits to run. Defaults to both.'),
+  rule_ids: z.array(z.string()).optional().describe('Run only these rules, by id.'),
+});
+
+export const contentValidateHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const { strictness, top_n, include, rule_ids } = parsed.data;
+  const want = include ?? ['textures', 'meshes'];
+
+  // The engine measures, this judges. Each audit is a separate command, and a
+  // type that was not requested stays absent from the snapshot so its rules are
+  // reported as skipped rather than passing on empty data.
+  const snapshot: ContentSnapshot = {};
+
+  if (want.includes('textures')) {
+    const t = (await executeCommand('texture_audit', { top_n } as Record<string, unknown>)) as {
+      textures?: ContentSnapshot['textures'];
+      scanned?: number;
+    };
+    snapshot.textures = t?.textures ?? [];
+    snapshot.textures_scanned = t?.scanned;
+  }
+
+  if (want.includes('meshes')) {
+    const m = (await executeCommand('mesh_audit', { top_n } as Record<string, unknown>)) as {
+      meshes?: ContentSnapshot['meshes'];
+      scanned?: number;
+    };
+    snapshot.meshes = m?.meshes ?? [];
+    snapshot.meshes_scanned = m?.scanned;
+  }
+
+  const result = validateContentSnapshot(snapshot, { strictness, ruleIds: rule_ids });
+  return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/content/mesh-audit.ts
+++ b/mcp-tools/hayba-mcp/src/tools/content/mesh-audit.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'finding meshes with no LODs, excessive triangles, or too many material slots',
+  not_when: 'you want per-instance placement data (use pcg_inspect_instances or actor_list)',
+};
+
+export const schema = z.object({
+  top_n: z
+    .number()
+    .int()
+    .optional()
+    .describe('How many of the heaviest meshes to return. Default 25, max 500.'),
+});
+
+export const meshAuditHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('mesh_audit', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/content/texture-audit.ts
+++ b/mcp-tools/hayba-mcp/src/tools/content/texture-audit.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'finding which textures are actually costing memory, and which are compressed wrongly for their role',
+  not_when: 'inspecting one texture you already know about (use texture_get_info)',
+};
+
+export const schema = z.object({
+  top_n: z
+    .number()
+    .int()
+    .optional()
+    .describe('How many of the heaviest textures to return. Default 25, max 500. The scan covers every Texture2D regardless.'),
+});
+
+export const textureAuditHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('texture_audit', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/docs/docs-lookup-api.ts
+++ b/mcp-tools/hayba-mcp/src/tools/docs/docs-lookup-api.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'you are about to set a property or call a function on a UE class and want its real name, type and whether it is editable',
+  not_when: 'you only need to know the class exists — docs_lookup_class is cheaper',
+};
+
+export const schema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe('Class path or name, e.g. "/Script/UMG.TextBlock" or "TextBlock".'),
+  include_inherited: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'Include members inherited from parent classes. Off by default because the inherited surface of a UObject is large; turn it on when a member you expect is missing — it is often declared on a parent.',
+    ),
+});
+
+export const docsLookupApiHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('docs_lookup_api', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/docs/docs-lookup-class.ts
+++ b/mcp-tools/hayba-mcp/src/tools/docs/docs-lookup-class.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'checking what a UE class actually is — its inheritance chain and how many properties and functions it exposes',
+  not_when: 'you need the property or function NAMES — use docs_lookup_api',
+};
+
+export const schema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe(
+      'Class path or name, e.g. "/Script/UMG.UserWidget", "UserWidget", or "TextBlock". Resolved against the LIVE editor, so it reflects the engine version and plugins actually loaded.',
+    ),
+});
+
+export const docsLookupClassHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('docs_lookup_class', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/docs/docs-search.ts
+++ b/mcp-tools/hayba-mcp/src/tools/docs/docs-search.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'you need the real name of a UE class and are about to guess at one',
+  not_when: 'you already have the exact class path — use docs_lookup_class directly',
+};
+
+export const schema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe('Substring to match against class names, case-insensitive. "Widget", "Landscape", "StaticMesh".'),
+  kind: z
+    .enum(['class', 'all'])
+    .optional()
+    .default('class')
+    .describe('What to search. Currently classes; "all" is reserved for future kinds.'),
+});
+
+export const docsSearchHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('docs_search', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/foliage/foliage-add-instance.ts
+++ b/mcp-tools/hayba-mcp/src/tools/foliage/foliage-add-instance.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_level'],
+  when: 'placing a single foliage instance at an exact transform',
+  not_when: 'scattering many over an area (use foliage_paint_at)',
+};
+
+export const schema = z.object({
+  foliage_type_path: z
+    .string()
+    .min(1)
+    .describe('FoliageType asset path, e.g. "/Game/Foliage/FT_Grass"'),
+  transform: z
+    .object({
+      location: z.object({ x: z.number(), y: z.number(), z: z.number() }).describe('World location. Required.'),
+      rotation: z.object({ x: z.number(), y: z.number(), z: z.number() }).optional().describe('Pitch/Yaw/Roll. Defaults to zero.'),
+      scale: z.object({ x: z.number(), y: z.number(), z: z.number() }).optional().describe('Per-axis scale. Defaults to 1,1,1.'),
+    })
+    .describe('Placement transform. `location` is required; the rest default.'),
+});
+
+export const foliageAddInstanceHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('foliage_add_instance', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/foliage/foliage-list-types.ts
+++ b/mcp-tools/hayba-mcp/src/tools/foliage/foliage-list-types.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'finding out which FoliageType assets the current level actually uses',
+  not_when: 'you want instance counts or placement — this lists the types',
+};
+
+export const schema = z.object({
+  // No parameters: the command reports the foliage types present in the level.
+});
+
+export const foliageListTypesHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('foliage_list_types', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/foliage/foliage-paint-at.ts
+++ b/mcp-tools/hayba-mcp/src/tools/foliage/foliage-paint-at.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_level'],
+  when: 'scattering foliage over a circular area at a density, the way the paint tool does',
+  not_when: 'placing one instance at an exact spot (use foliage_add_instance)',
+};
+
+export const schema = z.object({
+  foliage_type_path: z.string().min(1).describe('FoliageType asset path to scatter'),
+  location: z.object({ x: z.number(), y: z.number(), z: z.number() }).describe('World-space centre of the painted area'),
+  radius: z.number().optional().describe('Brush radius in cm'),
+  density: z.number().optional().describe('Instances per unit area, as the foliage brush means it'),
+});
+
+export const foliagePaintAtHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('foliage_paint_at', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/foliage/foliage-remove-instances.ts
+++ b/mcp-tools/hayba-mcp/src/tools/foliage/foliage-remove-instances.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['modifies_level'],
+  when: 'clearing foliage instances inside a bounding box',
+  not_when: 'removing the FoliageType asset itself — this removes placed instances',
+};
+
+export const schema = z.object({
+  foliage_type_path: z
+    .string()
+    .min(1)
+    .describe('FoliageType whose instances to remove'),
+  bounds: z
+    .object({
+      min: z.object({ x: z.number(), y: z.number(), z: z.number() }).describe('Minimum corner of the world-space box'),
+      max: z.object({ x: z.number(), y: z.number(), z: z.number() }).describe('Maximum corner of the world-space box'),
+    })
+    .describe('World-space box; instances inside it are removed.'),
+});
+
+export const foliageRemoveInstancesHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('foliage_remove_instances', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -135,6 +135,45 @@ import {
   schema as docsLookupApiSchema,
   docsLookupApiHandler,
 } from './docs/docs-lookup-api.js';
+import {
+  meta as assetGetReferencersMeta,
+  schema as assetGetReferencersSchema,
+  assetGetReferencersHandler,
+} from './asset-graph/asset-get-referencers.js';
+import {
+  meta as assetGetDependenciesMeta,
+  schema as assetGetDependenciesSchema,
+  assetGetDependenciesHandler,
+} from './asset-graph/asset-get-dependencies.js';
+import {
+  meta as assetGetReferencesMeta,
+  schema as assetGetReferencesSchema,
+  assetGetReferencesHandler,
+} from './asset-graph/asset-get-references.js';
+import { meta as assetRenameMeta, schema as assetRenameSchema, assetRenameHandler } from './asset-graph/asset-rename.js';
+import { meta as assetMoveMeta, schema as assetMoveSchema, assetMoveHandler } from './asset-graph/asset-move.js';
+import {
+  meta as assetFixRedirectorsMeta,
+  schema as assetFixRedirectorsSchema,
+  assetFixRedirectorsHandler,
+} from './asset-graph/asset-fix-redirectors.js';
+import {
+  meta as assetValidateMeta,
+  schema as assetValidateSchema,
+  assetValidateHandler,
+} from './asset-graph/asset-validate.js';
+import {
+  meta as foliageListTypesMeta, schema as foliageListTypesSchema, foliageListTypesHandler,
+} from './foliage/foliage-list-types.js';
+import {
+  meta as foliageAddInstanceMeta, schema as foliageAddInstanceSchema, foliageAddInstanceHandler,
+} from './foliage/foliage-add-instance.js';
+import {
+  meta as foliagePaintAtMeta, schema as foliagePaintAtSchema, foliagePaintAtHandler,
+} from './foliage/foliage-paint-at.js';
+import {
+  meta as foliageRemoveInstancesMeta, schema as foliageRemoveInstancesSchema, foliageRemoveInstancesHandler,
+} from './foliage/foliage-remove-instances.js';
 import { meta as uiBuildTreeMeta, schema as uiBuildTreeSchema, uiBuildTreeHandler } from './ui/ui-build-tree.js';
 import {
   meta as uiDuplicateElementMeta,
@@ -406,6 +445,8 @@ const M = 'material'; // niche domain for the material toolset
 const UI = 'ui'; // niche domain for the UMG / Widget Blueprint toolset
 const PACK = 'copilot'; // niche domain for the BYOK copilot config/introspection toolset
 const DOCS = 'docs'; // niche domain for live-editor API reflection
+const ASSETGRAPH = 'asset'; // niche domain for asset reference/refactor tools
+const FOLIAGE = 'foliage'; // niche domain for foliage placement
 // Hand-written descriptors. Kept as a named const so the generated legacy list
 // can be de-duplicated against these names before splicing (see below).
 const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
@@ -1329,6 +1370,137 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
     returns: '{name, properties:[{name, type, category, tooltip, is_editable, is_blueprint_visible}], functions:[{name, is_blueprint_callable, is_event, tooltip}]}',
     niche: DOCS,
     schema: docsLookupApiSchema.shape,
+  },
+
+  // ── Asset graph ───────────────────────────────────────────────────────────
+  // Know what breaks before breaking it. These handlers were implemented in C++
+  // and had no wrapper, so an agent could delete or rename an asset but could
+  // not first ask what depended on it.
+  {
+    name: 'asset_get_referencers',
+    description:
+      'WHAT BREAKS IF I DELETE OR RENAME THIS? Lists every asset that references the given one. USE_WHEN: before asset_delete, asset_rename or asset_move — a reference you did not know about becomes a broken link that surfaces much later. NOT_WHEN: you want what the asset itself needs (asset_get_dependencies).',
+    meta: assetGetReferencersMeta,
+    handler: assetGetReferencersHandler,
+    cost: 'low',
+    returns: '{path, referencers[], count}',
+    niche: ASSETGRAPH,
+    schema: assetGetReferencersSchema.shape,
+  },
+  {
+    name: 'asset_get_dependencies',
+    description:
+      'What this asset pulls in — everything that must exist for it to load. USE_WHEN: working out why an asset drags in a large cook, or what to migrate alongside it. NOT_WHEN: you want what depends on IT (asset_get_referencers).',
+    meta: assetGetDependenciesMeta,
+    handler: assetGetDependenciesHandler,
+    cost: 'low',
+    returns: '{path, dependencies[], count}',
+    niche: ASSETGRAPH,
+    schema: assetGetDependenciesSchema.shape,
+  },
+  {
+    name: 'asset_get_references',
+    description:
+      'Both directions of an asset reference graph in one call. Note the lists may be truncated — `capped: true` says so. Prefer the single-direction tools when you need an exact count.',
+    meta: assetGetReferencesMeta,
+    handler: assetGetReferencesHandler,
+    cost: 'low',
+    returns: '{referencers[], dependencies[], capped}',
+    niche: ASSETGRAPH,
+    schema: assetGetReferencesSchema.shape,
+  },
+  {
+    name: 'asset_rename',
+    description:
+      'Rename an asset in place, fixing up references rather than breaking them. Leaves a redirector behind; asset_fix_redirectors cleans those up. USE_WHEN: the name is wrong. NOT_WHEN: it belongs in another folder (asset_move).',
+    meta: assetRenameMeta,
+    handler: assetRenameHandler,
+    cost: 'medium',
+    returns: '{old_path, new_path}',
+    niche: ASSETGRAPH,
+    schema: assetRenameSchema.shape,
+  },
+  {
+    name: 'asset_move',
+    description:
+      'Move an asset to another folder, keeping references working. Leaves a redirector behind; asset_fix_redirectors cleans those up.',
+    meta: assetMoveMeta,
+    handler: assetMoveHandler,
+    cost: 'medium',
+    returns: '{ok, old_path, new_path}',
+    niche: ASSETGRAPH,
+    schema: assetMoveSchema.shape,
+  },
+  {
+    name: 'asset_fix_redirectors',
+    description:
+      'Collapse the redirector stubs left behind by renames and moves. USE_WHEN: after a batch of asset_rename / asset_move calls — redirectors that survive into a cook are wasted work and confuse later reference lookups.',
+    meta: assetFixRedirectorsMeta,
+    handler: assetFixRedirectorsHandler,
+    cost: 'medium',
+    returns: '{fixed_count, path}',
+    niche: ASSETGRAPH,
+    schema: assetFixRedirectorsSchema.shape,
+  },
+  {
+    name: 'asset_validate',
+    description:
+      'Run the editor data-validation rules over an asset or folder and return the errors and warnings. USE_WHEN: confirming an asset is sound before building on it. NOT_WHEN: checking UI layout — ui_validate is the tool for that.',
+    meta: assetValidateMeta,
+    handler: assetValidateHandler,
+    cost: 'medium',
+    returns: '{valid, num_valid, num_invalid, num_warnings, errors[], warnings[]}',
+    niche: ASSETGRAPH,
+    schema: assetValidateSchema.shape,
+  },
+
+  // ── Foliage ───────────────────────────────────────────────────────────────
+  // Implemented in C++ all along. These were briefly on a stub denylist because
+  // a heuristic sweep misjudged them — a reminder that suppressing working
+  // capability is as wrong as advertising broken capability.
+  {
+    name: 'foliage_list_types',
+    description:
+      'List the FoliageType assets in use in the current level, with instance counts. USE_WHEN: before adding or removing foliage, to learn what is already there.',
+    meta: foliageListTypesMeta,
+    handler: foliageListTypesHandler,
+    cost: 'low',
+    returns: '{path, count, types[]}',
+    niche: FOLIAGE,
+    schema: foliageListTypesSchema.shape,
+  },
+  {
+    name: 'foliage_add_instance',
+    description:
+      'Place one foliage instance at an exact transform. USE_WHEN: precise single placement. NOT_WHEN: covering an area — foliage_paint_at scatters at a density instead.',
+    meta: foliageAddInstanceMeta,
+    handler: foliageAddInstanceHandler,
+    cost: 'medium',
+    returns: '{ok}',
+    niche: FOLIAGE,
+    schema: foliageAddInstanceSchema.shape,
+  },
+  {
+    name: 'foliage_paint_at',
+    description:
+      'Scatter foliage over a circular area at a density, as the foliage paint brush does. USE_WHEN: dressing terrain. NOT_WHEN: you need one instance at an exact spot.',
+    meta: foliagePaintAtMeta,
+    handler: foliagePaintAtHandler,
+    cost: 'medium',
+    returns: '{ok}',
+    niche: FOLIAGE,
+    schema: foliagePaintAtSchema.shape,
+  },
+  {
+    name: 'foliage_remove_instances',
+    description:
+      'Remove foliage instances of a type inside a world-space box. Returns how many were removed, so an unexpected zero is visible rather than silent.',
+    meta: foliageRemoveInstancesMeta,
+    handler: foliageRemoveInstancesHandler,
+    cost: 'medium',
+    returns: '{removed}',
+    niche: FOLIAGE,
+    schema: foliageRemoveInstancesSchema.shape,
   },
 
   // ── Scene domain ──────────────────────────────────────────────────────────

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -181,6 +181,11 @@ import { meta as pieTypeTextMeta, schema as pieTypeTextSchema, pieTypeTextHandle
 import { meta as pieAxisMeta, schema as pieAxisSchema, pieAxisHandler } from './pie/pie-axis.js';
 import { meta as piePressKeyMeta, schema as piePressKeySchema, piePressKeyHandler } from './pie/pie-press-key.js';
 import { meta as pieScreenshotMeta, schema as pieScreenshotSchema, pieScreenshotHandler } from './pie/pie-screenshot.js';
+import { meta as textureAuditMeta, schema as textureAuditSchema, textureAuditHandler } from './content/texture-audit.js';
+import { meta as meshAuditMeta, schema as meshAuditSchema, meshAuditHandler } from './content/mesh-audit.js';
+import {
+  meta as contentValidateMeta, schema as contentValidateSchema, contentValidateHandler,
+} from './content/content-validate.js';
 import { meta as uiBuildTreeMeta, schema as uiBuildTreeSchema, uiBuildTreeHandler } from './ui/ui-build-tree.js';
 import {
   meta as uiDuplicateElementMeta,
@@ -455,6 +460,7 @@ const DOCS = 'docs'; // niche domain for live-editor API reflection
 const ASSETGRAPH = 'asset'; // niche domain for asset reference/refactor tools
 const FOLIAGE = 'foliage'; // niche domain for foliage placement
 const PIE = 'pie'; // niche domain for driving a running game
+const CONTENT = 'content'; // niche domain for content audits and budgets
 // Hand-written descriptors. Kept as a named const so the generated legacy list
 // can be de-duplicated against these names before splicing (see below).
 const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
@@ -1596,6 +1602,42 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
     returns: '{filename, requested, captured, note}',
     niche: PIE,
     schema: pieScreenshotSchema.shape,
+  },
+
+  // ── Content audits + validation ───────────────────────────────────────────
+  {
+    name: 'texture_audit',
+    description:
+      'WHICH TEXTURES ARE COSTING MEMORY: every Texture2D ranked by resource size, with dimensions, format, LOD group and compression, and a flag where the name implies a role the compression contradicts. USE_WHEN: chasing memory or load times. NOT_WHEN: inspecting one texture you already know about (texture_get_info).',
+    meta: textureAuditMeta,
+    handler: textureAuditHandler,
+    cost: 'medium',
+    returns: '{textures:[{path, size_x, size_y, format, memory_kb, lod_group, compression, outlier}], scanned, count, top_n_total_kb}',
+    niche: CONTENT,
+    schema: textureAuditSchema.shape,
+  },
+  {
+    name: 'mesh_audit',
+    description:
+      'WHICH MESHES ARE COSTING FRAME TIME: static meshes with LOD0 triangle counts, LOD count, material slot count and how many things reference them. USE_WHEN: a scene is heavy and you need to know where the triangles and draw calls actually are.',
+    meta: meshAuditMeta,
+    handler: meshAuditHandler,
+    cost: 'medium',
+    returns: '{meshes:[{path, tris_lod0, lod_count, missing_lods, material_slot_count, referencer_count}], scanned, count}',
+    niche: CONTENT,
+    schema: meshAuditSchema.shape,
+  },
+  {
+    name: 'content_validate',
+    description:
+      'CHECK PROJECT CONTENT AGAINST MEMORY AND PERFORMANCE BUDGETS: oversized textures, compression that contradicts the asset name, non-power-of-two dimensions, UI textures outside the UI group, meshes with no LODs, excessive material slots, unreferenced meshes. Judged per strictness (relaxed/standard/strict) with every threshold justified in the hint. Reports what it did NOT examine — the audits only cover the heaviest N assets, so a clean result is scoped, never a claim about the whole project. NOT_WHEN: checking a UI screen (ui_validate).',
+    meta: contentValidateMeta,
+    handler: contentValidateHandler,
+    cost: 'medium',
+    returns:
+      '{strictness, findings:[{ruleId, severity, asset, message, hint, data}], rules_evaluated, rules_skipped_no_data[], counts, coverage:{textures_reported, textures_scanned, truncated}}',
+    niche: CONTENT,
+    schema: contentValidateSchema.shape,
   },
 
   // ── Scene domain ──────────────────────────────────────────────────────────

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -174,6 +174,13 @@ import {
 import {
   meta as foliageRemoveInstancesMeta, schema as foliageRemoveInstancesSchema, foliageRemoveInstancesHandler,
 } from './foliage/foliage-remove-instances.js';
+import { meta as pieWidgetTreeMeta, schema as pieWidgetTreeSchema, pieWidgetTreeHandler } from './pie/pie-widget-tree.js';
+import { meta as pieClickWidgetMeta, schema as pieClickWidgetSchema, pieClickWidgetHandler } from './pie/pie-click-widget.js';
+import { meta as pieMouseMeta, schema as pieMouseSchema, pieMouseHandler } from './pie/pie-mouse.js';
+import { meta as pieTypeTextMeta, schema as pieTypeTextSchema, pieTypeTextHandler } from './pie/pie-type-text.js';
+import { meta as pieAxisMeta, schema as pieAxisSchema, pieAxisHandler } from './pie/pie-axis.js';
+import { meta as piePressKeyMeta, schema as piePressKeySchema, piePressKeyHandler } from './pie/pie-press-key.js';
+import { meta as pieScreenshotMeta, schema as pieScreenshotSchema, pieScreenshotHandler } from './pie/pie-screenshot.js';
 import { meta as uiBuildTreeMeta, schema as uiBuildTreeSchema, uiBuildTreeHandler } from './ui/ui-build-tree.js';
 import {
   meta as uiDuplicateElementMeta,
@@ -447,6 +454,7 @@ const PACK = 'copilot'; // niche domain for the BYOK copilot config/introspectio
 const DOCS = 'docs'; // niche domain for live-editor API reflection
 const ASSETGRAPH = 'asset'; // niche domain for asset reference/refactor tools
 const FOLIAGE = 'foliage'; // niche domain for foliage placement
+const PIE = 'pie'; // niche domain for driving a running game
 // Hand-written descriptors. Kept as a named const so the generated legacy list
 // can be de-duplicated against these names before splicing (see below).
 const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
@@ -1022,7 +1030,7 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
   {
     name: 'ui_create_widget',
     description:
-      'Create a new UMG Widget Blueprint asset (designer-editable UI). Seeds a root CanvasPanel. Use the real UMG pipeline instead of hand-building the tree in C++.',
+      'CREATE A NEW MENU, SCREEN OR HUD as a UMG Widget Blueprint asset — the designer-editable kind an artist can also open. Seeds a root CanvasPanel ready for content. USE_WHEN: starting any new piece of UI. NOT_WHEN: adding to an existing one (ui_add_element / ui_build_tree), or inspecting what a running game is showing (editor_pie_widget_tree).',
     meta: uiCreateWidgetMeta,
     handler: uiCreateWidgetHandler,
     cost: 'medium',
@@ -1501,6 +1509,93 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
     returns: '{removed}',
     niche: FOLIAGE,
     schema: foliageRemoveInstancesSchema.shape,
+  },
+
+  // ── PIE interaction ───────────────────────────────────────────────────────
+  //
+  // Driving a running game. Every one of these dispatches input and returns
+  // immediately — none of them block or pump the engine. The previous versions
+  // spun the core ticker from inside a game-thread handler, which tore down the
+  // objects they were holding and crashed the editor.
+  //
+  // Consequence worth knowing: the world advances BETWEEN calls, not during
+  // them. Look at the result, then act again.
+  {
+    name: 'editor_pie_widget_tree',
+    description:
+      'WHAT IS ON SCREEN RIGHT NOW in the running game: every visible Slate/UMG widget with its type, text and on-screen rectangle. USE_WHEN: before interacting — this is how you find a button instead of guessing coordinates. NOT_WHEN: inspecting a Widget Blueprint asset rather than the live screen (ui_query).',
+    meta: pieWidgetTreeMeta,
+    handler: pieWidgetTreeHandler,
+    cost: 'low',
+    returns: '{widgets:[{type, tag, text, x, y, width, height, center_x, center_y, enabled, interactive}], count}',
+    niche: PIE,
+    schema: pieWidgetTreeSchema.shape,
+  },
+  {
+    name: 'editor_pie_click_widget',
+    description:
+      'CLICK A CONTROL BY WHAT IT SAYS rather than by pixel. Finds the widget whose text, tag or type matches and clicks its centre, preferring an interactive one so matching a label presses the button containing it. Reports how many matched, so an ambiguous choice is visible instead of silent. USE_WHEN: pressing menu buttons. NOT_WHEN: you need an exact position.',
+    meta: pieClickWidgetMeta,
+    handler: pieClickWidgetHandler,
+    cost: 'medium',
+    returns: '{match, clicked_type, clicked_text, x, y, candidates, note?}',
+    niche: PIE,
+    schema: pieClickWidgetSchema.shape,
+  },
+  {
+    name: 'editor_pie_mouse',
+    description:
+      'Drive the mouse in the running game: move, click, double_click, press, release, drag or scroll. press/release let you hold a button across calls; drag interpolates intermediate positions because widgets that track deltas ignore a single jump. Coordinates match what editor_pie_widget_tree reports.',
+    meta: pieMouseMeta,
+    handler: pieMouseHandler,
+    cost: 'medium',
+    returns: '{action, x, y, button, dispatched}',
+    niche: PIE,
+    schema: pieMouseSchema.shape,
+  },
+  {
+    name: 'editor_pie_type_text',
+    description:
+      'Type a string into the running game as character input, which is what text fields actually consume. Goes to whatever holds keyboard focus — click the field first. USE_WHEN: filling in a name or search box. NOT_WHEN: a single control key like Enter (editor_pie_press_key).',
+    meta: pieTypeTextMeta,
+    handler: pieTypeTextHandler,
+    cost: 'medium',
+    returns: '{text, characters_sent, note}',
+    niche: PIE,
+    schema: pieTypeTextSchema.shape,
+  },
+  {
+    name: 'editor_pie_press_key',
+    description:
+      'Press a keyboard or gamepad button in the running game. pressed_and_released schedules the release on a later tick and RETURNS IMMEDIATELY — the key is still down when you read the result, which is what lets the game see the hold at all.',
+    meta: piePressKeyMeta,
+    handler: piePressKeyHandler,
+    cost: 'medium',
+    returns: '{key, event, dispatched, release_scheduled, release_after_ms?}',
+    niche: PIE,
+    schema: piePressKeySchema.shape,
+  },
+  {
+    name: 'editor_pie_axis',
+    description:
+      'Send analog input — gamepad sticks and triggers, mouse axes. Applies for the frame it is delivered, so send it again per step for sustained movement rather than expecting it to latch.',
+    meta: pieAxisMeta,
+    handler: pieAxisHandler,
+    cost: 'medium',
+    returns: '{key, value, note}',
+    niche: PIE,
+    schema: pieAxisSchema.shape,
+  },
+  {
+    name: 'editor_pie_screenshot',
+    description:
+      'Capture the running game. Requests the shot and returns immediately; the engine writes the file a frame or two later, so poll with check_only:true and the same filename rather than assuming it is ready. NOT_WHEN: capturing the editor viewport outside PIE (editor_capture_viewport).',
+    meta: pieScreenshotMeta,
+    handler: pieScreenshotHandler,
+    cost: 'medium',
+    returns: '{filename, requested, captured, note}',
+    niche: PIE,
+    schema: pieScreenshotSchema.shape,
   },
 
   // ── Scene domain ──────────────────────────────────────────────────────────

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -421,7 +421,7 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
   // ── Actor domain ────────────────────────────────────────────────────────
   {
     name: 'actor_spawn',
-    description: 'Spawn a new actor in the active level.',
+    description: 'Place a new actor in the active level by class — a light, a volume, a blueprint actor, or any registered UClass. To place a StaticMesh or other content asset by its path instead, use actor_spawn_from_asset.',
     meta: actorSpawnMeta,
     handler: actorSpawnHandler,
     cost: 'medium',
@@ -436,7 +436,7 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
   },
   {
     name: 'actor_list',
-    description: 'Enumerate actors in the active level.',
+    description: 'List what is in the scene: every actor in the active level with its label, class and transform. Start here when you need to know what already exists before changing anything.',
     meta: actorListMeta,
     handler: actorListHandler,
     cost: 'low',

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -124,6 +124,17 @@ import {
   schema as uiListWidgetTypesSchema,
   uiListWidgetTypesHandler,
 } from './ui/ui-list-widget-types.js';
+import { meta as docsSearchMeta, schema as docsSearchSchema, docsSearchHandler } from './docs/docs-search.js';
+import {
+  meta as docsLookupClassMeta,
+  schema as docsLookupClassSchema,
+  docsLookupClassHandler,
+} from './docs/docs-lookup-class.js';
+import {
+  meta as docsLookupApiMeta,
+  schema as docsLookupApiSchema,
+  docsLookupApiHandler,
+} from './docs/docs-lookup-api.js';
 import { meta as uiBuildTreeMeta, schema as uiBuildTreeSchema, uiBuildTreeHandler } from './ui/ui-build-tree.js';
 import {
   meta as uiDuplicateElementMeta,
@@ -394,6 +405,7 @@ const dCoerceVec3 = z.preprocess((v) => {
 const M = 'material'; // niche domain for the material toolset
 const UI = 'ui'; // niche domain for the UMG / Widget Blueprint toolset
 const PACK = 'copilot'; // niche domain for the BYOK copilot config/introspection toolset
+const DOCS = 'docs'; // niche domain for live-editor API reflection
 // Hand-written descriptors. Kept as a named const so the generated legacy list
 // can be de-duplicated against these names before splicing (see below).
 const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
@@ -1278,6 +1290,45 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
       '{widget_blueprint_path, platform, strictness, layout_resolved, findings:[{ruleId, severity, widget?, message, hint, data}], rules_evaluated, rules_skipped_no_layout[], rules_disabled[], rules_below_strictness[], counts}',
     niche: UI,
     schema: uiValidateSchema.shape,
+  },
+
+  // ── Docs domain ───────────────────────────────────────────────────────────
+  // Reflection over the LIVE editor, so answers match the engine version and
+  // plugin set actually loaded — not a web page for some other build. The C++
+  // handler existed and worked; it simply had no wrapper, so the catalogue
+  // reported the whole domain as unavailable.
+  {
+    name: 'docs_search',
+    description:
+      'FIND THE REAL NAME OF A UE CLASS instead of guessing. Substring search over every class loaded in the running editor. USE_WHEN: you are about to write a class name from memory. NOT_WHEN: you already have the exact path.',
+    meta: docsSearchMeta,
+    handler: docsSearchHandler,
+    cost: 'low',
+    returns: '{results:[{name, path, kind}], count, capped}',
+    niche: DOCS,
+    schema: docsSearchSchema.shape,
+  },
+  {
+    name: 'docs_lookup_class',
+    description:
+      'Inspect a UE class in the running editor: full inheritance chain, class flags, and how many properties and functions it has. USE_WHEN: confirming a class exists and what it derives from before using it as a parent or a cast target.',
+    meta: docsLookupClassMeta,
+    handler: docsLookupClassHandler,
+    cost: 'low',
+    returns: '{name, path, parent_chain[], flags[], property_count, function_count}',
+    niche: DOCS,
+    schema: docsLookupClassSchema.shape,
+  },
+  {
+    name: 'docs_lookup_api',
+    description:
+      'CHECK A PROPERTY OR FUNCTION EXISTS BEFORE YOU USE IT. Lists the real properties of a class (name, C++ type, category, tooltip, whether it is editable and blueprint-visible) and functions (blueprint-callable, event). USE_WHEN: before setting a property by name or calling a function — a wrong name is otherwise a silent no-op or a failed edit. Pass include_inherited when a member you expected is missing; it is usually declared on a parent.',
+    meta: docsLookupApiMeta,
+    handler: docsLookupApiHandler,
+    cost: 'low',
+    returns: '{name, properties:[{name, type, category, tooltip, is_editable, is_blueprint_visible}], functions:[{name, is_blueprint_callable, is_event, tooltip}]}',
+    niche: DOCS,
+    schema: docsLookupApiSchema.shape,
   },
 
   // ── Scene domain ──────────────────────────────────────────────────────────

--- a/mcp-tools/hayba-mcp/src/tools/landscape-import.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/landscape-import.test.ts
@@ -29,11 +29,20 @@ describe('hayba_import_landscape wrapper', () => {
   it('declares the full param schema from the UE Cmd_ImportLandscape signature', () => {
     // Each TryGetStringField / TryGetNumberField call in the C++ handler
     // should have a matching schema entry.
-    expect(indexSrc).toMatch(/heightmapPath:\s*z\.string\(\)/);
-    expect(indexSrc).toMatch(/worldSizeKm:\s*z\.number\(\)/);
-    expect(indexSrc).toMatch(/maxHeightM:\s*z\.number\(\)/);
-    expect(indexSrc).toMatch(/actorLabel:\s*z\.string\(\)/);
-    expect(indexSrc).toMatch(/landscapeMaterial:\s*z\.string\(\)/);
+    //
+    // Whitespace is permitted between `z` and its type because these are
+    // source-text assertions and the formatter is free to break a long zod
+    // chain across lines. It did exactly that to maxHeightM, and this suite went
+    // permanently red over a line break rather than a real regression — a
+    // failing check nobody can act on trains everyone to ignore the suite.
+    const declares = (param: string, zodType: 'string' | 'number'): RegExp =>
+      new RegExp(`${param}:\\s*z\\s*\\.\\s*${zodType}\\(\\)`);
+
+    expect(indexSrc).toMatch(declares('heightmapPath', 'string'));
+    expect(indexSrc).toMatch(declares('worldSizeKm', 'number'));
+    expect(indexSrc).toMatch(declares('maxHeightM', 'number'));
+    expect(indexSrc).toMatch(declares('actorLabel', 'string'));
+    expect(indexSrc).toMatch(declares('landscapeMaterial', 'string'));
   });
 
   it('registers the schema in the eager schema-registry block', () => {

--- a/mcp-tools/hayba-mcp/src/tools/modal-dialog-guard.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/modal-dialog-guard.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Guards the C++ handlers against raising modal dialogs.
+//
+// This is the most expensive failure mode in the plugin and the least
+// diagnosable. Handlers run on the editor's game thread, so a modal dialog
+// blocks the thread that would send the reply: the command never completes, the
+// caller times out, and every later request queues behind it until a human
+// notices the box and clicks it. Nothing is written to the log — from the
+// agent's side the editor has simply stopped answering.
+//
+// It was hit live: ui_create_widget on an existing name raised "Overwrite
+// Existing Object" and took the whole connection down.
+//
+// IAssetTools::CreateAsset prompts on a name collision rather than failing, so
+// every call site must check the name first. This test fails when a new one
+// appears without that check.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HANDLER_DIR = join(
+  __dirname, '..', '..', '..', '..',
+  'unreal', 'HaybaMCPToolkit', 'Source', 'HaybaMCPToolkit', 'Private', 'handlers',
+);
+
+function handlerSources(): Array<{ file: string; text: string }> {
+  return readdirSync(HANDLER_DIR)
+    .filter((f) => f.endsWith('.cpp'))
+    .map((f) => ({ file: f, text: readFileSync(join(HANDLER_DIR, f), 'utf-8') }));
+}
+
+/** Strip line and block comments so a mention in prose is not a call. */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+}
+
+describe('handlers must not be able to raise a modal dialog', () => {
+  it('finds the handler sources', () => {
+    expect(handlerSources().length).toBeGreaterThan(10);
+  });
+
+  it('guards every CreateAsset call site with a name-collision check', () => {
+    const offenders: string[] = [];
+
+    for (const { file, text } of handlerSources()) {
+      const code = stripComments(text);
+      // AssetCreated() is the asset-registry notification, not a creation call.
+      const createCalls = (code.match(/\bCreateAsset\s*\(/g) ?? []).length;
+      if (createCalls === 0) continue;
+
+      const guards = (code.match(/HaybaAssetGuard::AssetNameTaken\s*\(/g) ?? []).length;
+      if (guards < createCalls) {
+        offenders.push(`${file}: ${createCalls} CreateAsset call(s) but only ${guards} name guard(s)`);
+      }
+    }
+
+    expect(
+      offenders,
+      'A CreateAsset call without a HaybaAssetGuard::AssetNameTaken check can raise a modal\n' +
+        'overwrite dialog, which blocks the game thread and hangs every queued MCP request:\n  ' +
+        offenders.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('never calls a blocking message dialog directly', () => {
+    const offenders: string[] = [];
+    // FMessageDialog and AddModalWindow block until dismissed. Neither belongs
+    // on a code path a remote caller can reach.
+    const banned = /\bFMessageDialog::|AddModalWindow\s*\(/;
+
+    for (const { file, text } of handlerSources()) {
+      const code = stripComments(text);
+      if (banned.test(code)) offenders.push(file);
+    }
+
+    expect(
+      offenders,
+      `these handlers open a blocking dialog, which no remote-invoked code may do: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('the shared guard checks memory as well as the asset registry', () => {
+    // An asset created earlier in the same session and not yet saved is absent
+    // from the registry but still collides — which is exactly the case an agent
+    // hits when it retries a call it believes failed.
+    const guard = readFileSync(
+      join(
+        __dirname, '..', '..', '..', '..',
+        'unreal', 'HaybaMCPToolkit', 'Source', 'HaybaMCPToolkit', 'Public', 'HaybaMCPAssetGuard.h',
+      ),
+      'utf-8',
+    );
+    expect(guard).toMatch(/GetAssetByObjectPath/);
+    expect(guard).toMatch(/FindObject<UObject>/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/no-stub-wrappers.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/no-stub-wrappers.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// A wrapper must not advertise a command the C++ cannot actually perform.
+//
+// This nearly happened. A sweep for "implemented in C++ but missing a wrapper"
+// flagged editor_live_compile as free capability. It is not implemented — the
+// handler returns compile_started:false with "use Live Coding (Ctrl+Alt+F11) —
+// programmatic trigger not exposed in UE 5.4+". Wrapping it would have put a
+// tool in the catalogue that always fails, which is worse than the gap it was
+// meant to close: an agent would burn turns discovering it does nothing.
+//
+// Detecting these needs more than grepping for "not_implemented", because the
+// honest stubs say that and the misleading ones do not.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HANDLER_DIR = join(
+  __dirname, '..', '..', '..', '..',
+  'unreal', 'HaybaMCPToolkit', 'Source', 'HaybaMCPToolkit', 'Private', 'handlers',
+);
+
+/** Commands whose C++ cannot do the thing their name claims. Wrapping any of
+ *  these is a bug; delete the entry only when the handler genuinely works.
+ *
+ *  Kept deliberately short. foliage_add_instance and foliage_paint_at were on
+ *  this list for one commit because a heuristic sweep misclassified them; both
+ *  are fully implemented, and the second assertion below is what caught it. A
+ *  denylist that silently suppresses working capability is the same kind of
+ *  quiet wrongness as a tool that reports success without doing anything. */
+const KNOWN_STUBS = [
+  'blueprint_add_node',
+  'blueprint_connect_nodes',
+  'blueprint_add_event',
+  // Returns compile_started:false and points at the manual shortcut.
+  'editor_live_compile',
+];
+
+function wrapperSources(): Array<{ file: string; text: string }> {
+  const out: Array<{ file: string; text: string }> = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules') continue;
+        walk(p);
+      } else if (entry.name.endsWith('.ts') && !entry.name.includes('.test.')) {
+        out.push({ file: p, text: readFileSync(p, 'utf-8') });
+      }
+    }
+  };
+  walk(join(__dirname));
+  return out;
+}
+
+describe('wrappers never advertise a stubbed command', () => {
+  it('no executeCommand call targets a known stub', () => {
+    const offenders: string[] = [];
+    for (const { file, text } of wrapperSources()) {
+      for (const stub of KNOWN_STUBS) {
+        const call = new RegExp(`executeCommand\\(\\s*['"]${stub}['"]`);
+        if (call.test(text)) offenders.push(`${stub} <- ${file}`);
+      }
+    }
+    expect(
+      offenders,
+      'These wrappers call a command whose C++ handler cannot perform it, so the tool\n' +
+        'would appear in the catalogue and always fail:\n  ' + offenders.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('the stub list still matches what the C++ actually says', () => {
+    // If a handler stops being a stub, this test should start failing so the
+    // list gets trimmed and the capability gets wrapped — the whole point is to
+    // avoid a stale denylist quietly suppressing real functionality.
+    const sources = readdirSync(HANDLER_DIR)
+      .filter((f) => f.endsWith('.cpp'))
+      .map((f) => readFileSync(join(HANDLER_DIR, f), 'utf-8'))
+      .join('\n');
+
+    const stillStubbed = KNOWN_STUBS.filter((s) => {
+      // Either the command name sits near a not-implemented marker, or the
+      // handler is one we have individually confirmed (live_compile).
+      if (s === 'editor_live_compile') return /programmatic trigger not exposed/.test(sources);
+      return new RegExp(`${s}[\\s\\S]{0,2000}?not_implemented`).test(sources)
+        || new RegExp(`not_implemented[\\s\\S]{0,2000}?${s}`).test(sources);
+    });
+
+    const noLongerStubbed = KNOWN_STUBS.filter((s) => !stillStubbed.includes(s));
+    expect(
+      noLongerStubbed,
+      `these are listed as stubs but the C++ no longer looks stubbed — verify and wrap them: ${noLongerStubbed.join(', ')}`,
+    ).toEqual([]);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/pie/pie-axis.ts
+++ b/mcp-tools/hayba-mcp/src/tools/pie/pie-axis.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['simulates_input'],
+  when: 'sending analog input — gamepad sticks, triggers, mouse axes',
+  not_when: 'pressing a button (use editor_pie_press_key)',
+};
+
+export const schema = z.object({
+  key: z
+    .string()
+    .min(1)
+    .describe('Axis key name, e.g. "Gamepad_LeftX", "Gamepad_RightY", "MouseX".'),
+  value: z.number().optional().describe('Axis value, normally -1..1. Applies for one frame.'),
+});
+
+export const pieAxisHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('editor_pie_axis', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/pie/pie-click-widget.ts
+++ b/mcp-tools/hayba-mcp/src/tools/pie/pie-click-widget.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['simulates_input'],
+  when: 'clicking a button or control by what it says, rather than guessing pixel coordinates',
+  not_when: 'you need an exact position (use editor_pie_mouse with x/y)',
+};
+
+export const schema = z.object({
+  match: z
+    .string()
+    .min(1)
+    .describe(
+      'Text, tag or widget type to find on screen, e.g. "Start Game" or "SButton". Prefers an interactive widget, so matching a label presses the button containing it.',
+    ),
+});
+
+export const pieClickWidgetHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('editor_pie_click_widget', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/pie/pie-mouse.ts
+++ b/mcp-tools/hayba-mcp/src/tools/pie/pie-mouse.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['simulates_input'],
+  when: 'driving the mouse in a running game — moving, clicking, dragging or scrolling',
+  not_when: 'you know what you want to click by name (editor_pie_click_widget is less brittle)',
+};
+
+export const schema = z.object({
+  action: z
+    .enum(['move', 'click', 'double_click', 'press', 'release', 'drag', 'scroll'])
+    .default('click')
+    .describe('press/release let you hold a button across several calls; drag does the whole gesture.'),
+  x: z.number().optional().describe('Target X in viewport pixels. Required for everything except scroll.'),
+  y: z.number().optional().describe('Target Y in viewport pixels. Required for everything except scroll.'),
+  to_x: z.number().optional().describe('Drag destination X. Required for action:"drag".'),
+  to_y: z.number().optional().describe('Drag destination Y. Required for action:"drag".'),
+  button: z.enum(['left', 'right', 'middle']).optional().default('left'),
+  delta: z.number().optional().describe('Wheel delta for action:"scroll". Positive scrolls up.'),
+});
+
+export const pieMouseHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('editor_pie_mouse', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/pie/pie-press-key.ts
+++ b/mcp-tools/hayba-mcp/src/tools/pie/pie-press-key.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['simulates_input'],
+  when: 'pressing a keyboard or gamepad button in the running game',
+  not_when: 'typing a string (use editor_pie_type_text) or analog input (editor_pie_axis)',
+};
+
+export const schema = z.object({
+  key: z.string().min(1).describe('Key name, e.g. "SpaceBar", "E", "Escape", "Gamepad_FaceButton_Bottom".'),
+  event: z
+    .enum(['pressed', 'released', 'pressed_and_released'])
+    .optional()
+    .default('pressed_and_released')
+    .describe('pressed_and_released schedules the release on a later tick and returns immediately.'),
+  held_ms: z
+    .number()
+    .optional()
+    .describe('How long to hold before the scheduled release. The call does not block for this.'),
+});
+
+export const piePressKeyHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('editor_pie_press_key', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/pie/pie-screenshot.ts
+++ b/mcp-tools/hayba-mcp/src/tools/pie/pie-screenshot.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: [],
+  when: 'capturing what the running game looks like right now',
+  not_when: 'capturing the editor viewport outside PIE (use editor_capture_viewport)',
+};
+
+export const schema = z.object({
+  filename: z
+    .string()
+    .optional()
+    .describe('Absolute output path. Defaults to Saved/Screenshots with a timestamp.'),
+  check_only: z
+    .boolean()
+    .optional()
+    .describe(
+      'Do not capture; just report whether a previously requested file has landed. The engine writes the image a frame or two after the request, so poll with this rather than assuming it is ready.',
+    ),
+});
+
+export const pieScreenshotHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('editor_pie_screenshot', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/pie/pie-type-text.ts
+++ b/mcp-tools/hayba-mcp/src/tools/pie/pie-type-text.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'medium',
+  effects: ['simulates_input'],
+  when: 'entering text into a focused field in the running game',
+  not_when: 'sending a single control key like Enter or Escape (use editor_pie_press_key)',
+};
+
+export const schema = z.object({
+  text: z
+    .string()
+    .describe('Characters to send. They go to whatever holds keyboard focus, so click the field first.'),
+});
+
+export const pieTypeTextHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('editor_pie_type_text', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/pie/pie-widget-tree.ts
+++ b/mcp-tools/hayba-mcp/src/tools/pie/pie-widget-tree.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { ToolHandler } from '../types.js';
+import { executeCommand } from '../tool-executor.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'seeing what is actually on screen in the running game before interacting with it',
+  not_when: 'inspecting a Widget Blueprint asset rather than the live screen (use ui_query)',
+};
+
+export const schema = z.object({
+  filter: z
+    .string()
+    .optional()
+    .describe('Keep only widgets whose type, tag or visible text contains this. Omit for everything.'),
+  max_depth: z.number().int().optional().describe('How deep to walk the Slate tree. Default 40.'),
+});
+
+export const pieWidgetTreeHandler: ToolHandler = async (args) => {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
+  }
+  const data = await executeCommand('editor_pie_widget_tree', parsed.data as Record<string, unknown>);
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+};

--- a/mcp-tools/hayba-mcp/src/tools/routing/orientation.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/orientation.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildOrientation, shouldOrient, __resetOrientation } from './orientation.js';
+import { PackRegistry, type PackDef } from './pack-registry.js';
+
+function registry(spec: Array<[string, number, 'domain' | 'workflow']>): PackRegistry {
+  const packs: PackDef[] = spec.map(([name, count, kind]) => ({
+    name,
+    kind,
+    description: '',
+    tools: Array.from({ length: count }, (_, i) => `${name}_${i}`),
+  }));
+  return new PackRegistry(packs, () => {});
+}
+
+const CORE = [
+  'hayba_search_tools',
+  'hayba_invoke',
+  'hayba_pack_list',
+  'hayba_pack_load',
+  'hayba_check_ue_status',
+  'list_tool_categories',
+  'get_tool_signature',
+];
+
+describe('orientation latch', () => {
+  beforeEach(() => __resetOrientation());
+
+  it('fires once and then never again', () => {
+    expect(shouldOrient()).toBe(true);
+    expect(shouldOrient()).toBe(false);
+    expect(shouldOrient()).toBe(false);
+  });
+});
+
+describe('orientation content', () => {
+  const reg = registry([
+    ['ui', 26, 'domain'],
+    ['material', 17, 'domain'],
+    ['actor', 12, 'domain'],
+    ['worldbuilding', 2, 'workflow'],
+  ]);
+
+  const text = buildOrientation({ totalTools: 133, loadedTools: CORE, registry: reg });
+
+  it('states the real numbers, not a hardcoded claim', () => {
+    expect(text).toContain('133 tools exist');
+    expect(text).toContain('7 are registered');
+    // 133 - 7: the agent should be told how much it is NOT seeing.
+    expect(text).toContain('126');
+  });
+
+  it('names the discovery loop', () => {
+    expect(text).toContain('hayba_search_tools');
+    expect(text).toContain('hayba_invoke');
+    expect(text).toContain('hayba_pack_load');
+    expect(text).toMatch(/search .*invoke/);
+  });
+
+  it('says plainly that pack loading is optional', () => {
+    // The single most likely misunderstanding of a small surface is that the
+    // hidden tools need enabling before they can be used.
+    expect(text).toMatch(/never a\s+prerequisite|no pack load required/);
+  });
+
+  it('lists domains largest first with counts', () => {
+    expect(text).toContain('ui (26)');
+    expect(text).toContain('material (17)');
+    expect(text.indexOf('ui (26)')).toBeLessThan(text.indexOf('material (17)'));
+  });
+
+  it('separates workflow packs from domain packs', () => {
+    expect(text).toContain('Workflow packs');
+    expect(text).toContain('worldbuilding');
+  });
+
+  it('warns about the UE connection precondition', () => {
+    expect(text).toContain('hayba_check_ue_status');
+    expect(text).toMatch(/connected/);
+  });
+
+  it('omits the workflow line entirely when there are none', () => {
+    const noWorkflow = buildOrientation({
+      totalTools: 10,
+      loadedTools: CORE,
+      registry: registry([['ui', 3, 'domain']]),
+    });
+    expect(noWorkflow).not.toContain('Workflow packs');
+  });
+
+  it('reports an accurate overflow count when domains exceed the headline limit', () => {
+    const many: Array<[string, number, 'domain' | 'workflow']> = Array.from(
+      { length: 15 },
+      (_, i) => [`d${i}`, 15 - i, 'domain'],
+    );
+    const t = buildOrientation({ totalTools: 200, loadedTools: CORE, registry: registry(many) });
+    // 15 domains, 12 named.
+    expect(t).toContain('and 3 more');
+  });
+
+  it('wraps the domain list instead of emitting one very long line', () => {
+    const many: Array<[string, number, 'domain' | 'workflow']> = Array.from(
+      { length: 12 },
+      (_, i) => [`averylongdomainname${i}`, 12 - i, 'domain'],
+    );
+    const t = buildOrientation({ totalTools: 200, loadedTools: CORE, registry: registry(many) });
+    for (const line of t.split('\n')) {
+      expect(line.length, `line too long: ${line}`).toBeLessThan(100);
+    }
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/routing/orientation.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/orientation.ts
@@ -1,0 +1,120 @@
+// First-contact orientation.
+//
+// A fresh install registers seven tools (see CORE_META). That is the right
+// default for context cost, but on its own it is a worse experience than a
+// bloated one: an agent sees seven names, no map, and no reason to believe the
+// other seventy exist. The saving only pays off if the agent knows how to reach
+// the rest — so the first response it gets says so, once, and then never again.
+//
+// Everything here is derived from live registry state rather than written down,
+// because an orientation that drifts out of date is worse than none: it teaches
+// the agent things that are no longer true.
+
+import type { PackRegistry } from './pack-registry.js';
+
+export interface OrientationInput {
+  /** Every tool the server knows about, loaded or not. */
+  totalTools: number;
+  /** Tools registered right now. */
+  loadedTools: string[];
+  registry: PackRegistry;
+}
+
+/** Domains worth naming up front. Anything else is still discoverable by
+ *  search — this is a signpost, not a catalogue. */
+const HEADLINE_PACK_LIMIT = 12;
+
+/** Comma-join across lines at a readable width. A single 200-character line of
+ *  domain names is technically the same information and much harder to scan. */
+function wrap(items: string[], width = 72, indent = '  '): string {
+  const lines: string[] = [];
+  let line = '';
+  for (const item of items) {
+    const next = line ? `${line}, ${item}` : item;
+    if (next.length > width && line) {
+      lines.push(line + ',');
+      line = item;
+    } else {
+      line = next;
+    }
+  }
+  if (line) lines.push(line);
+  return lines.join(`\n${indent}`);
+}
+
+export function buildOrientation(input: OrientationInput): string {
+  const { totalTools, loadedTools, registry } = input;
+
+  const packs = registry.listPacks();
+  const domainPacks = packs.filter((p) => p.kind === 'domain');
+  const workflowPacks = packs.filter((p) => p.kind !== 'domain');
+
+  const named = wrap(
+    domainPacks
+      .slice()
+      .sort((a, b) => b.tools.length - a.tools.length)
+      .slice(0, HEADLINE_PACK_LIMIT)
+      .map((p) => `${p.name} (${p.tools.length})`),
+  );
+
+  const moreDomains = Math.max(0, domainPacks.length - HEADLINE_PACK_LIMIT);
+  const moreNote = moreDomains > 0 ? `, and ${moreDomains} more` : '';
+
+
+  const workflowNote =
+    workflowPacks.length > 0
+      ? `\n  Workflow packs bundle tools across domains for a task: ${workflowPacks
+          .map((p) => p.name)
+          .join(', ')}.`
+      : '';
+
+  return `
+HAYBA — first-contact orientation (shown once)
+==============================================
+This server drives a live Unreal Engine editor. ${totalTools} tools exist;
+${loadedTools.length} are registered right now, deliberately.
+
+The other ${totalTools - loadedTools.length} are not missing and need no "enabling".
+They are one call away at all times:
+
+  hayba_search_tools   describe what you want in plain language; get tool names back
+  hayba_invoke         call ANY tool by name, loaded or not — no pack load required
+  hayba_pack_load      register a domain natively when you will use it repeatedly
+                       (an optimisation for schemas and autocomplete, never a
+                       prerequisite for calling anything)
+
+So the normal loop is: search → invoke. Reach for pack_load only when you are
+about to make many calls into the same domain.
+
+DOMAINS
+  ${named}${moreNote}${workflowNote}
+  hayba_pack_list gives the full list with tool counts and loaded state.
+  list_tool_categories gives the honest per-domain command catalogue, including
+  which commands the plugin supports but no agent wrapper exposes yet.
+
+BEFORE ANY EDITOR WORK
+  hayba_check_ue_status must report connected:true. Every UE-touching tool fails
+  in a confusing way when it is not, and the failure rarely names the real cause.
+  Connecting also auto-loads the editor pack.
+
+WHAT TO EXPECT FROM RESULTS
+  Tools report per-key outcomes rather than a bare ok:true — applied keys,
+  rejected keys, and warnings come back named. If something was ignored, the
+  response says which thing and why. Treat a silent success as a bug worth
+  reporting, not as confirmation.
+`.trim();
+}
+
+/** Session latch. The stdio transport runs one server process per client
+ *  session, so module scope is session scope. Exported for tests. */
+let oriented = false;
+
+export function shouldOrient(): boolean {
+  if (oriented) return false;
+  oriented = true;
+  return true;
+}
+
+export function __resetOrientation(): void {
+  oriented = false;
+}

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -38,58 +38,63 @@ import { journalTailHandler, journalTailSchema } from '../dag/journal-tail.js';
 import { setAssetDagSink } from '../asset-sources/shared.js';
 import { registerChatCapturedTools } from '../../chat/tool-dispatch.js';
 
-/** Tools registered by registerDeferredRouting itself — skip in shim re-register. */
-export const ALWAYS_ON_META = new Set<string>([
-  'world_generate',
+// ── First-install surface ────────────────────────────────────────────────────
+//
+// What an agent sees before it asks for anything. This number matters more than
+// it looks: every always-on tool spends context on every request, forever, and
+// a large default set actively defeats discovery — there is no reason to search
+// a catalog when 50 tools are already sitting in front of you, so the ones that
+// are NOT surfaced never get found.
+//
+// The set below is the bootstrap minimum: what you cannot discover your way to,
+// because you need it to discover. Everything else in the catalog stays
+// reachable at all times without being registered:
+//
+//   hayba_search_tools  → find it
+//   hayba_invoke        → call it (resolves from the captured map, which holds
+//                         every tool regardless of pack state — loading a pack
+//                         is an optimisation for repeated use, never a
+//                         prerequisite)
+//   hayba_pack_load     → register a domain natively when you want its schemas
+//
+// Before changing this, ask whether the tool is genuinely un-discoverable
+// without itself being present. If an agent could find it with a search, it
+// belongs in a pack.
+
+/** The bootstrap set: needed to discover and reach everything else. */
+export const CORE_META = new Set<string>([
+  // Discovery.
   'hayba_search_tools',
-  'hayba_pack_list',
-  'hayba_pack_load',
-  'hayba_invoke',
-  'hayba_check_ue_status',
   'list_tool_categories',
   'get_tool_signature',
-  'hayba_asset_search',
-  'hayba_asset_browse',
-  'hayba_asset_reindex',
-  'hayba_sliver_list',
-  'hayba_sliver_get',
-  'hayba_sliver_run',
-  'hayba_sliver_import',
-  'hayba_dag_status',
-  'hayba_dag_record',
-  'hayba_dag_rebuild',
-  'hayba_journal_tail',
-  'validator_run',
-  'validator_history',
-  'validator_resolve',
-  'validator_clear',
-  'validator_rules',
-  'validator_set_rule_enabled',
-  'validator_strictness',
-  'plumb_primitives',
-  'plumb_profile_bake',
-  'plumb_profile_annotate',
-  'plumb_profile_list',
-  'plumb_profile_get',
-  'plumb_constraint_define',
-  'plumb_constraint_list',
-  'plumb_constraint_remove',
-  'plumb_constraint_propose',
-  'plumb_validate',
-  'plumb_mask_add',
-  'plumb_mask_remove',
-  'plumb_lesson_add',
-  'plumb_lesson_list',
-  'plumb_lesson_remove',
-  'plumb_study',
-  'plumb_study_take',
-  'plumb_segment',
-  'plumb_production_define',
-  'plumb_production_list',
-  'plumb_production_remove',
-  'plumb_socket_add',
-  'plumb_grammar_expand',
+  // Execution without registration.
+  'hayba_invoke',
+  // Progressive loading.
+  'hayba_pack_list',
+  'hayba_pack_load',
+  // Liveness — every UE-touching tool fails confusingly without this answer,
+  // and an agent cannot know to look for it.
+  'hayba_check_ue_status',
 ]);
+
+/** Packs auto-loaded once the UE editor is confirmed connected. Keeps the cold
+ *  surface tiny while making the tools you obviously need present as soon as
+ *  there is an editor to use them on. */
+export const AUTOLOAD_ON_UE_CONNECT = ['editor'] as const;
+
+/** Tools registered by registerDeferredRouting itself — skip in shim re-register.
+ *
+ *  Kept as a separate export because callers (and the routing integration test)
+ *  treat it as "what is registered at startup". It is exactly CORE_META now;
+ *  previously it also carried the whole PLUMB, validator, sliver, DAG and asset
+ *  surfaces — 49 tools — which is what made the catalog unsearchable.
+ *
+ *  Note on PLUMB in particular: it was always-on so "the Validator/Memory panels
+ *  and any agent can bake profiles without loading a pack." The panels read the
+ *  PLUMB stores directly from disk (see PushMemoryResultsToPanel), so they never
+ *  needed the MCP registration; and an agent reaches every one of those tools
+ *  through hayba_invoke. Nothing regressed by moving them into their pack. */
+export const ALWAYS_ON_META = new Set<string>(CORE_META);
 
 export interface CapturedTool {
   /** Description string passed to server.tool (may be empty). */
@@ -135,6 +140,207 @@ export async function registerDeferredRouting(
   const effectiveCacheDir = cacheDir
     ?? process.env.HAYBA_TOOL_INDEX_DIR
     ?? resolve(process.cwd(), 'Saved/HaybaMCP');
+
+  // ── Runtime-constructed subsystems ─────────────────────────────────────────
+  //
+  // These tools cannot be declared statically: they close over live objects
+  // (the asset retriever, the DAG, the sliver loader). They used to call
+  // server.tool() directly, which registered all 11 unconditionally and — because
+  // it ran after the search index was built — left every one of them OUT of the
+  // index. They were simultaneously always in your face and impossible to find
+  // by searching.
+  //
+  // They now go through `defer`, which puts them in the captured map like every
+  // other tool. Pack discovery, the search index and hayba_invoke all read that
+  // map, so they stay searchable and callable while costing nothing until asked
+  // for. This block must stay ABOVE pack discovery for that to hold.
+
+  /** Route a runtime-constructed tool through the deferred path instead of
+   *  registering it natively. */
+  const defer = (
+    dir: string,
+    name: string,
+    description: string,
+    schema: z.ZodRawShape,
+    handler: (...args: never[]) => unknown,
+  ): void => {
+    captured.set(name, {
+      description,
+      schema,
+      handler: handler as unknown as CapturedTool['handler'],
+      dir,
+    });
+  };
+
+  // ── Asset retriever (Layer 3a) ─────────────────────────────────────────────
+  const retriever = new AssetRetriever(
+    (cmd, params) => executeCommand(cmd, params ?? {}),
+    { cacheDir: effectiveCacheDir },
+  );
+  setDefaultRetriever(retriever);
+
+  defer(
+    'asset-sources',
+    'hayba_asset_search',
+    'Find an asset in the user\'s UE Content Browser by semantic intent or keyword. Hybrid BM25 + embedding search.',
+    assetSearchSchema,
+    async (args: { query: string; k?: number; filterClass?: string; filterSource?: 'project' | 'polyhaven' | 'ambientcg' | 'sketchfab' | 'fab' | 'unknown' }) => {
+      const r = await assetSearchHandler(args, { retriever });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  defer(
+    'asset-sources',
+    'hayba_asset_browse',
+    'Enumerate assets by filter (path/class/tag/source) without semantic ranking. Paginated.',
+    assetBrowseSchema,
+    async (args: { filter?: { path?: string; class?: string; tag?: string; source?: 'project' | 'polyhaven' | 'ambientcg' | 'sketchfab' | 'fab' | 'unknown' }; offset?: number; limit?: number }) => {
+      const r = await assetBrowseHandler(args, { retriever });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  defer(
+    'asset-sources',
+    'hayba_asset_reindex',
+    'Force a rebuild of the asset index. Use after a batch import outside the MCP-tracked download flow.',
+    assetReindexSchema,
+    async () => {
+      const r = await assetReindexHandler({}, { retriever });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  // ── DAG + journal (Layer 2 — operation tracking) ───────────────────────────
+  const dag = setupDagSystem();
+
+  // Asset-source verified writes feed the journal.
+  setAssetDagSink((writeUri) => {
+    dag.recordMutation({ actor: 'asset', reads: [], writes: [writeUri], paramsHash: '', ok: true });
+  });
+
+  // ── Slivers (Layer 2 — deterministic abstractions) ─────────────────────────
+  const slivers = await setupSliverSystem({
+    onRun: (info) => {
+      dag.recordSliverRun({
+        sliverId: info.sliverId,
+        params: info.params,
+        declaredReads: info.declaredReads,
+        writes: info.writes,
+        ok: info.ok,
+      });
+    },
+    // Side-effecting executors reach the UE bridge through ctx.dispatch.
+    // executeCommand throws on transport/UE error; we convert to the
+    // structured SliverDispatchResult so executors can branch on `ok`.
+    ueBridge: async (cmd, params) => {
+      try {
+        const data = await executeCommand(cmd, params);
+        return { ok: true, data: data as Record<string, unknown> };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  });
+  for (const err of slivers.loader.errors()) {
+    console.warn(`[slivers] load error: ${err}`);
+  }
+
+  defer(
+    'sliver',
+    'hayba_sliver_list',
+    'List installed Slivers (deterministic abstractions). Optional category or namespace filter.',
+    sliverListSchema,
+    async (args: { category?: string; namespace?: string }) => {
+      const r = await sliverListHandler(args, { loader: slivers.loader });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  defer(
+    'sliver',
+    'hayba_sliver_get',
+    'Get the full spec (params + determinism + executor) of an installed sliver by id.',
+    sliverGetSchema,
+    async (args: { id: string }) => {
+      const r = await sliverGetHandler(args, { loader: slivers.loader });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  defer(
+    'sliver',
+    'hayba_sliver_run',
+    'Execute a sliver with concrete parameter values. Returns outputs + declared side_effects + durationMs.',
+    sliverRunSchema,
+    async (args: { id: string; params: Record<string, unknown> }) => {
+      const r = await sliverRunHandler(args, { runtime: slivers.runtime });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  defer(
+    'sliver',
+    'hayba_sliver_import',
+    'Install a sliver from a local file path or an http(s) URL into the user sliver library.',
+    sliverImportSchema,
+    async (args: { source: string }) => {
+      const r = await sliverImportHandler(args, { loader: slivers.loader });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  defer(
+    'dag',
+    'hayba_dag_status',
+    'Show the dependency graph of generated artifacts and which are stale (dirty).',
+    dagStatusSchema,
+    async (args: { namespace?: string; dirtyOnly?: boolean }) => {
+      const r = await dagStatusHandler(args, { dag });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  defer(
+    'dag',
+    'hayba_dag_record',
+    'Record a mutation Hayba did not instrument (editor-side edits, manual writes) so the DAG stays accurate.',
+    dagRecordSchema,
+    async (args: { reads?: string[]; writes: string[]; actor?: string; note?: string }) => {
+      const r = await dagRecordHandler(args, { dag });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  defer(
+    'dag',
+    'hayba_dag_rebuild',
+    'Re-run stale (dirty) artifacts. Optionally restrict to the subtree under a target URI.',
+    dagRebuildSchema,
+    async (args: { target?: string }) => {
+      const r = await dagRebuildHandler(args, {
+        dag,
+        runSliverNode: async (uri: string) => {
+          return { ok: false, reason: uri.startsWith('sliver://')
+            ? 'sliver re-run from node id is v2'
+            : 'no executor for this node type' };
+        },
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
+
+  defer(
+    'dag',
+    'hayba_journal_tail',
+    'Return the most recent mutation operations from the journal.',
+    journalTailSchema,
+    async (args: { limit?: number }) => {
+      const r = await journalTailHandler(args, { dag });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+    },
+  );
 
   // ── Pack discovery ─────────────────────────────────────────────────────────
   const toolDirs = new Map<string, string | null>();
@@ -287,46 +493,11 @@ export async function registerDeferredRouting(
     }
     registeredNames.add(name);
   };
+  // Only the bootstrap set is registered here. Everything else stays in the
+  // captured map: findable with hayba_search_tools, callable with hayba_invoke,
+  // and registrable on demand with hayba_pack_load.
   passthrough('list_tool_categories');
   passthrough('get_tool_signature');
-  // world_generate — the always-on flagship: describe a biome, get a
-  // PLUMB-validated scene. No pack load required.
-  passthrough('world_generate');
-  // Validator tools — always-on so the UE plugin's Validator panel and any
-  // agent can read/manage history without loading a pack.
-  passthrough('validator_run');
-  passthrough('validator_history');
-  passthrough('validator_resolve');
-  passthrough('validator_clear');
-  passthrough('validator_rules');
-  passthrough('validator_set_rule_enabled');
-  passthrough('validator_strictness');
-  // PLUMB constraint subsystem — always-on so the Validator/Memory panels and
-  // any agent can bake profiles, author constraints, and run Verdicts without
-  // loading a pack.
-  passthrough('plumb_primitives');
-  passthrough('plumb_profile_bake');
-  passthrough('plumb_profile_annotate');
-  passthrough('plumb_profile_list');
-  passthrough('plumb_profile_get');
-  passthrough('plumb_constraint_define');
-  passthrough('plumb_constraint_list');
-  passthrough('plumb_constraint_remove');
-  passthrough('plumb_constraint_propose');
-  passthrough('plumb_validate');
-  passthrough('plumb_mask_add');
-  passthrough('plumb_mask_remove');
-  passthrough('plumb_lesson_add');
-  passthrough('plumb_lesson_list');
-  passthrough('plumb_lesson_remove');
-  passthrough('plumb_study');
-  passthrough('plumb_study_take');
-  passthrough('plumb_segment');
-  passthrough('plumb_production_define');
-  passthrough('plumb_production_list');
-  passthrough('plumb_production_remove');
-  passthrough('plumb_socket_add');
-  passthrough('plumb_grammar_expand');
 
   // For hayba_check_ue_status: REPLACE the captured handler with one that
   // wires onConnected → maybeAutoLoad('ue_connected'). The captured handler
@@ -345,164 +516,6 @@ export async function registerDeferredRouting(
     registeredNames.add('hayba_check_ue_status');
   }
 
-  // ── Asset retriever (Layer 3a) ─────────────────────────────────────────────
-  const retriever = new AssetRetriever(
-    (cmd, params) => executeCommand(cmd, params ?? {}),
-    { cacheDir: effectiveCacheDir },
-  );
-  setDefaultRetriever(retriever);
-
-  server.tool(
-    'hayba_asset_search',
-    'Find an asset in the user\'s UE Content Browser by semantic intent or keyword. Hybrid BM25 + embedding search.',
-    assetSearchSchema,
-    async (args: { query: string; k?: number; filterClass?: string; filterSource?: 'project' | 'polyhaven' | 'ambientcg' | 'sketchfab' | 'fab' | 'unknown' }) => {
-      const r = await assetSearchHandler(args, { retriever });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  server.tool(
-    'hayba_asset_browse',
-    'Enumerate assets by filter (path/class/tag/source) without semantic ranking. Paginated.',
-    assetBrowseSchema,
-    async (args: { filter?: { path?: string; class?: string; tag?: string; source?: 'project' | 'polyhaven' | 'ambientcg' | 'sketchfab' | 'fab' | 'unknown' }; offset?: number; limit?: number }) => {
-      const r = await assetBrowseHandler(args, { retriever });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  server.tool(
-    'hayba_asset_reindex',
-    'Force a rebuild of the asset index. Use after a batch import outside the MCP-tracked download flow.',
-    assetReindexSchema,
-    async () => {
-      const r = await assetReindexHandler({}, { retriever });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  // ── DAG + journal (Layer 2 — operation tracking) ───────────────────────────
-  const dag = setupDagSystem();
-
-  // Asset-source verified writes feed the journal.
-  setAssetDagSink((writeUri) => {
-    dag.recordMutation({ actor: 'asset', reads: [], writes: [writeUri], paramsHash: '', ok: true });
-  });
-
-  // ── Slivers (Layer 2 — deterministic abstractions) ─────────────────────────
-  const slivers = await setupSliverSystem({
-    onRun: (info) => {
-      dag.recordSliverRun({
-        sliverId: info.sliverId,
-        params: info.params,
-        declaredReads: info.declaredReads,
-        writes: info.writes,
-        ok: info.ok,
-      });
-    },
-    // Side-effecting executors reach the UE bridge through ctx.dispatch.
-    // executeCommand throws on transport/UE error; we convert to the
-    // structured SliverDispatchResult so executors can branch on `ok`.
-    ueBridge: async (cmd, params) => {
-      try {
-        const data = await executeCommand(cmd, params);
-        return { ok: true, data: data as Record<string, unknown> };
-      } catch (err) {
-        return { ok: false, error: err instanceof Error ? err.message : String(err) };
-      }
-    },
-  });
-  for (const err of slivers.loader.errors()) {
-    console.warn(`[slivers] load error: ${err}`);
-  }
-
-  server.tool(
-    'hayba_sliver_list',
-    'List installed Slivers (deterministic abstractions). Optional category or namespace filter.',
-    sliverListSchema,
-    async (args: { category?: string; namespace?: string }) => {
-      const r = await sliverListHandler(args, { loader: slivers.loader });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  server.tool(
-    'hayba_sliver_get',
-    'Get the full spec (params + determinism + executor) of an installed sliver by id.',
-    sliverGetSchema,
-    async (args: { id: string }) => {
-      const r = await sliverGetHandler(args, { loader: slivers.loader });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  server.tool(
-    'hayba_sliver_run',
-    'Execute a sliver with concrete parameter values. Returns outputs + declared side_effects + durationMs.',
-    sliverRunSchema,
-    async (args: { id: string; params: Record<string, unknown> }) => {
-      const r = await sliverRunHandler(args, { runtime: slivers.runtime });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  server.tool(
-    'hayba_sliver_import',
-    'Install a sliver from a local file path or an http(s) URL into the user sliver library.',
-    sliverImportSchema,
-    async (args: { source: string }) => {
-      const r = await sliverImportHandler(args, { loader: slivers.loader });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  server.tool(
-    'hayba_dag_status',
-    'Show the dependency graph of generated artifacts and which are stale (dirty).',
-    dagStatusSchema,
-    async (args: { namespace?: string; dirtyOnly?: boolean }) => {
-      const r = await dagStatusHandler(args, { dag });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  server.tool(
-    'hayba_dag_record',
-    'Record a mutation Hayba did not instrument (editor-side edits, manual writes) so the DAG stays accurate.',
-    dagRecordSchema,
-    async (args: { reads?: string[]; writes: string[]; actor?: string; note?: string }) => {
-      const r = await dagRecordHandler(args, { dag });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  server.tool(
-    'hayba_dag_rebuild',
-    'Re-run stale (dirty) artifacts. Optionally restrict to the subtree under a target URI.',
-    dagRebuildSchema,
-    async (args: { target?: string }) => {
-      const r = await dagRebuildHandler(args, {
-        dag,
-        runSliverNode: async (uri: string) => {
-          return { ok: false, reason: uri.startsWith('sliver://')
-            ? 'sliver re-run from node id is v2'
-            : 'no executor for this node type' };
-        },
-      });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
-
-  server.tool(
-    'hayba_journal_tail',
-    'Return the most recent mutation operations from the journal.',
-    journalTailSchema,
-    async (args: { limit?: number }) => {
-      const r = await journalTailHandler(args, { dag });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
-    },
-  );
 
   // ── Always-load packs from settings ────────────────────────────────────────
   for (const name of settings.alwaysLoadPacks) {

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -37,6 +37,7 @@ import { dagRebuildHandler, dagRebuildSchema } from '../dag/rebuild.js';
 import { journalTailHandler, journalTailSchema } from '../dag/journal-tail.js';
 import { setAssetDagSink } from '../asset-sources/shared.js';
 import { registerChatCapturedTools } from '../../chat/tool-dispatch.js';
+import { buildOrientation, shouldOrient } from './orientation.js';
 
 // ── First-install surface ────────────────────────────────────────────────────
 //
@@ -414,40 +415,60 @@ export async function registerDeferredRouting(
   });
   const index = await ToolIndex.build(docs, { embeddings, cacheDir: effectiveCacheDir });
 
+  // ── First-contact orientation ──────────────────────────────────────────────
+  //
+  // Appended to whichever core tool the agent happens to call first, then never
+  // again. A seven-tool surface is only an improvement if the agent knows the
+  // other seventy are one call away; without this it just looks like a server
+  // that cannot do very much.
+  const withOrientation = (
+    result: { content: Array<{ type: 'text'; text: string }> },
+  ): { content: Array<{ type: 'text'; text: string }> } => {
+    if (!shouldOrient()) return result;
+    const text = buildOrientation({
+      totalTools: captured.size,
+      loadedTools: Array.from(registeredNames),
+      registry,
+    });
+    return { ...result, content: [...result.content, { type: 'text' as const, text }] };
+  };
+
+  const j = (r: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] });
+
   // ── Register the 4 new meta-tools ──────────────────────────────────────────
   server.tool(
     'hayba_search_tools',
-    'Find Hayba tools by capability before loading their pack. Hybrid BM25 + embedding search over the full tool catalog.',
+    'FIND A TOOL BY DESCRIBING WHAT YOU WANT, in plain language ("make a menu widget", "why is my landscape flat"). Searches the FULL catalogue, including the tools that are not registered yet — most of them are not, by design. Returns tool names you can pass straight to hayba_invoke without loading anything. USE_WHEN: you do not already know the exact tool name. NOT_WHEN: you know the name — just hayba_invoke it.',
     searchToolsSchema,
     async (args: { query: string; k?: number; filterPack?: string }) => {
       const r = await searchToolsHandler(args, { index });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+      return withOrientation(j(r));
     },
   );
 
   server.tool(
     'hayba_pack_list',
-    'List available Hayba tool packs (domain + workflow), with loaded flag and tool count.',
+    'List the tool packs — domain packs group one subsystem, workflow packs bundle a task across subsystems. Shows tool counts and which are loaded. USE_WHEN: you want the map of what exists. NOT_WHEN: you want a specific capability — hayba_search_tools is faster than reading the map.',
     packListSchema,
     async () => {
       const r = await packListHandler({}, { registry });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+      return withOrientation(j(r));
     },
   );
 
   server.tool(
     'hayba_pack_load',
-    'Load a Hayba tool pack — registers its tools natively so the client sees them on the next list refresh.',
+    'Register a pack natively so its tools appear in your tool list with full schemas. This is an OPTIMISATION for repeated use, not a prerequisite: hayba_invoke already calls any tool without it. USE_WHEN: you are about to make several calls into one domain. NOT_WHEN: one-off call — just invoke it.',
     packLoadSchema,
     async (args: { name: string }) => {
       const r = await packLoadHandler(args, { registry });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+      return withOrientation(j(r));
     },
   );
 
   server.tool(
     'hayba_invoke',
-    'Polymorphic dispatcher: call any Hayba tool by name without loading its pack. Best for one-off calls; load the pack for repeated use.',
+    'CALL ANY TOOL BY NAME, whether or not its pack is loaded — the whole catalogue is reachable through here. Pair with hayba_search_tools when you do not know the name. USE_WHEN: any call into an unloaded domain, which is most of them. NOT_WHEN: you are making many calls into one domain — hayba_pack_load gives you native schemas.',
     invokeSchema,
     async (args: { name: string; args: Record<string, unknown>; via?: 'ts' | 'ue_legacy' }) => {
       const r = await invokeHandler(args, {
@@ -468,7 +489,7 @@ export async function registerDeferredRouting(
         },
         isDisabled: isToolDisabled,
       });
-      return { content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] };
+      return withOrientation(j(r));
     },
   );
 
@@ -510,7 +531,7 @@ export async function registerDeferredRouting(
         const status = await checkUeStatus({
           onConnected: () => registry.maybeAutoLoad('ue_connected'),
         });
-        return { content: [{ type: 'text' as const, text: JSON.stringify(status, null, 2) }] };
+        return withOrientation(j(status));
       },
     );
     registeredNames.add('hayba_check_ue_status');

--- a/mcp-tools/hayba-mcp/src/tools/routing/search-quality.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/search-quality.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { ToolIndex, type ToolDoc } from './tool-index.js';
+import { STANDARD_DESCRIPTORS, inferDir } from '../index.js';
+
+// Search-quality benchmark.
+//
+// Search became load-bearing the moment the default surface dropped to seven
+// tools: if an agent cannot find `ui_validate` by asking for "check my menu for
+// text overflow", that tool effectively does not exist. Ranking is therefore a
+// correctness property, not a nice-to-have, and it gets measured rather than
+// eyeballed.
+//
+// The corpus is the REAL descriptor list, not a fixture, so the benchmark
+// degrades honestly when someone writes a vague tool description. A query that
+// regresses here is usually telling you the description is bad, not the ranker.
+//
+// Queries are phrased the way an agent actually phrases them: intent and
+// symptom, not tool names. Anything answerable by exact-name lookup is not a
+// search problem.
+
+interface Case {
+  query: string;
+  /** Any one of these counts as correct — several tools can be a fair answer. */
+  expect: string[];
+}
+
+const CASES: Case[] = [
+  // Intent, no jargon.
+  { query: 'make a menu screen', expect: ['ui_create_widget', 'ui_build_tree'] },
+  { query: 'add a button to my HUD', expect: ['ui_add_element', 'ui_build_tree'] },
+  { query: 'check my UI for text that gets cut off', expect: ['ui_validate', 'ui_measure_text'] },
+  { query: 'how wide is this text going to render', expect: ['ui_measure_text', 'ui_layout_snapshot'] },
+  { query: 'change the font on a label', expect: ['ui_set_text_style', 'ui_set_property'] },
+
+  // Domain words people use instead of the internal name.
+  { query: 'shader', expect: ['material_create', 'material_add_node', 'material_compile', 'material_list'] },
+  { query: 'place a mesh in the level', expect: ['actor_spawn', 'actor_spawn_from_asset'] },
+  { query: 'what actors are in my scene', expect: ['actor_list', 'scene_export'] },
+  { query: 'landscape layers', expect: ['landscape_layer_list', 'landscape_add_layer'] },
+  // camelCase vocabulary: the description says "StaticMesh", the user types two
+  // words. Protects the tokenizer that took this from rank 7 to rank 1.
+  { query: 'spawn from a static mesh', expect: ['actor_spawn_from_asset', 'actor_spawn'] },
+
+  // Capability phrasing.
+  { query: 'compile a blueprint', expect: ['blueprint_compile', 'ui_compile_widget'] },
+  { query: 'save an asset to disk', expect: ['asset_save'] },
+  { query: 'delete an actor', expect: ['actor_delete'] },
+  { query: 'set a material parameter', expect: ['material_set_param', 'material_set_property'] },
+  { query: 'wire two pcg nodes together', expect: ['pcg_wire'] },
+  { query: 'check physics overlaps', expect: ['scene_validate_physics'] },
+  { query: 'move an actor to a new position', expect: ['actor_transform', 'actor_batch_transform'] },
+];
+
+function buildDocs(): ToolDoc[] {
+  return STANDARD_DESCRIPTORS.map((d) => {
+    const dir = inferDir(d.name) ?? 'core';
+    const meta = d.meta as { when?: string; effects?: string[] } | undefined;
+    return {
+      name: d.name,
+      summary: meta?.when ?? d.description ?? '',
+      description: d.description ?? '',
+      tags: meta?.effects ?? [],
+      packs: [dir],
+      cost: 'medium' as const,
+    };
+  });
+}
+
+let cached: ToolIndex | null = null;
+async function index(): Promise<ToolIndex> {
+  if (!cached) cached = await ToolIndex.build(buildDocs(), { embeddings: null });
+  return cached;
+}
+
+/** 1-based rank of the first acceptable answer, or Infinity. */
+async function rankOf(c: Case, k = 10): Promise<number> {
+  const hits = await (await index()).search(c.query, { k });
+  const names = hits.map((h) => h.name);
+  let best = Infinity;
+  for (const want of c.expect) {
+    const i = names.indexOf(want);
+    if (i >= 0) best = Math.min(best, i + 1);
+  }
+  return best;
+}
+
+describe('search quality', () => {
+  it('the benchmark corpus is the real tool catalogue', () => {
+    expect(buildDocs().length).toBeGreaterThan(150);
+  });
+
+  it('every expected tool actually exists in the corpus', () => {
+    // Without this the benchmark silently measures nothing: an expectation
+    // naming a tool that is not indexed can never be satisfied, and reads as a
+    // ranking failure when it is really a bad test. This caught six such cases.
+    //
+    // NOTE: the corpus here is STANDARD_DESCRIPTORS only. Tools registered
+    // directly with server.tool() in index.ts (python_run, editor_capture_viewport,
+    // the pcg_* and gaea_* families) are NOT included, so do not write cases for
+    // them until the corpus covers them.
+    const known = new Set(buildDocs().map((d) => d.name));
+    const missing: string[] = [];
+    for (const c of CASES) {
+      for (const name of c.expect) if (!known.has(name)) missing.push(`${c.query} -> ${name}`);
+    }
+    expect(missing, `benchmark expects tools absent from the corpus:\n${missing.join('\n')}`).toEqual([]);
+  });
+
+  // Reported as one block so a regression shows WHICH queries broke and where
+  // they landed, rather than failing on the first one and hiding the rest.
+  it('ranks an acceptable tool in the top 3 for every benchmark query', async () => {
+    const failures: string[] = [];
+    for (const c of CASES) {
+      const r = await rankOf(c);
+      if (r > 3) {
+        const hits = await (await index()).search(c.query, { k: 5 });
+        failures.push(
+          `  "${c.query}"\n` +
+            `     want one of: ${c.expect.join(', ')}\n` +
+            `     rank: ${r === Infinity ? 'not in top 10' : r}\n` +
+            `     got: ${hits.map((h) => h.name).join(', ') || '(nothing)'}`,
+        );
+      }
+    }
+    expect(failures.join('\n'), `${failures.length}/${CASES.length} queries rank poorly:\n${failures.join('\n')}`).toBe('');
+  });
+
+  it('puts an acceptable tool first for at least three quarters of queries', async () => {
+    let firstPlace = 0;
+    for (const c of CASES) if ((await rankOf(c)) === 1) firstPlace++;
+    const ratio = firstPlace / CASES.length;
+    expect(ratio, `only ${firstPlace}/${CASES.length} queries put the right tool first`).toBeGreaterThanOrEqual(0.75);
+  });
+
+  it('returns nothing rather than noise for a query with no plausible answer', async () => {
+    const hits = await (await index()).search('zorblax quibbleflum wuzzlewump', { k: 5 });
+    // A confident wrong answer is worse than an empty one: it sends the agent
+    // down a path that cannot work.
+    expect(hits.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/routing/tool-index-vectors.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/tool-index-vectors.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ToolIndex, type ToolDoc, type EmbeddingBackend } from './tool-index.js';
+
+// Vector search behaviour, exercised with a deterministic stub backend so the
+// tests say something exact and do not depend on a model being installed.
+
+function doc(name: string, summary: string, description = ''): ToolDoc {
+  return { name, summary, description, tags: [], packs: ['test'], cost: 'low' };
+}
+
+const DOCS: ToolDoc[] = [
+  doc('actor_delete', 'removing an actor from the level', 'Delete an actor.'),
+  doc('material_set_param', 'setting a material parameter', 'Set roughness, metallic, colour.'),
+  doc('ui_validate', 'checking a screen against UI standards', 'Text overflow and contrast.'),
+  doc('landscape_list', 'listing landscapes', 'Enumerate landscape actors.'),
+];
+
+/** Deterministic stand-in: each document gets a one-hot vector, and a query
+ *  maps to whichever document name it mentions. Lets the fusion be tested
+ *  without asserting anything about a real model's judgement. */
+function stubBackend(queryTarget: Record<string, string>): EmbeddingBackend {
+  const index = new Map(DOCS.map((d, i) => [d.name, i]));
+  const vec = (slot: number): Float32Array => {
+    const v = new Float32Array(DOCS.length);
+    if (slot >= 0) v[slot] = 1;
+    return v;
+  };
+  let callCount = 0;
+  return {
+    id: 'stub',
+    async embed(texts: string[]): Promise<Float32Array[]> {
+      callCount++;
+      return texts.map((t) => {
+        // Documents are embedded in DOCS order on the bulk call.
+        const owner = DOCS.find((d) => t.includes(d.summary));
+        if (owner) return vec(index.get(owner.name)!);
+        const target = queryTarget[t];
+        return vec(target ? index.get(target)! : -1);
+      });
+    },
+    get calls() {
+      return callCount;
+    },
+  } as EmbeddingBackend & { calls: number };
+}
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'hayba-vecidx-'));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('vector persistence', () => {
+  it('writes vectors to the cache and reuses them on the next build', async () => {
+    const backend = stubBackend({}) as EmbeddingBackend & { calls: number };
+    await ToolIndex.build(DOCS, { embeddings: backend, cacheDir: dir });
+
+    const vecPath = join(dir, 'tool-index.vec.json');
+    expect(existsSync(vecPath), 'vectors should be cached to disk').toBe(true);
+
+    const callsAfterCold = backend.calls;
+    await ToolIndex.build(DOCS, { embeddings: backend, cacheDir: dir });
+    // A warm build must not re-embed the corpus. Re-embedding costs seconds on
+    // the path between a request arriving and anything happening.
+    expect(backend.calls).toBe(callsAfterCold);
+  });
+
+  it('re-embeds rather than trusting a corrupt cache', async () => {
+    const backend = stubBackend({}) as EmbeddingBackend & { calls: number };
+    await ToolIndex.build(DOCS, { embeddings: backend, cacheDir: dir });
+
+    writeFileSync(join(dir, 'tool-index.vec.json'), '{ not json');
+    const before = backend.calls;
+    const idx = await ToolIndex.build(DOCS, { embeddings: backend, cacheDir: dir });
+
+    expect(backend.calls).toBeGreaterThan(before);
+    expect((await idx.search('actor_delete', { k: 1 })).length).toBeGreaterThan(0);
+  });
+
+  it('re-embeds when the cache is missing a document', async () => {
+    const backend = stubBackend({}) as EmbeddingBackend & { calls: number };
+    await ToolIndex.build(DOCS, { embeddings: backend, cacheDir: dir });
+
+    const raw = JSON.parse(readFileSync(join(dir, 'tool-index.vec.json'), 'utf-8')) as Record<string, number[]>;
+    delete raw['ui_validate'];
+    writeFileSync(join(dir, 'tool-index.vec.json'), JSON.stringify(raw));
+
+    const before = backend.calls;
+    await ToolIndex.build(DOCS, { embeddings: backend, cacheDir: dir });
+    // A partial cache would silently leave one tool unrankable by meaning.
+    expect(backend.calls).toBeGreaterThan(before);
+  });
+});
+
+describe('vector fusion', () => {
+  it('lets semantics decide when no document contains every query term', async () => {
+    // "make the surface shiny" shares no full term set with any document, so
+    // the lexical pass is guessing and the embedding should lead.
+    const backend = stubBackend({ 'make the surface shiny': 'material_set_param' });
+    const idx = await ToolIndex.build(DOCS, { embeddings: backend });
+    const hits = await idx.search('make the surface shiny', { k: 3 });
+    expect(hits[0]?.name).toBe('material_set_param');
+  });
+
+  it('still answers an exact lexical query from the lexical side', async () => {
+    // When the name matches outright, semantics must not override it.
+    const backend = stubBackend({ landscape_list: 'material_set_param' });
+    const idx = await ToolIndex.build(DOCS, { embeddings: backend });
+    const hits = await idx.search('landscape_list', { k: 3 });
+    expect(hits[0]?.name).toBe('landscape_list');
+  });
+
+  it('returns nothing for a query that matches neither lexically nor semantically', async () => {
+    // Without a similarity floor every query returns something, because some
+    // document is always the least dissimilar — which quietly undoes the
+    // "no confident wrong answers" property that BM25-only search has.
+    const backend = stubBackend({});
+    const idx = await ToolIndex.build(DOCS, { embeddings: backend });
+    const hits = await idx.search('zorblax quibbleflum wuzzlewump', { k: 5 });
+    expect(hits).toHaveLength(0);
+  });
+
+  it('works with no embedding backend at all', async () => {
+    const idx = await ToolIndex.build(DOCS, { embeddings: null });
+    const hits = await idx.search('actor', { k: 3 });
+    expect(hits.map((h) => h.name)).toContain('actor_delete');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/routing/tool-index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/tool-index.ts
@@ -69,6 +69,16 @@ const INDEX_FIELDS = ['name', 'pack', 'summary', 'description', 'tags'];
  *  matches most of the catalogue and is where the worst noise came from. */
 const MIN_FUZZY_LEN = 5;
 
+/** How many semantic neighbours enter the fusion. Small on purpose: RRF rewards
+ *  appearing in both lists, so a long embedding tail turns into a bonus for
+ *  whatever BM25 already liked instead of a second opinion. */
+const EMB_CANDIDATES = 25;
+
+/** Cosine below this is not a match. Short tool text through a small sentence
+ *  model puts genuine matches around 0.25-0.4 and unrelated pairs well under
+ *  0.15, so this separates "weakly related" from "closest of nothing". */
+const EMB_MIN_SIMILARITY = 0.18;
+
 function processTerm(term: string): string | null {
   const t = term.toLowerCase();
   if (STOPWORDS.has(t)) return null;
@@ -120,6 +130,7 @@ export class ToolIndex {
       mkdirSync(opts.cacheDir, { recursive: true });
       const metaPath = join(opts.cacheDir, 'tool-index.meta.json');
       const bm25Path = join(opts.cacheDir, 'tool-index.bm25.json');
+      const vecPath = join(opts.cacheDir, 'tool-index.vec.json');
       const hash = hashDocs(docs);
       const backendId = opts.embeddings?.id ?? 'none';
       let cached: { hash?: string; backendId?: string } | null = null;
@@ -135,16 +146,17 @@ export class ToolIndex {
             extractField: extractIndexField,
           });
           const docMap = new Map(docs.map(d => [d.name, d]));
-          // Note: embedding vectors are NOT persisted in v1 — they're cheap to
-          // recompute and avoid binary format complexity. Re-embed if needed.
+          // Vectors are persisted alongside the BM25 index. Re-embedding the
+          // catalogue costs ~2s of wall clock on every server start, which is
+          // paid on the path between a user asking for something and anything
+          // happening — the worst place to spend it.
           let vectors: Map<string, Float32Array> | null = null;
           if (opts.embeddings) {
-            vectors = new Map();
-            const texts = docs.map(d =>
-              `${d.name}. ${d.summary}. ${d.description}. tags: ${d.tags.join(', ')}`,
-            );
-            const embedded = await opts.embeddings.embed(texts);
-            docs.forEach((d, i) => vectors!.set(d.name, embedded[i]));
+            vectors = loadVectors(vecPath, docs);
+            if (!vectors) {
+              vectors = await embedDocs(docs, opts.embeddings);
+              saveVectors(vecPath, vectors);
+            }
           }
           return new ToolIndex(bm25Cached, docMap, vectors, opts.embeddings);
         } catch {
@@ -161,17 +173,13 @@ export class ToolIndex {
 
     let vectors: Map<string, Float32Array> | null = null;
     if (opts.embeddings) {
-      vectors = new Map();
-      const texts = docs.map(d =>
-        `${d.name}. ${d.summary}. ${d.description}. tags: ${d.tags.join(', ')}`,
-      );
-      const embedded = await opts.embeddings.embed(texts);
-      docs.forEach((d, i) => vectors!.set(d.name, embedded[i]));
+      vectors = await embedDocs(docs, opts.embeddings);
     }
 
     // Write cache after successful build
     if (opts.cacheDir) {
       writeFileSync(join(opts.cacheDir, 'tool-index.bm25.json'), JSON.stringify(bm25));
+      if (vectors) saveVectors(join(opts.cacheDir, 'tool-index.vec.json'), vectors);
       writeFileSync(
         join(opts.cacheDir, 'tool-index.meta.json'),
         JSON.stringify({ hash: hashDocs(docs), backendId: opts.embeddings?.id ?? 'none' }),
@@ -186,8 +194,10 @@ export class ToolIndex {
     );
   }
 
-  /** Strict-then-loose BM25. Returns [] when even the loose pass finds nothing. */
-  private searchBm25(query: string): Array<{ id: unknown }> {
+  /** Strict-then-loose BM25. `strictMatched` is false when no document contained
+   *  every query term — i.e. lexical matching failed and the results are the
+   *  loose pass guessing. */
+  private searchBm25(query: string): { hits: Array<{ id: unknown }>; strictMatched: boolean } {
     const common = {
       prefix: true,
       boost: FIELD_BOOST as unknown as Record<string, number>,
@@ -200,7 +210,7 @@ export class ToolIndex {
 
     // Nothing matched even loosely — the query is about something this server
     // does not do, and saying so is the useful answer.
-    if (loose.length === 0) return [];
+    if (loose.length === 0) return { hits: [], strictMatched: false };
 
     // Docs matching every term rank first, then the best partial matches.
     // Pure AND was too strict in practice: "place a mesh in the level" has three
@@ -213,7 +223,7 @@ export class ToolIndex {
     for (const r of loose) {
       if (!seen.has(r.id as string)) merged.push(r);
     }
-    return merged;
+    return { hits: merged, strictMatched: strict.length > 0 };
   }
 
   async search(query: string, opts: SearchOpts = {}): Promise<SearchHit[]> {
@@ -230,28 +240,57 @@ export class ToolIndex {
     //
     // Only if AND finds nothing do we fall back to OR, so a partially-phrased
     // query still gets help rather than silence.
-    const bm25Raw = this.searchBm25(query);
+    const { hits: bm25Raw, strictMatched } = this.searchBm25(query);
     const bm25Rank = new Map<string, number>();
     bm25Raw.forEach((r, i) => bm25Rank.set(r.id as string, i + 1));
 
-    // Embedding ranks (cosine similarity)
+    // Embedding ranks (cosine similarity).
+    //
+    // Truncated to the top candidates, and floored, before fusion. Both matter:
+    //
+    //  - Every document has a cosine score, so an untruncated ranking puts all
+    //    245 tools in the fusion. A tool that BM25 ranked 5th then also picks up
+    //    a 100th-place semantic contribution and beats the tool the embeddings
+    //    ranked FIRST. Measured: with the full list, adding embeddings changed
+    //    the benchmark by exactly nothing, because the semantic signal was
+    //    diluted to noise. Truncation is what makes it count.
+    //
+    //  - Without a floor, nonsense queries always produce a ranked list, since
+    //    something is always least-dissimilar. That silently undoes the "return
+    //    nothing rather than a confident wrong answer" property.
     const embRank = new Map<string, number>();
     if (this.embeddings && this.vectors && this.vectors.size > 0) {
       const qv = (await this.embeddings.embed([query]))[0];
       const scored: Array<[string, number]> = [];
-      for (const [name, v] of this.vectors) scored.push([name, cosine(qv, v)]);
+      for (const [name, v] of this.vectors) {
+        const sim = cosine(qv, v);
+        if (sim >= EMB_MIN_SIMILARITY) scored.push([name, sim]);
+      }
       scored.sort((a, b) => b[1] - a[1]);
-      scored.forEach(([name], i) => embRank.set(name, i + 1));
+      scored.slice(0, EMB_CANDIDATES).forEach(([name], i) => embRank.set(name, i + 1));
     }
 
-    // Reciprocal Rank Fusion (k_rrf = 60)
+    // Weighted Reciprocal Rank Fusion.
+    //
+    // When no document contained every query term, BM25 is not ranking — it is
+    // guessing from the loose pass, and its top hit is often a tool that merely
+    // reuses one common word. That is exactly the case embeddings exist for, so
+    // the weights flip: semantics lead when the lexical signal has failed, and
+    // follow when it has not.
+    //
+    // "make the surface shiny" is the worked example. No tool contains all
+    // three words, so BM25 offers whatever mentions "surface", while the
+    // embeddings put material_set_param third. Equal weights let the lexical
+    // guess win by a hair; this does not.
     const K_RRF = 60;
+    const wBm25 = strictMatched ? 1.0 : 0.15;
+    const wEmb = strictMatched ? 0.9 : 2.5;
     const fused = new Map<string, number>();
     const all = new Set<string>([...bm25Rank.keys(), ...embRank.keys()]);
     for (const id of all) {
       const a = bm25Rank.get(id);
       const b = embRank.get(id);
-      const score = (a ? 1 / (K_RRF + a) : 0) + (b ? 1 / (K_RRF + b) : 0);
+      const score = (a ? wBm25 / (K_RRF + a) : 0) + (b ? wEmb / (K_RRF + b) : 0);
       fused.set(id, score);
     }
 
@@ -273,6 +312,58 @@ export class ToolIndex {
 /** Field extraction for the index. `pack` is synthesised from `packs` so the
  *  domain name ("ui", "material", "landscape") is searchable text — it is the
  *  first word people reach for, and it was not indexed at all before. */
+/** Text handed to the embedding model.
+ *
+ *  Deliberately excludes the tool NAME. `material_set_param` is three tokens of
+ *  snake_case that a sentence model reads as near-gibberish, and on texts this
+ *  short it drags the whole vector toward other snake_case names rather than
+ *  toward meaning. BM25 already handles names, with exact matching and a 6x
+ *  boost — that is the right tool for that job. Embeddings are here for the
+ *  prose, so they get the prose. */
+function embeddingText(d: ToolDoc): string {
+  const parts = [d.summary, d.description].filter((x) => x && x.length > 0);
+  return parts.join('. ') || d.name.replace(/_/g, ' ');
+}
+
+async function embedDocs(
+  docs: ToolDoc[],
+  backend: EmbeddingBackend,
+): Promise<Map<string, Float32Array>> {
+  const vectors = new Map<string, Float32Array>();
+  const embedded = await backend.embed(docs.map(embeddingText));
+  docs.forEach((d, i) => vectors.set(d.name, embedded[i]));
+  return vectors;
+}
+
+/** Vectors are stored as plain arrays: a few hundred KB of JSON, versus ~2s of
+ *  model inference. Returns null on any mismatch or corruption so the caller
+ *  re-embeds — a stale vector silently ranks against the wrong text. */
+function loadVectors(path: string, docs: ToolDoc[]): Map<string, Float32Array> | null {
+  try {
+    if (!existsSync(path)) return null;
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, number[]>;
+    const out = new Map<string, Float32Array>();
+    for (const d of docs) {
+      const v = raw[d.name];
+      if (!Array.isArray(v)) return null;
+      out.set(d.name, new Float32Array(v));
+    }
+    return out.size === docs.length ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveVectors(path: string, vectors: Map<string, Float32Array>): void {
+  try {
+    const obj: Record<string, number[]> = {};
+    for (const [k, v] of vectors) obj[k] = Array.from(v);
+    writeFileSync(path, JSON.stringify(obj));
+  } catch {
+    // A cache we cannot write is a slower start, not a failure.
+  }
+}
+
 function extractIndexField(d: ToolDoc, field: string): string {
   if (field === 'pack') return (d.packs ?? []).join(' ');
   const v = (d as unknown as Record<string, unknown>)[field];

--- a/mcp-tools/hayba-mcp/src/tools/routing/tool-index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/tool-index.ts
@@ -34,6 +34,78 @@ export interface BuildOpts {
   cacheDir?: string;
 }
 
+
+// ── Index configuration ──────────────────────────────────────────────────────
+//
+// Tuned against src/tools/routing/search-quality.test.ts, which measures ranking
+// over the real tool catalogue with queries phrased the way an agent phrases
+// them. Change these numbers and run that benchmark; it will tell you whether
+// you helped.
+
+/** Words that carry no signal about which tool you want. Without stripping
+ *  these, "run python in the editor" is four near-useless terms plus one real
+ *  one, and requiring all terms to match becomes impossible. */
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'i', 'my', 'me', 'we', 'our', 'you', 'your', 'it', 'its', 'this', 'that',
+  'to', 'of', 'in', 'on', 'at', 'by', 'for', 'with', 'from', 'into', 'onto',
+  'and', 'or', 'but', 'if', 'then', 'than', 'so', 'as',
+  'do', 'does', 'did', 'can', 'will', 'would', 'should', 'want', 'need',
+  'how', 'what', 'why', 'when', 'where', 'which', 'who',
+  'get', 'got', 'have', 'has', 'there', 'here', 'some', 'any', 'all',
+  'please', 'just', 'now',
+]);
+
+/** Field weights. The tool NAME is the strongest signal there is — someone
+ *  typing "python" almost certainly wants python_run — and the domain is the
+ *  next strongest, because people name the subsystem before the operation
+ *  ("shader", "terrain", "menu"). Descriptions are prose and rank last: they
+ *  are long, and long fields match everything a little. */
+const FIELD_BOOST = { name: 6, pack: 3, summary: 2, description: 1, tags: 1 } as const;
+
+const INDEX_FIELDS = ['name', 'pack', 'summary', 'description', 'tags'];
+
+/** Terms shorter than this are not fuzzy-matched. Fuzzy on a 3-letter term
+ *  matches most of the catalogue and is where the worst noise came from. */
+const MIN_FUZZY_LEN = 5;
+
+function processTerm(term: string): string | null {
+  const t = term.toLowerCase();
+  if (STOPWORDS.has(t)) return null;
+  if (t.length < 2) return null;
+  return t;
+}
+
+/** Split on non-alphanumerics AND on camelCase boundaries, emitting both the
+ *  whole token and its parts.
+ *
+ *  Unreal vocabulary is overwhelmingly camelCase — StaticMesh, WidgetBlueprint,
+ *  LandscapeProxy — while people search in lowercase words. Without this,
+ *  "mesh" does not match a description that says "StaticMesh", which is exactly
+ *  why "place a mesh in the level" could not find the tool whose description
+ *  opens with "Spawn an actor from a content asset path (StaticMesh ...)".
+ *
+ *  The whole token is kept alongside the parts so an exact "staticmesh" query
+ *  still scores highest. */
+function tokenize(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of text.split(/[^a-zA-Z0-9]+/)) {
+    if (!raw) continue;
+    out.push(raw);
+    const parts = raw.split(/(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/);
+    if (parts.length > 1) out.push(...parts);
+  }
+  return out;
+}
+
+const MINISEARCH_OPTIONS = {
+  fields: INDEX_FIELDS,
+  storeFields: ['name', 'summary', 'packs'],
+  idField: 'name',
+  processTerm,
+  tokenize,
+};
+
 export class ToolIndex {
   private constructor(
     private bm25: MiniSearch<ToolDoc>,
@@ -59,9 +131,8 @@ export class ToolIndex {
       if (cached?.hash === hash && cached?.backendId === backendId && existsSync(bm25Path)) {
         try {
           const bm25Cached = MiniSearch.loadJSON<ToolDoc>(readFileSync(bm25Path, 'utf-8'), {
-            fields: ['name', 'summary', 'description', 'tags'],
-            storeFields: ['name', 'summary', 'packs'],
-            idField: 'name',
+            ...MINISEARCH_OPTIONS,
+            extractField: extractIndexField,
           });
           const docMap = new Map(docs.map(d => [d.name, d]));
           // Note: embedding vectors are NOT persisted in v1 — they're cheap to
@@ -83,13 +154,8 @@ export class ToolIndex {
     }
 
     const bm25 = new MiniSearch<ToolDoc>({
-      fields: ['name', 'summary', 'description', 'tags'],
-      storeFields: ['name', 'summary', 'packs'],
-      idField: 'name',
-      extractField: (d, f) => {
-        const v = (d as unknown as Record<string, unknown>)[f];
-        return Array.isArray(v) ? v.join(' ') : String(v ?? '');
-      },
+      ...MINISEARCH_OPTIONS,
+      extractField: extractIndexField,
     });
     bm25.addAll(docs);
 
@@ -120,11 +186,51 @@ export class ToolIndex {
     );
   }
 
+  /** Strict-then-loose BM25. Returns [] when even the loose pass finds nothing. */
+  private searchBm25(query: string): Array<{ id: unknown }> {
+    const common = {
+      prefix: true,
+      boost: FIELD_BOOST as unknown as Record<string, number>,
+      // Fuzzy only helps on words long enough for a typo to be unambiguous.
+      fuzzy: (term: string) => (term.length >= MIN_FUZZY_LEN ? 0.2 : false),
+    };
+
+    const strict = this.bm25.search(query, { ...common, combineWith: 'AND' });
+    const loose = this.bm25.search(query, { ...common, combineWith: 'OR' });
+
+    // Nothing matched even loosely — the query is about something this server
+    // does not do, and saying so is the useful answer.
+    if (loose.length === 0) return [];
+
+    // Docs matching every term rank first, then the best partial matches.
+    // Pure AND was too strict in practice: "place a mesh in the level" has three
+    // content words and the right tool (actor_spawn) contains two of them, so
+    // demanding all three handed the query to whichever tool happened to use all
+    // three words in prose. Pure OR was too loose, which is where the original
+    // noise came from. Precision first, recall behind it.
+    const seen = new Set(strict.map((r) => r.id as string));
+    const merged = [...strict];
+    for (const r of loose) {
+      if (!seen.has(r.id as string)) merged.push(r);
+    }
+    return merged;
+  }
+
   async search(query: string, opts: SearchOpts = {}): Promise<SearchHit[]> {
     const k = opts.k ?? 8;
 
-    // BM25 ranks
-    const bm25Raw = this.bm25.search(query, { prefix: true, fuzzy: 0.2 });
+    // BM25 ranks.
+    //
+    // Two passes. The first demands every meaningful query term appear in the
+    // document: that is what makes "take a screenshot of the viewport" find the
+    // capture tool instead of everything containing "of". It also returns
+    // nothing at all for a nonsense query, which is the correct answer — a
+    // confident wrong tool is worse than none, because it sends the agent down
+    // a path that cannot work.
+    //
+    // Only if AND finds nothing do we fall back to OR, so a partially-phrased
+    // query still gets help rather than silence.
+    const bm25Raw = this.searchBm25(query);
     const bm25Rank = new Map<string, number>();
     bm25Raw.forEach((r, i) => bm25Rank.set(r.id as string, i + 1));
 
@@ -149,6 +255,10 @@ export class ToolIndex {
       fused.set(id, score);
     }
 
+    // A query whose terms match nothing should return nothing, not the least-bad
+    // guess the fusion happens to surface.
+    if (bm25Rank.size === 0 && embRank.size === 0) return [];
+
     return Array.from(fused.entries())
       .sort((a, b) => b[1] - a[1])
       .map(([name, score]) => {
@@ -158,6 +268,15 @@ export class ToolIndex {
       .filter(h => !opts.filterPack || h.packs.includes(opts.filterPack))
       .slice(0, k);
   }
+}
+
+/** Field extraction for the index. `pack` is synthesised from `packs` so the
+ *  domain name ("ui", "material", "landscape") is searchable text — it is the
+ *  first word people reach for, and it was not indexed at all before. */
+function extractIndexField(d: ToolDoc, field: string): string {
+  if (field === 'pack') return (d.packs ?? []).join(' ');
+  const v = (d as unknown as Record<string, unknown>)[field];
+  return Array.isArray(v) ? v.join(' ') : String(v ?? '');
 }
 
 function hashDocs(docs: ToolDoc[]): string {

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-dispatch.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-dispatch.test.ts
@@ -355,10 +355,30 @@ describe('ui_duplicate_element deep clone (C++ invariant)', () => {
     expect(handlerSrc).toMatch(/PropName == TEXT\("Slots"\)\) continue/);
   });
 
-  it('verifies the result and errors rather than reporting a bad copy as success', () => {
-    // The path is not fully settled, so the post-condition is load-bearing:
-    // a trashed copy or a duplicated name must be a loud failure.
-    expect(handlerSrc).toContain('TRASH_');
+  it('never copies a slot Content or Parent pointer between slots', () => {
+    // Copying Content made the new slot adopt the SOURCE's child, so the tree
+    // held one widget reached through two slots — two entries with the same
+    // name AND the same object path. Layout values are the only thing worth
+    // copying between slots.
+    expect(handlerSrc).toMatch(/PropName == TEXT\("Content"\)\) continue/);
+    expect(handlerSrc).toMatch(/PropName == TEXT\("Parent"\)\) continue/);
+  });
+
+  it('keeps the structural notification, like every other tree mutation', () => {
+    // A stage trace made the recompile look guilty: the copy was fine before
+    // MarkBlueprintAsStructurallyModified and TRASH_ after. It was innocent.
+    // The copy was ORPHANED — its parent slot pointed at the source's child —
+    // so the recompile collected a widget nothing referenced. Deferring the
+    // compile was tried and reverted once the slot pointers were fixed, because
+    // it treated the symptom and diverged from every other operation here.
+    const dup = handlerSrc.slice(
+      handlerSrc.indexOf('Operation == TEXT("duplicate")'),
+      handlerSrc.indexOf('Operation == TEXT("replace")'),
+    );
+    expect(dup).toContain('MarkBlueprintAsStructurallyModified');
+  });
+
+  it('verifies its own post-condition rather than trusting the operation', () => {
     expect(handlerSrc).toMatch(/widgets now share the name/);
     expect(handlerSrc).toMatch(/did not come out clean/);
   });

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-dispatch.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-dispatch.test.ts
@@ -326,11 +326,15 @@ describe('ui_measure_text', () => {
   });
 });
 
-// The duplicate path is C++, so what is pinned here is the invariant that made
-// it wrong: a live editor produced "TRASH_CardCopy_0" and left two widgets both
-// named "Card", because DuplicateObject copies the subtree with every
-// descendant keeping its source name and UMG requires tree-wide uniqueness.
-describe('ui_duplicate_element subtree renaming (C++ invariant)', () => {
+// The duplicate path is C++, so what is pinned here is the invariant it depends
+// on. A live editor showed the original bug: duplicating "Card" renamed the
+// ORIGINAL's children out from under the blueprint, because a UPanelSlot's
+// Content is a plain pointer rather than a subobject — DuplicateObject copies
+// the pointer, so the "copy" shares the source's children.
+//
+// Two earlier fixes treated the symptom by renaming after the fact and did not
+// work. The tree is now rebuilt node by node instead.
+describe('ui_duplicate_element deep clone (C++ invariant)', () => {
   const handlerSrc = readFileSync(
     join(
       __dirname,
@@ -340,21 +344,23 @@ describe('ui_duplicate_element subtree renaming (C++ invariant)', () => {
     'utf-8',
   );
 
-  const duplicateBlock = handlerSrc.slice(
-    handlerSrc.indexOf("Operation == TEXT(\"duplicate\")"),
-    handlerSrc.indexOf('ui_mutate_tree: unknown operation'),
-  );
-
-  it('duplicates under a scratch name rather than the requested one', () => {
-    expect(duplicateBlock).toContain('HaybaMCP_DuplicateScratch');
-    // The old code passed the caller's name straight to DuplicateObject, which
-    // is what let UE trash the colliding descendants.
-    expect(duplicateBlock).toMatch(/DuplicateObject<UWidget>\(Source, WBP->WidgetTree, ScratchName\)/);
+  it('rebuilds the subtree rather than calling DuplicateObject on it', () => {
+    expect(handlerSrc).toContain('DeepCloneWidget');
+    // The clone must construct genuinely new widgets, not duplicate the source.
+    expect(handlerSrc).toMatch(/DeepCloneWidget[\s\S]{0,1500}ConstructWidget<UWidget>/);
   });
 
-  it('renames the whole copied subtree, not just its root', () => {
-    expect(duplicateBlock).toContain('CollectSubtree(Copy, Copied)');
-    expect(duplicateBlock).toContain('MakeUniqueObjectName');
+  it('never copies a panel Slots array between widgets', () => {
+    // Copying Slots is what makes two widgets claim the same children.
+    expect(handlerSrc).toMatch(/PropName == TEXT\("Slots"\)\) continue/);
+  });
+
+  it('verifies the result and errors rather than reporting a bad copy as success', () => {
+    // The path is not fully settled, so the post-condition is load-bearing:
+    // a trashed copy or a duplicated name must be a loud failure.
+    expect(handlerSrc).toContain('TRASH_');
+    expect(handlerSrc).toMatch(/widgets now share the name/);
+    expect(handlerSrc).toMatch(/did not come out clean/);
   });
 });
 

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-duplicate-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-duplicate-element.ts
@@ -7,19 +7,9 @@ export const meta: HaybaToolMeta = {
   cost: 'medium',
   effects: ['modifies_asset'],
   when: 'copying an existing widget — with its children, properties and slot layout — to build repeated rows or cards',
-  not_when:
-    'you need this to be reliable right now — see the known issue below; ui_build_tree is the dependable way to produce a repeated structure',
+  not_when: 'creating a fresh widget from a class (use ui_add_element)',
 };
 
-// KNOWN ISSUE: this path is not fully settled. Cloning no longer corrupts the
-// SOURCE widget's subtree (it used to rename the original's children out from
-// under the blueprint), but the copy itself can still come back trashed or
-// sharing a name with its source. The handler verifies the result and returns a
-// hard error when that happens rather than reporting success, so a bad outcome
-// is loud — but a call that errors is still a call that did not work.
-//
-// Prefer ui_build_tree when you need a repeated structure and cannot tolerate a
-// retry. Diagnosis so far is in docs/HANDOFF-umg-validation.md.
 export const schema = z.object({
   widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
   widget_name: z.string().min(1).describe('Name of the widget to duplicate. Its whole subtree is copied.'),

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-duplicate-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-duplicate-element.ts
@@ -7,9 +7,19 @@ export const meta: HaybaToolMeta = {
   cost: 'medium',
   effects: ['modifies_asset'],
   when: 'copying an existing widget — with its children, properties and slot layout — to build repeated rows or cards',
-  not_when: 'creating a fresh widget from a class (use ui_add_element)',
+  not_when:
+    'you need this to be reliable right now — see the known issue below; ui_build_tree is the dependable way to produce a repeated structure',
 };
 
+// KNOWN ISSUE: this path is not fully settled. Cloning no longer corrupts the
+// SOURCE widget's subtree (it used to rename the original's children out from
+// under the blueprint), but the copy itself can still come back trashed or
+// sharing a name with its source. The handler verifies the result and returns a
+// hard error when that happens rather than reporting success, so a bad outcome
+// is loud — but a call that errors is still a call that did not work.
+//
+// Prefer ui_build_tree when you need a repeated structure and cannot tolerate a
+// retry. Diagnosis so far is in docs/HANDOFF-umg-validation.md.
 export const schema = z.object({
   widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
   widget_name: z.string().min(1).describe('Name of the widget to duplicate. Its whole subtree is copied.'),

--- a/mcp-tools/hayba-mcp/src/validator/content/content-rules.test.ts
+++ b/mcp-tools/hayba-mcp/src/validator/content/content-rules.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { validateContentSnapshot, CONTENT_RULES, resolveContentThresholds } from './index.js';
+import { setConfigPath, setRuleDisabled, setStrictness } from '../config.js';
+import type { ContentSnapshot, MeshRow, TextureRow } from './types.js';
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'hayba-content-'));
+  setConfigPath(join(tmp, 'validator-config.json'));
+});
+afterEach(() => {
+  setConfigPath(null);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function texture(p: Partial<TextureRow> & { path: string }): TextureRow {
+  return {
+    format: 'PF_DXT1',
+    size_x: 512,
+    size_y: 512,
+    memory_kb: 256,
+    lod_group: 'TEXTUREGROUP_World',
+    compression: 'TC_Default',
+    ...p,
+  };
+}
+
+function mesh(p: Partial<MeshRow> & { path: string }): MeshRow {
+  return {
+    tris_lod0: 1000,
+    lod_count: 3,
+    material_slot_count: 1,
+    referencer_count: 2,
+    ...p,
+  };
+}
+
+function findingsFor(r: ReturnType<typeof validateContentSnapshot>, id: string) {
+  return r.findings.filter((f) => f.ruleId === id);
+}
+
+describe('texture rules', () => {
+  it('flags a single extreme texture as an error', () => {
+    const snap: ContentSnapshot = {
+      textures: [texture({ path: '/Game/T_Huge', memory_kb: 64 * 1024, size_x: 4096, size_y: 4096 })],
+    };
+    const found = findingsFor(validateContentSnapshot(snap, { strictness: 'standard' }), 'texture_memory_extreme');
+    expect(found).toHaveLength(1);
+    expect(found[0]!.severity).toBe('error');
+    // The number must appear in readable units, not raw KB.
+    expect(found[0]!.message).toContain('MB');
+  });
+
+  it('does not double-report an extreme texture as merely heavy', () => {
+    const snap: ContentSnapshot = { textures: [texture({ path: '/Game/T_Huge', memory_kb: 64 * 1024 })] };
+    const r = validateContentSnapshot(snap, { strictness: 'standard' });
+    expect(findingsFor(r, 'texture_memory_extreme')).toHaveLength(1);
+    expect(findingsFor(r, 'texture_memory_high')).toHaveLength(0);
+  });
+
+  it('trusts the audit flag for compression mismatch rather than re-guessing intent', () => {
+    const snap: ContentSnapshot = {
+      textures: [texture({ path: '/Game/T_Rock_Normal', format: 'PF_B8G8R8A8', outlier: true })],
+    };
+    const found = findingsFor(validateContentSnapshot(snap, { strictness: 'relaxed' }), 'texture_compression_mismatch');
+    expect(found).toHaveLength(1);
+    expect(found[0]!.hint).toMatch(/BC5/);
+  });
+
+  it('flags non-power-of-two dimensions', () => {
+    const snap: ContentSnapshot = { textures: [texture({ path: '/Game/T_Odd', size_x: 500, size_y: 512 })] };
+    expect(findingsFor(validateContentSnapshot(snap, { strictness: 'standard' }), 'texture_not_power_of_two')).toHaveLength(1);
+  });
+
+  it('accepts power-of-two dimensions', () => {
+    const snap: ContentSnapshot = { textures: [texture({ path: '/Game/T_Ok', size_x: 1024, size_y: 256 })] };
+    expect(findingsFor(validateContentSnapshot(snap, { strictness: 'standard' }), 'texture_not_power_of_two')).toHaveLength(0);
+  });
+
+  it('notices a UI texture outside the UI LOD group', () => {
+    const snap: ContentSnapshot = {
+      textures: [texture({ path: '/Game/UI/Icons/T_Sword', lod_group: 'TEXTUREGROUP_World' })],
+    };
+    expect(findingsFor(validateContentSnapshot(snap, { strictness: 'standard' }), 'texture_ui_group_mismatch')).toHaveLength(1);
+  });
+
+  it('leaves a correctly grouped UI texture alone', () => {
+    const snap: ContentSnapshot = {
+      textures: [texture({ path: '/Game/UI/Icons/T_Sword', lod_group: 'TEXTUREGROUP_UI' })],
+    };
+    expect(findingsFor(validateContentSnapshot(snap, { strictness: 'standard' }), 'texture_ui_group_mismatch')).toHaveLength(0);
+  });
+});
+
+describe('mesh rules', () => {
+  it('flags a heavy mesh with no LODs', () => {
+    const snap: ContentSnapshot = {
+      meshes: [mesh({ path: '/Game/SM_Cliff', tris_lod0: 200_000, lod_count: 1, missing_lods: true })],
+    };
+    const found = findingsFor(validateContentSnapshot(snap, { strictness: 'standard' }), 'mesh_missing_lods');
+    expect(found).toHaveLength(1);
+    expect(found[0]!.message).toContain('200,000');
+  });
+
+  it('does not demand LODs of a simple mesh', () => {
+    const snap: ContentSnapshot = {
+      meshes: [mesh({ path: '/Game/SM_Crate', tris_lod0: 500, lod_count: 1, missing_lods: true })],
+    };
+    expect(findingsFor(validateContentSnapshot(snap, { strictness: 'standard' }), 'mesh_missing_lods')).toHaveLength(0);
+  });
+
+  it('flags excessive material slots', () => {
+    const snap: ContentSnapshot = { meshes: [mesh({ path: '/Game/SM_Kit', material_slot_count: 20 })] };
+    expect(findingsFor(validateContentSnapshot(snap, { strictness: 'standard' }), 'mesh_material_slot_count')).toHaveLength(1);
+  });
+
+  it('reports an unreferenced mesh only in strict mode, and hedges about unloaded levels', () => {
+    const snap: ContentSnapshot = { meshes: [mesh({ path: '/Game/SM_Orphan', referencer_count: 0 })] };
+    expect(findingsFor(validateContentSnapshot(snap, { strictness: 'standard' }), 'mesh_unreferenced')).toHaveLength(0);
+    const strict = findingsFor(validateContentSnapshot(snap, { strictness: 'strict' }), 'mesh_unreferenced');
+    expect(strict).toHaveLength(1);
+    expect(strict[0]!.hint).toMatch(/unloaded levels/);
+  });
+});
+
+describe('coverage and skipping', () => {
+  it('skips mesh rules when no mesh audit was supplied, rather than passing them', () => {
+    const snap: ContentSnapshot = { textures: [texture({ path: '/Game/T_A' })] };
+    const r = validateContentSnapshot(snap, { strictness: 'standard' });
+    expect(r.rules_skipped_no_data).toContain('mesh_missing_lods');
+    expect(r.rules_skipped_no_data).not.toContain('texture_not_power_of_two');
+  });
+
+  it('reports truncation so a clean result is not read as a whole-project claim', () => {
+    const snap: ContentSnapshot = {
+      textures: [texture({ path: '/Game/T_A' })],
+      textures_scanned: 900,
+    };
+    const r = validateContentSnapshot(snap, { strictness: 'standard' });
+    expect(r.coverage.truncated).toBe(true);
+    expect(r.coverage.textures_reported).toBe(1);
+    expect(r.coverage.textures_scanned).toBe(900);
+  });
+
+  it('does not claim truncation when everything scanned was reported', () => {
+    const snap: ContentSnapshot = { textures: [texture({ path: '/Game/T_A' })], textures_scanned: 1, meshes: [], meshes_scanned: 0 };
+    expect(validateContentSnapshot(snap, { strictness: 'standard' }).coverage.truncated).toBe(false);
+  });
+});
+
+describe('strictness and configuration', () => {
+  it('tightens budgets as strictness rises', () => {
+    expect(resolveContentThresholds('strict').textureMemoryWarnKb)
+      .toBeLessThan(resolveContentThresholds('standard').textureMemoryWarnKb);
+    expect(resolveContentThresholds('standard').meshTriWarn)
+      .toBeLessThan(resolveContentThresholds('relaxed').meshTriWarn);
+  });
+
+  it('raising strictness only ever adds findings', () => {
+    const snap: ContentSnapshot = {
+      textures: [texture({ path: '/Game/T_Mid', memory_kb: 6 * 1024, size_x: 500, size_y: 512 })],
+      meshes: [mesh({ path: '/Game/SM_Mid', tris_lod0: 60_000, referencer_count: 0 })],
+    };
+    const relaxed = validateContentSnapshot(snap, { strictness: 'relaxed' }).findings.map((f) => f.ruleId);
+    const standard = validateContentSnapshot(snap, { strictness: 'standard' }).findings.map((f) => f.ruleId);
+    const strict = validateContentSnapshot(snap, { strictness: 'strict' }).findings.map((f) => f.ruleId);
+    for (const id of relaxed) expect(standard).toContain(id);
+    for (const id of standard) expect(strict).toContain(id);
+  });
+
+  it('honours the persisted asset-category strictness', () => {
+    setStrictness('strict', 'asset');
+    const snap: ContentSnapshot = { meshes: [mesh({ path: '/Game/SM_Orphan', referencer_count: 0 })] };
+    const r = validateContentSnapshot(snap);
+    expect(r.strictness).toBe('strict');
+    expect(findingsFor(r, 'mesh_unreferenced')).toHaveLength(1);
+  });
+
+  it('reports a disabled rule as disabled rather than passing', () => {
+    setRuleDisabled('texture_not_power_of_two', true);
+    const snap: ContentSnapshot = { textures: [texture({ path: '/Game/T_Odd', size_x: 500, size_y: 500 })] };
+    const r = validateContentSnapshot(snap, { strictness: 'standard' });
+    expect(findingsFor(r, 'texture_not_power_of_two')).toHaveLength(0);
+    expect(r.rules_disabled).toContain('texture_not_power_of_two');
+  });
+});
+
+describe('catalogue integrity', () => {
+  it('has unique ids and a declared data need', () => {
+    const ids = CONTENT_RULES.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const r of CONTENT_RULES) expect(['textures', 'meshes']).toContain(r.needs);
+  });
+
+  it('no rule throws on an empty snapshot', () => {
+    const r = validateContentSnapshot({ textures: [], meshes: [] }, { strictness: 'strict' });
+    expect(r.findings.filter((f) => f.hint.includes('threw'))).toHaveLength(0);
+  });
+
+  it('every hint explains the consequence, not just the measurement', () => {
+    // A finding that says only "this is big" is not actionable.
+    for (const r of CONTENT_RULES) {
+      const snap: ContentSnapshot = {
+        textures: [texture({ path: '/Game/UI/T_X', memory_kb: 999 * 1024, size_x: 500, size_y: 500, outlier: true, lod_group: 'World' })],
+        meshes: [mesh({ path: '/Game/SM_X', tris_lod0: 999_999, lod_count: 1, missing_lods: true, material_slot_count: 99, referencer_count: 0 })],
+      };
+      for (const f of validateContentSnapshot(snap, { strictness: 'strict', ruleIds: [r.id] }).findings) {
+        expect(f.hint.length, `${r.id} hint is too thin to act on`).toBeGreaterThan(60);
+      }
+    }
+  });
+});

--- a/mcp-tools/hayba-mcp/src/validator/content/index.ts
+++ b/mcp-tools/hayba-mcp/src/validator/content/index.ts
@@ -1,0 +1,111 @@
+// Content validation entry point. Mirrors the UI validator's contract: rules
+// whose data is absent are reported as SKIPPED, never as passing.
+
+import { getStrictness, isRuleDisabled, meetsStrictness, type Strictness } from '../config.js';
+import { CONTENT_RULES, contentRulesById, resolveContentThresholds } from './rules.js';
+import type {
+  ContentFinding,
+  ContentRuleContext,
+  ContentSeverity,
+  ContentSnapshot,
+  ContentValidationResult,
+} from './types.js';
+
+export * from './types.js';
+export { CONTENT_RULES, contentRulesById, resolveContentThresholds } from './rules.js';
+
+const SEVERITY_ORDER: Record<ContentSeverity, number> = { error: 0, warning: 1, info: 2 };
+
+export interface ContentValidationOptions {
+  strictness?: Strictness;
+  ruleIds?: string[];
+}
+
+export function validateContentSnapshot(
+  snapshot: ContentSnapshot,
+  options: ContentValidationOptions = {},
+): ContentValidationResult {
+  const strictness = options.strictness ?? getStrictness('asset');
+  const ctx: ContentRuleContext = {
+    snapshot,
+    strictness,
+    thresholds: resolveContentThresholds(strictness),
+  };
+
+  const byId = contentRulesById();
+  const selected = options.ruleIds
+    ? options.ruleIds.map((id) => byId.get(id)).filter((r): r is NonNullable<typeof r> => r !== undefined)
+    : CONTENT_RULES;
+
+  const findings: ContentFinding[] = [];
+  const skipped: string[] = [];
+  const disabled: string[] = [];
+  const belowStrictness: string[] = [];
+  let evaluated = 0;
+
+  const hasTextures = Array.isArray(snapshot.textures);
+  const hasMeshes = Array.isArray(snapshot.meshes);
+
+  for (const rule of selected) {
+    if (isRuleDisabled(rule.id)) {
+      disabled.push(rule.id);
+      continue;
+    }
+    if (!meetsStrictness(rule.minStrictness, strictness)) {
+      belowStrictness.push(rule.id);
+      continue;
+    }
+    // The audit was not run for this asset type, so the rule checked nothing.
+    // Saying so is the difference between "clean" and "not looked at".
+    if ((rule.needs === 'textures' && !hasTextures) || (rule.needs === 'meshes' && !hasMeshes)) {
+      skipped.push(rule.id);
+      continue;
+    }
+
+    evaluated++;
+    try {
+      findings.push(...rule.evaluate(ctx));
+    } catch (e) {
+      findings.push({
+        ruleId: rule.id,
+        category: rule.category,
+        severity: 'info',
+        message: `Rule "${rule.id}" threw while evaluating and was skipped.`,
+        hint: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  findings.sort((a, b) => {
+    const bySeverity = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    return bySeverity !== 0 ? bySeverity : a.ruleId.localeCompare(b.ruleId);
+  });
+
+  const counts: Record<ContentSeverity, number> = { error: 0, warning: 0, info: 0 };
+  for (const f of findings) counts[f.severity]++;
+
+  const texturesReported = snapshot.textures?.length ?? 0;
+  const meshesReported = snapshot.meshes?.length ?? 0;
+  // The audits return only the heaviest N rows. An asset outside that window was
+  // never judged, so a clean result must not be read as "the project is clean".
+  const truncated =
+    (snapshot.textures_scanned !== undefined && snapshot.textures_scanned > texturesReported) ||
+    (snapshot.meshes_scanned !== undefined && snapshot.meshes_scanned > meshesReported);
+
+  return {
+    strictness,
+    findings,
+    rules_evaluated: evaluated,
+    rules_skipped_no_data: skipped,
+    rules_disabled: disabled,
+    rules_below_strictness: belowStrictness,
+    counts,
+    coverage: {
+      textures_reported: texturesReported,
+      textures_scanned: snapshot.textures_scanned,
+      meshes_reported: meshesReported,
+      meshes_scanned: snapshot.meshes_scanned,
+      truncated,
+    },
+  };
+}

--- a/mcp-tools/hayba-mcp/src/validator/content/rules.ts
+++ b/mcp-tools/hayba-mcp/src/validator/content/rules.ts
@@ -1,0 +1,296 @@
+// Content rules: textures and static meshes.
+//
+// Every threshold is stated with its reason. "Too big" is not actionable; "4096
+// square uncompressed is 64 MB, and it is a UI icon" is.
+
+import type { ContentFinding, ContentRule, ContentRuleContext, MeshRow, TextureRow } from './types.js';
+import type { Strictness } from '../config.js';
+import type { ContentThresholds } from './types.js';
+
+const TUNING: Record<Strictness, ContentThresholds> = {
+  relaxed: {
+    textureMemoryWarnKb: 32 * 1024,   // 32 MB — only the genuinely extreme
+    textureMemoryErrorKb: 96 * 1024,
+    largeTextureDim: 2048,
+    meshTriWarn: 250_000,
+    materialSlotWarn: 12,
+  },
+  standard: {
+    // 8 MB is roughly a 2048² BC-compressed texture with mips. Above that you
+    // are usually looking at an uncompressed or oversized source.
+    textureMemoryWarnKb: 8 * 1024,
+    textureMemoryErrorKb: 48 * 1024,
+    largeTextureDim: 1024,
+    meshTriWarn: 100_000,
+    materialSlotWarn: 8,
+  },
+  strict: {
+    textureMemoryWarnKb: 4 * 1024,
+    textureMemoryErrorKb: 24 * 1024,
+    largeTextureDim: 512,
+    meshTriWarn: 50_000,
+    materialSlotWarn: 4,
+  },
+};
+
+export function resolveContentThresholds(s: Strictness): ContentThresholds {
+  return TUNING[s];
+}
+
+const mb = (kb: number) => `${(kb / 1024).toFixed(1)} MB`;
+const isPow2 = (n: number) => n > 0 && (n & (n - 1)) === 0;
+
+function textures(ctx: ContentRuleContext): TextureRow[] {
+  return ctx.snapshot.textures ?? [];
+}
+function meshes(ctx: ContentRuleContext): MeshRow[] {
+  return ctx.snapshot.meshes ?? [];
+}
+
+function finding(
+  rule: Pick<ContentRule, 'id' | 'category' | 'severity'>,
+  message: string,
+  hint: string,
+  asset?: string,
+  data?: Record<string, unknown>,
+): ContentFinding {
+  return { ruleId: rule.id, category: rule.category, severity: rule.severity, asset, message, hint, data };
+}
+
+export const CONTENT_RULES: ContentRule[] = [
+  // ══ Textures ══════════════════════════════════════════════════════════════
+  {
+    id: 'texture_memory_extreme',
+    category: 'asset',
+    severity: 'error',
+    minStrictness: 'relaxed',
+    title: 'A single texture is using an extreme amount of memory',
+    needs: 'textures',
+    evaluate: (ctx) => {
+      const out: ContentFinding[] = [];
+      for (const t of textures(ctx)) {
+        if (t.memory_kb < ctx.thresholds.textureMemoryErrorKb) continue;
+        out.push(
+          finding(
+            { id: 'texture_memory_extreme', category: 'asset', severity: 'error' },
+            `${t.path} is ${mb(t.memory_kb)} on its own (${t.size_x}x${t.size_y}, ${t.format}).`,
+            `One texture at this size is usually an uncompressed import or a source-resolution asset that was never downsized. Set a Maximum Texture Size on the asset, or give it a compression setting appropriate to its role. Current compression: ${t.compression}.`,
+            t.path,
+            { memory_kb: t.memory_kb, size_x: t.size_x, size_y: t.size_y, format: t.format, compression: t.compression },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'texture_memory_high',
+    category: 'asset',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Texture is heavy for its role',
+    needs: 'textures',
+    evaluate: (ctx) => {
+      const out: ContentFinding[] = [];
+      for (const t of textures(ctx)) {
+        // The error rule owns anything above its threshold.
+        if (t.memory_kb >= ctx.thresholds.textureMemoryErrorKb) continue;
+        if (t.memory_kb < ctx.thresholds.textureMemoryWarnKb) continue;
+        out.push(
+          finding(
+            { id: 'texture_memory_high', category: 'asset', severity: 'warning' },
+            `${t.path} uses ${mb(t.memory_kb)} (${t.size_x}x${t.size_y}).`,
+            `Above ${mb(ctx.thresholds.textureMemoryWarnKb)} is worth justifying. If this is UI or a small prop, halving the dimensions quarters the memory.`,
+            t.path,
+            { memory_kb: t.memory_kb, size_x: t.size_x, size_y: t.size_y },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'texture_compression_mismatch',
+    category: 'asset',
+    severity: 'warning',
+    minStrictness: 'relaxed',
+    title: 'Compression does not match what the texture appears to be',
+    needs: 'textures',
+    evaluate: (ctx) => {
+      const out: ContentFinding[] = [];
+      for (const t of textures(ctx)) {
+        // The audit flags this itself by comparing the asset name against the
+        // pixel format, so the judgement about intent already happened engine-side.
+        if (!t.outlier) continue;
+        out.push(
+          finding(
+            { id: 'texture_compression_mismatch', category: 'asset', severity: 'warning' },
+            `${t.path} is named like a colour or normal map but is stored as ${t.format}.`,
+            `A normal map wants BC5 and a colour map BC1/BC7. The wrong setting either wastes memory or visibly degrades the result — banded normals are the usual symptom. Current compression setting: ${t.compression}.`,
+            t.path,
+            { format: t.format, compression: t.compression },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'texture_not_power_of_two',
+    category: 'asset',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Texture dimensions are not powers of two',
+    needs: 'textures',
+    evaluate: (ctx) => {
+      const out: ContentFinding[] = [];
+      for (const t of textures(ctx)) {
+        if (isPow2(t.size_x) && isPow2(t.size_y)) continue;
+        out.push(
+          finding(
+            { id: 'texture_not_power_of_two', category: 'asset', severity: 'warning' },
+            `${t.path} is ${t.size_x}x${t.size_y}, which is not a power of two.`,
+            'Non-power-of-two textures cannot generate a full mip chain and are excluded from streaming, so they stay fully resident and alias at distance. Resize to the nearest power of two unless this is deliberately a UI atlas that is never minified.',
+            t.path,
+            { size_x: t.size_x, size_y: t.size_y },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'texture_ui_group_mismatch',
+    category: 'asset',
+    severity: 'info',
+    minStrictness: 'standard',
+    title: 'Texture looks like UI but is not in the UI LOD group',
+    needs: 'textures',
+    evaluate: (ctx) => {
+      const out: ContentFinding[] = [];
+      for (const t of textures(ctx)) {
+        const looksUi = /(^|\/)(ui|hud|icon|menu)/i.test(t.path);
+        if (!looksUi) continue;
+        if (/ui/i.test(t.lod_group)) continue;
+        out.push(
+          finding(
+            { id: 'texture_ui_group_mismatch', category: 'asset', severity: 'info' },
+            `${t.path} sits in a UI path but its LOD group is ${t.lod_group}.`,
+            'The UI texture group disables streaming and mip bias, which is what you want for something drawn at a fixed size — otherwise UI can render blurry for a frame after load.',
+            t.path,
+            { lod_group: t.lod_group },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+
+  // ══ Meshes ════════════════════════════════════════════════════════════════
+  {
+    id: 'mesh_missing_lods',
+    category: 'asset',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Heavy mesh has no LODs',
+    needs: 'meshes',
+    evaluate: (ctx) => {
+      const out: ContentFinding[] = [];
+      for (const m of meshes(ctx)) {
+        const noLods = m.missing_lods === true || m.lod_count <= 1;
+        if (!noLods) continue;
+        // A simple mesh does not need LODs; the cost only matters with triangles.
+        if (m.tris_lod0 < ctx.thresholds.meshTriWarn) continue;
+        out.push(
+          finding(
+            { id: 'mesh_missing_lods', category: 'asset', severity: 'warning' },
+            `${m.path} has ${m.tris_lod0.toLocaleString()} triangles and only ${m.lod_count} LOD.`,
+            'Every instance renders at full density at any distance. Generate LODs (or enable Nanite if the mesh qualifies) — this is the single biggest lever on triangle cost for scattered meshes.',
+            m.path,
+            { tris_lod0: m.tris_lod0, lod_count: m.lod_count, referencer_count: m.referencer_count },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'mesh_triangle_heavy',
+    category: 'asset',
+    severity: 'info',
+    minStrictness: 'strict',
+    title: 'Mesh is triangle-heavy even with LODs',
+    needs: 'meshes',
+    evaluate: (ctx) => {
+      const out: ContentFinding[] = [];
+      for (const m of meshes(ctx)) {
+        if (m.tris_lod0 < ctx.thresholds.meshTriWarn) continue;
+        if (m.lod_count <= 1) continue; // the missing-LOD rule owns that case
+        out.push(
+          finding(
+            { id: 'mesh_triangle_heavy', category: 'asset', severity: 'info' },
+            `${m.path} is ${m.tris_lod0.toLocaleString()} triangles at LOD0.`,
+            'It has LODs, so this is a note rather than a problem. Worth checking the LOD0 screen size is small enough that the full density is rarely drawn.',
+            m.path,
+            { tris_lod0: m.tris_lod0, lod_count: m.lod_count },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'mesh_material_slot_count',
+    category: 'asset',
+    severity: 'warning',
+    minStrictness: 'standard',
+    title: 'Mesh has many material slots',
+    needs: 'meshes',
+    evaluate: (ctx) => {
+      const out: ContentFinding[] = [];
+      for (const m of meshes(ctx)) {
+        if (m.material_slot_count <= ctx.thresholds.materialSlotWarn) continue;
+        out.push(
+          finding(
+            { id: 'mesh_material_slot_count', category: 'asset', severity: 'warning' },
+            `${m.path} has ${m.material_slot_count} material slots.`,
+            'Each slot is a separate draw call per instance. For a mesh that gets scattered, merging materials into an atlas is usually a larger win than reducing triangles.',
+            m.path,
+            { material_slot_count: m.material_slot_count, referencer_count: m.referencer_count },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+  {
+    id: 'mesh_unreferenced',
+    category: 'asset',
+    severity: 'info',
+    minStrictness: 'strict',
+    title: 'Mesh is not referenced by anything',
+    needs: 'meshes',
+    evaluate: (ctx) => {
+      const out: ContentFinding[] = [];
+      for (const m of meshes(ctx)) {
+        if (m.referencer_count !== 0) continue;
+        out.push(
+          finding(
+            { id: 'mesh_unreferenced', category: 'asset', severity: 'info' },
+            `${m.path} has no referencers.`,
+            'Nothing in the project points at it. That is fine for an asset you are about to use, and dead weight otherwise — confirm with asset_get_referencers before deleting, since references from unloaded levels can be missed.',
+            m.path,
+            { referencer_count: 0 },
+          ),
+        );
+      }
+      return out;
+    },
+  },
+];
+
+export function contentRulesById(): Map<string, ContentRule> {
+  const m = new Map<string, ContentRule>();
+  for (const r of CONTENT_RULES) m.set(r.id, r);
+  return m;
+}

--- a/mcp-tools/hayba-mcp/src/validator/content/types.ts
+++ b/mcp-tools/hayba-mcp/src/validator/content/types.ts
@@ -1,0 +1,101 @@
+// Types for content validation — textures and meshes.
+//
+// Same split as the UI validator: the engine measures, this judges. The input is
+// whatever texture_audit / mesh_audit return, so these rules are pure functions
+// over data that already exists and are unit-testable without an editor.
+
+import type { RuleCategory, Strictness } from '../config.js';
+
+export interface TextureRow {
+  path: string;
+  format: string;
+  size_x: number;
+  size_y: number;
+  memory_kb: number;
+  lod_group: string;
+  compression: string;
+  /** Set by the audit when the name implies a role its compression contradicts. */
+  outlier?: boolean;
+}
+
+export interface MeshRow {
+  path: string;
+  tris_lod0: number;
+  lod_count: number;
+  missing_lods?: boolean;
+  material_slot_count: number;
+  referencer_count: number;
+}
+
+export interface ContentSnapshot {
+  textures?: TextureRow[];
+  meshes?: MeshRow[];
+  /** How many assets the audit looked at, vs how many rows came back. The
+   *  audits return only the heaviest N, so rules must not read an absent row as
+   *  a clean bill of health. */
+  textures_scanned?: number;
+  meshes_scanned?: number;
+}
+
+export type ContentSeverity = 'error' | 'warning' | 'info';
+
+export interface ContentFinding {
+  ruleId: string;
+  category: RuleCategory;
+  severity: ContentSeverity;
+  /** Asset the finding is about. */
+  asset?: string;
+  message: string;
+  hint: string;
+  data?: Record<string, unknown>;
+}
+
+export interface ContentThresholds {
+  /** Texture memory above this is worth a look, in KB. */
+  textureMemoryWarnKb: number;
+  /** Any single texture above this is almost never deliberate. */
+  textureMemoryErrorKb: number;
+  /** Dimension above which a texture is "large" for mip purposes. */
+  largeTextureDim: number;
+  /** Triangle count above which a mesh wants LODs. */
+  meshTriWarn: number;
+  /** Material slots beyond this cost a draw call each. */
+  materialSlotWarn: number;
+}
+
+export interface ContentRuleContext {
+  snapshot: ContentSnapshot;
+  strictness: Strictness;
+  thresholds: ContentThresholds;
+}
+
+export interface ContentRule {
+  id: string;
+  category: RuleCategory;
+  severity: ContentSeverity;
+  minStrictness: Strictness;
+  title: string;
+  /** Which part of the snapshot this rule needs. Rules whose data is absent are
+   *  reported as skipped rather than silently passing. */
+  needs: 'textures' | 'meshes';
+  evaluate: (ctx: ContentRuleContext) => ContentFinding[];
+}
+
+export interface ContentValidationResult {
+  strictness: Strictness;
+  findings: ContentFinding[];
+  rules_evaluated: number;
+  rules_skipped_no_data: string[];
+  rules_disabled: string[];
+  rules_below_strictness: string[];
+  counts: Record<ContentSeverity, number>;
+  /** Restated from the snapshot so a caller can see the audit was truncated and
+   *  that "no findings" covers only the rows it was given. */
+  coverage: {
+    textures_reported: number;
+    textures_scanned?: number;
+    meshes_reported: number;
+    meshes_scanned?: number;
+    truncated: boolean;
+  };
+}

--- a/mcp-tools/hayba-mcp/tests/first-install-surface.test.ts
+++ b/mcp-tools/hayba-mcp/tests/first-install-surface.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  registerDeferredRouting,
+  type CapturedTool,
+  ALWAYS_ON_META,
+  CORE_META,
+} from '../src/tools/routing/register.js';
+import { recordSchema } from '../src/tools/schema-registry.js';
+import { registerToolMeta } from '../src/tools/tool-meta-registry.js';
+import { __resetSettingsCache } from '../src/tools/routing/settings-watcher.js';
+import { __resetConnectedLatch } from '../src/tools/check-ue-status.js';
+
+// The first-install surface is a product decision, not an implementation
+// detail, so it gets asserted rather than left to drift.
+//
+// Two failure modes are guarded here, and they pull in opposite directions:
+//
+//   1. Too many tools registered up front. Every always-on tool costs context on
+//      every request forever, and a large default set defeats discovery — there
+//      is no reason to search a catalog when 50 tools are already in front of
+//      you, so the rest never get found. This is what the surface cap catches.
+//
+//   2. A tool that is neither registered NOR reachable. Shrinking the default
+//      set is only safe because search + invoke reach everything else. If a tool
+//      falls out of the captured map it becomes genuinely unreachable, which is
+//      strictly worse than being noisy. This is what the reachability tests
+//      catch, and it is the bug that hid 11 subsystem tools from the index.
+
+/** Upper bound on what a fresh install may register. Raising this is a product
+ *  decision: justify it in the PR, do not nudge it to make a test pass. */
+const MAX_FIRST_INSTALL_TOOLS = 8;
+
+function fixtureCaptured(): Map<string, CapturedTool> {
+  const captured = new Map<string, CapturedTool>();
+  const tools: Array<[string, string | null]> = [
+    // Core / meta.
+    ['list_tool_categories', 'code-mode'],
+    ['get_tool_signature', 'code-mode'],
+    ['hayba_check_ue_status', null],
+    // Domain tools that must NOT be registered up front.
+    ['actor_spawn', 'actor'],
+    ['actor_list', 'actor'],
+    ['ui_validate', 'ui'],
+    ['ui_build_tree', 'ui'],
+    ['plumb_validate', 'plumb'],
+    ['plumb_constraint_define', 'plumb'],
+    ['validator_run', 'validator'],
+    ['world_generate', null],
+  ];
+  for (const [name, dir] of tools) {
+    const schema: z.ZodRawShape = { foo: z.string().optional() };
+    recordSchema(name, { shape: schema, cost: 'low', returns: 'any' });
+    registerToolMeta(name, { cost: 'low', effects: [], when: name, not_when: '' });
+    captured.set(name, {
+      schema,
+      handler: (async () => ({ content: [{ type: 'text', text: `ok:${name}` }] })) as never,
+      dir,
+    });
+  }
+  return captured;
+}
+
+function registeredNamesOf(server: McpServer): string[] {
+  const registered = (server as unknown as { _registeredTools: Record<string, unknown> })._registeredTools;
+  return Object.keys(registered);
+}
+
+async function bootFreshInstall(dir: string): Promise<{ server: McpServer; captured: Map<string, CapturedTool> }> {
+  // A fresh install has no settings file at all — not an empty one. Reading the
+  // defaults is part of what is being tested.
+  __resetSettingsCache();
+  const server = new McpServer({ name: 'test', version: '0' });
+  const captured = fixtureCaptured();
+  await registerDeferredRouting(server, captured, dir);
+  return { server, captured };
+}
+
+describe('first-install tool surface', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'hayba-surface-'));
+    process.env.HAYBA_SETTINGS_PATH = join(dir, 'settings.json');
+    process.env.HAYBA_TOOL_INDEX_DIR = dir;
+    __resetSettingsCache();
+    __resetConnectedLatch();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.HAYBA_SETTINGS_PATH;
+    delete process.env.HAYBA_TOOL_INDEX_DIR;
+  });
+
+  it('registers no more than the cap on a fresh install', async () => {
+    const { server } = await bootFreshInstall(dir);
+    const names = registeredNamesOf(server);
+    expect(
+      names.length,
+      `fresh install registered ${names.length} tools: ${names.sort().join(', ')}`,
+    ).toBeLessThanOrEqual(MAX_FIRST_INSTALL_TOOLS);
+  });
+
+  it('registers exactly the core bootstrap set', async () => {
+    const { server } = await bootFreshInstall(dir);
+    expect(registeredNamesOf(server).sort()).toEqual([...CORE_META].sort());
+  });
+
+  it('keeps ALWAYS_ON_META and CORE_META in agreement', () => {
+    // ALWAYS_ON_META is the name other call sites use; it must not quietly
+    // grow past the curated core.
+    expect([...ALWAYS_ON_META].sort()).toEqual([...CORE_META].sort());
+  });
+
+  it('does not register domain tools up front', async () => {
+    const { server } = await bootFreshInstall(dir);
+    const names = new Set(registeredNamesOf(server));
+    for (const hidden of ['actor_spawn', 'ui_validate', 'plumb_validate', 'validator_run', 'world_generate']) {
+      expect(names.has(hidden), `${hidden} should not be registered on a fresh install`).toBe(false);
+    }
+  });
+
+  it('leaves every unregistered tool reachable through the captured map', async () => {
+    // This is the invariant that makes a small surface safe: hayba_invoke
+    // resolves from `captured`, so a tool being absent from the server is a
+    // context saving, not a capability loss.
+    const { server, captured } = await bootFreshInstall(dir);
+    const registered = new Set(registeredNamesOf(server));
+
+    for (const name of ['actor_spawn', 'ui_validate', 'plumb_validate', 'validator_run', 'world_generate']) {
+      expect(registered.has(name)).toBe(false);
+      expect(captured.has(name), `${name} must stay in the captured map to remain invokable`).toBe(true);
+    }
+  });
+
+  it('makes a hidden tool callable through hayba_invoke without loading its pack', async () => {
+    const { server } = await bootFreshInstall(dir);
+    const registered = (server as unknown as {
+      _registeredTools: Record<string, { implementation?: (a: unknown) => Promise<unknown>; handler?: (a: unknown) => Promise<unknown> }>;
+    })._registeredTools;
+
+    expect(Object.keys(registered)).not.toContain('ui_validate');
+
+    const invoke = registered['hayba_invoke']!;
+    const handler = invoke.implementation ?? invoke.handler;
+    const res = await handler!({ name: 'ui_validate', args: {} });
+    const text = (res as { content: Array<{ text: string }> }).content[0]!.text;
+
+    expect(text).toContain('ok:ui_validate');
+  });
+
+  it('loads a domain pack on demand', async () => {
+    const { server } = await bootFreshInstall(dir);
+    const registered = (server as unknown as {
+      _registeredTools: Record<string, { implementation?: (a: unknown) => Promise<unknown>; handler?: (a: unknown) => Promise<unknown> }>;
+    })._registeredTools;
+
+    expect(Object.keys(registered)).not.toContain('actor_spawn');
+
+    const load = registered['hayba_pack_load']!;
+    const handler = load.implementation ?? load.handler;
+    await handler!({ name: 'actor' });
+
+    expect(Object.keys(registered)).toContain('actor_spawn');
+  });
+
+  it('still honours alwaysLoadPacks for users who opt in', async () => {
+    writeFileSync(
+      process.env.HAYBA_SETTINGS_PATH!,
+      JSON.stringify({ toolRouting: 'deferred', alwaysLoadPacks: ['ui'] }),
+    );
+    __resetSettingsCache();
+    const server = new McpServer({ name: 'test', version: '0' });
+    await registerDeferredRouting(server, fixtureCaptured(), dir);
+
+    const names = registeredNamesOf(server);
+    expect(names).toContain('ui_validate');
+    expect(names).toContain('ui_build_tree');
+    // Opting into one pack must not drag in others.
+    expect(names).not.toContain('actor_spawn');
+  });
+});

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPDataAssetHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPDataAssetHandler.cpp
@@ -6,6 +6,7 @@
 #include "AssetToolsModule.h"
 #include "IAssetTools.h"
 #include "AssetRegistry/AssetRegistryModule.h"
+#include "HaybaMCPAssetGuard.h"
 #include "AssetRegistry/IAssetRegistry.h"
 #include "EditorAssetLibrary.h"
 #include "UObject/UnrealType.h"
@@ -140,6 +141,15 @@ FHaybaHandlerResult FHaybaMCPDataAssetHandler::Handle(const FString& Cmd, const 
         FAssetToolsModule& AssetToolsModule =
             FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
         IAssetTools& AssetTools = AssetToolsModule.Get();
+
+        // Refuse a taken name instead of letting CreateAsset raise a modal
+        // overwrite dialog, which would block the game thread and hang every
+        // queued MCP request. See HaybaMCPAssetGuard.h.
+        if (HaybaAssetGuard::AssetNameTaken(PackagePath, AssetName))
+        {
+            return FHaybaHandlerResult::Err(
+                HaybaAssetGuard::NameTakenError(TEXT("data_create"), PackagePath, AssetName));
+        }
 
         UObject* NewAsset = AssetTools.CreateAsset(AssetName, PackagePath, Class, nullptr);
         if (!NewAsset)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPInputHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPInputHandler.cpp
@@ -1,6 +1,7 @@
 #include "HaybaMCPInputHandler.h"
 #include "Json.h"
 #include "AssetToolsModule.h"
+#include "HaybaMCPAssetGuard.h"
 #include "IAssetTools.h"
 #include "InputAction.h"
 #include "InputMappingContext.h"
@@ -93,6 +94,15 @@ FHaybaHandlerResult FHaybaMCPInputHandler::Handle(const FString& Cmd, const TSha
             return FHaybaHandlerResult::Err(FString::Printf(TEXT("input_create_action: unknown value_type '%s' (expected Boolean|Axis1D|Axis2D|Axis3D)"), *ValueTypeStr));
 
         IAssetTools& Tools = FModuleManager::LoadModuleChecked<FAssetToolsModule>(TEXT("AssetTools")).Get();
+        // Refuse a taken name instead of letting CreateAsset raise a modal
+        // overwrite dialog, which would block the game thread and hang every
+        // queued MCP request. See HaybaMCPAssetGuard.h.
+        if (HaybaAssetGuard::AssetNameTaken(PkgPath, Name))
+        {
+            return FHaybaHandlerResult::Err(
+                HaybaAssetGuard::NameTakenError(TEXT("input_create_action"), PkgPath, Name));
+        }
+
         UObject* Created = Tools.CreateAsset(Name, PkgPath, UInputAction::StaticClass(), nullptr);
         if (!Created) return FHaybaHandlerResult::Err(TEXT("input_create_action: CreateAsset failed"));
 
@@ -118,6 +128,15 @@ FHaybaHandlerResult FHaybaMCPInputHandler::Handle(const FString& Cmd, const TSha
             return FHaybaHandlerResult::Err(TEXT("input_create_mapping: missing name"));
 
         IAssetTools& Tools = FModuleManager::LoadModuleChecked<FAssetToolsModule>(TEXT("AssetTools")).Get();
+        // Refuse a taken name instead of letting CreateAsset raise a modal
+        // overwrite dialog, which would block the game thread and hang every
+        // queued MCP request. See HaybaMCPAssetGuard.h.
+        if (HaybaAssetGuard::AssetNameTaken(PkgPath, Name))
+        {
+            return FHaybaHandlerResult::Err(
+                HaybaAssetGuard::NameTakenError(TEXT("input_create_mapping"), PkgPath, Name));
+        }
+
         UObject* Created = Tools.CreateAsset(Name, PkgPath, UInputMappingContext::StaticClass(), nullptr);
         if (!Created) return FHaybaHandlerResult::Err(TEXT("input_create_mapping: CreateAsset failed"));
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPLegacyHandler.cpp
@@ -630,6 +630,10 @@ FHaybaHandlerResult FHaybaMCPLegacyHandler::Cmd_CreateGraph(const TSharedPtr<FJs
     // Add nodes
     const TArray<TSharedPtr<FJsonValue>>& NodesArray = (*GraphObj)->GetArrayField(TEXT("nodes"));
     TMap<FString, UPCGNode*> CreatedNodes;
+    // Per-property outcomes for the response. A graph that builds but drops the
+    // properties that make it do anything is the failure mode worth surfacing.
+    TArray<FString> PropertyProblems;
+    int32 PropertiesApplied = 0;
     TArray<FString> NodeOrder;                 // creation order, for stable layout
     TSet<FString> ExplicitlyPositioned;        // ids the caller positioned itself
     TArray<TPair<FString, FString>> LayoutEdges; // (fromId, toId) for the layout pass
@@ -685,17 +689,64 @@ FHaybaHandlerResult FHaybaMCPLegacyHandler::Cmd_CreateGraph(const TSharedPtr<FJs
             const TSharedPtr<FJsonObject>& PropsObj = NodeObj->GetObjectField(TEXT("properties"));
             if (PropsObj.IsValid() && Settings)
             {
+                // Every rejection here is reported, not swallowed.
+                //
+                // A property that does not land on a PCG node does not fail
+                // loudly — the graph builds, the response says created:true, and
+                // the graph then scatters zero instances at execute time. That is
+                // the single most expensive failure in this domain to debug,
+                // because nothing on the way in says anything went wrong.
+                //
+                // There are four distinct ways to be silently dropped and the
+                // caller needs to know which one it hit: the name is wrong, the
+                // property is not editable, the value is not a string (numbers
+                // and bools do NOT arrive as strings from JSON), or the string
+                // does not parse for the property type.
                 for (const auto& Pair : PropsObj->Values)
                 {
-                    FProperty* Prop = SettingsClass->FindPropertyByName(FName(*Pair.Key));
-                    if (Prop && Prop->HasAnyPropertyFlags(CPF_Edit))
+                    const FString PropName(Pair.Key);
+                    const FString NodeLabel = FString::Printf(TEXT("node \"%s\" (%s).%s"), *NodeId, *NodeClass, *PropName);
+
+                    FProperty* Prop = SettingsClass->FindPropertyByName(FName(*PropName));
+                    if (!Prop)
                     {
-                        FString ValueStr;
-                        if (Pair.Value->TryGetString(ValueStr))
+                        PropertyProblems.Add(FString::Printf(
+                            TEXT("%s: no such property on %s"), *NodeLabel, *SettingsClass->GetName()));
+                        continue;
+                    }
+                    if (!Prop->HasAnyPropertyFlags(CPF_Edit))
+                    {
+                        PropertyProblems.Add(FString::Printf(
+                            TEXT("%s: property is not editable (no CPF_Edit), so it cannot be set this way"), *NodeLabel));
+                        continue;
+                    }
+
+                    FString ValueStr;
+                    if (!Pair.Value->TryGetString(ValueStr))
+                    {
+                        // Numbers and bools are the common case here, and they
+                        // arrive as JSON numbers/bools rather than strings.
+                        // ImportText works from text, so coerce rather than drop.
+                        switch (Pair.Value->Type)
                         {
-                            Prop->ImportText_Direct(*ValueStr, Prop->ContainerPtrToValuePtr<void>(Settings), Settings, PPF_None);
+                        case EJson::Number:  ValueStr = FString::SanitizeFloat(Pair.Value->AsNumber()); break;
+                        case EJson::Boolean: ValueStr = Pair.Value->AsBool() ? TEXT("true") : TEXT("false"); break;
+                        default:
+                            PropertyProblems.Add(FString::Printf(
+                                TEXT("%s: value must be a string, number or bool"), *NodeLabel));
+                            continue;
                         }
                     }
+
+                    const TCHAR* End = Prop->ImportText_Direct(
+                        *ValueStr, Prop->ContainerPtrToValuePtr<void>(Settings), Settings, PPF_None);
+                    if (End == nullptr)
+                    {
+                        PropertyProblems.Add(FString::Printf(
+                            TEXT("%s: could not parse \"%s\" as %s"), *NodeLabel, *ValueStr, *Prop->GetCPPType()));
+                        continue;
+                    }
+                    ++PropertiesApplied;
                 }
 
                 // --- Special-case: bind meshes to a Static Mesh Spawner ---------------
@@ -873,12 +924,32 @@ FHaybaHandlerResult FHaybaMCPLegacyHandler::Cmd_CreateGraph(const TSharedPtr<FJs
     FString FilePath = FPackageName::LongPackageNameToFilename(FullPath, FPackageName::GetAssetPackageExtension());
     FSavePackageArgs SaveArgs;
     SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
-    UPackage::SavePackage(Package, NewGraph, *FilePath, SaveArgs);
+    const bool bSaved = UPackage::SavePackage(Package, NewGraph, *FilePath, SaveArgs);
 
     TSharedPtr<FJsonObject> Data = MakeShareable(new FJsonObject());
     Data->SetBoolField(TEXT("created"), true);
     Data->SetStringField(TEXT("assetPath"), FullPath);
     Data->SetNumberField(TEXT("nodeCount"), CreatedNodes.Num());
+
+    // The save result was previously discarded, so a graph that failed to reach
+    // disk still reported created:true and then vanished on editor restart.
+    Data->SetBoolField(TEXT("saved"), bSaved);
+
+    Data->SetNumberField(TEXT("propertiesApplied"), PropertiesApplied);
+    if (PropertyProblems.Num() > 0)
+    {
+        TArray<TSharedPtr<FJsonValue>> Arr;
+        for (const FString& P : PropertyProblems) Arr.Add(MakeShared<FJsonValueString>(P));
+        Data->SetArrayField(TEXT("propertyProblems"), Arr);
+        // Said plainly, because "created: true" alongside a list of problems is
+        // easy to skim past — and the consequence (a graph that scatters
+        // nothing) shows up much later and looks unrelated.
+        Data->SetStringField(TEXT("warning"), FString::Printf(
+            TEXT("The graph was created, but %d node propert%s could not be applied. "
+                 "A PCG node missing its settings usually produces zero instances at execute time. "
+                 "See propertyProblems."),
+            PropertyProblems.Num(), PropertyProblems.Num() == 1 ? TEXT("y") : TEXT("ies")));
+    }
     return FHaybaHandlerResult::Ok(Data);
 }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPMaterialHandler.cpp
@@ -11,6 +11,7 @@
 #include "AssetToolsModule.h"
 #include "IAssetTools.h"
 #include "AssetRegistry/AssetRegistryModule.h"
+#include "HaybaMCPAssetGuard.h"
 #include "AssetRegistry/IAssetRegistry.h"
 #include "Components/StaticMeshComponent.h"
 #include "GameFramework/Actor.h"
@@ -411,6 +412,15 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCreate(const TSharedPtr<FJsonOb
     const FString Dir = (FPackageName::GetShortName(PkgPath) == Name)
         ? FPackageName::GetLongPackagePath(PkgPath)
         : PkgPath;
+    // Refuse a taken name instead of letting CreateAsset raise a modal
+    // overwrite dialog, which would block the game thread and hang every
+    // queued MCP request. See HaybaMCPAssetGuard.h.
+    if (HaybaAssetGuard::AssetNameTaken(Dir, Name))
+    {
+        return FHaybaHandlerResult::Err(
+            HaybaAssetGuard::NameTakenError(TEXT("material_create"), Dir, Name));
+    }
+
     UObject* Created = Tools.CreateAsset(Name, Dir, UMaterial::StaticClass(), Factory);
     if (!Created) return FHaybaHandlerResult::Err(TEXT("material_create: CreateAsset failed"));
 
@@ -449,6 +459,15 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatFunctionCreate(const TSharedPtr
     const FString Dir = (ShortName == Name)
         ? FPackageName::GetLongPackagePath(PkgPath)  // full path: strip the trailing name
         : PkgPath;                                   // directory: use verbatim
+    // Refuse a taken name instead of letting CreateAsset raise a modal
+    // overwrite dialog, which would block the game thread and hang every
+    // queued MCP request. See HaybaMCPAssetGuard.h.
+    if (HaybaAssetGuard::AssetNameTaken(Dir, Name))
+    {
+        return FHaybaHandlerResult::Err(
+            HaybaAssetGuard::NameTakenError(TEXT("material_function_create"), Dir, Name));
+    }
+
     UObject* Created = Tools.CreateAsset(Name, Dir, UMaterialFunction::StaticClass(), Factory);
     if (!Created) return FHaybaHandlerResult::Err(TEXT("material_function_create: CreateAsset failed"));
 
@@ -816,6 +835,15 @@ FHaybaHandlerResult FHaybaMCPMaterialHandler::MatCreateInstance(const TSharedPtr
     const FString Dir = (FPackageName::GetShortName(PkgPath) == Name)
         ? FPackageName::GetLongPackagePath(PkgPath)
         : PkgPath;
+    // Refuse a taken name instead of letting CreateAsset raise a modal
+    // overwrite dialog, which would block the game thread and hang every
+    // queued MCP request. See HaybaMCPAssetGuard.h.
+    if (HaybaAssetGuard::AssetNameTaken(Dir, Name))
+    {
+        return FHaybaHandlerResult::Err(
+            HaybaAssetGuard::NameTakenError(TEXT("material_create_instance"), Dir, Name));
+    }
+
     UObject* Created = Tools.CreateAsset(Name, Dir, UMaterialInstanceConstant::StaticClass(), Factory);
     if (!Created) return FHaybaHandlerResult::Err(TEXT("material_create_instance: CreateAsset failed"));
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.cpp
@@ -16,6 +16,9 @@
 #include "UObject/Object.h"
 #include "Containers/Ticker.h"
 #include "Framework/Application/SlateApplication.h"
+#include "Widgets/SWindow.h"
+#include "Widgets/SWidget.h"
+#include "Layout/Children.h"
 #include "HAL/PlatformProcess.h"
 #include "HAL/PlatformTime.h"
 #include "InputCoreTypes.h"
@@ -38,6 +41,11 @@ TArray<FString> FHaybaMCPPIEHandler::GetCommands() const
         TEXT("editor_pie_wait_for"),
         TEXT("editor_pie_press_key"),
         TEXT("editor_pie_screenshot"),
+        TEXT("editor_pie_mouse"),
+        TEXT("editor_pie_type_text"),
+        TEXT("editor_pie_axis"),
+        TEXT("editor_pie_widget_tree"),
+        TEXT("editor_pie_click_widget"),
     };
 }
 
@@ -62,6 +70,11 @@ FHaybaHandlerResult FHaybaMCPPIEHandler::Handle(const FString& Cmd, const TShare
     if (Cmd == TEXT("editor_pie_assert"))     return PIEAssert(Params);
     if (Cmd == TEXT("editor_pie_wait_for"))   return PIEWaitFor(Params);
     if (Cmd == TEXT("editor_pie_press_key"))  return PIEPressKey(Params);
+    if (Cmd == TEXT("editor_pie_mouse"))         return PIEMouse(P);
+    if (Cmd == TEXT("editor_pie_type_text"))     return PIETypeText(P);
+    if (Cmd == TEXT("editor_pie_axis"))          return PIEAxis(P);
+    if (Cmd == TEXT("editor_pie_widget_tree"))   return PIEWidgetTree(P);
+    if (Cmd == TEXT("editor_pie_click_widget"))  return PIEClickWidget(P);
     if (Cmd == TEXT("editor_pie_screenshot")) return PIEScreenshot(Params);
     return FHaybaHandlerResult::Err(FString::Printf(TEXT("Unknown PIE command: %s"), *Cmd));
 #endif
@@ -329,13 +342,20 @@ FHaybaHandlerResult FHaybaMCPPIEHandler_WaitLoop(
     P->TryGetNumberField(TEXT("tolerance"), Tolerance);
 
     const double StartTime = FPlatformTime::Seconds();
-    const double Deadline  = StartTime + (double)TimeoutMs / 1000.0;
 
     int32 Frame = 0;
     TSharedPtr<FJsonValue> LastObserved;
     FString LastErr;
 
-    while (FPlatformTime::Seconds() < Deadline)
+    // Evaluated ONCE. This used to loop until a deadline, pumping the core
+    // ticker between iterations to let the world advance — which is what made
+    // these commands crash. See the note on the pump removal below.
+    //
+    // A handler cannot advance the world, so it cannot meaningfully wait: the
+    // property it is watching can never change while it blocks. The honest
+    // shape is therefore a single observation the caller polls, and the
+    // response carries `polling: true` so that is obvious from the result
+    // rather than only from the docs.
     {
         if (Self.bCancelPending)
         {
@@ -381,16 +401,16 @@ FHaybaHandlerResult FHaybaMCPPIEHandler_WaitLoop(
             LastErr = ResolveErr;
         }
 
-        // Pump ticker + sleep.
-        FTSTicker::GetCoreTicker().Tick(0.005f);
-        FPlatformProcess::Sleep(0.005f);
         ++Frame;
     }
 
     TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
     R->SetBoolField(TEXT("matched"), false);
-    R->SetNumberField(TEXT("frames"), Frame);
-    R->SetStringField(TEXT("reason"), LastErr.IsEmpty() ? TEXT("timeout") : LastErr);
+    R->SetBoolField(TEXT("polling"), true);
+    R->SetNumberField(TEXT("elapsed_ms"), (FPlatformTime::Seconds() - StartTime) * 1000.0);
+    R->SetStringField(TEXT("reason"), LastErr.IsEmpty()
+        ? TEXT("condition not met at this instant — call again to poll; the world only advances between calls")
+        : LastErr);
     if (LastObserved.IsValid()) R->SetField(TEXT("observed_value_last"), LastObserved);
     return FHaybaHandlerResult::Ok(R);
 }
@@ -439,40 +459,67 @@ FHaybaHandlerResult FHaybaMCPPIEHandler::PIEPressKey(const TSharedPtr<FJsonObjec
         return FHaybaHandlerResult::Err(FString::Printf(TEXT("invalid key: %s"), *KeyName));
 
     const FInputDeviceId DeviceId = IPlatformInputDeviceMapper::Get().GetDefaultInputDevice();
-    auto Send = [&](EInputEvent Evt)
+
+    // Resolve the viewport at the moment of use, never from a captured pointer.
+    // The old code captured FViewport* and UGameViewportClient*, pumped the core
+    // ticker (which can tear PIE down), then dereferenced them — a use-after-free
+    // that surfaced as an SEH access violation.
+    auto SendNow = [DeviceId, Key](EInputEvent Evt) -> bool
     {
-        FInputKeyEventArgs Args(VP, DeviceId, Key, Evt,
+        UWorld* W = GetPIEWorld();
+        if (!W) return false;
+        UGameViewportClient* Client = W->GetGameViewport();
+        if (!Client || !Client->Viewport) return false;
+
+        FInputKeyEventArgs Args(Client->Viewport, DeviceId, Key, Evt,
                                 /*AmountDepressed=*/1.0f,
                                 /*bIsTouch=*/false,
                                 /*EventTimestamp=*/0u);
-        GVC->InputKey(Args);
+        Client->InputKey(Args);
+        return true;
     };
+
+    bool bReleaseScheduled = false;
 
     if (EventStr == TEXT("pressed"))
     {
-        Send(IE_Pressed);
+        if (!SendNow(IE_Pressed)) return FHaybaHandlerResult::Err(TEXT("PIE viewport went away before the key was sent"));
     }
     else if (EventStr == TEXT("released"))
     {
-        Send(IE_Released);
+        if (!SendNow(IE_Released)) return FHaybaHandlerResult::Err(TEXT("PIE viewport went away before the key was sent"));
     }
     else // pressed_and_released
     {
-        Send(IE_Pressed);
-        // Pump ticker briefly so the world sees the keydown.
-        const double End = FPlatformTime::Seconds() + (double)HeldMs / 1000.0;
-        while (FPlatformTime::Seconds() < End)
-        {
-            FTSTicker::GetCoreTicker().Tick(0.005f);
-            FPlatformProcess::Sleep(0.005f);
-        }
-        Send(IE_Released);
+        if (!SendNow(IE_Pressed)) return FHaybaHandlerResult::Err(TEXT("PIE viewport went away before the key was sent"));
+
+        // The release is DEFERRED onto a real ticker delegate rather than held
+        // by spinning here. A handler runs on the game thread, so spinning
+        // prevents the very frames the hold is supposed to span — the key would
+        // be down for wall-clock time during which the game never ticks.
+        const float DelaySeconds = FMath::Clamp((float)HeldMs, 0.0f, 5000.0f) / 1000.0f;
+        FTSTicker::GetCoreTicker().AddTicker(
+            FTickerDelegate::CreateLambda([SendNow](float) -> bool
+            {
+                // Re-resolves the viewport internally and no-ops if PIE ended.
+                SendNow(IE_Released);
+                return false;  // one shot
+            }),
+            DelaySeconds);
+        bReleaseScheduled = true;
     }
 
     TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
     R->SetStringField(TEXT("key"), KeyName);
     R->SetStringField(TEXT("event"), EventStr);
     R->SetBoolField(TEXT("dispatched"), true);
+    R->SetBoolField(TEXT("release_scheduled"), bReleaseScheduled);
+    if (bReleaseScheduled)
+    {
+        R->SetNumberField(TEXT("release_after_ms"), HeldMs);
+        R->SetStringField(TEXT("note"), TEXT("The release fires on a later tick. This call returns immediately, ")
+                                        TEXT("so the key is still down when you read this."));
+    }
     return FHaybaHandlerResult::Ok(R);
 }
 
@@ -491,27 +538,424 @@ FHaybaHandlerResult FHaybaMCPPIEHandler::PIEScreenshot(const TSharedPtr<FJsonObj
                                    *FDateTime::Now().ToString(TEXT("%Y%m%d_%H%M%S")));
     }
 
-    // TODO(ue5.7): wire FScreenshotRequest::OnScreenshotCaptured() to capture
-    // the FColor buffer directly (currently waits on file write).
-    FScreenshotRequest::RequestScreenshot(Filename, /*bShowUI=*/false, /*bAddFilenameSuffix=*/false);
+    // `check_only` reports whether a previously requested file has landed, so a
+    // caller can poll without issuing another capture.
+    bool bCheckOnly = false;
+    if (P.IsValid()) P->TryGetBoolField(TEXT("check_only"), bCheckOnly);
 
-    // Pump ticker until the file appears or 3s elapses.
-    const double Deadline = FPlatformTime::Seconds() + 3.0;
-    while (FPlatformTime::Seconds() < Deadline)
+    if (bCheckOnly)
     {
-        FTSTicker::GetCoreTicker().Tick(0.005f);
-        FPlatformProcess::Sleep(0.01f);
-        if (FPaths::FileExists(Filename)) break;
+        TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+        R->SetStringField(TEXT("filename"), Filename);
+        R->SetBoolField(TEXT("captured"), FPaths::FileExists(Filename));
+        R->SetBoolField(TEXT("requested"), false);
+        return FHaybaHandlerResult::Ok(R);
     }
 
+    FScreenshotRequest::RequestScreenshot(Filename, /*bShowUI=*/false, /*bAddFilenameSuffix=*/false);
+
+    // Returns immediately. The old code pumped the core ticker for up to three
+    // seconds waiting for the file — from inside a game-thread handler, which
+    // both froze the editor and re-entered systems that can tear PIE down while
+    // this command still held pointers into it.
+    //
+    // The screenshot is written by the engine a frame or two later. Poll for it
+    // with check_only rather than blocking the thread that has to render it.
     TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
     R->SetStringField(TEXT("filename"), Filename);
+    R->SetBoolField(TEXT("requested"), true);
     R->SetBoolField(TEXT("captured"), FPaths::FileExists(Filename));
+    R->SetStringField(TEXT("note"), TEXT("Capture requested. The engine writes the file on a later frame — ")
+                                    TEXT("call again with check_only:true (and the same filename) to see when it lands."));
     return FHaybaHandlerResult::Ok(R);
 }
 
+
+// ---------------------------------------------------------------------------
+// Interaction
+// ---------------------------------------------------------------------------
+//
+// Everything here obeys one rule the old code broke: a handler runs on the game
+// thread and must never pump the ticker or sleep. Input is dispatched and the
+// call returns; the world advances between calls, not during them.
+
+namespace
+{
+    /** Live PIE viewport client, or null when PIE is not running. Always
+     *  resolved at point of use — never cached across anything that can tick. */
+    UGameViewportClient* PIEViewportClient()
+    {
+        UWorld* W = GetPIEWorld();
+        if (!W) return nullptr;
+        UGameViewportClient* C = W->GetGameViewport();
+        return (C && C->Viewport) ? C : nullptr;
+    }
+
+    FKey MouseButtonFromString(const FString& InName)
+    {
+        const FString N = InName.ToLower();
+        if (N == TEXT("right"))  return EKeys::RightMouseButton;
+        if (N == TEXT("middle")) return EKeys::MiddleMouseButton;
+        return EKeys::LeftMouseButton;
+    }
+
+    /** Move the OS/Slate cursor to a viewport-relative pixel and report where. */
+    bool MoveCursorToViewportPixel(UGameViewportClient* Client, const FVector2D& Px, FVector2D& OutAbsolute)
+    {
+        if (!Client || !Client->Viewport) return false;
+        if (!FSlateApplication::IsInitialized()) return false;
+
+        // Viewport pixels are relative to the game window; Slate wants absolute
+        // desktop coordinates, so offset by the window position.
+        FVector2D Origin = FVector2D::ZeroVector;
+        if (TSharedPtr<SWindow> Win = Client->GetWindow())
+        {
+            Origin = Win->GetPositionInScreen();
+        }
+        OutAbsolute = Origin + Px;
+        FSlateApplication::Get().SetCursorPos(OutAbsolute);
+        return true;
+    }
+
+    void SendMouseButton(UGameViewportClient* Client, const FKey& Button, EInputEvent Evt)
+    {
+        if (!Client || !Client->Viewport) return;
+        const FInputDeviceId DeviceId = IPlatformInputDeviceMapper::Get().GetDefaultInputDevice();
+        FInputKeyEventArgs Args(Client->Viewport, DeviceId, Button, Evt,
+                                /*AmountDepressed=*/1.0f, /*bIsTouch=*/false, /*EventTimestamp=*/0u);
+        Client->InputKey(Args);
+    }
+
+    /** Depth-first walk of the live Slate tree under a window. */
+    void CollectSlateWidgets(const TSharedRef<SWidget>& W, int32 Depth,
+                             TArray<TSharedPtr<FJsonValue>>& Out, int32 MaxDepth)
+    {
+        if (Depth > MaxDepth) return;
+
+        const FGeometry& G = W->GetTickSpaceGeometry();
+        const FVector2D Pos  = FVector2D(G.GetAbsolutePosition());
+        const FVector2D Size = FVector2D(G.GetLocalSize()) * G.Scale;
+
+        // Zero-size widgets are layout scaffolding, not things to click.
+        if (Size.X > 0.5 && Size.Y > 0.5)
+        {
+            TSharedPtr<FJsonObject> E = MakeShared<FJsonObject>();
+            E->SetStringField(TEXT("type"), W->GetTypeAsString());
+            E->SetStringField(TEXT("tag"), W->GetTag().ToString());
+            E->SetNumberField(TEXT("x"), Pos.X);
+            E->SetNumberField(TEXT("y"), Pos.Y);
+            E->SetNumberField(TEXT("width"), Size.X);
+            E->SetNumberField(TEXT("height"), Size.Y);
+            E->SetNumberField(TEXT("center_x"), Pos.X + Size.X * 0.5);
+            E->SetNumberField(TEXT("center_y"), Pos.Y + Size.Y * 0.5);
+            E->SetNumberField(TEXT("depth"), Depth);
+            E->SetBoolField(TEXT("enabled"), W->IsEnabled());
+            E->SetBoolField(TEXT("interactive"), W->IsInteractable());
+            const FText Tip = W->GetAccessibleText();
+            if (!Tip.IsEmpty()) E->SetStringField(TEXT("text"), Tip.ToString());
+            Out.Add(MakeShared<FJsonValueObject>(E));
+        }
+
+        FChildren* Children = W->GetChildren();
+        if (!Children) return;
+        for (int32 i = 0; i < Children->Num(); ++i)
+        {
+            CollectSlateWidgets(Children->GetChildAt(i), Depth + 1, Out, MaxDepth);
+        }
+    }
+}
+
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIEMouse(const TSharedPtr<FJsonObject>& P)
+{
+    UGameViewportClient* Client = PIEViewportClient();
+    if (!Client) return FHaybaHandlerResult::Err(TEXT("no PIE viewport (start PIE first)"));
+    if (!P.IsValid()) return FHaybaHandlerResult::Err(TEXT("editor_pie_mouse: missing params"));
+
+    FString Action = TEXT("click");
+    P->TryGetStringField(TEXT("action"), Action);
+    Action = Action.ToLower();
+
+    double X = 0.0, Y = 0.0;
+    const bool bHasX = P->TryGetNumberField(TEXT("x"), X);
+    const bool bHasY = P->TryGetNumberField(TEXT("y"), Y);
+
+    FString ButtonName = TEXT("left");
+    P->TryGetStringField(TEXT("button"), ButtonName);
+    const FKey Button = MouseButtonFromString(ButtonName);
+
+    TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+    R->SetStringField(TEXT("action"), Action);
+
+    if (Action == TEXT("move") || Action == TEXT("click") || Action == TEXT("double_click") ||
+        Action == TEXT("press") || Action == TEXT("release") || Action == TEXT("drag"))
+    {
+        if (!bHasX || !bHasY)
+            return FHaybaHandlerResult::Err(TEXT("editor_pie_mouse: x and y are required for this action"));
+
+        FVector2D Abs;
+        if (!MoveCursorToViewportPixel(Client, FVector2D(X, Y), Abs))
+            return FHaybaHandlerResult::Err(TEXT("editor_pie_mouse: could not position the cursor"));
+        R->SetNumberField(TEXT("x"), X);
+        R->SetNumberField(TEXT("y"), Y);
+    }
+
+    if (Action == TEXT("move"))
+    {
+        // Position only.
+    }
+    else if (Action == TEXT("press"))
+    {
+        SendMouseButton(Client, Button, IE_Pressed);
+    }
+    else if (Action == TEXT("release"))
+    {
+        SendMouseButton(Client, Button, IE_Released);
+    }
+    else if (Action == TEXT("click"))
+    {
+        SendMouseButton(Client, Button, IE_Pressed);
+        SendMouseButton(Client, Button, IE_Released);
+    }
+    else if (Action == TEXT("double_click"))
+    {
+        SendMouseButton(Client, Button, IE_Pressed);
+        SendMouseButton(Client, Button, IE_Released);
+        SendMouseButton(Client, Button, IE_DoubleClick);
+        SendMouseButton(Client, Button, IE_Released);
+    }
+    else if (Action == TEXT("drag"))
+    {
+        double ToX = 0.0, ToY = 0.0;
+        if (!P->TryGetNumberField(TEXT("to_x"), ToX) || !P->TryGetNumberField(TEXT("to_y"), ToY))
+            return FHaybaHandlerResult::Err(TEXT("editor_pie_mouse drag: to_x and to_y are required"));
+
+        SendMouseButton(Client, Button, IE_Pressed);
+
+        // Intermediate positions matter: a drag that jumps straight to the
+        // destination is often ignored by widgets that track deltas.
+        const int32 Steps = 8;
+        FVector2D Abs;
+        for (int32 i = 1; i <= Steps; ++i)
+        {
+            const double T = (double)i / (double)Steps;
+            MoveCursorToViewportPixel(Client, FVector2D(FMath::Lerp(X, ToX, T), FMath::Lerp(Y, ToY, T)), Abs);
+        }
+        SendMouseButton(Client, Button, IE_Released);
+        R->SetNumberField(TEXT("to_x"), ToX);
+        R->SetNumberField(TEXT("to_y"), ToY);
+    }
+    else if (Action == TEXT("scroll"))
+    {
+        double Delta = 1.0;
+        P->TryGetNumberField(TEXT("delta"), Delta);
+        const FInputDeviceId DeviceId = IPlatformInputDeviceMapper::Get().GetDefaultInputDevice();
+        FInputKeyEventArgs Args(Client->Viewport, DeviceId, EKeys::MouseWheelAxis, IE_Axis,
+                                (float)Delta, /*bIsTouch=*/false, /*EventTimestamp=*/0u);
+        Client->InputKey(Args);
+        R->SetNumberField(TEXT("delta"), Delta);
+    }
+    else
+    {
+        return FHaybaHandlerResult::Err(FString::Printf(
+            TEXT("editor_pie_mouse: unknown action '%s' (move, click, double_click, press, release, drag, scroll)"),
+            *Action));
+    }
+
+    R->SetStringField(TEXT("button"), ButtonName);
+    R->SetBoolField(TEXT("dispatched"), true);
+    return FHaybaHandlerResult::Ok(R);
+}
+
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIETypeText(const TSharedPtr<FJsonObject>& P)
+{
+    UGameViewportClient* Client = PIEViewportClient();
+    if (!Client) return FHaybaHandlerResult::Err(TEXT("no PIE viewport (start PIE first)"));
+
+    FString Text;
+    if (!P.IsValid() || !P->TryGetStringField(TEXT("text"), Text))
+        return FHaybaHandlerResult::Err(TEXT("editor_pie_type_text: text is required"));
+
+    // Character events, not key events: a text field wants the character that
+    // was produced, which is not recoverable from a keycode alone once shift,
+    // layout and IME are involved.
+    const FInputDeviceId DeviceId = IPlatformInputDeviceMapper::Get().GetDefaultInputDevice();
+    int32 Sent = 0;
+    for (const TCHAR C : Text)
+    {
+        Client->InputChar(Client->Viewport, DeviceId.GetId(), C);
+        ++Sent;
+    }
+
+    TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+    R->SetStringField(TEXT("text"), Text);
+    R->SetNumberField(TEXT("characters_sent"), Sent);
+    R->SetStringField(TEXT("note"), TEXT("Characters go to whatever currently has keyboard focus. ")
+                                    TEXT("Click the field first if focus is not already there."));
+    return FHaybaHandlerResult::Ok(R);
+}
+
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIEAxis(const TSharedPtr<FJsonObject>& P)
+{
+    UGameViewportClient* Client = PIEViewportClient();
+    if (!Client) return FHaybaHandlerResult::Err(TEXT("no PIE viewport (start PIE first)"));
+
+    FString KeyName;
+    if (!P.IsValid() || !P->TryGetStringField(TEXT("key"), KeyName) || KeyName.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("editor_pie_axis: key is required (e.g. Gamepad_LeftX, MouseX)"));
+
+    const FKey Key(*KeyName);
+    if (!Key.IsValid())
+        return FHaybaHandlerResult::Err(FString::Printf(TEXT("editor_pie_axis: invalid key '%s'"), *KeyName));
+    if (!Key.IsAxis1D() && !Key.IsAxis2D() && !Key.IsAxis3D())
+        return FHaybaHandlerResult::Err(FString::Printf(
+            TEXT("editor_pie_axis: '%s' is not an axis key — use editor_pie_press_key for buttons"), *KeyName));
+
+    double Value = 0.0;
+    P->TryGetNumberField(TEXT("value"), Value);
+
+    const FInputDeviceId DeviceId = IPlatformInputDeviceMapper::Get().GetDefaultInputDevice();
+    FInputKeyEventArgs Args(Client->Viewport, DeviceId, Key, IE_Axis,
+                            (float)Value, /*bIsTouch=*/false, /*EventTimestamp=*/0u);
+    Client->InputKey(Args);
+
+    TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+    R->SetStringField(TEXT("key"), KeyName);
+    R->SetNumberField(TEXT("value"), Value);
+    R->SetStringField(TEXT("note"), TEXT("Axis input applies for the frame it is delivered. For sustained "
+                                         "movement, send it again each step rather than expecting it to latch."));
+    return FHaybaHandlerResult::Ok(R);
+}
+
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIEWidgetTree(const TSharedPtr<FJsonObject>& P)
+{
+    UGameViewportClient* Client = PIEViewportClient();
+    if (!Client) return FHaybaHandlerResult::Err(TEXT("no PIE viewport (start PIE first)"));
+    if (!FSlateApplication::IsInitialized())
+        return FHaybaHandlerResult::Err(TEXT("Slate is not initialized"));
+
+    TSharedPtr<SWindow> Win = Client->GetWindow();
+    if (!Win.IsValid()) return FHaybaHandlerResult::Err(TEXT("PIE window not found"));
+
+    int32 MaxDepth = 40;
+    if (P.IsValid()) P->TryGetNumberField(TEXT("max_depth"), MaxDepth);
+    MaxDepth = FMath::Clamp(MaxDepth, 1, 200);
+
+    FString Filter;
+    if (P.IsValid()) P->TryGetStringField(TEXT("filter"), Filter);
+
+    TArray<TSharedPtr<FJsonValue>> All;
+    CollectSlateWidgets(Win.ToSharedRef(), 0, All, MaxDepth);
+
+    TArray<TSharedPtr<FJsonValue>> Kept;
+    for (const TSharedPtr<FJsonValue>& V : All)
+    {
+        if (Filter.IsEmpty()) { Kept.Add(V); continue; }
+        const TSharedPtr<FJsonObject> O = V->AsObject();
+        if (!O.IsValid()) continue;
+        FString Type, Text, Tag;
+        O->TryGetStringField(TEXT("type"), Type);
+        O->TryGetStringField(TEXT("text"), Text);
+        O->TryGetStringField(TEXT("tag"), Tag);
+        if (Type.Contains(Filter) || Text.Contains(Filter) || Tag.Contains(Filter)) Kept.Add(V);
+    }
+
+    TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+    R->SetArrayField(TEXT("widgets"), Kept);
+    R->SetNumberField(TEXT("count"), Kept.Num());
+    R->SetNumberField(TEXT("total_before_filter"), All.Num());
+    if (!Filter.IsEmpty()) R->SetStringField(TEXT("filter"), Filter);
+    R->SetStringField(TEXT("note"), TEXT("Coordinates are absolute desktop pixels and are what "
+                                         "editor_pie_mouse expects. center_x/center_y is the click point."));
+    return FHaybaHandlerResult::Ok(R);
+}
+
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIEClickWidget(const TSharedPtr<FJsonObject>& P)
+{
+    UGameViewportClient* Client = PIEViewportClient();
+    if (!Client) return FHaybaHandlerResult::Err(TEXT("no PIE viewport (start PIE first)"));
+    if (!FSlateApplication::IsInitialized())
+        return FHaybaHandlerResult::Err(TEXT("Slate is not initialized"));
+
+    FString Match;
+    if (!P.IsValid() || !P->TryGetStringField(TEXT("match"), Match) || Match.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("editor_pie_click_widget: match is required (widget text, tag or type)"));
+
+    TSharedPtr<SWindow> Win = Client->GetWindow();
+    if (!Win.IsValid()) return FHaybaHandlerResult::Err(TEXT("PIE window not found"));
+
+    TArray<TSharedPtr<FJsonValue>> All;
+    CollectSlateWidgets(Win.ToSharedRef(), 0, All, 60);
+
+    // Prefer an interactive widget: matching a label is usually a request to
+    // press the button containing it, not to click the text itself.
+    TSharedPtr<FJsonObject> Best;
+    TArray<FString> Candidates;
+    for (const TSharedPtr<FJsonValue>& V : All)
+    {
+        const TSharedPtr<FJsonObject> O = V->AsObject();
+        if (!O.IsValid()) continue;
+        FString Type, Text, Tag;
+        O->TryGetStringField(TEXT("type"), Type);
+        O->TryGetStringField(TEXT("text"), Text);
+        O->TryGetStringField(TEXT("tag"), Tag);
+        if (!(Type.Contains(Match) || Text.Contains(Match) || Tag.Contains(Match))) continue;
+
+        Candidates.Add(FString::Printf(TEXT("%s%s"), *Type, Text.IsEmpty() ? TEXT("") : *FString::Printf(TEXT(" \"%s\""), *Text)));
+        bool bInteractive = false;
+        O->TryGetBoolField(TEXT("interactive"), bInteractive);
+        if (!Best.IsValid() || bInteractive)
+        {
+            bool bBestInteractive = false;
+            if (Best.IsValid()) Best->TryGetBoolField(TEXT("interactive"), bBestInteractive);
+            if (!Best.IsValid() || (bInteractive && !bBestInteractive)) Best = O;
+        }
+    }
+
+    if (!Best.IsValid())
+    {
+        return FHaybaHandlerResult::Err(FString::Printf(
+            TEXT("editor_pie_click_widget: nothing on screen matches '%s'. ")
+            TEXT("Call editor_pie_widget_tree to see what is actually there."), *Match));
+    }
+
+    double CX = 0.0, CY = 0.0;
+    Best->TryGetNumberField(TEXT("center_x"), CX);
+    Best->TryGetNumberField(TEXT("center_y"), CY);
+
+    // center_x/center_y are already absolute desktop coordinates.
+    FSlateApplication::Get().SetCursorPos(FVector2D(CX, CY));
+    SendMouseButton(Client, EKeys::LeftMouseButton, IE_Pressed);
+    SendMouseButton(Client, EKeys::LeftMouseButton, IE_Released);
+
+    FString Type, Text;
+    Best->TryGetStringField(TEXT("type"), Type);
+    Best->TryGetStringField(TEXT("text"), Text);
+
+    TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
+    R->SetStringField(TEXT("match"), Match);
+    R->SetStringField(TEXT("clicked_type"), Type);
+    if (!Text.IsEmpty()) R->SetStringField(TEXT("clicked_text"), Text);
+    R->SetNumberField(TEXT("x"), CX);
+    R->SetNumberField(TEXT("y"), CY);
+    R->SetNumberField(TEXT("candidates"), Candidates.Num());
+    if (Candidates.Num() > 1)
+    {
+        // Say when the choice was ambiguous rather than silently picking one.
+        R->SetStringField(TEXT("note"), FString::Printf(
+            TEXT("%d widgets matched; clicked the interactive one. Use editor_pie_widget_tree and "
+                 "editor_pie_mouse with explicit coordinates if that was the wrong choice."), Candidates.Num()));
+    }
+    return FHaybaHandlerResult::Ok(R);
+}
+
+
 #else  // !WITH_EDITOR
 
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIEMouse(const TSharedPtr<FJsonObject>&)      { return FHaybaHandlerResult::Err(TEXT("editor-only")); }
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIETypeText(const TSharedPtr<FJsonObject>&)   { return FHaybaHandlerResult::Err(TEXT("editor-only")); }
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIEAxis(const TSharedPtr<FJsonObject>&)       { return FHaybaHandlerResult::Err(TEXT("editor-only")); }
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIEWidgetTree(const TSharedPtr<FJsonObject>&) { return FHaybaHandlerResult::Err(TEXT("editor-only")); }
+FHaybaHandlerResult FHaybaMCPPIEHandler::PIEClickWidget(const TSharedPtr<FJsonObject>&){ return FHaybaHandlerResult::Err(TEXT("editor-only")); }
 FHaybaHandlerResult FHaybaMCPPIEHandler::PIEAssert(const TSharedPtr<FJsonObject>&)    { return FHaybaHandlerResult::Err(TEXT("editor-only")); }
 FHaybaHandlerResult FHaybaMCPPIEHandler::PIEWaitFor(const TSharedPtr<FJsonObject>&)   { return FHaybaHandlerResult::Err(TEXT("editor-only")); }
 FHaybaHandlerResult FHaybaMCPPIEHandler::PIEPressKey(const TSharedPtr<FJsonObject>&)  { return FHaybaHandlerResult::Err(TEXT("editor-only")); }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.h
@@ -27,6 +27,13 @@ private:
     FHaybaHandlerResult PIEPressKey(const TSharedPtr<FJsonObject>& P);
     FHaybaHandlerResult PIEScreenshot(const TSharedPtr<FJsonObject>& P);
 
+    // Interaction surface: everything an agent needs to drive a running game.
+    FHaybaHandlerResult PIEMouse(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult PIETypeText(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult PIEAxis(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult PIEWidgetTree(const TSharedPtr<FJsonObject>& P);
+    FHaybaHandlerResult PIEClickWidget(const TSharedPtr<FJsonObject>& P);
+
 #if WITH_EDITOR
     void EnsureLifecycleHooks();
     void OnBeginPIE(const bool bIsSimulating);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -78,6 +78,7 @@
 #include "Styling/CoreStyle.h"
 #include "AssetRegistry/IAssetRegistry.h"
 #include "HaybaMCPAssetGuard.h"
+#include "HaybaMCPSaveVerify.h"
 #include "HaybaMCPReflection.h"
 #include "HaybaMCPParams.h"
 #include "HaybaMCPUILayout.h"
@@ -937,20 +938,15 @@ namespace
         return R;
     }
 
-    bool SaveWidgetPackage(UWidgetBlueprint* WBP)
+    /** Save and verify against the file system. See HaybaMCPSaveVerify.h — the
+     *  previous version returned a bare bool and the caller then inferred
+     *  success from IsDirty(), which answers a different question and reported
+     *  false on saves that had in fact reached disk. */
+    HaybaSaveVerify::FResult SaveWidgetPackage(UWidgetBlueprint* WBP)
     {
-        if (!WBP) return false;
+        if (!WBP) return HaybaSaveVerify::FResult{};
         WBP->MarkPackageDirty();
-        UPackage* Pkg = WBP->GetOutermost();
-        if (!Pkg) return false;
-
-        const FString FileName = FPackageName::LongPackageNameToFilename(
-            Pkg->GetName(), FPackageName::GetAssetPackageExtension());
-
-        FSavePackageArgs Args;
-        Args.TopLevelFlags = RF_Public | RF_Standalone;
-        Args.SaveFlags = SAVE_NoError;
-        return UPackage::SavePackage(Pkg, WBP, *FileName, Args);
+        return HaybaSaveVerify::SaveAndVerify(WBP);
     }
 }
 
@@ -1926,17 +1922,24 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleCompile(const TSharedPtr<FJsonObje
     bool bSaveOnSuccess = false;
     P->TryGetBoolField(TEXT("save_on_success"), bSaveOnSuccess);
 
+    HaybaSaveVerify::FResult SaveResult;
+    bool bAttemptedSave = false;
     if (bSaveOnSuccess && CR.bSuccess)
     {
-        if (!SaveWidgetPackage(WBP))
+        bAttemptedSave = true;
+        SaveResult = SaveWidgetPackage(WBP);
+        if (!SaveResult.DidReachDisk())
         {
-            return FHaybaHandlerResult::Err(TEXT("ui_compile_widget: compile succeeded but save failed"));
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("ui_compile_widget: compile succeeded but the change did not reach disk. %s"),
+                *SaveResult.Note));
         }
     }
 
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetBoolField(TEXT("success"), CR.bSuccess);
     Out->SetStringField(TEXT("status"), CR.Status);
+    if (bAttemptedSave) HaybaSaveVerify::Describe(SaveResult, Out);
 
     if (CR.Warnings.Num() > 0)
     {
@@ -1991,22 +1994,20 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSave(const TSharedPtr<FJsonObject>
         }
     }
 
-    if (!SaveWidgetPackage(WBP))
-    {
-        return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_save_widget: SavePackage failed for %s"), *WBP->GetPathName()));
-    }
-
-    UPackage* Pkg = WBP->GetOutermost();
-    const bool bDirtyAfter = Pkg ? Pkg->IsDirty() : true;
+    const HaybaSaveVerify::FResult SaveResult = SaveWidgetPackage(WBP);
 
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetStringField(TEXT("saved_path"), WBP->GetPathName());
-    Out->SetBoolField(TEXT("success"), !bDirtyAfter);
-    Out->SetBoolField(TEXT("package_dirty_after_save"), bDirtyAfter);
+    HaybaSaveVerify::Describe(SaveResult, Out);
 
-    if (bDirtyAfter)
+    // `saved` comes from the file system, not from the dirty flag. A caller
+    // about to restart the editor needs a straight answer to "is my work on
+    // disk", and inferring it from IsDirty() gave the wrong one.
+    if (!SaveResult.DidReachDisk())
     {
-        return FHaybaHandlerResult::Ok(Out);
+        return FHaybaHandlerResult::Err(FString::Printf(
+            TEXT("ui_save_widget: %s did not reach disk. %s"),
+            *WBP->GetPathName(), *SaveResult.Note));
     }
 
     return FHaybaHandlerResult::Ok(Out);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -231,6 +231,15 @@ namespace
             // the same children, which is a corrupt tree rather than a copy.
             // Children are rebuilt explicitly by the caller instead.
             if (PropName == TEXT("Slots")) continue;
+            // Structural links on a UPanelSlot. Copying these is what made a
+            // duplicated subtree adopt the ORIGINAL's widgets: the new slot's
+            // Content was overwritten with a pointer to the source's child, so
+            // the tree showed one widget reached through two slots — two entries
+            // with the same name AND the same object path. Layout values are the
+            // only thing worth copying between slots; who they point at is set
+            // by AddChild and must survive.
+            if (PropName == TEXT("Content")) continue;
+            if (PropName == TEXT("Parent")) continue;
 
             FProperty* DstProp = To->GetClass()->FindPropertyByName(PropName);
             if (!DstProp) continue;
@@ -787,6 +796,10 @@ namespace
         if (!W) return;
         Out->SetStringField(TEXT("name"), W->GetName());
         Out->SetStringField(TEXT("class"), W->GetClass()->GetName());
+        // Full object path. Display names can repeat in a malformed tree, and
+        // two entries showing one name is ambiguous between "two widgets" and
+        // "one widget reached through two slots" — the path distinguishes them.
+        Out->SetStringField(TEXT("object_path"), W->GetPathName());
 
         if (bIncludeGuid && WBP)
         {
@@ -987,6 +1000,38 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleCreateWidget(const TSharedPtr<FJso
     if (!ParentClass) ParentClass = UUserWidget::StaticClass();
     if (!ParentClass->IsChildOf(UUserWidget::StaticClass()))
         return FHaybaHandlerResult::Err(TEXT("ui_create_widget: parent_class must derive from UserWidget"));
+
+    // Refuse a name that is already taken, rather than letting CreateAsset ask.
+    //
+    // AssetTools::CreateAsset raises a modal "Overwrite Existing Object" dialog
+    // when the name collides. Handlers run on the game thread, so that dialog
+    // blocks the thread that would service the reply: the command never
+    // completes, the caller times out, and every subsequent MCP request hangs
+    // behind it until a human clicks the box. One tool call takes the whole
+    // connection down, and nothing in the logs says why.
+    //
+    // Nothing about "this name is taken" needs a human, so it is answered here.
+    {
+        const FString ObjectPath = FString::Printf(TEXT("%s/%s.%s"), *PkgPath, *AssetName, *AssetName);
+        const FAssetRegistryModule& RegistryModule =
+            FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+        const FAssetData Existing =
+            RegistryModule.Get().GetAssetByObjectPath(FSoftObjectPath(ObjectPath));
+
+        // Check the registry AND memory: an asset created earlier this session
+        // and not yet saved is absent from the registry but still collides.
+        const bool bExists = Existing.IsValid()
+            || FindObject<UObject>(nullptr, *ObjectPath) != nullptr;
+
+        if (bExists)
+        {
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("ui_create_widget: '%s' already exists at %s. Pick another name, or edit the existing asset ")
+                TEXT("(ui_query to inspect it). This is refused rather than prompting, because a modal overwrite ")
+                TEXT("dialog would block the editor's game thread and hang every MCP request behind it."),
+                *AssetName, *PkgPath));
+        }
+    }
 
     FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
     UWidgetBlueprintFactory* Factory = NewObject<UWidgetBlueprintFactory>();
@@ -1289,6 +1334,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleQuery(const TSharedPtr<FJsonObject
             TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
             Entry->SetStringField(TEXT("name"), Widget->GetName());
             Entry->SetStringField(TEXT("class"), Widget->GetClass()->GetName());
+            Entry->SetStringField(TEXT("object_path"), Widget->GetPathName());
             Entry->SetStringField(TEXT("parent"), Widget->GetParent() ? Widget->GetParent()->GetName() : FString());
             if (bIncludeSlot) Entry->SetStringField(TEXT("slot_class"), ResolveSlotType(Widget));
             if (bIncludeGuid)
@@ -1655,10 +1701,17 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
                 TEXT("wanted \"%s\", got \"%s\""), *RootName.ToString(), *Copy->GetName()));
         }
 
+        // Stage capture. Two rounds of fixes were spent guessing WHICH call
+        // trashes the copy; recording the name at each step answers it in one
+        // build instead.
+        const FString NameAfterClone = Copy->GetName();
+
         UPanelSlot* NewSlot = TargetParent->AddChild(Copy);
         if (!NewSlot)
             return FHaybaHandlerResult::Err(FString::Printf(
                 TEXT("ui_mutate_tree duplicate: '%s' refused the child (panel is full)"), *TargetParent->GetName()));
+
+        const FString NameAfterAddChild = Copy->GetName();
 
         if (Source->Slot && NewSlot->GetClass() == Source->Slot->GetClass())
         {
@@ -1678,8 +1731,26 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
             ApplySlotPropsChecked(NewSlot, *SlotProps);
         }
 
+        // Structural, like every other tree mutation here.
+        //
+        // A stage trace showed the copy surviving the clone and AddChild, then
+        // becoming TRASH_ across this call — which looked like the recompile was
+        // at fault. It was not. The copy was ORPHANED (its parent slot pointed
+        // at the source's child, because slot Content was being copied), and the
+        // recompile simply collected a widget nothing referenced. Fixing the
+        // slot pointers made it reachable, and it now survives compilation like
+        // every other widget these tools create.
         FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
         WBP->MarkPackageDirty();
+
+        {
+            TSharedPtr<FJsonObject> Stages = MakeShared<FJsonObject>();
+            Stages->SetStringField(TEXT("after_clone"), NameAfterClone);
+            Stages->SetStringField(TEXT("after_add_child"), NameAfterAddChild);
+            Stages->SetStringField(TEXT("final"), Copy->GetName());
+            Stages->SetStringField(TEXT("object_path"), Copy->GetPathName());
+            Out->SetObjectField(TEXT("name_stages"), Stages);
+        }
 
         Out->SetStringField(TEXT("source"), WidgetName);
         Out->SetStringField(TEXT("name"), Copy->GetName());
@@ -1728,11 +1799,16 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
 
             if (Defects.Num() > 0)
             {
+                // Carry the stage trace in the error itself. The success payload
+                // is discarded on this path, and the whole point of recording
+                // where the name changed is to know WHICH call broke it.
                 return FHaybaHandlerResult::Err(FString::Printf(
                     TEXT("ui_mutate_tree duplicate: the copy did not come out clean — %s. ")
+                    TEXT("Name by stage: after_clone=\"%s\" after_add_child=\"%s\" final=\"%s\". ")
                     TEXT("The blueprint has NOT been saved; discard the change by reloading the asset. ")
                     TEXT("Build the widget explicitly with ui_build_tree instead."),
-                    *FString::Join(Defects, TEXT("; "))));
+                    *FString::Join(Defects, TEXT("; ")),
+                    *NameAfterClone, *NameAfterAddChild, *Copy->GetName()));
             }
         }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -225,7 +225,12 @@ namespace
             if (SrcProp->HasAnyPropertyFlags(CPF_Transient | CPF_DuplicateTransient | CPF_EditorOnly)) continue;
 
             const FName PropName = SrcProp->GetFName();
-            if (PropName == TEXT("Slot")) continue;  // owned by the parent panel
+            if (PropName == TEXT("Slot")) continue;   // owned by the parent panel
+            // A panel's Slots array holds pointers to slot objects whose Content
+            // points at the SOURCE's children. Copying it makes two widgets claim
+            // the same children, which is a corrupt tree rather than a copy.
+            // Children are rebuilt explicitly by the caller instead.
+            if (PropName == TEXT("Slots")) continue;
 
             FProperty* DstProp = To->GetClass()->FindPropertyByName(PropName);
             if (!DstProp) continue;
@@ -257,6 +262,61 @@ namespace
 
         return W->IsA<UEditableText>() || W->IsA<UEditableTextBox>() ||
                W->IsA<UMultiLineEditableTextBox>() || W->IsA<USpinBox>() || W->IsA<USlider>();
+    }
+
+    /** Recursively clone a widget and its children into `WBP`'s widget tree.
+     *
+     *  DuplicateObject cannot do this. A UPanelSlot's Content is a plain pointer
+     *  to a widget owned by the WidgetTree, not a subobject of the panel, so
+     *  duplication copies the POINTER: the "copy" ends up sharing the original's
+     *  children, and renaming the copy's subtree renames the original's widgets
+     *  out from under the blueprint. That was observable as two widgets with the
+     *  same name and a child that had silently moved.
+     *
+     *  So the tree is rebuilt node by node: construct a widget of the same class,
+     *  copy its properties, then recurse and re-parent, copying each slot's
+     *  layout across as we go. Every widget produced is genuinely new.
+     *
+     *  Returns nullptr if construction fails at any level. */
+    UWidget* DeepCloneWidget(UWidgetBlueprint* WBP, UWidget* Source, FName DesiredName, int32 Depth = 0)
+    {
+        if (!WBP || !WBP->WidgetTree || !Source) return nullptr;
+        if (Depth > 64) return nullptr;  // defensive: a cycle would never terminate
+
+        UClass* Cls = Source->GetClass();
+        const FName Name = DesiredName.IsNone()
+            ? MakeUniqueObjectName(WBP->WidgetTree, Cls, Source->GetFName())
+            : DesiredName;
+
+        UWidget* New = WBP->WidgetTree->ConstructWidget<UWidget>(Cls, Name);
+        if (!New) return nullptr;
+
+        CopyCommonProperties(Source, New);
+
+        if (UPanelWidget* SrcPanel = Cast<UPanelWidget>(Source))
+        {
+            UPanelWidget* NewPanel = Cast<UPanelWidget>(New);
+            if (NewPanel)
+            {
+                for (int32 i = 0; i < SrcPanel->GetChildrenCount(); ++i)
+                {
+                    UWidget* SrcChild = SrcPanel->GetChildAt(i);
+                    if (!SrcChild) continue;
+
+                    UWidget* NewChild = DeepCloneWidget(WBP, SrcChild, NAME_None, Depth + 1);
+                    if (!NewChild) continue;
+
+                    UPanelSlot* NewSlot = NewPanel->AddChild(NewChild);
+                    if (NewSlot && SrcChild->Slot && NewSlot->GetClass() == SrcChild->Slot->GetClass())
+                    {
+                        CopyCommonProperties(SrcChild->Slot, NewSlot);
+                        NewSlot->SynchronizeProperties();
+                    }
+                }
+            }
+        }
+
+        return New;
     }
 
     UWidget* FindWidgetByName(UWidgetTree* Tree, const FString& Name)
@@ -1574,41 +1634,25 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
         // leaves the blueprint with a mangled copy and two widgets answering to
         // the same name. So duplicate under a scratch name first, then rename
         // the whole subtree to unique names before anything else sees it.
-        const FName ScratchName = MakeUniqueObjectName(
-            WBP->WidgetTree, Source->GetClass(), TEXT("HaybaMCP_DuplicateScratch"));
+        // Rebuild the subtree rather than duplicating it. See DeepCloneWidget:
+        // DuplicateObject leaves the copy pointing at the ORIGINAL's children,
+        // because a slot's Content is a plain pointer rather than a subobject.
+        // Two earlier attempts to fix that by renaming after the fact were
+        // treating the symptom — the copy and the original genuinely shared
+        // widgets, so renaming "the copy's" subtree renamed the original's.
+        const FName RootName = NewName.IsEmpty()
+            ? MakeUniqueObjectName(WBP->WidgetTree, Source->GetClass(), Source->GetFName())
+            : FName(*NewName);
 
-        UWidget* Copy = DuplicateObject<UWidget>(Source, WBP->WidgetTree, ScratchName);
+        UWidget* Copy = DeepCloneWidget(WBP, Source, RootName);
         if (!Copy)
-            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree duplicate: DuplicateObject failed"));
+            return FHaybaHandlerResult::Err(TEXT("ui_mutate_tree duplicate: could not clone the widget subtree"));
 
-        // The root of the copy takes the caller's name (or a unique variant of
-        // the source's); every descendant takes a unique variant of its own.
+        TArray<FString> RenameFallbacks;
+        if (Copy->GetFName() != RootName)
         {
-            TArray<UWidget*> Copied;
-            CollectSubtree(Copy, Copied);
-            for (UWidget* W : Copied)
-            {
-                if (!W) continue;
-
-                const bool bIsRoot = (W == Copy);
-                FName Desired;
-                if (bIsRoot && !NewName.IsEmpty())
-                {
-                    Desired = FName(*NewName);
-                }
-                else
-                {
-                    // Base the unique name on the SOURCE widget's name, not the
-                    // scratch name, so a duplicated "Row" reads "Row_1".
-                    const FName Base = bIsRoot ? Source->GetFName() : W->GetFName();
-                    Desired = MakeUniqueObjectName(WBP->WidgetTree, W->GetClass(), Base);
-                }
-
-                if (W->GetFName() != Desired)
-                {
-                    W->Rename(*Desired.ToString(), WBP->WidgetTree, REN_DontCreateRedirectors | REN_DoNotDirty);
-                }
-            }
+            RenameFallbacks.Add(FString::Printf(
+                TEXT("wanted \"%s\", got \"%s\""), *RootName.ToString(), *Copy->GetName()));
         }
 
         UPanelSlot* NewSlot = TargetParent->AddChild(Copy);
@@ -1641,6 +1685,63 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
         Out->SetStringField(TEXT("name"), Copy->GetName());
         Out->SetStringField(TEXT("parent"), TargetParent->GetName());
         Out->SetNumberField(TEXT("widgets_duplicated"), Subtree.Num());
+
+        // Post-condition check. Two rounds of fixes have improved this path
+        // without fully settling it: the clone no longer corrupts the ORIGINAL's
+        // subtree, but the copy can still come back trashed or sharing a name
+        // with its source. Rather than return ok on a tree that is wrong, verify
+        // what actually landed and say so.
+        //
+        // This is deliberately a hard error. A silently mis-shaped widget tree is
+        // the expensive kind of failure — it surfaces later as a binding that
+        // cannot resolve, with nothing pointing back at the call that caused it.
+        {
+            const FString FinalName = Copy->GetName();
+            TArray<FString> Defects;
+
+            if (FinalName.StartsWith(TEXT("TRASH_")))
+            {
+                Defects.Add(FString::Printf(
+                    TEXT("the copy was trashed by the engine and is named \"%s\""), *FinalName));
+            }
+            if (!NewName.IsEmpty() && FinalName != NewName)
+            {
+                Defects.Add(FString::Printf(
+                    TEXT("asked for \"%s\" but the copy is named \"%s\""), *NewName, *FinalName));
+            }
+
+            // Two widgets answering to one name means later lookups are
+            // ambiguous, which is how the original corruption presented.
+            TMap<FString, int32> NameCounts;
+            WBP->WidgetTree->ForEachWidget([&NameCounts](UWidget* W)
+            {
+                if (W) NameCounts.FindOrAdd(W->GetName())++;
+            });
+            for (const auto& Pair : NameCounts)
+            {
+                if (Pair.Value > 1)
+                {
+                    Defects.Add(FString::Printf(
+                        TEXT("%d widgets now share the name \"%s\""), Pair.Value, *Pair.Key));
+                }
+            }
+
+            if (Defects.Num() > 0)
+            {
+                return FHaybaHandlerResult::Err(FString::Printf(
+                    TEXT("ui_mutate_tree duplicate: the copy did not come out clean — %s. ")
+                    TEXT("The blueprint has NOT been saved; discard the change by reloading the asset. ")
+                    TEXT("Build the widget explicitly with ui_build_tree instead."),
+                    *FString::Join(Defects, TEXT("; "))));
+            }
+        }
+
+        if (RenameFallbacks.Num() > 0)
+        {
+            TArray<TSharedPtr<FJsonValue>> Arr;
+            for (const FString& R : RenameFallbacks) Arr.Add(MakeShared<FJsonValueString>(R));
+            Out->SetArrayField(TEXT("rename_fallbacks"), Arr);
+        }
         return FHaybaHandlerResult::Ok(Out);
     }
     else if (Operation == TEXT("replace"))

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -77,6 +77,7 @@
 #include "Engine/Blueprint.h"
 #include "Styling/CoreStyle.h"
 #include "AssetRegistry/IAssetRegistry.h"
+#include "HaybaMCPAssetGuard.h"
 #include "HaybaMCPReflection.h"
 #include "HaybaMCPParams.h"
 #include "HaybaMCPUILayout.h"
@@ -1001,36 +1002,13 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleCreateWidget(const TSharedPtr<FJso
     if (!ParentClass->IsChildOf(UUserWidget::StaticClass()))
         return FHaybaHandlerResult::Err(TEXT("ui_create_widget: parent_class must derive from UserWidget"));
 
-    // Refuse a name that is already taken, rather than letting CreateAsset ask.
-    //
-    // AssetTools::CreateAsset raises a modal "Overwrite Existing Object" dialog
-    // when the name collides. Handlers run on the game thread, so that dialog
-    // blocks the thread that would service the reply: the command never
-    // completes, the caller times out, and every subsequent MCP request hangs
-    // behind it until a human clicks the box. One tool call takes the whole
-    // connection down, and nothing in the logs says why.
-    //
-    // Nothing about "this name is taken" needs a human, so it is answered here.
+    // Refuse a taken name instead of letting CreateAsset raise a modal overwrite
+    // dialog, which would block the game thread and hang every queued MCP
+    // request. See HaybaMCPAssetGuard.h for why this is worth guarding.
+    if (HaybaAssetGuard::AssetNameTaken(PkgPath, AssetName))
     {
-        const FString ObjectPath = FString::Printf(TEXT("%s/%s.%s"), *PkgPath, *AssetName, *AssetName);
-        const FAssetRegistryModule& RegistryModule =
-            FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
-        const FAssetData Existing =
-            RegistryModule.Get().GetAssetByObjectPath(FSoftObjectPath(ObjectPath));
-
-        // Check the registry AND memory: an asset created earlier this session
-        // and not yet saved is absent from the registry but still collides.
-        const bool bExists = Existing.IsValid()
-            || FindObject<UObject>(nullptr, *ObjectPath) != nullptr;
-
-        if (bExists)
-        {
-            return FHaybaHandlerResult::Err(FString::Printf(
-                TEXT("ui_create_widget: '%s' already exists at %s. Pick another name, or edit the existing asset ")
-                TEXT("(ui_query to inspect it). This is refused rather than prompting, because a modal overwrite ")
-                TEXT("dialog would block the editor's game thread and hang every MCP request behind it."),
-                *AssetName, *PkgPath));
-        }
+        return FHaybaHandlerResult::Err(
+            HaybaAssetGuard::NameTakenError(TEXT("ui_create_widget"), PkgPath, AssetName));
     }
 
     FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPAssetGuard.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPAssetGuard.h
@@ -1,0 +1,67 @@
+#pragma once
+
+// Guards against handlers raising modal dialogs.
+//
+// This exists because of a failure that is disproportionately expensive to
+// diagnose. Handlers run on the editor's game thread. A modal dialog blocks that
+// thread, which is the same thread that would send the reply — so the command
+// never completes, the caller times out, and every subsequent request queues
+// behind it until a human notices the box and clicks it. Nothing is written to
+// the log. From the agent's side the whole editor has simply stopped answering.
+//
+// IAssetTools::CreateAsset is the common way to trip it: on a name collision it
+// asks "Overwrite Existing Object?" rather than failing. Nothing about that
+// question needs a human — the caller supplied the name and can supply another —
+// so it is answered here, before the dialog can appear.
+//
+// Any handler calling an editor API that can prompt should check first. If you
+// add a call to CreateAsset, DeleteAssets, RenameAssets or friends, assume it
+// prompts until you have checked the engine source.
+
+#include "CoreMinimal.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetRegistry/IAssetRegistry.h"
+#include "UObject/SoftObjectPath.h"
+
+namespace HaybaAssetGuard
+{
+    /** Object path UE will use for an asset at `PackagePath`/`AssetName`. */
+    inline FString MakeObjectPath(const FString& PackagePath, const FString& AssetName)
+    {
+        FString Dir = PackagePath;
+        Dir.RemoveFromEnd(TEXT("/"));
+        return FString::Printf(TEXT("%s/%s.%s"), *Dir, *AssetName, *AssetName);
+    }
+
+    /** True when something already occupies that asset path.
+     *
+     *  Checks the asset registry AND live memory: an asset created earlier in
+     *  the same session and not yet saved is absent from the registry but still
+     *  collides, and that is exactly the case an agent hits when it retries a
+     *  call it thinks failed. */
+    inline bool AssetNameTaken(const FString& PackagePath, const FString& AssetName)
+    {
+        const FString ObjectPath = MakeObjectPath(PackagePath, AssetName);
+
+        const FAssetRegistryModule& RegistryModule =
+            FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+        if (RegistryModule.Get().GetAssetByObjectPath(FSoftObjectPath(ObjectPath)).IsValid())
+        {
+            return true;
+        }
+
+        return FindObject<UObject>(nullptr, *ObjectPath) != nullptr;
+    }
+
+    /** Error text for a taken name. Says why it refuses rather than prompting,
+     *  because the alternative failure mode is invisible and the reader deserves
+     *  to know the tool chose this deliberately. */
+    inline FString NameTakenError(const FString& Command, const FString& PackagePath, const FString& AssetName)
+    {
+        return FString::Printf(
+            TEXT("%s: '%s' already exists at %s. Choose another name, or edit the existing asset. ")
+            TEXT("This is refused rather than prompting to overwrite, because a modal dialog would block ")
+            TEXT("the editor's game thread and hang every MCP request behind it."),
+            *Command, *AssetName, *PackagePath);
+    }
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPSaveVerify.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPSaveVerify.h
@@ -1,0 +1,113 @@
+#pragma once
+
+// Saving, reported honestly.
+//
+// "Did my change reach disk?" is the question a caller most needs answered
+// before restarting the editor, and it was the one thing our save tools could
+// not answer clearly. The old ui_save_widget derived its `success` field from
+// `UPackage::IsDirty()` AFTER the save — which is a different question. A
+// package can be written to disk correctly and still report dirty, so a caller
+// who had just saved successfully was told `success: false` and had to guess.
+//
+// The fix is to stop inferring from flags and check the artefact. This helper
+// stats the target file before and after the save, so the answer comes from the
+// file system rather than from engine bookkeeping:
+//
+//   saved            the save call itself reported success
+//   file_written     the file exists AND its timestamp advanced — ground truth
+//   still_dirty      informational only; NEVER the success signal
+//
+// If those three ever disagree, the response says so in words instead of
+// leaving the caller to reconcile them.
+
+#include "CoreMinimal.h"
+#include "HAL/FileManager.h"
+#include "Misc/PackageName.h"
+#include "UObject/Package.h"
+#include "UObject/SavePackage.h"
+#include "Dom/JsonObject.h"
+
+namespace HaybaSaveVerify
+{
+    struct FResult
+    {
+        /** UPackage::SavePackage's own return value. */
+        bool bSaveCallSucceeded = false;
+        /** The file exists on disk after the call. */
+        bool bFileExists = false;
+        /** Its timestamp advanced, i.e. this call actually rewrote it. */
+        bool bFileWritten = false;
+        /** Package still flagged dirty. Informational — a saved package can
+         *  legitimately remain dirty, so this must not gate success. */
+        bool bStillDirty = false;
+        int64 FileSize = 0;
+        FString FilePath;
+        /** Plain-language note when the signals disagree; empty when they don't. */
+        FString Note;
+
+        /** The honest answer to "did my change reach disk". */
+        bool DidReachDisk() const { return bFileExists && (bFileWritten || bSaveCallSucceeded); }
+    };
+
+    /** Save `Asset`'s package and verify the result against the file system. */
+    inline FResult SaveAndVerify(UObject* Asset)
+    {
+        FResult R;
+        if (!Asset) { R.Note = TEXT("no asset supplied"); return R; }
+
+        UPackage* Pkg = Asset->GetOutermost();
+        if (!Pkg) { R.Note = TEXT("asset has no package"); return R; }
+
+        R.FilePath = FPackageName::LongPackageNameToFilename(
+            Pkg->GetName(), FPackageName::GetAssetPackageExtension());
+
+        IFileManager& FM = IFileManager::Get();
+        const FDateTime Before = FM.GetTimeStamp(*R.FilePath);   // min value when absent
+
+        FSavePackageArgs Args;
+        Args.TopLevelFlags = RF_Public | RF_Standalone;
+        Args.SaveFlags = SAVE_NoError;
+        R.bSaveCallSucceeded = UPackage::SavePackage(Pkg, Asset, *R.FilePath, Args);
+
+        const FDateTime After = FM.GetTimeStamp(*R.FilePath);
+        R.bFileExists = FM.FileExists(*R.FilePath);
+        R.bFileWritten = R.bFileExists && After > Before;
+        R.FileSize = R.bFileExists ? FM.FileSize(*R.FilePath) : 0;
+        R.bStillDirty = Pkg->IsDirty();
+
+        // Reconcile the signals in words, so a caller never has to.
+        if (!R.bFileExists)
+        {
+            R.Note = TEXT("No file on disk after the save. The change is NOT persisted.");
+        }
+        else if (!R.bSaveCallSucceeded && R.bFileWritten)
+        {
+            R.Note = TEXT("SavePackage reported failure but the file was rewritten. Treat as saved; ")
+                     TEXT("check the editor log for what it objected to.");
+        }
+        else if (R.bSaveCallSucceeded && !R.bFileWritten)
+        {
+            R.Note = TEXT("Save reported success and the file exists, but its timestamp did not advance — ")
+                     TEXT("usually means the contents were already identical. Nothing was lost.");
+        }
+        else if (R.bStillDirty)
+        {
+            R.Note = TEXT("Written to disk, but the package still reads dirty. That is normal after some ")
+                     TEXT("edits and does NOT mean the save failed — file_written is the signal that matters.");
+        }
+        return R;
+    }
+
+    /** Write the result into a response object under stable field names. */
+    inline void Describe(const FResult& R, const TSharedPtr<FJsonObject>& Out)
+    {
+        if (!Out.IsValid()) return;
+        Out->SetBoolField(TEXT("saved"), R.DidReachDisk());
+        Out->SetBoolField(TEXT("file_written"), R.bFileWritten);
+        Out->SetBoolField(TEXT("save_call_succeeded"), R.bSaveCallSucceeded);
+        Out->SetBoolField(TEXT("still_dirty"), R.bStillDirty);
+        Out->SetStringField(TEXT("file_path"), R.FilePath);
+        Out->SetNumberField(TEXT("file_size"), static_cast<double>(R.FileSize));
+        if (!R.Note.IsEmpty()) Out->SetStringField(TEXT("note"), R.Note);
+    }
+}


### PR DESCRIPTION
Five changes, in the order they were asked for.

## 1. First-install surface: 49 tools → 7

Routing already defaulted to `deferred`, but 49 tools were hardcoded always-on (23 PLUMB, 7 validator, 4 sliver, 4 DAG, 3 asset). That defeats the whole point at the door: every always-on tool costs context on every request forever, and a large default set *suppresses* discovery — there is no reason to search a catalogue when 50 tools are already in front of you, so the ones not surfaced never get found.

The set is now the bootstrap minimum: search, invoke, pack_list, pack_load, check_ue_status, list_tool_categories, get_tool_signature.

Safe because nothing became unreachable — `hayba_invoke` resolves from the captured map, which holds every tool regardless of pack state.

**This exposed a worse bug:** the 11 runtime-constructed tools (asset/DAG/sliver) called `server.tool()` directly, *after* the search index was built. They were registered unconditionally **and** absent from the index — always in your face, and impossible to find by searching. Now deferred like everything else.

## 2. First-contact orientation

Seven tools with no map is worse than fifty. A one-shot orientation on first contact gives the real counts, the search → invoke loop, the domain list, and the UE-connection precondition — derived from live registry state, because an orientation that drifts teaches things that are no longer true.

## 3. Search that ranks the right tool

Now measured, not assumed. Baseline: **5/16 first-place, 10/16 outside top 3**, and "run python in the editor" did not find `python_run`. Now **14/21 first, 19/21 top-3**.

Fixed: no field boosting (name now 6x, domain 3x), no stopword filtering, OR-matching so any weak term ranked, fuzzy on 3-letter terms, the domain never indexed, and camelCase never split (`StaticMesh` vs "static mesh" — measured rank 7 → 1).

A nonsense query now returns nothing. A confident wrong tool is worse than an empty result.

## 4. Vector search that actually contributes

The embedding backend was already wired and already working — and having **zero effect**. Turning it on changed the benchmark by exactly nothing.

Three bugs, each individually fatal:
- **Fusion dilution** — the semantic side ranked all 245 docs, and RRF rewards appearing in both lists, so a tool BM25 put 5th beat the one embeddings ranked *first*. Truncated to top 25.
- **The tool name was in the embedded text** — `material_set_param` is gibberish to a sentence model and dragged vectors toward other snake_case names. Names are BM25's job.
- **Equal weights** — when no doc contains every query term, BM25 is guessing. Weights now flip so semantics lead exactly then.

Paraphrases like "make the surface shiny" went from unfindable to top-3. Vectors are persisted: **cold 1765ms → warm 13ms**, identical results.

## 5. Honesty audit

Most of the codebase already handles this well — the actor and blueprint property setters coerce numbers/bools, check `ImportText_Direct`, and name what they skipped.

The legacy PCG graph-creation path did none of it, dropping properties silently four different ways (including *every numeric setting*, since numbers do not arrive as strings from JSON) and returning `created: true`. That is the worst place for it: a PCG node missing its settings still builds a valid graph, and the symptom arrives later as "scattered zero instances" — there are validator rules devoted to that symptom. Now every rejection is named with its reason. The discarded `SavePackage` result is captured too.

## CI

Both long-standing failures fixed. `room-grammar.test.ts` read an absolute path on one machine (now a committed fixture); `landscape-import.test.ts` regexed source text that the formatter reflowed. **1050/1050 green across 120 files.**

## Caveat

The PCG handler change is **not compiled** — the editor was reopened mid-session and Live Coding blocks UBT. Braces balance and referenced variables are in scope, but it needs a real build before it is trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUbaP2TVPqkSzUL18h2NCc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-level orientation guidance for tool/workflow discovery and improved tool discovery output (callable vs. unavailable, on-demand pack behavior).
  * Expanded tool surfaces for Docs, Asset Graph, Foliage, and PIE (new interaction and foliage/publishing/lookup tools).
  * Added persisted, vector-enhanced tool search with improved ranking and caching.
* **Bug Fixes**
  * Graph creation now reports save status and property-application issues.
  * Prevented asset-name collisions from triggering editor overwrite/modal dialogs; improved UI cloning/duplication to avoid corrupted widget trees and improved widget disambiguation.
* **Documentation**
  * Updated UMG validation handoff notes with corrected verification details.
* **Tests**
  * Added/expanded routing, indexing, modal-safety, and tool-catalog coverage tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->