### PR TITLE
feat(mcp): surface physics, world-partition and the stranded editor commands

### DIFF
--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -4110,6 +4110,304 @@
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": "Compiles an animation blueprint and reports the compiler's own errors and warnings. Every anim_blueprint_* write leaves the asset needing a compile, and an uncompiled blueprint keeps running its previous generated class — so skipping this makes edits look like they did nothing."
+    },
+    "physics_set_simulate": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPhysicsHandler::PhysicsSetSimulate",
+      "params": [
+        {
+          "name": "actor_id",
+          "type": "string",
+          "required": true,
+          "description": "Actor name or editor label in the current editor world"
+        },
+        {
+          "name": "enabled",
+          "type": "boolean",
+          "required": true
+        },
+        {
+          "name": "component_name",
+          "type": "string",
+          "required": false,
+          "description": "Which primitive component. Omitted means the root component, falling back to the first primitive component found."
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "actor_id",
+            "type": "string"
+          },
+          {
+            "name": "simulating",
+            "type": "boolean",
+            "description": "Read back off the component after the write, not echoed — a component that refused to simulate reports false here"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Turns rigid-body simulation on or off for one primitive component in the EDITOR world. The reply reads the flag back off the component rather than repeating the request, so a component that cannot simulate (no collision, no body instance) is visible as simulating:false with ok:true. Editor-world only: this is not how you drive physics during PIE."
+    },
+    "physics_set_collision_profile": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPhysicsHandler::PhysicsSetCollisionProfile",
+      "params": [
+        {
+          "name": "actor_id",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "profile_name",
+          "type": "string",
+          "required": true,
+          "description": "A profile from Project Settings > Collision, e.g. BlockAll, OverlapAllDynamic, NoCollision"
+        },
+        {
+          "name": "component_name",
+          "type": "string",
+          "required": false,
+          "description": "Defaults to the root primitive component"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "component",
+            "type": "string"
+          },
+          {
+            "name": "requested_profile",
+            "type": "string",
+            "description": "What you asked for"
+          },
+          {
+            "name": "profile",
+            "type": "string",
+            "description": "What the component is actually on, read back after the write"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Assigns a named collision profile to a component and READS IT BACK. An unrecognised profile name leaves the component on whatever it had, so a mismatch between requested_profile and profile is returned as an error naming the current profile rather than as a success. Profiles come from the project Collision settings, e.g. BlockAll, OverlapAll, NoCollision, Pawn."
+    },
+    "physics_add_impulse": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPPhysicsHandler::PhysicsAddImpulse",
+      "params": [
+        {
+          "name": "actor_id",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "impulse",
+          "type": "array",
+          "required": true,
+          "description": "[x,y,z]. Fewer than three numbers is rejected rather than zero-filled."
+        },
+        {
+          "name": "velocity_change",
+          "type": "boolean",
+          "required": false,
+          "description": "true applies the vector as a velocity change, ignoring mass"
+        },
+        {
+          "name": "component_name",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "component",
+            "type": "string"
+          },
+          {
+            "name": "linear_velocity",
+            "type": "object",
+            "description": "{x,y,z} read off the body after the impulse — an observable to compare against what you asked for"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Applies an impulse to a primitive component in the editor world and reports the resulting linear velocity. A component that is not simulating physics discards an impulse silently, so that case is REFUSED with a message naming the fix rather than answering applied:true — the old reply was true of the call and false of the world. Turn simulation on with physics_set_simulate first."
+    },
+    "wp_get_cells": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPWorldPartitionHandler::WpGetCells",
+      "params": [],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "cells",
+            "type": "array",
+            "description": "cell_id, bounds{min,max}, actor_count, top_classes (top 5 by count)"
+          },
+          {
+            "name": "total",
+            "type": "number",
+            "description": "How many cells exist"
+          },
+          {
+            "name": "returned",
+            "type": "number",
+            "description": "Present only when the list was cut short at 100"
+          },
+          {
+            "name": "truncated",
+            "type": "boolean",
+            "description": "Present only when total exceeds what was returned"
+          },
+          {
+            "name": "cell_source",
+            "type": "string",
+            "description": "Always \"computed_grid\" — see the note"
+          },
+          {
+            "name": "grid_size_cm",
+            "type": "number",
+            "description": "The fixed bin size used, 51200"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "A spatial summary of where actors are: it bins every actor in the editor world onto a fixed 512m grid and reports per-bin counts and the classes that dominate each. These are NOT the World Partition runtime cells — cell ids and bounds will not match the partition's own, which is why the reply says cell_source. Requires World Partition to be enabled on the map; use it to find the busy regions before deciding where to look."
+    },
+    "wp_load_cell": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPWorldPartitionHandler::WpLoadCell",
+      "params": [
+        {
+          "name": "cell_id",
+          "type": "string",
+          "required": false,
+          "description": "Accepted and ignored — the command cannot load anything"
+        }
+      ],
+      "returns": {
+        "shape": "object"
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "NOT IMPLEMENTED, and it says so rather than pretending. World Partition cell loading is interactive-only in the editor and there is no programmatic path here yet, so every call returns an error naming that limit. It previously returned ok with loaded:false, which let a caller loop over cells and conclude the world was loaded."
+    },
+    "wp_get_streaming_state": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPWorldPartitionHandler::WpGetStreamingState",
+      "params": [],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "enabled",
+            "type": "boolean",
+            "description": "Whether the current editor world has a World Partition at all"
+          },
+          {
+            "name": "streaming_sources",
+            "type": "string",
+            "description": "Always \"not_enumerated\" — sources are not counted here, and the field says so rather than reporting a zero that would read as measured"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Answers one question honestly: does the current editor world use World Partition. It previously also reported a hard-coded source_count of 0 — a field named for a measurement that always answers zero reads as \"measured, none found\", so it now names itself not_enumerated instead of inventing a number."
+    },
+    "editor_get_performance_stats": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPEditorHandler::GetPerformanceStats",
+      "params": [],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "fps",
+            "type": "number",
+            "description": "Engine rolling average"
+          },
+          {
+            "name": "frame_ms",
+            "type": "number"
+          },
+          {
+            "name": "render_thread_ms",
+            "type": "number",
+            "description": "Converted from engine cycles"
+          },
+          {
+            "name": "game_thread_ms",
+            "type": "number",
+            "description": "Converted from engine cycles"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Editor frame timing: average fps, frame time, and the two thread times. These are whole-editor averages, not a profile of one operation — an idle editor with a compile running reads badly and that is not a scene problem. The thread times are cycle counters converted through FPlatformTime::ToMilliseconds; they were previously emitted RAW under _ms names, so every reading of those two fields used to be wrong by the platform cycle factor."
+    },
+    "editor_live_compile": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPEditorHandler::LiveCompile",
+      "params": [],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "compile_requested",
+            "type": "boolean",
+            "description": "The trigger was issued. NOT that the compile succeeded — the outcome never comes back through this call."
+          },
+          {
+            "name": "result_source",
+            "type": "string",
+            "description": "Where to read the actual outcome"
+          },
+          {
+            "name": "log_dir",
+            "type": "string",
+            "description": "Absolute project log directory"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Triggers a Live Coding compile of the running editor. It is asynchronous: poll the editor log for 'Live coding succeeded' or 'LogLiveCoding: Error', matching on a COUNT of terminal lines rather than presence, because earlier runs are still in the file. Compile ERRORS are not in the editor log at all — they are in UnrealBuildTool\\Log.txt. A brand-new handler CLASS still needs a full editor restart; Live Coding cannot register one."
+    },
+    "editor_set_viewport_mode": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPEditorHandler::SetViewportMode",
+      "params": [
+        {
+          "name": "mode",
+          "type": "string",
+          "required": true,
+          "description": "lit | unlit | wireframe | detail_lighting | lighting_only | shader_complexity"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "mode",
+            "type": "string"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Switches the active editor viewport's view mode — wireframe to read geometry density, shader_complexity to find expensive materials, unlit to judge albedo without lighting. This changes what a HUMAN is looking at and does not change back on its own, so put it back to lit when you are done rather than leaving someone else's viewport in wireframe."
     }
   }
 }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPEditorHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPEditorHandler.cpp
