### PR TITLE
feat(mcp): make the project, audio and mesh-list commands reachable

### DIFF
--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -3037,6 +3037,464 @@
       "agent_callable": true,
       "has_ts_wrapper": true,
       "notes": "Analog input for sticks, triggers and mouse axes. Applies for one frame; resend per step for sustained movement."
+    },
+    "project_get_info": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPProjectHandler::Handle",
+      "params": [],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "project_name",
+            "type": "string"
+          },
+          {
+            "name": "project_dir",
+            "type": "string",
+            "description": "Absolute path, forward slashes"
+          },
+          {
+            "name": "content_dir",
+            "type": "string"
+          },
+          {
+            "name": "saved_dir",
+            "type": "string",
+            "description": "Where the editor log lives — the first place to look when a command claims success"
+          },
+          {
+            "name": "engine_version",
+            "type": "string"
+          },
+          {
+            "name": "engine_association",
+            "type": "string"
+          },
+          {
+            "name": "description",
+            "type": "string"
+          },
+          {
+            "name": "category",
+            "type": "string"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Where this project is on disk and which engine built it. Call it before any path-building work rather than guessing a content root, and to resolve the Saved/ directory the editor log lives in. Takes no parameters."
+    },
+    "project_get_settings": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPProjectHandler::Handle",
+      "params": [],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "project_id",
+            "type": "string"
+          },
+          {
+            "name": "project_name",
+            "type": "string"
+          },
+          {
+            "name": "project_version",
+            "type": "string"
+          },
+          {
+            "name": "company_name",
+            "type": "string"
+          },
+          {
+            "name": "homepage",
+            "type": "string"
+          },
+          {
+            "name": "support_contact",
+            "type": "string"
+          },
+          {
+            "name": "description",
+            "type": "string"
+          },
+          {
+            "name": "copyright_notice",
+            "type": "string"
+          },
+          {
+            "name": "editor_startup_map",
+            "type": "string",
+            "description": "Read from GEngineIni, not from GeneralProjectSettings"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Reads UGeneralProjectSettings — the identity fields shown on the Project Settings > Description page — plus the editor startup map. Read-only; use project_set_settings to change any of them. Fields that were never filled in come back as empty strings, not as missing keys."
+    },
+    "project_set_settings": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPProjectHandler::Handle",
+      "params": [
+        {
+          "name": "section",
+          "type": "string",
+          "required": false,
+          "description": "Raw-ini mode: the ini section, e.g. /Script/EngineSettings.GameMapsSettings. Requires key and value; writes GEngineIni and takes precedence over the named fields below."
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "required": false,
+          "description": "Raw-ini mode: the ini key. Only with section + value."
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "required": false,
+          "description": "Raw-ini mode: the value to write. Only with section + key."
+        },
+        {
+          "name": "project_name",
+          "type": "string",
+          "required": false,
+          "description": "Named mode: written to DefaultGame.ini"
+        },
+        {
+          "name": "company_name",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "homepage",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "project_version",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "company_distinguished_name",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "project_id",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "support_contact",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "copyright_notice",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "ok",
+            "type": "boolean"
+          },
+          {
+            "name": "updated",
+            "type": "array",
+            "description": "Named mode: exactly which fields were written. Check it — a field this command does not recognise is not reported per-key."
+          },
+          {
+            "name": "section",
+            "type": "string",
+            "description": "Raw-ini mode only"
+          },
+          {
+            "name": "key",
+            "type": "string",
+            "description": "Raw-ini mode only"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Writes project identity settings to the ini files, in two modes: pass section+key+value to write any ini key directly, or pass any of the named fields to write DefaultGame.ini. It flushes to disk immediately — this edits config the whole team shares, so prefer project_get_settings first. Values are strings in both modes."
+    },
+    "project_list_plugins": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPProjectHandler::Handle",
+      "params": [],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "plugins",
+            "type": "array",
+            "description": "name, friendly_name, version, version_name, enabled, category, description, is_engine"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Every ENABLED plugin, engine and project alike, with its version and category. This is the reliable way to answer 'is Water/PCG/Niagara available here' before calling a domain that needs one — a capability probe against reality rather than an assumption. Disabled plugins are not listed at all."
+    },
+    "mesh_get_info": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPStaticMeshHandler::MeshGetInfo",
+      "params": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": true,
+          "description": "Object path of a UStaticMesh, e.g. /Engine/BasicShapes/Cube.Cube"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "lod_count",
+            "type": "number"
+          },
+          {
+            "name": "triangle_count_lod0",
+            "type": "number"
+          },
+          {
+            "name": "num_vertices_lod0",
+            "type": "number"
+          },
+          {
+            "name": "lod_screen_sizes",
+            "type": "array",
+            "description": "One entry per source model, in LOD order"
+          },
+          {
+            "name": "material_slots",
+            "type": "array",
+            "description": "name + material_path per slot; material_path is empty when the slot has no material"
+          },
+          {
+            "name": "bounds",
+            "type": "object",
+            "description": "min / max / extents, each {x,y,z}"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": true,
+      "notes": "Triangle and vertex counts, the LOD chain with its screen sizes, material slots and local bounds for one static mesh. Called from TS by the physical-asset baker and world_generate for bounds, so it is documented here rather than surfaced as its own agent tool: agents should reach for mesh_get_bounds / mesh_get_lods / mesh_get_materials, which split the same information and do not load the asset whole."
+    },
+    "mesh_set_lod": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPStaticMeshHandler::MeshSetLOD",
+      "params": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": true,
+          "description": "Object path of the UStaticMesh"
+        },
+        {
+          "name": "lod_index",
+          "type": "number",
+          "required": true,
+          "description": "Which source model; must be within lod_count from mesh_get_info"
+        },
+        {
+          "name": "screen_size",
+          "type": "number",
+          "required": true,
+          "description": "Screen size at which this LOD takes over"
+        },
+        {
+          "name": "reduction_percent_triangles",
+          "type": "number",
+          "required": false,
+          "description": "Optional triangle-reduction target for this LOD"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "ok",
+            "type": "boolean"
+          },
+          {
+            "name": "lod_index",
+            "type": "number"
+          },
+          {
+            "name": "screen_size",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Sets a LOD's screen size (and optionally its reduction target) on a static mesh, then rebuilds it. Editor-only, and it modifies the asset — save it afterwards. It REFUSES a mesh with any zero-UV LOD, because the rebuild would hit an engine assert and take the editor down with it; that refusal is a real limit of the asset, not a bug in this command."
+    },
+    "mesh_list": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPStaticMeshHandler::MeshList",
+      "params": [
+        {
+          "name": "path_prefix",
+          "type": "string",
+          "required": false,
+          "description": "Keep only assets whose object path starts with this, e.g. /Game/Aphrosia. Omitted means every static mesh the registry knows, engine content included."
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "meshes",
+            "type": "array",
+            "description": "path, name, package_path"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Enumerate static meshes from the asset registry without loading any of them — the cheap way to find something to place or inspect. Always pass path_prefix on a real project unless you actually want engine content in the results. Exact subclasses only, so a mesh subclass is not listed."
+    },
+    "audio_list": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPAudioHandler::AudioList",
+      "params": [
+        {
+          "name": "path_prefix",
+          "type": "string",
+          "required": false,
+          "description": "Keep only sounds whose object path starts with this. Omitted means everything, including the large engine sound set."
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "sounds",
+            "type": "array",
+            "description": "path, name, class, and duration_seconds / sample_rate when the registry has them cached"
+          },
+          {
+            "name": "count",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Enumerate USoundBase assets (waves, cues, MetaSound sources) from the asset registry, including subclasses, without loading them. Duration and sample rate come from registry tags, so they are present for most assets but not guaranteed — a missing key means untagged, not zero."
+    },
+    "audio_play": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPAudioHandler::AudioPlay",
+      "params": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": true,
+          "description": "Object path of a USoundBase"
+        },
+        {
+          "name": "volume",
+          "type": "number",
+          "required": false,
+          "default": 1
+        },
+        {
+          "name": "pitch",
+          "type": "number",
+          "required": false,
+          "default": 1
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "ok",
+            "type": "boolean"
+          },
+          {
+            "name": "playing",
+            "type": "string",
+            "description": "Asset name actually loaded and played"
+          },
+          {
+            "name": "volume",
+            "type": "number"
+          },
+          {
+            "name": "pitch",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Play a sound 2D through the editor's current world, for auditioning an asset. The reply says the sound loaded and playback was started — it cannot tell you anything was audible, so treat it as dispatch, not as evidence. Needs an active world; it fails rather than queueing if there is none."
+    },
+    "audio_set_volume": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPAudioHandler::AudioSetVolume",
+      "params": [
+        {
+          "name": "category",
+          "type": "string",
+          "required": true,
+          "description": "Only 'master' is implemented; any other category is an explicit error rather than a silent no-op"
+        },
+        {
+          "name": "volume",
+          "type": "number",
+          "required": true,
+          "description": "Multiplier, 1.0 being unchanged"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "ok",
+            "type": "boolean"
+          },
+          {
+            "name": "category",
+            "type": "string"
+          },
+          {
+            "name": "volume",
+            "type": "number"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Sets the transient primary volume on the main audio device — the master bus, and only that. Per-category mixing (music, sfx, ui) would need Sound Class / Sound Mix routing and is not implemented; asking for one of those categories returns an error naming the limit. The change is transient and does not persist."
     }
   }
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPProjectHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPProjectHandler.cpp
@@ -61,13 +61,16 @@ static TSharedRef<FJsonObject> GetSettings()
     return Out;
 }
 
