### PR TITLE
Migrate to zod 4

### DIFF
--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -33,7 +33,7 @@
     "minisearch": "^7.2.0",
     "openai": "^6.45.0",
     "youtube-transcript-api": "^3.0.6",
-    "zod": "^3.23.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.5",

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
@@ -129,8 +129,11 @@ function zodToJsonSchema(t: ZodTypeAny): { schema: JsonSchema; optional: boolean
       optional = true;
     inner = (inner as unknown as { _def: { innerType: ZodTypeAny } })._def.innerType;
   }
-  while (inner instanceof z.ZodEffects) {
-    inner = (inner as unknown as { _def: { schema: ZodTypeAny } })._def.schema;
+  // zod 4: ZodEffects became ZodPipe, whose ends are `_def.in` / `_def.out`.
+  // Follow the end that is not the transform.
+  while (inner instanceof z.ZodPipe) {
+    const { in: pin, out: pout } = inner._def as unknown as { in: ZodTypeAny; out: ZodTypeAny };
+    inner = pout instanceof z.ZodTransform ? pin : pout;
   }
 
   let schema: JsonSchema;
@@ -154,8 +157,9 @@ function zodToJsonSchema(t: ZodTypeAny): { schema: JsonSchema; optional: boolean
   else if (inner instanceof z.ZodRecord) schema = { type: 'object' };
   else schema = {};
 
-  const desc = (t as unknown as { _def?: { description?: string } })._def?.description
-    ?? (inner as unknown as { _def?: { description?: string } })._def?.description;
+  // zod 4: .describe() lives on the public `.description` getter now, not on
+  // `_def.description` — which reads undefined rather than throwing.
+  const desc = t.description ?? inner.description;
   if (desc) schema.description = desc;
   return { schema, optional };
 }

--- a/mcp-tools/hayba-mcp/src/slivers/spec-schema.ts
+++ b/mcp-tools/hayba-mcp/src/slivers/spec-schema.ts
@@ -41,7 +41,7 @@ const determinism = z.object({
 
 const requirement = z.object({
   primitive: z.string().min(1),
-  params: z.record(z.unknown()).optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
   binding: z.object({
     asset: z.string().optional(),
     tag: z.object({ axis: z.string(), value: z.string() }).optional(),

--- a/mcp-tools/hayba-mcp/src/tools/__tests__/schema-registry-describe.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/__tests__/schema-registry-describe.test.ts
@@ -1,0 +1,114 @@
+/**
+ * How a Zod schema is rendered into a tool signature.
+ *
+ * `describeZod` is what an agent reads when it asks what a tool takes, and it
+ * works entirely through Zod's internals — which zod 4 rearranged wholesale:
+ *
+ *   ZodEffects            -> ZodPipe, with `_def.in` / `_def.out`
+ *   `_def.typeName`       -> `_def.type` ("ZodString" -> "string")
+ *   `_def.values` (enum)  -> the public `.options`
+ *   `_def.type` (array)   -> `_def.element`   ← the nasty one: the old name
+ *                            still exists and now holds the string "array"
+ *   `_def.description`    -> the public `.description` getter
+ *
+ * None of those throw when read from the old place. They return undefined, so
+ * the migration typechecked clean and the entire catalogue quietly lost its
+ * parameter documentation — every param rendering as "string (optional)" with
+ * nothing after it. One assertion in legacy-tool-factory.test.ts caught it.
+ * This file is the coverage that should have existed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { recordSchema, deriveSignature } from '../schema-registry.js';
+
+function sigFor(shape: z.ZodRawShape): Record<string, string> {
+  const name = `__probe_${Math.random().toString(36).slice(2)}`;
+  recordSchema(name, { shape, cost: 'low', returns: 'any' });
+  const sig = deriveSignature(name);
+  expect(sig, 'deriveSignature should find a recorded schema').not.toBeNull();
+  return sig!.params;
+}
+
+describe('describeZod under zod 4', () => {
+  it('renders primitives with required/optional', () => {
+    const p = sigFor({
+      a: z.string(),
+      b: z.number().optional(),
+      c: z.boolean(),
+    });
+    expect(p.a).toBe('string (required)');
+    expect(p.b).toBe('number (optional)');
+    expect(p.c).toBe('bool (required)');
+  });
+
+  it('keeps .describe() text — the regression that typechecked clean', () => {
+    const p = sigFor({
+      actor_label: z.string().describe('Editor actor label'),
+      wrapped: z.string().describe('inner text').optional(),
+    });
+    expect(p.actor_label).toContain('Editor actor label');
+    // The description sits on the inner schema once .optional() wraps it, so
+    // reading only the outer schema loses it.
+    expect(p.wrapped).toContain('inner text');
+    expect(p.wrapped).toContain('(optional)');
+  });
+
+  it('lists enum members rather than the word "enum"', () => {
+    const p = sigFor({ mode: z.enum(['fast', 'slow']) });
+    expect(p.mode).toContain('"fast"');
+    expect(p.mode).toContain('"slow"');
+  });
+
+  it('renders arrays by element type, not as "array[]"', () => {
+    // zod 4 kept `_def.type` on arrays but repurposed it to the literal string
+    // "array"; the element moved to `_def.element`. Reading the old name yields
+    // a plausible-looking nothing — this would render "array[]" or "any[]".
+    //
+    // The nested "(required)" is pre-existing: describeZod recurses into itself
+    // for the element and the qualifier comes along. Ugly, not wrong, and not
+    // this change's business.
+    const p = sigFor({ names: z.array(z.string()) });
+    expect(p.names).toContain('string');
+    expect(p.names).toContain('[]');
+    expect(p.names).not.toContain('array[]');
+    expect(p.names).not.toContain('any[]');
+  });
+
+  it('renders tuples element-wise', () => {
+    const p = sigFor({ loc: z.tuple([z.number(), z.number(), z.number()]) });
+    expect(p.loc.startsWith('[')).toBe(true);
+    expect(p.loc.match(/number/g)?.length).toBe(3);
+  });
+
+  it('sees through preprocess to the real type', () => {
+    const p = sigFor({
+      n: z.preprocess((v) => (typeof v === 'string' ? Number(v) : v), z.number()),
+    });
+    expect(p.n, 'a preprocessed number should still read as a number').toContain('number');
+  });
+
+  it('keeps object/any legible', () => {
+    const p = sigFor({
+      opts: z.object({ x: z.string() }).optional(),
+      any: z.unknown(),
+    });
+    expect(p.opts).toContain('object');
+    expect(p.opts).toContain('(optional)');
+    expect(p.any).toContain('any');
+  });
+
+  it('PINS A KNOWN INACCURACY: a defaulted param is reported as required', () => {
+    // Pre-existing, not a zod 4 regression — the unwrap loop steps through
+    // ZodDefault without setting the optional flag, and this predates the
+    // migration.
+    //
+    // It is still wrong from the caller's side: a param with a default does not
+    // have to be supplied, and telling an agent "required" makes it invent a
+    // value rather than let the default apply. Pinned here so the behaviour is
+    // visible and so fixing it fails this test loudly rather than silently
+    // changing what every tool advertises. See the follow-up issue.
+    const p = sigFor({ d: z.string().default('x') });
+    expect(p.d).toContain('(required)');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -1433,7 +1433,7 @@ export const PCG_DESCRIPTORS: ToolDescriptor[] = [
         .enum(['epic-default', 'gamedevtv', 'custom'])
         .optional()
         .describe('Preset to load (required at start stage)'),
-      answers: z.record(z.unknown()).optional().describe('Accumulated user responses from previous stages'),
+      answers: z.record(z.string(), z.unknown()).optional().describe('Accumulated user responses from previous stages'),
       target: z.enum(['global', 'project']).optional().describe('Where to save (required at save stage)'),
       projectRoot: z.string().optional().describe('UE project root path (required if target is project)'),
     },
@@ -2182,7 +2182,7 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
         .describe('Name of an existing PANEL widget to parent under; defaults to the root panel'),
       name: z.string().optional().describe('Name for the new widget (auto-generated if omitted)'),
       slot_props: z
-        .record(z.union([z.number(), z.string(), z.boolean()]))
+        .record(z.string(), z.union([z.number(), z.string(), z.boolean()]))
         .optional()
         .describe('Slot layout props: x/y/w/h (canvas), fill/padding (box); other keys set on the slot by reflection'),
     },
@@ -3985,7 +3985,7 @@ function recordEagerSchemas(reg: (name: string, shape: z.ZodRawShape, cost: Cost
     {
       stage: z.enum(['start', 'folders', 'naming', 'workflow', 'confirm', 'save']),
       preset: z.enum(['epic-default', 'gamedevtv', 'custom']).optional(),
-      answers: z.record(z.unknown()).optional(),
+      answers: z.record(z.string(), z.unknown()).optional(),
       target: z.enum(['global', 'project']).optional(),
       projectRoot: z.string().optional(),
     },

--- a/mcp-tools/hayba-mcp/src/tools/legacy-tool-factory.ts
+++ b/mcp-tools/hayba-mcp/src/tools/legacy-tool-factory.ts
@@ -114,7 +114,9 @@ function zodForParam(p: LegacyParam): z.ZodTypeAny {
 
 /** Build the Zod raw shape for one command's params[]. */
 function shapeFor(params: LegacyParam[]): z.ZodRawShape {
-  const shape: z.ZodRawShape = {};
+  // zod 4 types ZodRawShape as Readonly, so it cannot be built by assignment.
+  // Assemble a mutable record and widen on return.
+  const shape: Record<string, z.ZodTypeAny> = {};
   for (const p of params ?? []) {
     let t = zodForParam(p);
     if (p.description) t = t.describe(p.description);

--- a/mcp-tools/hayba-mcp/src/tools/plumb/tools.ts
+++ b/mcp-tools/hayba-mcp/src/tools/plumb/tools.ts
@@ -194,7 +194,7 @@ const bindingSchema = z.object({
 export const plumbConstraintDefineSchema = {
   id: z.string(),
   primitive: z.string().describe('One of the closed primitive ids (see plumb_primitives)'),
-  params: z.record(z.unknown()).optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
   binding: bindingSchema.describe('Exactly one of {asset, tag}'),
   hard: z.boolean().optional().describe('Override the primitive default hard/soft'),
   note: z.string().optional(),
@@ -282,7 +282,7 @@ const transformSchema = z.object({
 const instanceSchema = z.object({
   object: z.string(),
   asset: z.string().optional(),
-  tags: z.record(z.string()).optional(),
+  tags: z.record(z.string(), z.string()).optional(),
   transform: transformSchema,
 });
 
@@ -501,7 +501,7 @@ export const plumbProductionDefineSchema = {
   id: z.string(),
   lhs: z.object({
     kind: z.string(),
-    when: z.record(z.unknown()).optional(),
+    when: z.record(z.string(), z.unknown()).optional(),
   }),
   rhs: z.array(emitOpSchema).min(1),
   guards: z.array(z.string()).optional().describe('Constraint ids that must pass before this production fires'),
@@ -564,7 +564,7 @@ export async function plumbSocketAddHandler(args: {
 export const plumbGrammarExpandSchema = {
   seed: z.object({
     kind: z.string(),
-    attrs: z.record(z.union([z.number(), z.string(), z.boolean()])).optional(),
+    attrs: z.record(z.string(), z.union([z.number(), z.string(), z.boolean()])).optional(),
   }).describe('Seed symbol to expand from'),
 };
 export async function plumbGrammarExpandHandler(args: {

--- a/mcp-tools/hayba-mcp/src/tools/register-tool.ts
+++ b/mcp-tools/hayba-mcp/src/tools/register-tool.ts
@@ -92,7 +92,9 @@ export function defineTool<S extends z.ZodRawShape>(d: {
   returns: string;
   niche?: string;
   handler: (
-    args: z.objectOutputType<S, z.ZodTypeAny>,
+    // zod 4 removed z.objectOutputType; inferring through ZodObject is
+    // the supported way to get the parsed shape's output type.
+    args: z.infer<z.ZodObject<S>>,
     session: SessionManager,
   ) => Promise<ToolResult>;
 }): ToolDescriptor {

--- a/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
@@ -22,7 +22,7 @@ export const UE_LEGACY_ALLOWLIST: ReadonlySet<string> = LEGACY_ALLOWLIST;
 
 export const invokeSchema = {
   name: z.string().min(1),
-  args: z.record(z.unknown()).default({}),
+  args: z.record(z.string(), z.unknown()).default({}),
   via: z.enum(['ts', 'ue_legacy']).optional().default('ts')
     .describe('Dispatch route. "ts" (default) looks the tool up in the TS captured map. "ue_legacy" calls executeCommand(name, args) directly against the UE plugin — only commands marked agent_callable:true in legacy-commands/sidecar.json are accepted.'),
 };

--- a/mcp-tools/hayba-mcp/src/tools/schema-registry.ts
+++ b/mcp-tools/hayba-mcp/src/tools/schema-registry.ts
@@ -56,31 +56,46 @@ function describeZod(t: ZodTypeAny): string {
     if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable) optional = true;
     inner = (inner as any)._def.innerType;
   }
-  // ZodEffects (preprocess/refine) wraps a schema.
-  while (inner instanceof z.ZodEffects) {
-    inner = (inner as any)._def.schema;
+  // zod 4 replaced ZodEffects with ZodPipe: preprocess/transform are a pipe
+  // whose two ends are `_def.in` and `_def.out`. Describe the end that is not
+  // the transform itself — for z.preprocess(fn, schema) that is `out`, for
+  // schema.transform(fn) it is `in`.
+  while (inner instanceof z.ZodPipe) {
+    const { in: pin, out: pout } = inner._def as unknown as { in: ZodTypeAny; out: ZodTypeAny };
+    inner = pout instanceof z.ZodTransform ? pin : pout;
   }
 
   let typeStr: string;
   if (inner instanceof z.ZodString) typeStr = 'string';
   else if (inner instanceof z.ZodNumber) typeStr = 'number';
   else if (inner instanceof z.ZodBoolean) typeStr = 'bool';
-  else if (inner instanceof z.ZodEnum) typeStr = (inner._def.values as string[]).map(v => `"${v}"`).join('|');
+  // `.options` is public API in zod 4; `_def.values` is gone.
+  else if (inner instanceof z.ZodEnum) typeStr = (inner.options as string[]).map(v => `"${v}"`).join('|');
   else if (inner instanceof z.ZodTuple) {
     const items = (inner._def.items as ZodTypeAny[]).map(describeZod).join(',');
     typeStr = `[${items}]`;
   } else if (inner instanceof z.ZodArray) {
-    typeStr = `${describeZod(inner._def.type)}[]`;
+    // zod 4 renamed the array's element from `_def.type` to `_def.element`;
+    // `_def.type` still exists but now holds the string "array", so reading the
+    // old name yields a schema-shaped nothing rather than an error.
+    typeStr = `${describeZod(inner.element as ZodTypeAny)}[]`;
   } else if (inner instanceof z.ZodObject) {
     typeStr = 'object';
   } else if (inner instanceof z.ZodAny || inner instanceof z.ZodUnknown) {
     typeStr = 'any';
   } else {
-    typeStr = inner._def?.typeName?.replace(/^Zod/, '').toLowerCase() ?? 'any';
+    // zod 4: `_def.typeName` ("ZodString") became `_def.type` ("string").
+    typeStr = (inner._def as unknown as { type?: string })?.type ?? 'any';
   }
 
   const qualifier = optional ? '(optional)' : '(required)';
-  const desc = (t as any)._def?.description ?? (inner as any)._def?.description;
+  // zod 4 moved .describe() out of `_def.description` and onto a public
+  // `.description` getter. Reading the old location returns undefined rather
+  // than throwing, so every parameter description silently became
+  // "string (optional)" with nothing after it — the typecheck stayed green and
+  // the whole tool catalogue lost its documentation. Caught by
+  // legacy-tool-factory.test.ts, which asserts one description survives.
+  const desc = t.description ?? inner.description;
   return desc ? `${typeStr} ${qualifier} — ${desc}` : `${typeStr} ${qualifier}`;
 }
 

--- a/mcp-tools/hayba-mcp/src/tools/sliver/run.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sliver/run.ts
@@ -5,7 +5,7 @@ import type { SliverRunResult } from '../../slivers/types.js';
 
 export const sliverRunSchema = {
   id: z.string().min(1),
-  params: z.record(z.unknown()).default({}),
+  params: z.record(z.string(), z.unknown()).default({}),
 };
 
 export interface SliverRunCtx { runtime: SliverRuntime; }

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-add-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-add-element.ts
@@ -30,7 +30,7 @@ export const schema = z.object({
     .describe('Name of an existing PANEL widget to parent under. Defaults to the root panel; errors if the root is not a panel and none is given.'),
   name: z.string().optional().describe('Name for the new widget (auto-generated if omitted).'),
   slot_props: z
-    .record(z.union([z.number(), z.string(), z.boolean()]))
+    .record(z.string(), z.union([z.number(), z.string(), z.boolean()]))
     .optional()
     .describe(
       'Slot layout props. Canvas slot: x, y, w, h (offsets). Box slot: fill, padding. Any other key is set on the slot by reflection.',

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-build-tree.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-build-tree.ts
@@ -11,7 +11,7 @@ export const meta: HaybaToolMeta = {
 };
 
 const propertyValue: z.ZodType<unknown> = z.lazy(() =>
-  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(propertyValue), z.record(propertyValue)]),
+  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(propertyValue), z.record(z.string(), propertyValue)]),
 );
 
 // Recursive by construction: a node's children are nodes. z.lazy is required
@@ -25,8 +25,8 @@ const nodeSchema: z.ZodType<unknown> = z.lazy(() =>
         'Widget class — short name ("VerticalBox", "TextBlock") or a full class path, including your own /Game/... widget blueprint classes',
       ),
     name: z.string().optional().describe('Name for this widget. Must be unique in the blueprint; auto-generated if omitted.'),
-    properties: z.record(propertyValue).optional().describe('Properties set on the widget itself'),
-    slot_props: z.record(propertyValue).optional().describe('Layout properties for this widget slot in its parent'),
+    properties: z.record(z.string(), propertyValue).optional().describe('Properties set on the widget itself'),
+    slot_props: z.record(z.string(), propertyValue).optional().describe('Layout properties for this widget slot in its parent'),
     children: z.array(nodeSchema).optional().describe('Child nodes. Only valid when `class` is a panel widget.'),
   }),
 );

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-duplicate-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-duplicate-element.ts
@@ -19,7 +19,7 @@ export const schema = z.object({
     .optional()
     .describe('Panel to place the copy under. Defaults to the source widget own parent (i.e. a sibling copy).'),
   slot_props: z
-    .record(z.union([z.number(), z.string(), z.boolean(), z.array(z.number())]))
+    .record(z.string(), z.union([z.number(), z.string(), z.boolean(), z.array(z.number())]))
     .optional()
     .describe('Slot layout overrides for the copy, applied after the source slot layout is cloned.'),
 });

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-reparent-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-reparent-element.ts
@@ -15,7 +15,7 @@ export const schema = z.object({
   widget_name: z.string().min(1).describe('Name of the widget to reparent'),
   new_parent_name: z.string().min(1).describe('Name of the existing panel widget to reparent under'),
   slot_props: z
-    .record(z.union([z.number(), z.string(), z.boolean()]))
+    .record(z.string(), z.union([z.number(), z.string(), z.boolean()]))
     .optional()
     .describe('Optional slot layout props for the new parent slot'),
 });

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-widget-properties.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-widget-properties.ts
@@ -14,20 +14,20 @@ export const meta: HaybaToolMeta = {
 // which contains an FLinearColor. The handler applies nested JSON objects field
 // by field via reflection, so the schema must not flatten them away.
 const propertyValue: z.ZodType<unknown> = z.lazy(() =>
-  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(propertyValue), z.record(propertyValue)]),
+  z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(propertyValue), z.record(z.string(), propertyValue)]),
 );
 
 export const schema = z.object({
   widget_blueprint_path: z.string().min(1).describe('Full path of the target Widget Blueprint'),
   widget_name: z.string().min(1).describe('Name of the widget to set properties on'),
   properties: z
-    .record(propertyValue)
+    .record(z.string(), propertyValue)
     .optional()
     .describe(
       'Property values keyed by their real UE property name (e.g. "Text", "ColorAndOpacity", "Font"). Values may be nested objects for struct properties, arrays for colors/vectors, or an asset path string for object references.',
     ),
   slot_props: z
-    .record(propertyValue)
+    .record(z.string(), propertyValue)
     .optional()
     .describe(
       'Layout properties applied to the widget’s PANEL SLOT rather than the widget: canvas (anchors/position/size/alignment/auto_size/z_order), box (fill/padding/alignment), grid (row/column/spans). Keys the slot type does not support come back in unknown_slot_props instead of being silently dropped.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "workspaces": [
         "packages/*",
-        "mcp-tools/*"
+        "mcp-tools/hayba-mcp"
       ],
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -41,7 +41,7 @@
         "minisearch": "^7.2.0",
         "openai": "^6.45.0",
         "youtube-transcript-api": "^3.0.6",
-        "zod": "^3.23.0"
+        "zod": "^4.4.3"
       },
       "bin": {
         "hayba-mcp": "dist/index.js"
@@ -1664,9 +1664,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1684,9 +1681,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1704,9 +1698,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1724,9 +1715,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1744,9 +1732,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1764,9 +1749,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5200,9 +5182,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5224,9 +5203,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5248,9 +5224,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5272,9 +5245,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7513,9 +7483,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
Closes #318. Unblocks #316, where this was bundled with ten unrelated bumps.

## The five error classes

| | |
|---|---|
| `z.record(V)` → `z.record(K, V)` | 19 sites |
| `ZodEffects` → `ZodPipe` (`_def.in` / `_def.out`) | 2 |
| `z.objectOutputType` removed → `z.infer<z.ZodObject<S>>` | 1 |
| `ZodRawShape` is `Readonly` | 1 |
| Internals moved (see below) | 3 |

The `record` rewrite used paren matching, not a regex, so nested unions in the value type couldn't be mis-split — and every rewrite was checked to be an actual Zod record rather than some other method named `record`.

## Why a green typecheck wasn't enough

zod 4 moved several things, and **none of the old reads throw — they return `undefined`**:

```
_def.typeName ("ZodString")  →  _def.type ("string")
enum _def.values             →  public .options
array _def.type              →  _def.element      ← still exists, now holds "array"
.describe()                  →  public .description getter
```

With all 26 errors fixed the build was clean and the entire tool catalogue had **silently lost its parameter documentation** — every param rendering as `string (optional)` with nothing after it. That string is what an agent reads to decide how to call a tool. A single assertion in `legacy-tool-factory.test.ts` caught it.

The array case is worse: reading the old name yields something plausible rather than nothing.

## Coverage

`describeZod` is the function that renders every tool signature, and it had one line of coverage. It has eight tests now — primitives, descriptions surviving `.optional()`, enum members, array element type, tuples, preprocess. **Verified by mutation**: restoring either old read turns them red.

## One thing deliberately not fixed

A param with `.default()` is reported as `(required)`. The unwrap loop steps through `ZodDefault` without setting the optional flag, and that predates this PR. It is wrong from the caller's side — an agent told "required" invents a value instead of letting the default apply — but fixing it changes what every affected tool advertises, which doesn't belong in a dependency migration. Pinned by a test that names it, so a future fix fails loudly instead of drifting.

## Gate

`tsc --noEmit` clean · **1390 tests across 143 files** · `lint:legacy-wrappers` OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated schema validation for improved compatibility with the latest validation library version.
  * Improved schema descriptions, enums, arrays, transforms, and optional fields when displaying tool signatures.
  * Standardized object parameter handling to require string keys across tools.
  * Added support for nested object values in widget properties and slot settings.

* **Tests**
  * Added coverage for schema rendering and parameter requiredness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->