@@ -504,10 +504,28 @@ FHaybaHandlerResult FHaybaMCPEditorHandler::StreamLog(const TSharedPtr<FJsonObje
 
 FHaybaHandlerResult FHaybaMCPEditorHandler::LiveCompile(const TSharedPtr<FJsonObject>& P)
 {
-    // Hot Reload was removed in UE 5.4+; Live Coding replaces it but its public C++ API is limited.
+    // This returned Ok with compile_started:false and "programmatic trigger not
+    // exposed in UE 5.4+". That reason was wrong: the LiveCoding.Compile console
+    // command triggers it, and it is the route WORKFLOW-improving-the-mcp.md has
+    // told agents to use through editor_run_console_command all along. The
+    // command that exists for this job was the only thing refusing to do it.
+    if (!GEngine)
+        return FHaybaHandlerResult::Err(TEXT("editor_live_compile: GEngine not available"));
+
+    UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+    GEngine->Exec(World, TEXT("LiveCoding.Compile"), *GLog);
+
     TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject());
-    Result->SetBoolField(TEXT("compile_started"), false);
-    Result->SetStringField(TEXT("reason"), TEXT("Use Live Coding (Ctrl+Alt+F11) — programmatic trigger not exposed in UE 5.4+"));
+    // "Requested", not "succeeded". The compile runs asynchronously in
+    // LiveCodingConsole and its outcome never comes back through this call, so
+    // claiming a result here would be precisely the lie this codebase keeps
+    // finding in its own replies.
+    Result->SetBoolField(TEXT("compile_requested"), true);
+    Result->SetStringField(TEXT("result_source"),
+        TEXT("asynchronous — poll the editor log for 'Live coding succeeded' or 'LogLiveCoding: Error', "
+             "matching on a COUNT of those lines rather than presence, since earlier runs are still in the file. "
+             "Compile ERRORS are not in the editor log at all; they are in UnrealBuildTool\\Log.txt."));
+    Result->SetStringField(TEXT("log_dir"), FPaths::ConvertRelativePathToFull(FPaths::ProjectLogDir()));
     return FHaybaHandlerResult::Ok(Result);
 }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPWorldPartitionHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPWorldPartitionHandler.cpp