-static TSharedRef<FJsonObject> SetSetting(const TSharedPtr<FJsonObject>& Params)
+// Returns an error string when nothing was written, empty otherwise. The two
+// failure cases used to be reported as an `error` field inside an Ok response —
+// a caller checking `ok` was told a settings write succeeded when not one key
+// had been touched.
+static FHaybaHandlerResult SetSetting(const TSharedPtr<FJsonObject>& Params)
 {
     auto Out = MakeShared<FJsonObject>();
     if (!Params.IsValid())
     {
-        Out->SetStringField(TEXT("error"), TEXT("missing params"));
-        return Out;
+        return FHaybaHandlerResult::Err(TEXT("project_set_settings: no params object was supplied"));
     }
 
     // Generic passthrough: explicit section/key/value into a chosen ini.
@@ -81,7 +84,7 @@ static TSharedRef<FJsonObject> SetSetting(const TSharedPtr<FJsonObject>& Params)
         Out->SetBoolField(TEXT("ok"), true);
         Out->SetStringField(TEXT("section"), Section);
         Out->SetStringField(TEXT("key"),     Key);
-        return Out;
+        return FHaybaHandlerResult::Ok(Out);
     }
 
     // Typed: write GeneralProjectSettings fields to GGameIni (DefaultGame.ini).
