### PR TITLE
fix(tools): a param with a default is optional, and the default is named

### DIFF
--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { recordSchema } from '../tools/schema-registry.js';
 import {
   runAgentLoop,
   buildToolCatalog,
@@ -324,5 +326,31 @@ describe('buildToolCatalog', () => {
     // registry-derived branch is covered by integration; here we assert the
     // function runs and honours the no-shape skip without throwing.
     expect(Array.isArray(tools)).toBe(true);
+  });
+
+  // The second copy of the rule shared in tools/zod-unwrap.ts. This surface and
+  // the tool catalogue's prose describer once disagreed about `.default()`
+  // (#322), so the same parameter was advertised two different ways depending
+  // on which one an agent was reading. Both are pinned now.
+  it('a defaulted param is not required, and the schema carries the default', () => {
+    recordSchema('zzz_default_probe', {
+      shape: {
+        needed: z.string(),
+        capped: z.number().default(5),
+        maybe: z.string().optional(),
+      },
+      cost: 'low',
+      returns: '{ok}',
+    });
+
+    const tool = buildToolCatalog({ listCommands: () => ['zzz_default_probe'] })
+      .find((t) => t.name === 'zzz_default_probe');
+
+    expect(tool, 'the probe tool should be in the catalog').toBeDefined();
+    const schema = tool!.input_schema as { required?: string[]; properties: Record<string, { default?: unknown }> };
+    expect(schema.required, 'only the genuinely required param is required').toEqual(['needed']);
+    expect(schema.properties.capped.default, 'the value it gets by omitting it').toBe(5);
+    expect(schema.properties.maybe, 'a plain optional has no default to report')
+      .not.toHaveProperty('default');
   });
 });

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
@@ -38,6 +38,7 @@ import type {
   LLMStopReason,
 } from '../agents/llm-client.js';
 import { deriveSignature, getRawShape, listRecordedCommands } from '../tools/schema-registry.js';
+import { unwrapZod } from '../tools/zod-unwrap.js';
 import { getToolMeta } from '../tools/tool-meta-registry.js';
 import { describeMeta } from '../tools/hayba-tool-meta.js';
 import { NON_IDEMPOTENT, executeCommand } from '../tools/tool-executor.js';