@@ -117,15 +117,38 @@ FHaybaHandlerResult FHaybaMCPWorldPartitionHandler::WpGetCells(const TSharedPtr<
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
     Out->SetArrayField(TEXT("cells"), CellArr);
     Out->SetNumberField(TEXT("total"), Cells.Num());
+    // These are NOT the World Partition's runtime cells. They are actor
+    // locations binned onto a fixed grid by this handler — a useful spatial
+    // summary, and a different thing entirely, since the real grid size and
+    // cell bounds come from the partition config. A caller had no way to know
+    // which of the two it was holding.
+    Out->SetStringField(TEXT("cell_source"), TEXT("computed_grid"));
+    Out->SetNumberField(TEXT("grid_size_cm"), CellSize);
+    Out->SetStringField(TEXT("cell_source_note"),
+        TEXT("Cells are computed by binning actor locations onto a fixed grid in this handler, "
+             "NOT read from the World Partition runtime hash — cell ids and bounds will not match "
+             "the partition's own cells."));
+    if (Cells.Num() > Emitted)
+    {
+        // The 100-cell cap was silent: `total` disagreed with the array length
+        // and nothing said why.
+        Out->SetNumberField(TEXT("returned"), Emitted);
+        Out->SetBoolField(TEXT("truncated"), true);
+    }
     return FHaybaHandlerResult::Ok(Out);
 }
 
 FHaybaHandlerResult FHaybaMCPWorldPartitionHandler::WpLoadCell(const TSharedPtr<FJsonObject>& P)
 {
-    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
-    Out->SetBoolField(TEXT("loaded"), false);
-    Out->SetStringField(TEXT("reason"), TEXT("interactive_loading_only"));
-    return FHaybaHandlerResult::Ok(Out);
+    // Same family as the source_count fix above: this returned Ok with
+    // loaded:false for every call it has ever received. An unconditional no-op
+    // reporting success is worse than an unimplemented command — a caller loops
+    // over cells, gets ok every time, and concludes the world is loaded. It
+    // never loads anything, so it now says so.
+    return FHaybaHandlerResult::Err(TEXT(
+        "wp_load_cell: not implemented — World Partition cell loading is interactive-only in the editor. "
+        "There is no programmatic path here yet; load the region in the editor, or use wp_get_cells to see "
+        "what exists without loading it."));
 }
 
 FHaybaHandlerResult FHaybaMCPWorldPartitionHandler::WpGetStreamingState(const TSharedPtr<FJsonObject>& P)


