### PR TITLE
feat(ue): the UI set-properties seam — parse and shape leave the editor behind

### DIFF
--- a/docs/handoffs/HANDOFF-architecture-cleanup.md
+++ b/docs/handoffs/HANDOFF-architecture-cleanup.md
@@ -55,7 +55,7 @@ npm run lint:legacy-wrappers        # SEPARATE from npm test. Easy to forget.
 grep -E "Test Completed" /d/Projects/aphrosia/Saved/Logs/Aphrosia.log
 ```
 
-Expected: **12 of 13 `Hayba.MCP` tests pass.** The one failure is
+Expected: **14 of 15 `Hayba.MCP` tests pass.** The one failure is
 `Hayba.MCP.UI.RenderWidgetToPng`, which fails **only** under `-NullRHI` and
 passes with a real RHI (drop the flag to confirm). It is not a regression.
 
@@ -176,10 +176,14 @@ recorded at both sites. Do not "fix" one to match the other.
 
 Pick one domain, do it end-to-end, verify at rung 5, commit. Do not batch.
 
-Candidates by remaining reads: **UI** has a seam but only for slot-payload
-naming — `HandleSetProperties` still interleaves widget traversal, `Modify()`/
-`PostEditChange()` and response shaping, and at 3,113 lines it is the biggest
-single win left. After that, `Blueprint` (943 lines, 25 reads, has a reader, no
-seam).
+`ui_set_widget_properties` is **done** — Parse and Shape are in `HaybaUIOps`,
+Execute stayed in the handler because applying properties needs UMG slot classes
+and `FBlueprintEditorUtils`. That asymmetry is the point and is worth copying:
+the pure halves are where the bugs were, so extract those and leave the engine
+half alone. `FHaybaParamReader` gained `OptionalObject` and `Raw()` doing it.
+
+Next candidates: the rest of the UI handler (`HandleMutateTree` is ~580 lines
+across six sub-commands, each re-reading `widget_name` its own way), then
+`Blueprint` (943 lines, 25 reads, has a reader, no seam).
 
 Check first whether the domain needs it. Two of four did not.

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-set-slot-layout.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-set-slot-layout.ts
@@ -96,8 +96,10 @@ export const uiSetSlotLayoutHandler: ToolHandler = async (args) => {
   }
 
   // The UE handler reads `slot_props`. This tool used to send `slot_layout`,
-  // which no handler revision ever read, so every call failed outright with
-  // "no properties or slot_props provided".
+  // which no handler revision ever read, so every call failed outright as
+  // having sent no payload. The handler now accepts all three spellings and
+  // names the one it read back (HaybaUIOps::ResolveSlotProps); keep sending the
+  // documented one so the reply stays silent about it.
   const data = await executeCommand('ui_set_widget_properties', {
     widget_blueprint_path,
     widget_name,

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaUIOps.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaUIOps.cpp
@@ -27,6 +27,72 @@ namespace HaybaUIOps
         return Out;
     }
 
+    bool FSetPropertiesRequest::HasAnythingToApply() const
+    {
+        const bool bHasProps = Properties.IsValid() && Properties->Values.Num() > 0;
+        const bool bHasSlot  = Slot.IsSet() && Slot.Object->Values.Num() > 0;
+        return bHasProps || bHasSlot;
+    }
+
+    FSetPropertiesRequest ParseSetProperties(FHaybaParamReader& R)
+    {
+        FSetPropertiesRequest Req;
+        Req.BlueprintPath = R.RequiredString(TEXT("widget_blueprint_path"));
+        Req.WidgetName    = R.RequiredString(TEXT("widget_name"));
+        Req.Properties    = R.OptionalObject(TEXT("properties"));
+        Req.Slot          = ResolveSlotProps(R.Raw());
+
+        if (!Req.HasAnythingToApply())
+        {
+            // An empty `properties` object reads as a well-formed request and is
+            // not one. Left to the editor it marks the blueprint dirty, applies
+            // nothing, and fails with an empty list of rejected keys.
+            R.AddError(TEXT("no properties to apply — pass 'properties' (widget properties) "
+                            "and/or 'slot_props' (layout on the parent panel's slot), each a non-empty object"));
+        }
+        return Req;
+    }
+
+    FString SlotKeyName(const FString& Key)
+    {
+        return FString::Printf(TEXT("slot.%s"), *Key);
+    }
+
+    TSharedPtr<FJsonObject> ShapeSetProperties(const FSetPropertiesResult& Result)
+    {
+        auto ToJsonArray = [](const TArray<FString>& In)
+        {
+            TArray<TSharedPtr<FJsonValue>> Arr;
+            for (const FString& S : In) Arr.Add(MakeShared<FJsonValueString>(S));
+            return Arr;
+        };
+
+        TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+        Out->SetStringField(TEXT("widget_name"), Result.WidgetName);
+        Out->SetNumberField(TEXT("succeeded"), Result.Succeeded);
+        Out->SetNumberField(TEXT("failed"), Result.Failed);
+        if (Result.FailedProps.Num() > 0)      Out->SetArrayField(TEXT("failed_properties"), ToJsonArray(Result.FailedProps));
+        if (Result.UnknownSlotProps.Num() > 0) Out->SetArrayField(TEXT("unknown_slot_props"), ToJsonArray(Result.UnknownSlotProps));
+        if (Result.Warnings.Num() > 0)         Out->SetArrayField(TEXT("warnings"), ToJsonArray(Result.Warnings));
+
+        // Only worth saying when the caller did not use the documented name: a
+        // response that always carries it teaches nothing, and one that never
+        // does lets a deprecated spelling look like the right one.
+        if (Result.SlotSpelling != ESlotPropsSpelling::None &&
+            Result.SlotSpelling != ESlotPropsSpelling::SlotProps)
+        {
+            Out->SetStringField(TEXT("slot_props_read_from"), SpellingName(Result.SlotSpelling));
+        }
+        return Out;
+    }
+
+    FString NothingAppliedError(const FSetPropertiesResult& Result)
+    {
+        return FString::Printf(
+            TEXT("ui_set_widget_properties: nothing applied to '%s'. Rejected: %s"),
+            *Result.WidgetName, *FString::Join(Result.FailedProps, TEXT(", ")));
+    }
+
     const TCHAR* SpellingName(ESlotPropsSpelling Spelling)
     {
         switch (Spelling)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaUIOpsTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaUIOpsTest.cpp
@@ -11,6 +11,7 @@
 
 #include "Misc/AutomationTest.h"
 #include "HaybaUIOps.h"
+#include "HaybaMCPParams.h"
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -89,6 +90,175 @@ bool FHaybaUIOpsResolveSlotPropsTest::RunTest(const FString&)
               FString(SpellingName(ESlotPropsSpelling::SlotLayout)), FString(TEXT("slot_layout")));
     TestEqual(TEXT("None has no name"),
               FString(SpellingName(ESlotPropsSpelling::None)), FString());
+
+    return true;
+}
+
+// ── ui_set_widget_properties: parse ─────────────────────────────────────────
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaUIOpsParseSetPropertiesTest,
+    "Hayba.MCP.UIOps.ParseSetProperties",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaUIOpsParseSetPropertiesTest::RunTest(const FString&)
+{
+    using namespace HaybaUIOps;
+
+    {
+        FHaybaParamReader R(
+            Json(TEXT(R"({"widget_blueprint_path":"/Game/W.W","widget_name":"Title","properties":{"Text":"hi"}})")),
+            TEXT("ui_set_widget_properties"));
+        const FSetPropertiesRequest Req = ParseSetProperties(R);
+        TestFalse(TEXT("a well-formed request parses"), R.HasErrors());
+        TestEqual(TEXT("path"), Req.BlueprintPath, FString(TEXT("/Game/W.W")));
+        TestEqual(TEXT("widget"), Req.WidgetName, FString(TEXT("Title")));
+        TestTrue(TEXT("properties come through"), Req.Properties.IsValid());
+        TestFalse(TEXT("no slot payload was sent"), Req.Slot.IsSet());
+    }
+
+    {
+        // Slot layout alone is a complete request — the widget properties object
+        // is optional, and requiring it rejected every pure-layout call.
+        FHaybaParamReader R(
+            Json(TEXT(R"({"widget_blueprint_path":"/Game/W.W","widget_name":"Title","slot_layout":{"Padding":4}})")),
+            TEXT("ui_set_widget_properties"));
+        const FSetPropertiesRequest Req = ParseSetProperties(R);
+        TestFalse(TEXT("slot-only is valid"), R.HasErrors());
+        TestTrue(TEXT("and the spelling is carried to the reply"),
+                 Req.Slot.Spelling == ESlotPropsSpelling::SlotLayout);
+    }
+
+    {
+        // The case this seam exists for. An empty `properties` object is a
+        // well-formed request that asks for nothing; it used to load the
+        // blueprint, mark the package dirty and fail with an empty list of
+        // rejected keys, which reads as "your property names are all wrong".
+        FHaybaParamReader R(
+            Json(TEXT(R"({"widget_blueprint_path":"/Game/W.W","widget_name":"Title","properties":{}})")),
+            TEXT("ui_set_widget_properties"));
+        ParseSetProperties(R);
+        TestTrue(TEXT("an empty properties object is rejected before the editor"), R.HasErrors());
+        TestTrue(TEXT("and the error says what to send"),
+                 R.ErrorMessage().Contains(TEXT("properties")) && R.ErrorMessage().Contains(TEXT("slot_props")));
+    }
+
+    {
+        FHaybaParamReader R(
+            Json(TEXT(R"({"widget_blueprint_path":"/Game/W.W","widget_name":"Title"})")),
+            TEXT("ui_set_widget_properties"));
+        ParseSetProperties(R);
+        TestTrue(TEXT("no payload at all is rejected"), R.HasErrors());
+    }
+
+    {
+        FHaybaParamReader R(
+            Json(TEXT(R"({"widget_blueprint_path":"/Game/W.W","widget_name":"Title","slot_props":{}})")),
+            TEXT("ui_set_widget_properties"));
+        ParseSetProperties(R);
+        TestTrue(TEXT("an empty slot payload is nothing to apply either"), R.HasErrors());
+    }
+
+    {
+        // Every problem in one message rather than one round trip per mistake:
+        // the old handler returned on the first missing field.
+        FHaybaParamReader R(Json(TEXT(R"({})")), TEXT("ui_set_widget_properties"));
+        ParseSetProperties(R);
+        const FString Msg = R.ErrorMessage();
+        TestTrue(TEXT("names the command"), Msg.Contains(TEXT("ui_set_widget_properties")));
+        TestTrue(TEXT("reports the missing blueprint path"), Msg.Contains(TEXT("widget_blueprint_path")));
+        TestTrue(TEXT("and the missing widget name, together"), Msg.Contains(TEXT("widget_name")));
+    }
+
+    {
+        // A null `properties` must not read as an empty object and slip past the
+        // has-anything check as "present".
+        FHaybaParamReader R(
+            Json(TEXT(R"({"widget_blueprint_path":"/Game/W.W","widget_name":"Title","properties":null})")),
+            TEXT("ui_set_widget_properties"));
+        const FSetPropertiesRequest Req = ParseSetProperties(R);
+        TestFalse(TEXT("null is not a properties object"), Req.Properties.IsValid());
+        TestTrue(TEXT("so there is nothing to apply"), R.HasErrors());
+    }
+
+    return true;
+}
+
+// ── ui_set_widget_properties: shape ─────────────────────────────────────────
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaUIOpsShapeSetPropertiesTest,
+    "Hayba.MCP.UIOps.ShapeSetProperties",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaUIOpsShapeSetPropertiesTest::RunTest(const FString&)
+{
+    using namespace HaybaUIOps;
+
+    {
+        FSetPropertiesResult Res;
+        Res.WidgetName = TEXT("Title");
+        Res.Succeeded = 2;
+        const TSharedPtr<FJsonObject> Out = ShapeSetProperties(Res);
+
+        FString Name;
+        TestTrue(TEXT("the widget is named"), Out->TryGetStringField(TEXT("widget_name"), Name) && Name == TEXT("Title"));
+        TestEqual(TEXT("counts are reported"), (int32)Out->GetNumberField(TEXT("succeeded")), 2);
+        TestEqual(TEXT("including the zero"), (int32)Out->GetNumberField(TEXT("failed")), 0);
+        // Empty lists are omitted rather than sent as [] — an absent key reads
+        // as "nothing to say", an empty array invites a caller to look for one.
+        TestFalse(TEXT("no empty failed_properties"), Out->HasField(TEXT("failed_properties")));
+        TestFalse(TEXT("no empty warnings"), Out->HasField(TEXT("warnings")));
+        TestFalse(TEXT("the documented spelling is not worth mentioning"),
+                  Out->HasField(TEXT("slot_props_read_from")));
+    }
+
+    {
+        // A deprecated spelling must be named, or a caller cannot tell being
+        // right from being forgiven and never learns the documented name.
+        FSetPropertiesResult Res;
+        Res.WidgetName = TEXT("Title");
+        Res.Succeeded = 1;
+        Res.SlotSpelling = ESlotPropsSpelling::SlotLayout;
+        const TSharedPtr<FJsonObject> Out = ShapeSetProperties(Res);
+        FString From;
+        TestTrue(TEXT("the spelling used is reported"),
+                 Out->TryGetStringField(TEXT("slot_props_read_from"), From) && From == TEXT("slot_layout"));
+    }
+
+    {
+        FSetPropertiesResult Res;
+        Res.WidgetName = TEXT("Title");
+        Res.Succeeded = 1;
+        Res.Failed = 2;
+        Res.FailedProps = { TEXT("Nope"), SlotKeyName(TEXT("Padding")) };
+        Res.UnknownSlotProps = { TEXT("Padding") };
+        Res.Warnings = { TEXT("Slot is a UCanvasPanelSlot") };
+        const TSharedPtr<FJsonObject> Out = ShapeSetProperties(Res);
+
+        const TArray<TSharedPtr<FJsonValue>>* Failed = nullptr;
+        TestTrue(TEXT("rejected keys are listed"), Out->TryGetArrayField(TEXT("failed_properties"), Failed));
+        TestEqual(TEXT("all of them"), Failed->Num(), 2);
+        // A flat list mixing widget and slot keys would be ambiguous: a slot has
+        // its own property namespace and "Padding" exists in both.
+        TestEqual(TEXT("slot keys are prefixed so they cannot be confused with widget ones"),
+                  (*Failed)[1]->AsString(), FString(TEXT("slot.Padding")));
+        TestTrue(TEXT("unknown slot keys are called out separately"),
+                 Out->HasField(TEXT("unknown_slot_props")));
+        TestTrue(TEXT("warnings survive"), Out->HasField(TEXT("warnings")));
+    }
+
+    {
+        FSetPropertiesResult Res;
+        Res.WidgetName = TEXT("Title");
+        Res.Failed = 1;
+        Res.FailedProps = { TEXT("Nope") };
+        TestTrue(TEXT("nothing applied is a failure, not an ok with zeroes"), Res.AppliedNothing());
+        const FString Msg = NothingAppliedError(Res);
+        TestTrue(TEXT("the error names the widget"), Msg.Contains(TEXT("Title")));
+        TestTrue(TEXT("and the key that was rejected, so the caller can fix it"),
+                 Msg.Contains(TEXT("Nope")));
+    }
 
     return true;
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -1253,13 +1253,20 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleAddElement(const TSharedPtr<FJsonO
 
 FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJsonObject>& P)
 {
-    FString BPPath, WidgetName;
-    if (!P->TryGetStringField(TEXT("widget_blueprint_path"), BPPath) || BPPath.IsEmpty())
-        return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: missing widget_blueprint_path"));
-    if (!P->TryGetStringField(TEXT("widget_name"), WidgetName) || WidgetName.IsEmpty())
-        return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: missing widget_name"));
+    // 1. Parse — pure, no editor. Everything the wire format decides (which
+    //    fields are required, which of three spellings the slot payload used,
+    //    whether there is a single key to apply) is settled before anything is
+    //    loaded, and every problem is reported in one message. See HaybaUIOps.h.
+    FHaybaParamReader R(P, TEXT("ui_set_widget_properties"));
+    const HaybaUIOps::FSetPropertiesRequest Req = HaybaUIOps::ParseSetProperties(R);
+    if (R.HasErrors())
+        return FHaybaHandlerResult::Err(R.ErrorMessage());
 
-    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *BPPath);
+    const FString& WidgetName = Req.WidgetName;
+    const TSharedPtr<FJsonObject> SlotPropsObj = Req.Slot.Object;
+
+    // 2. Execute — needs the editor.
+    UWidgetBlueprint* WBP = LoadObject<UWidgetBlueprint>(nullptr, *Req.BlueprintPath);
     if (!WBP || !WBP->WidgetTree)
         return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: widget blueprint not found"));
 
@@ -1267,24 +1274,17 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
     if (!Widget)
         return FHaybaHandlerResult::Err(FString::Printf(TEXT("ui_set_widget_properties: widget '%s' not found"), *WidgetName));
 
-    const TSharedPtr<FJsonObject>* Props = nullptr;
-    P->TryGetObjectField(TEXT("properties"), Props);
+    HaybaUIOps::FSetPropertiesResult Result;
+    Result.WidgetName   = WidgetName;
+    Result.SlotSpelling = Req.Slot.Spelling;
 
-    // Which of the three shipped spellings the slot payload arrived under is a
-    // wire-format question, not a widget one — see HaybaUIOps.h for why there
-    // are three and what it cost. Resolved outside this function so it can be
-    // tested without an editor.
-    const HaybaUIOps::FSlotPropsPayload SlotPayload = HaybaUIOps::ResolveSlotProps(P);
-    const TSharedPtr<FJsonObject> SlotPropsObj = SlotPayload.Object;
-
-    if ((!Props || !Props->IsValid()) && !SlotPayload.IsSet())
-        return FHaybaHandlerResult::Err(TEXT("ui_set_widget_properties: no properties or slot_props provided"));
-
-    int32 Succeeded = 0;
-    int32 Failed = 0;
-    TArray<FString> FailedProps;
-    TArray<FString> UnknownSlotProps;
-    TArray<FString> Warnings;
+    // References, not copies: the block below writes straight into Result, which
+    // is the only thing the reply is built from.
+    int32& Succeeded = Result.Succeeded;
+    int32& Failed = Result.Failed;
+    TArray<FString>& FailedProps = Result.FailedProps;
+    TArray<FString>& UnknownSlotProps = Result.UnknownSlotProps;
+    TArray<FString>& Warnings = Result.Warnings;
     {
         // No FScopedTransaction: these are automation-tool edits with no undo/redo
         // requirement, and the global editor transaction buffer (GEditor->Trans) can
@@ -1293,9 +1293,9 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
         WBP->Modify();
         Widget->Modify();
 
-        if (Props && Props->IsValid())
+        if (Req.Properties.IsValid())
         {
-            for (const auto& Pair : (*Props)->Values)
+            for (const auto& Pair : Req.Properties->Values)
             {
                 const FString PropertyName(Pair.Key);
                 if (HaybaReflection::SetProp(Widget, PropertyName, Pair.Value))
@@ -1317,7 +1317,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
                 for (const auto& Pair : SlotPropsObj->Values)
                 {
                     ++Failed;
-                    FailedProps.Add(FString::Printf(TEXT("slot.%s"), *FString(Pair.Key)));
+                    FailedProps.Add(HaybaUIOps::SlotKeyName(FString(Pair.Key)));
                 }
                 Warnings.Add(FString::Printf(
                     TEXT("'%s' has no panel slot (it is the root widget, or its parent is not a panel), so slot layout was not applied."),
@@ -1340,7 +1340,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
                 for (const FString& Key : SlotResult.Unknown)
                 {
                     UnknownSlotProps.Add(Key);
-                    FailedProps.Add(FString::Printf(TEXT("slot.%s"), *Key));
+                    FailedProps.Add(HaybaUIOps::SlotKeyName(Key));
                 }
                 if (SlotResult.Unknown.Num() > 0)
                 {
@@ -1375,37 +1375,13 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleSetProperties(const TSharedPtr<FJs
         WBP->MarkPackageDirty();
     }
 
-    auto ToJsonArray = [](const TArray<FString>& In)
+    // 3. Shape — pure.
+    if (Result.AppliedNothing())
     {
-        TArray<TSharedPtr<FJsonValue>> Arr;
-        for (const FString& S : In) Arr.Add(MakeShared<FJsonValueString>(S));
-        return Arr;
-    };
-
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetStringField(TEXT("widget_name"), WidgetName);
-    Out->SetNumberField(TEXT("succeeded"), Succeeded);
-    Out->SetNumberField(TEXT("failed"), Failed);
-    if (FailedProps.Num() > 0)      Out->SetArrayField(TEXT("failed_properties"), ToJsonArray(FailedProps));
-    if (UnknownSlotProps.Num() > 0) Out->SetArrayField(TEXT("unknown_slot_props"), ToJsonArray(UnknownSlotProps));
-    if (Warnings.Num() > 0)         Out->SetArrayField(TEXT("warnings"), ToJsonArray(Warnings));
-    // Name the spelling the slot payload arrived under. A caller using a
-    // deprecated one currently cannot tell it worked by tolerance rather than
-    // by being right, so it never learns to send the documented name.
-    if (SlotPayload.IsSet() && SlotPayload.Spelling != HaybaUIOps::ESlotPropsSpelling::SlotProps)
-    {
-        Out->SetStringField(TEXT("slot_props_read_from"),
-                            HaybaUIOps::SpellingName(SlotPayload.Spelling));
+        return FHaybaHandlerResult::Err(HaybaUIOps::NothingAppliedError(Result));
     }
 
-    if (Succeeded == 0)
-    {
-        return FHaybaHandlerResult::Err(FString::Printf(
-            TEXT("ui_set_widget_properties: nothing applied to '%s'. Rejected: %s"),
-            *WidgetName, *FString::Join(FailedProps, TEXT(", "))));
-    }
-
-    return FHaybaHandlerResult::Ok(Out);
+    return FHaybaHandlerResult::Ok(HaybaUIOps::ShapeSetProperties(Result));
 }
 
 FHaybaHandlerResult FHaybaMCPUIHandler::HandleQuery(const TSharedPtr<FJsonObject>& P)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPParams.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPParams.h
@@ -162,6 +162,23 @@ public:
         return FRotator(V->X, V->Y, V->Z);
     }
 
+    /** Reads a nested object. Absent, null and "present but not an object" all
+     *  come back unset — a handler that treats a null as an empty object goes on
+     *  to apply nothing and reports having applied it. */
+    TSharedPtr<FJsonObject> OptionalObject(const TCHAR* Key) const
+    {
+        if (bParamsMissing) return nullptr;
+        const TSharedPtr<FJsonObject>* Found = nullptr;
+        if (!Params->TryGetObjectField(Key, Found) || !Found || !Found->IsValid()) return nullptr;
+        return *Found;
+    }
+
+    /** The params object itself, for the rare read this class cannot express —
+     *  chiefly a field whose *name* is the question (see
+     *  HaybaUIOps::ResolveSlotProps). Not a general escape hatch: a read that
+     *  belongs here should be added here. Null when no params were supplied. */
+    const TSharedPtr<FJsonObject>& Raw() const { return Params; }
+
     /** Record a problem the reader cannot detect on its own (a value out of
      *  range, a combination that does not make sense). */
     void AddError(const FString& Message) { Errors.Add(Message); }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaUIOps.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaUIOps.h
@@ -12,6 +12,7 @@
 
 #include "CoreMinimal.h"
 #include "Dom/JsonObject.h"
+#include "HaybaMCPParams.h"
 
 namespace HaybaUIOps
 {
@@ -48,4 +49,66 @@ namespace HaybaUIOps
      *  deprecated spelling should be told which one it used rather than left to
      *  infer that it worked by accident. */
     const TCHAR* SpellingName(ESlotPropsSpelling Spelling);
+
+    // ── ui_set_widget_properties ─────────────────────────────────────────────
+    //
+    // Same three-way split as HaybaActorOps.h — Parse / Execute / Shape — with
+    // one difference: Execute stays in the handler. Applying properties needs
+    // the widget tree, UMG slot classes, Modify()/PostEditChange() and
+    // FBlueprintEditorUtils, none of which this header should drag in. Parse and
+    // Shape are the halves that are pure, and they are the halves that were
+    // wrong: the payload-naming bug and the counter that credited a success per
+    // *submitted* key rather than per applied one both lived here.
+
+    struct FSetPropertiesRequest
+    {
+        FString BlueprintPath;
+        FString WidgetName;
+        /** Widget properties. Null when the caller sent none — which is not the
+         *  same as an empty object, though both mean "nothing to apply". */
+        TSharedPtr<FJsonObject> Properties;
+        FSlotPropsPayload Slot;
+
+        /** Whether there is a single key to write. A request naming a widget and
+         *  carrying no keys used to reach the editor, mark the blueprint dirty
+         *  and come back "nothing applied ... Rejected: " with an empty list. */
+        bool HasAnythingToApply() const;
+    };
+
+    struct FSetPropertiesResult
+    {
+        FString WidgetName;
+        /** Keys the widget or its slot actually took. Not the count submitted:
+         *  slot keys used to be counted as successes before the slot was asked
+         *  whether it understood them. */
+        int32 Succeeded = 0;
+        int32 Failed = 0;
+        TArray<FString> FailedProps;
+        TArray<FString> UnknownSlotProps;
+        TArray<FString> Warnings;
+        /** Which spelling the slot payload arrived under, so the reply can name
+         *  a deprecated one instead of forgiving it in silence. */
+        ESlotPropsSpelling SlotSpelling = ESlotPropsSpelling::None;
+
+        bool AppliedNothing() const { return Succeeded == 0; }
+    };
+
+    /** 1. Parse — pure. Errors accumulate on the reader; check R.HasErrors().
+     *
+     *  "You sent no keys" is decided here rather than after the blueprint loads,
+     *  so a caller with two mistakes hears about both at once instead of being
+     *  told about the blueprint and then, a round trip later, about the payload. */
+    FSetPropertiesRequest ParseSetProperties(FHaybaParamReader& R);
+
+    /** How a slot key is named in `failed_properties`, so widget and slot keys
+     *  cannot be confused with each other in a flat list. */
+    FString SlotKeyName(const FString& Key);
+
+    /** 3. Shape — pure. */
+    TSharedPtr<FJsonObject> ShapeSetProperties(const FSetPropertiesResult& Result);
+
+    /** The message for a request where nothing landed. Naming the rejected keys
+     *  is the difference between "your property names are wrong" and a bare
+     *  failure the caller can only respond to by guessing. */
+    FString NothingAppliedError(const FSetPropertiesResult& Result);
 }


### PR DESCRIPTION
Continues #320. `ui_set_widget_properties` was the largest remaining example of the shape that issue is about: one function that read the wire format, walked the widget tree, called `Modify()`/`PostEditChange()` and built the reply.

## What moved

Parse and Shape go to `HaybaUIOps`, following `HaybaActorOps`. **Execute stays in the handler** — applying properties needs UMG slot classes and `FBlueprintEditorUtils`, which that header should not drag in. The asymmetry is the point: the pure halves are the ones that have carried the bugs (the payload naming that dropped a correct request on the floor, and a counter that credited a success per *submitted* key rather than per applied one).

`FHaybaParamReader` gains `OptionalObject` — absent, null and present-but-not-an-object all read as unset, so a null cannot pass for an empty object — and `Raw()`, for the one read whose question is a field's *name*.

## One behaviour change

"You sent no keys to apply" is a wire-format question, so it is now answered before the blueprint loads and alongside every other param problem. An empty `properties` object used to reach the editor, mark the package dirty, and come back `nothing applied ... Rejected: ` with an empty list — which reads as "your property names are all wrong" when the truth is that none were sent.

## Verification

Rung 5, observed.

- **C++**: 14 of 15 `Hayba.MCP` pass (was 12 of 13). The failure is `UI.RenderWidgetToPng`, which fails only under `-NullRHI`, as before.
- **Mutation-tested**, both new tests: disabling the has-anything-to-apply check fails `UIOps.ParseSetProperties`; always emitting `slot_props_read_from` fails `UIOps.ShapeSetProperties`. Reverted, rebuilt, both green.
- **TS**: `tsc --noEmit` clean, 1391 tests green, `lint:legacy-wrappers` clean.
- **Live editor**, on a throwaway probe widget:
  - bogus path + empty `properties` → the payload complaint, not "widget blueprint not found" (the discriminating case for the reordering above);
  - a real call → `succeeded: 2, failed: 2, failed_properties: ["NotAProperty", "slot.NotASlotKey"]` plus the slot-type warning;
  - the deprecated `slot_layout` spelling → `slot_props_read_from: "slot_layout"`.
- Editor left clean: probe deleted, `dirty_count: 0`, PIE not running.

The handoff is updated — expected test count, and the next candidates (the rest of the UI handler, then `Blueprint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved widget property updates with clearer validation and standardized results.
  - Added support for slot properties using accepted naming variations.
  - Responses now identify applied, failed, unknown, and unsupported properties, along with warnings.
  - Added clearer errors when no properties are successfully applied.

- **Documentation**
  - Updated guidance to identify the supported slot-property payload format and current verification status.

- **Tests**
  - Expanded coverage for valid requests, empty payloads, validation errors, slot-property handling, warnings, and response formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->