@@ -113,28 +114,9 @@ interface JsonSchema {
 }
 
 function zodToJsonSchema(t: ZodTypeAny): { schema: JsonSchema; optional: boolean } {
-  let optional = false;
-  let inner: ZodTypeAny = t;
-  while (
-    inner instanceof z.ZodOptional ||
-    inner instanceof z.ZodDefault ||
-    inner instanceof z.ZodNullable
-  ) {
-    // ZodDefault also makes the field optional (a default is supplied when absent).
-    if (
-      inner instanceof z.ZodOptional ||
-      inner instanceof z.ZodNullable ||
-      inner instanceof z.ZodDefault
-    )
-      optional = true;
-    inner = (inner as unknown as { _def: { innerType: ZodTypeAny } })._def.innerType;
-  }
-  // zod 4: ZodEffects became ZodPipe, whose ends are `_def.in` / `_def.out`.
-  // Follow the end that is not the transform.
-  while (inner instanceof z.ZodPipe) {
-    const { in: pin, out: pout } = inner._def as unknown as { in: ZodTypeAny; out: ZodTypeAny };
-    inner = pout instanceof z.ZodTransform ? pin : pout;
-  }
+  // Shared with the tool catalogue's describer — see zod-unwrap.ts. These two
+  // used to answer "is this optional?" differently for the same schema.
+  const { inner, optional, hasDefault, defaultValue } = unwrapZod(t);
 
   let schema: JsonSchema;
   if (inner instanceof z.ZodString) schema = { type: 'string' };
@@ -161,6 +143,10 @@ function zodToJsonSchema(t: ZodTypeAny): { schema: JsonSchema; optional: boolean
   // `_def.description` — which reads undefined rather than throwing.
   const desc = t.description ?? inner.description;
   if (desc) schema.description = desc;
+  // `default` is a JSON Schema keyword, and the model reads it: knowing the
+  // value it gets by omitting a parameter is what makes omitting it a choice
+  // rather than a gamble.
+  if (hasDefault && defaultValue !== undefined) schema.default = defaultValue;
   return { schema, optional };
 }
 

--- a/mcp-tools/hayba-mcp/src/tools/__tests__/schema-registry-describe.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/__tests__/schema-registry-describe.test.ts
@@ -98,17 +98,38 @@ describe('describeZod under zod 4', () => {
     expect(p.any).toContain('any');
   });
 
-  it('PINS A KNOWN INACCURACY: a defaulted param is reported as required', () => {
-    // Pre-existing, not a zod 4 regression — the unwrap loop steps through
-    // ZodDefault without setting the optional flag, and this predates the
-    // migration.
-    //
-    // It is still wrong from the caller's side: a param with a default does not
-    // have to be supplied, and telling an agent "required" makes it invent a
-    // value rather than let the default apply. Pinned here so the behaviour is
-    // visible and so fixing it fails this test loudly rather than silently
-    // changing what every tool advertises. See the follow-up issue.
+  // This replaces a test named "PINS A KNOWN INACCURACY", which asserted that a
+  // defaulted param was advertised as `(required)` so that fixing it would fail
+  // loudly rather than silently change what every tool advertises. #322 is that
+  // fix; the pin has done its job and is now inverted.
+  it('a defaulted param is optional, and says what the default is', () => {
     const p = sigFor({ d: z.string().default('x') });
-    expect(p.d).toContain('(required)');
+    expect(p.d, 'a param with a default does not have to be supplied').toContain('(optional');
+    expect(p.d, 'and telling an agent it is required makes it invent a value').not.toContain('(required)');
+    expect(p.d, 'knowing the value it would get is what makes omitting it a choice').toContain('default: "x"');
+  });
+
+  it('reports a default it cannot quote briefly as existing rather than in full', () => {
+    // Every parameter line is paid for in the context window of every agent
+    // that reads the catalogue.
+    const p = sigFor({ d: z.array(z.string()).default(['a'.repeat(60)]) });
+    expect(p.d).toContain('(optional');
+    expect(p.d).toContain('has a default');
+    expect(p.d.length, 'the long value itself is not pasted in').toBeLessThan(80);
+  });
+
+  it('still separates a plain optional from a defaulted one', () => {
+    // "may be omitted" and "may be omitted, and here is what you get" are
+    // different facts; collapsing them loses the second.
+    const p = sigFor({ o: z.string().optional(), d: z.number().default(5) });
+    expect(p.o).toContain('(optional)');
+    expect(p.d).toContain('default: 5');
+  });
+
+  it('sees a default through the wrappers around it', () => {
+    // .optional().default() and .default().optional() are both real spellings
+    // in this codebase (py-tool-factory descriptors use the first).
+    expect(sigFor({ d: z.number().optional().default(5) }).d).toContain('default: 5');
+    expect(sigFor({ d: z.number().default(5).optional() }).d).toContain('default: 5');
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/py-tool-factory.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/py-tool-factory.test.ts
@@ -175,7 +175,10 @@ describe('registerPyTool', () => {
     expect(sig!.returns).toBe('{ok, echoed}');
     expect(sig!.params.target).toContain('string');
     expect(sig!.params.target).toContain('(required)');
-    expect(sig!.params.limit).toContain('(optional)'); // defaulted ⇒ optional
+    // Defaulted ⇒ optional, and the default is named so a caller can decide
+    // whether to override it instead of guessing a value (#322).
+    expect(sig!.params.limit).toContain('(optional');
+    expect(sig!.params.limit).toContain('default: 5');
   });
 
   it('registers tool meta for cost lookup', () => {

--- a/mcp-tools/hayba-mcp/src/tools/schema-registry.ts
+++ b/mcp-tools/hayba-mcp/src/tools/schema-registry.ts
@@ -5,6 +5,7 @@
 // drifts every time a tool changes.
 
 import { z, type ZodRawShape, type ZodTypeAny } from 'zod';
+import { unwrapZod, formatDefault } from './zod-unwrap.js';
 
 export type Cost = 'low' | 'medium' | 'high';
 
@@ -44,26 +45,8 @@ export function deriveSignature(name: string): DerivedSignature | null {
 // Mirrors the style of the hand-maintained dict: type first, then "(required)"
 // or "(optional)", with describe() text appended when present.
 function describeZod(t: ZodTypeAny): string {
-  // Unwrap optionals/defaults to reach the inner type, but remember we did.
-  let optional = false;
-  let inner: ZodTypeAny = t;
-  // ZodOptional / ZodDefault / ZodNullable all expose ._def.innerType
-  while (
-    inner instanceof z.ZodOptional ||
-    inner instanceof z.ZodDefault ||
-    inner instanceof z.ZodNullable
-  ) {
-    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable) optional = true;
-    inner = (inner as any)._def.innerType;
-  }
-  // zod 4 replaced ZodEffects with ZodPipe: preprocess/transform are a pipe
-  // whose two ends are `_def.in` and `_def.out`. Describe the end that is not
-  // the transform itself — for z.preprocess(fn, schema) that is `out`, for
-  // schema.transform(fn) it is `in`.
-  while (inner instanceof z.ZodPipe) {
-    const { in: pin, out: pout } = inner._def as unknown as { in: ZodTypeAny; out: ZodTypeAny };
-    inner = pout instanceof z.ZodTransform ? pin : pout;
-  }
+  // What the wrappers mean is decided in one place — see zod-unwrap.ts.
+  const { inner, optional, hasDefault, defaultValue } = unwrapZod(t);
 
   let typeStr: string;
   if (inner instanceof z.ZodString) typeStr = 'string';
@@ -88,7 +71,15 @@ function describeZod(t: ZodTypeAny): string {
     typeStr = (inner._def as unknown as { type?: string })?.type ?? 'any';
   }
 
-  const qualifier = optional ? '(optional)' : '(required)';
+  // Naming the default is worth a few tokens: it tells an agent both that it
+  // may omit the parameter AND what happens if it does, so it can decide
+  // whether to override rather than guess a value that is already there.
+  const shownDefault = hasDefault ? formatDefault(defaultValue) : null;
+  const qualifier = hasDefault
+    ? (shownDefault ? `(optional, default: ${shownDefault})` : '(optional, has a default)')
+    : optional
+      ? '(optional)'
+      : '(required)';
   // zod 4 moved .describe() out of `_def.description` and onto a public
   // `.description` getter. Reading the old location returns undefined rather
   // than throwing, so every parameter description silently became

--- a/mcp-tools/hayba-mcp/src/tools/schema-single-source.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/schema-single-source.test.ts
@@ -191,8 +191,10 @@ describe('single-source migration: hayba_introspect (via pyTemplate factory)', (
     const sig = deriveSignature('hayba_introspect');
     expect(sig).not.toBeNull();
     expect(sig!.cost).toBe('low');
-    expect(sig!.params['mode']).toMatch(/\(optional\)/);
-    expect(sig!.params['settings_class']).toMatch(/\(optional\)/);
+    // `mode` is optional AND defaulted, so it also names the default (#322).
+    expect(sig!.params['mode']).toMatch(/\(optional/);
+    expect(sig!.params['mode']).toContain('default: "auto"');
+    expect(sig!.params['settings_class']).toMatch(/\(optional/);
     expect(sig!.returns).toContain('input_pins');
   });
 });
@@ -242,8 +244,9 @@ describe('single-source migration: pcg_wire (via pyTemplate factory)', () => {
     const sig = deriveSignature('pcg_wire');
     expect(sig).not.toBeNull();
     expect(sig!.cost).toBe('low');
-    expect(sig!.params['from_pin']).toMatch(/\(optional\)/);
-    expect(sig!.params['to_pin']).toMatch(/\(optional\)/);
+    // Both are defaulted pin labels, so both name their default (#322).
+    expect(sig!.params['from_pin']).toContain('default: "Out"');
+    expect(sig!.params['to_pin']).toMatch(/\(optional/);
     expect(sig!.returns).toContain('from_pin');
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/zod-unwrap.ts
+++ b/mcp-tools/hayba-mcp/src/tools/zod-unwrap.ts
@@ -1,0 +1,91 @@
+// The one place that decides what a zod wrapper MEANS to a caller.
+//
+// Two describers walk the same wrappers for different outputs: schema-registry
+// renders prose for the tool catalogue, agent-loop emits JSON Schema for the
+// chat sidecar. They each grew their own copy of the unwrap loop, and the
+// copies disagreed — agent-loop treated `.default()` as optional, the catalogue
+// did not, so the same parameter was advertised two different ways depending on
+// which surface an agent was looking at (#322). ADR-0007: two copies of one
+// rule diverge, and the divergence is the bug.
+//
+// The rule lives here now. The two describers keep their own rendering.
+
+import { z, type ZodTypeAny } from 'zod';
+
+export interface UnwrappedZod {
+  /** The type underneath every wrapper — what to render. */
+  inner: ZodTypeAny;
+  /** Whether the caller may omit this parameter. */
+  optional: boolean;
+  /** Whether omitting it produces a value rather than nothing. */
+  hasDefault: boolean;
+  /** That value, when there is one. */
+  defaultValue?: unknown;
+}
+
+/**
+ * Strip optional/default/nullable wrappers and see through a pipe.
+ *
+ * `.default()` counts as optional. It is the whole point of the wrapper: the
+ * parameter does not have to be supplied. Advertising it as required makes an
+ * agent invent a value instead of letting the default apply, which quietly
+ * stops the default from being the default on every agent-driven call.
+ */
+export function unwrapZod(t: ZodTypeAny): UnwrappedZod {
+  let optional = false;
+  let hasDefault = false;
+  let defaultValue: unknown;
+  let inner: ZodTypeAny = t;
+
+  // ZodOptional / ZodDefault / ZodNullable all expose ._def.innerType.
+  while (
+    inner instanceof z.ZodOptional ||
+    inner instanceof z.ZodDefault ||
+    inner instanceof z.ZodNullable
+  ) {
+    if (inner instanceof z.ZodDefault) {
+      optional = true;
+      if (!hasDefault) {
+        // The OUTERMOST default is the one that applies, so keep the first seen.
+        hasDefault = true;
+        // zod 4 stores the value itself; zod 3 stored a thunk. Reading the
+        // wrong shape here yields a function where a value was expected rather
+        // than throwing, so handle both and let the tests say which is live.
+        const raw = (inner._def as unknown as { defaultValue: unknown }).defaultValue;
+        defaultValue = typeof raw === 'function' ? (raw as () => unknown)() : raw;
+      }
+    } else {
+      optional = true;
+    }
+    inner = (inner as unknown as { _def: { innerType: ZodTypeAny } })._def.innerType;
+  }
+
+  // zod 4 replaced ZodEffects with ZodPipe: preprocess/transform are a pipe
+  // whose two ends are `_def.in` and `_def.out`. Describe the end that is not
+  // the transform — for z.preprocess(fn, schema) that is `out`, for
+  // schema.transform(fn) it is `in`.
+  while (inner instanceof z.ZodPipe) {
+    const { in: pin, out: pout } = inner._def as unknown as { in: ZodTypeAny; out: ZodTypeAny };
+    inner = pout instanceof z.ZodTransform ? pin : pout;
+  }
+
+  return { inner, optional, hasDefault, defaultValue };
+}
+
+/**
+ * A default rendered for a human-readable signature, or null when it is not
+ * worth the tokens.
+ *
+ * Every tool's parameter list is paid for in the context window of every agent
+ * that reads the catalogue, so a default that would take more room than the
+ * parameter it documents is reported as existing rather than quoted in full.
+ */
+export function formatDefault(value: unknown): string | null {
+  let text: string;
+  try {
+    text = JSON.stringify(value) ?? 'null';
+  } catch {
+    return null; // circular or otherwise unprintable — say nothing rather than throw
+  }
+  return text.length <= 40 ? text : null;
+}


### PR DESCRIPTION
Closes #322.

`describeZod` rendered `z.string().default('x')` as `string (required)` — the unwrap loop stepped through `ZodDefault` without setting the optional flag. It is the failure shape `docs/WORKFLOW-improving-the-mcp.md` is written around: not false, but it makes the caller do the wrong thing. An agent told a parameter is required invents a value rather than letting the default apply, so the default silently stops being the default on every agent-driven call.

## The copy, not just the bug

Two copies of that unwrap loop existed and they disagreed: `chat/agent-loop.ts` treated `.default()` as optional, the tool catalogue did not. The same parameter was advertised two different ways depending on which surface an agent was reading.

Per ADR-0007 the fix is to delete the copy rather than sync it. The rule now lives in `tools/zod-unwrap.ts`; the two describers keep only their own rendering (prose for the catalogue, JSON Schema for the sidecar).

## Both now name the default

The more useful half of the fix: knowing what you get by omitting a parameter is what makes omitting it a choice rather than a gamble.

- prose: `string (optional, default: "x")`
- JSON Schema: the `default` keyword

A default too long to quote is reported as existing rather than pasted in — every parameter line is paid for in the context window of every agent that reads the catalogue.

## Tests

The test named **PINS A KNOWN INACCURACY** is inverted, as its own comment asked. Three others asserted the literal `(optional)` for params that are optional *and* defaulted; they now assert the default too.

Mutation-tested: making `ZodDefault` non-optional fails the agent-loop catalog test; never recording the default fails four describe tests. **Both surfaces go red from one broken rule** — which is the point of sharing it. Reverted, green.

`tsc --noEmit` clean · 1395 tests green (was 1391) · `lint:legacy-wrappers` clean.

Rung note: verified by test, not against a live agent. `dist/` is rebuilt but the MCP server process needs a restart before the catalogue an agent sees changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)