@@ -108,13 +111,18 @@ static TSharedRef<FJsonObject> SetSetting(const TSharedPtr<FJsonObject>& Params)
 
     if (Updated.Num() == 0)
     {
-        Out->SetStringField(TEXT("error"), TEXT("project_set_settings: no recognized fields provided"));
-        return Out;
+        // Nothing recognised is a caller error, not a successful no-op. Name the
+        // fields that exist so the next attempt can be right.
+        return FHaybaHandlerResult::Err(TEXT(
+            "project_set_settings: nothing was written — no recognized field was supplied. "
+            "Pass section+key+value to write an ini key directly, or one or more of: "
+            "project_name, company_name, description, homepage, project_version, "
+            "company_distinguished_name, project_id, support_contact, copyright_notice."));
     }
     GConfig->Flush(false, GGameIni);
     Out->SetBoolField(TEXT("ok"), true);
     Out->SetArrayField(TEXT("updated"), Updated);
-    return Out;
+    return FHaybaHandlerResult::Ok(Out);
 }
 
 static TSharedRef<FJsonObject> ListPlugins()
@@ -144,7 +152,7 @@ FHaybaHandlerResult FHaybaMCPProjectHandler::Handle(const FString& Cmd, const TS
 {
     if (Cmd == TEXT("project_get_info"))     return FHaybaHandlerResult::Ok(GetInfo());
     if (Cmd == TEXT("project_get_settings")) return FHaybaHandlerResult::Ok(GetSettings());
-    if (Cmd == TEXT("project_set_settings")) return FHaybaHandlerResult::Ok(SetSetting(Params));
+    if (Cmd == TEXT("project_set_settings")) return SetSetting(Params);
     if (Cmd == TEXT("project_list_plugins")) return FHaybaHandlerResult::Ok(ListPlugins());
     return FHaybaHandlerResult::Err(FString::Printf(TEXT("ProjectHandler: unknown command %s"), *Cmd));
 }


### PR DESCRIPTION
Closes #8.

## The finding

`list_tool_categories` reports **415 plugin commands, 355 callable**. The gap is not features that were never built — it is C++ that shipped with nothing exposing it. Entire domains sit at zero callable: `project`, `audio`, `input`, `bt`, `anim`, `net`, `physics`, `gas`, `metasound`, `wp`.

That is why #8 read as open. Every command it asks for already existed and answered correctly when called; no agent could reach any of them.

## This PR

Descriptors for `project_get_info` / `project_get_settings` / `project_set_settings` / `project_list_plugins`, `audio_play` / `audio_list` / `audio_set_volume`, `mesh_list`, `mesh_set_lod`.

**Every one was called against the running editor before it was described.** The params, return fields and limits come from what came back, not from reading the signature.

`mesh_get_info` deliberately stays internal: TS already calls it (the physical-asset baker, `world_generate`), so the wrapper lint is right to require `has_ts_wrapper: true`, and agents have `mesh_get_bounds` / `mesh_get_lods` / `mesh_get_materials` covering the same ground without loading the whole asset. The note now says that instead of leaving the next reader to rediscover it.

Two real limits are written into the descriptions rather than left to be hit at runtime: `audio_set_volume` implements the master bus only, and `audio_play` can report that playback started but cannot tell you anything was audible.

## A silent liar, found by probing

`project_set_settings` returned `ok: true` with an `error` field when it recognised no field and wrote nothing. A caller checking `ok` was told a settings write succeeded when not one key had been touched — the exact shape `docs/WORKFLOW-improving-the-mcp.md` exists to catch. It now returns an error naming every field it accepts.

Verified live after a Live Coding compile (`Live coding succeeded` in the log): the unrecognised case returns `ok: false`; a real write returns `updated: ["support_contact"]`. That probe write was reverted and `Config/DefaultGame.ini` is byte-unchanged (mtime still 2026-07-31).

## Gate

`tsc --noEmit` clean · 1405 tests green · `lint:legacy-wrappers` OK (94 entries).

Rung note: the C++ fix is rung 5 (observed live, both branches). The new descriptors are not visible to a **running** MCP server until it restarts and rereads the sidecar — that restart is yours to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)