### PR DESCRIPTION
Finishes the main plugin's side of the unreachable-command sweep (#8, #21, #23, #20, #17). Nine descriptors: `physics_set_simulate` / `physics_set_collision_profile` / `physics_add_impulse`, `wp_get_cells` / `wp_load_cell` / `wp_get_streaming_state`, `editor_get_performance_stats` / `editor_live_compile` / `editor_set_viewport_mode`.

## This lands on top of 39af7b1d

That commit fixed the same three handlers in parallel, from a live editor. **Where we overlapped, it wins** — it reads the collision profile back and errors on a mismatch, refuses an impulse on a component that is not simulating and reports the resulting velocity, and answers `streaming_sources: "not_enumerated"` rather than deleting the field. Better than what I had, and live-verified.

The descriptors here describe **that** behaviour. A descriptor written against the wrong response shape is worse than no descriptor, so they were rewritten after reconciling rather than shipped as drafted.

(We also both independently made the same cycle→millisecond fix on `editor_get_performance_stats`. Only one copy survives — that one.)

## Three fixes that are new here

**`editor_live_compile` refused with a false reason.** It returned `ok: true`, `compile_started: false`, *"programmatic trigger not exposed in UE 5.4+"*. That is wrong — `LiveCoding.Compile` triggers it, it is the route `docs/WORKFLOW-improving-the-mcp.md` tells agents to take via `editor_run_console_command`, and it is how this session compiled four times. **The command that exists for this job was the only thing refusing to do it.** It now triggers and reports `compile_requested` — not success, because the outcome arrives asynchronously in the log, including the trap that compile *errors* live in `UnrealBuildTool\Log.txt` rather than the editor log.

**`wp_load_cell` was an unconditional no-op returning `ok`.** Every call it has ever received returned `ok: true, loaded: false`. A caller loops over cells, gets `ok` each time, and concludes the world is loaded. It now returns an error naming the limit: World Partition cell loading is interactive-only and there is no programmatic path here.

**`wp_get_cells` was quietly lying about what it returns.** These are not World Partition cells — the handler bins actor locations onto a fixed 512 m grid, which is a useful spatial summary and an entirely different thing from the partition's runtime cells, whose size and bounds come from config. It also truncated at 100 while reporting the true `total`, so the array length silently disagreed with the count. The reply now carries `cell_source: "computed_grid"`, `grid_size_cm`, and `returned` / `truncated`.

## Limits written into the descriptions

Rather than left to be discovered at the point of failure: `physics_add_impulse` needs simulation on first and says so; `editor_set_viewport_mode` changes what a human is looking at and does not revert on its own; `editor_get_performance_stats` reports whole-editor averages, so an idle editor with a compile running reads badly and that is not a scene problem.

## Verification — read before merging

**TypeScript is green:** `tsc --noEmit` clean, 119 legacy-description tests, `lint:legacy-wrappers` OK at 117 entries.

**The C++ is not fully compile-verified in this exact form.** The same three changes compiled and linked cleanly in an earlier full build (`UnrealEditor-HaybaMCPToolkit.dll`, step 391/395). Since then the reconciliation altered only comments and renamed one response field (`log_file` → `log_dir`). A confirming build was started and stopped at 174/396. **Run one before merging.**

Nothing here was re-probed against a live editor either — the editor was closed partway through this work.

## Unrelated, but blocking

The host project does not link. `Module.Aphrosia` has nine unresolved externals on `UStewardshipSubsystem` UFUNCTIONs (`GetTaxRate`, `GetTaxPolicy`, `SetTaxRate`, `GetDemesne`, `BuildHoldingStatement`, `BuildDemesneStatement`, `GetOverlordOf`, `GetBaseProduction`, `GetTradeBalance`) that are declared but never defined. Not from this repo. The plugin builds; the editor will not start until those are implemented or stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands for controlling physics simulation, collision profiles, and impulses.
  * Added World Partition inspection and cell-loading commands.
  * Added editor performance statistics, Live Coding compilation, and viewport display mode controls.

* **Bug Fixes**
  * Live Coding now properly triggers asynchronous compilation and reports log locations.
  * World Partition responses now clearly identify grid limitations, truncation, and unsupported loading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->