### PR TITLE
feat(mcp): the last main-plugin commands, and two that should not be offered

### DIFF
--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -4109,7 +4109,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Compiles an animation blueprint and reports the compiler's own errors and warnings. Every anim_blueprint_* write leaves the asset needing a compile, and an uncompiled blueprint keeps running its previous generated class — so skipping this makes edits look like they did nothing."
+      "notes": "Compiles an ANIMATION blueprint (ABP) — the animation state-machine asset, not an ordinary class. Reports the compiler errors and warnings. Every anim_blueprint_* write leaves the asset needing this, and an uncompiled ABP keeps running its previously generated class, so state-machine edits look like they did nothing."
     },
     "physics_set_simulate": {
       "aliases": [],
@@ -4194,7 +4194,7 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "Assigns a named collision profile to a component and READS IT BACK. An unrecognised profile name leaves the component on whatever it had, so a mismatch between requested_profile and profile is returned as an error naming the current profile rather than as a success. Profiles come from the project Collision settings, e.g. BlockAll, OverlapAll, NoCollision, Pawn."
+      "notes": "Assigns a named collision profile to one primitive component and READS IT BACK. An unrecognised name leaves the component on whatever it had, so a mismatch between requested_profile and profile is returned as an error naming the current setting rather than as a success. Names come from the project Collision settings, e.g. BlockAll, NoCollision, Pawn. This SETS a profile; to find out what is currently intersecting what, use scene_validate_physics."
     },
     "physics_add_impulse": {
       "aliases": [],
@@ -4298,9 +4298,9 @@
       "returns": {
         "shape": "object"
       },
-      "agent_callable": true,
+      "agent_callable": false,
       "has_ts_wrapper": false,
-      "notes": "NOT IMPLEMENTED, and it says so rather than pretending. World Partition cell loading is interactive-only in the editor and there is no programmatic path here yet, so every call returns an error naming that limit. It previously returned ok with loaded:false, which let a caller loop over cells and conclude the world was loaded."
+      "notes": "NOT IMPLEMENTED, and it says so rather than pretending: World Partition cell loading is interactive-only in the editor, so every call returns an error naming that limit. It previously returned ok with loaded:false, which let a caller loop over cells and conclude the world was loaded. agent_callable:false — an honest error is still a command that can never succeed, and the catalogue should not offer it."
     },
     "wp_get_streaming_state": {
       "aliases": [],
@@ -4408,6 +4408,190 @@
       "agent_callable": true,
       "has_ts_wrapper": false,
       "notes": "Switches the active editor viewport's view mode — wireframe to read geometry density, shader_complexity to find expensive materials, unlit to judge albedo without lighting. This changes what a HUMAN is looking at and does not change back on its own, so put it back to lit when you are done rather than leaving someone else's viewport in wireframe."
+    },
+    "placement_validate": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPActorHandler::PlacementValidate",
+      "params": [
+        {
+          "name": "class_path",
+          "type": "string",
+          "required": true,
+          "description": "Class you intend to spawn, e.g. /Script/Engine.StaticMeshActor"
+        },
+        {
+          "name": "location",
+          "type": "array",
+          "required": false,
+          "description": "[x,y,z] of the intended placement. A short array is an error, not a silent zero — a 2-element location once made this report a clean spot at the origin."
+        },
+        {
+          "name": "rotation",
+          "type": "array",
+          "required": false,
+          "description": "[pitch,yaw,roll]"
+        },
+        {
+          "name": "scale",
+          "type": "array",
+          "required": false,
+          "description": "[x,y,z]"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "valid",
+            "type": "boolean",
+            "description": "True when nothing overlaps the intended placement"
+          },
+          {
+            "name": "overlaps",
+            "type": "array",
+            "description": "id + class of each actor already occupying the space"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Asks whether an actor of this class would collide with anything if spawned at this transform, WITHOUT spawning it. Use it before actor_spawn when placing into a populated scene — cheaper than spawning, checking, and deleting. It answers about overlap only: it does not tell you whether the spot makes sense, is on navmesh, or is inside geometry."
+    },
+    "blueprint_add_function": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPBlueprintHandler::AddFunction",
+      "params": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": true,
+          "description": "Object path of the UBlueprint"
+        },
+        {
+          "name": "function_name",
+          "type": "string",
+          "required": true,
+          "description": "A name already used by this blueprint is NOT rejected — see the note"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "function_name",
+            "type": "string"
+          },
+          {
+            "name": "compiled_clean",
+            "type": "boolean",
+            "description": "READ THIS. False means the function was added and the blueprint no longer compiles."
+          },
+          {
+            "name": "compile_errors",
+            "type": "array",
+            "description": "Present when the compile failed"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Adds an empty function graph to a blueprint and recompiles. Check compiled_clean, not just ok: adding a function whose name is already taken SUCCEEDS and leaves the blueprint broken with 'Found more than one function with the same name' — verified live. The reply reports the compiler's verdict, but the operation is not rolled back, so a duplicate name costs you a manual repair."
+    },
+    "blueprint_document": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPBlueprintHandler::Document",
+      "params": [
+        {
+          "name": "path",
+          "type": "string",
+          "required": true,
+          "description": "Object path of the UBlueprint"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "documentation",
+            "type": "string",
+            "description": "One WHEN ... THEN ... line per event, e.g. \"WHEN Event BeginPlay THEN END\""
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Renders a blueprint's EVENT GRAPH as pseudo-English — a fast way to see what a blueprint reacts to without opening it. It covers events only: user-defined function graphs do not appear, so a blueprint documented as three bare events may still have functions. Use blueprint_get_info for structure."
+    },
+    "level_get_spatial_index": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPLevelHandler::GetSpatialIndex",
+      "params": [],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "status",
+            "type": "string",
+            "description": "Always \"deferred\""
+          },
+          {
+            "name": "see",
+            "type": "string",
+            "description": "Always \"scene_export\""
+          }
+        ]
+      },
+      "agent_callable": false,
+      "has_ts_wrapper": false,
+      "notes": "NOT IMPLEMENTED — returns status:\"deferred\" pointing at scene_export, for every call. Documented here so get_tool_signature can explain it, but agent_callable:false so it does not appear as capability an agent can spend a turn discovering is empty. Use scene_export, or wp_get_cells for a spatial summary."
+    },
+    "level_set_bookmark": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPLevelHandler::SetBookmark",
+      "params": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "Bookmark identifier"
+        },
+        {
+          "name": "location",
+          "type": "array",
+          "required": false,
+          "description": "[x,y,z]; defaults to the current viewport camera position when omitted"
+        },
+        {
+          "name": "rotation",
+          "type": "array",
+          "required": false,
+          "description": "[pitch,yaw,roll]"
+        }
+      ],
+      "returns": {
+        "shape": "object"
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Stores a named camera position in the current level so it can be returned to later. Bookmarks live in the LEVEL, so this dirties the map and persists only if the level is saved — do not use it as scratch state on a map someone else is working in. NOT VERIFIED LIVE: described from the handler source, because verifying it means dirtying a real level."
+    },
+    "level_goto_bookmark": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPLevelHandler::GotoBookmark",
+      "params": [
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "description": "A bookmark previously stored by level_set_bookmark"
+        }
+      ],
+      "returns": {
+        "shape": "object"
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Moves the editor viewport to a stored bookmark. This changes what a human is looking at, so it is not a neutral read — prefer editor_set_camera when you just need a viewpoint for a capture. NOT VERIFIED LIVE: described from the handler source."
     }
   }
 }

--- a/mcp-tools/hayba-mcp/src/tools/no-stub-wrappers.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/no-stub-wrappers.test.ts
@@ -6,11 +6,17 @@ import { fileURLToPath } from 'node:url';
 // A wrapper must not advertise a command the C++ cannot actually perform.
 //
 // This nearly happened. A sweep for "implemented in C++ but missing a wrapper"
-// flagged editor_live_compile as free capability. It is not implemented — the
-// handler returns compile_started:false with "use Live Coding (Ctrl+Alt+F11) —
-// programmatic trigger not exposed in UE 5.4+". Wrapping it would have put a
-// tool in the catalogue that always fails, which is worse than the gap it was
-// meant to close: an agent would burn turns discovering it does nothing.
+// flagged editor_live_compile as free capability, and the handler said it was
+// not possible: compile_started:false, "programmatic trigger not exposed in UE
+// 5.4+". Wrapping a command that always fails is worse than the gap it closes.
+//
+// That reason turned out to be FALSE. LiveCoding.Compile triggers a compile
+// perfectly well, and editor_run_console_command had been the documented way to
+// do it all along — the handler was the only thing refusing. It now works, so it
+// has left this list. The near-miss is still worth remembering, but the lesson
+// changed shape: a handler's own explanation of why it cannot do something is a
+// claim like any other, and this one went unchecked long enough to become a
+// denylist entry and a test comment.
 //
 // Detecting these needs more than grepping for "not_implemented", because the
 // honest stubs say that and the misleading ones do not.
@@ -30,8 +36,12 @@ const HANDLER_DIR = join(
  *  denylist that silently suppresses working capability is the same kind of
  *  quiet wrongness as a tool that reports success without doing anything. */
 const KNOWN_STUBS = [
-  // Returns compile_started:false and points at the manual shortcut.
-  'editor_live_compile',
+  // Returns status:"deferred" pointing at scene_export, for every call.
+  'level_get_spatial_index',
+  // Returns an error naming the limit: World Partition cell loading is
+  // interactive-only in the editor. Honest, but still a command that can never
+  // succeed, so nothing should wrap it as capability.
+  'wp_load_cell',
 ];
 
 function wrapperSources(): Array<{ file: string; text: string }> {
@@ -77,9 +87,12 @@ describe('wrappers never advertise a stubbed command', () => {
       .join('\n');
 
     const stillStubbed = KNOWN_STUBS.filter((s) => {
-      // Either the command name sits near a not-implemented marker, or the
-      // handler is one we have individually confirmed (live_compile).
-      if (s === 'editor_live_compile') return /programmatic trigger not exposed/.test(sources);
+      // Each entry needs a marker that is specific to how THAT handler declines,
+      // because the honest stubs phrase it differently and a generic grep for
+      // "not_implemented" misses them. If a handler is reworked, its marker
+      // disappears and this test starts failing — which is the point.
+      if (s === 'level_get_spatial_index') return /SetStringField\(TEXT\("status"\), TEXT\("deferred"\)\)/.test(sources);
+      if (s === 'wp_load_cell') return /wp_load_cell: not implemented/.test(sources);
       return new RegExp(`${s}[\\s\\S]{0,2000}?not_implemented`).test(sources)
         || new RegExp(`not_implemented[\\s\\S]{0,2000}?${s}`).test(sources);
     });


### PR DESCRIPTION
Ends the unreachable-command sweep for the main plugin. Every command `HaybaMCPToolkit` implements now either has a descriptor or is deliberately marked not callable.

## Surfaced

**Probed live:** `placement_validate` (reports overlaps for an intended transform without spawning), `blueprint_add_function`, `blueprint_document`, `level_get_spatial_index`.

**Not probed:** `level_set_bookmark` and `level_goto_bookmark` write into a level, and verifying them means dirtying a real map. Their descriptions say they are unverified rather than implying otherwise.

## Two commands are documented but `agent_callable: false`

Following the rule `no-stub-wrappers.test.ts` already sets — do not offer a command that can never succeed, because an agent burns turns discovering it does nothing:

- `level_get_spatial_index` returns `status: "deferred"` for every call
- `wp_load_cell` returns an honest error — honest, but still never successful

Both stay visible to `get_tool_signature`.

## That guard needed updating in the other direction too

`editor_live_compile` was its **only** entry, on the grounds that a programmatic Live Coding trigger *"is not exposed in UE 5.4+"*. That reason was false, the command now works (#330), and it has left the list.

The comment records why, because the lesson changed shape: a handler's own explanation of why it cannot do something is a claim like any other, and this one went unchecked long enough to become a denylist entry **and** a test comment justifying it.

## Two findings worth keeping

**`blueprint_add_function` accepts a name the blueprint already uses.** It adds the function, the compile fails with *"Found more than one function with the same name"*, and the reply is `ok: true` carrying `compile_errors`. The asset is left broken and is not rolled back. Verified live — the description now says to read `compiled_clean`, not `ok`.

**`blueprint_create`'s `package_path` is the full intended asset path, and its trailing component is discarded.** Passing a folder — the obvious reading — puts the asset one directory up: `package_path: "/Game/Temp"` + `name: "BP_SeamProbe"` created `/Game/BP_SeamProbe` and saved it to disk. The response reports the real path, so it is honest; the parameter *name* is the trap. The contract is shared with `material_create`, so this is documented rather than changed unilaterally.

## The benchmark caught me

`search-quality.test.ts` dropped to 12/17 because two of my own descriptions outranked better answers: `physics_set_collision_profile` beat `scene_validate_physics` for *"check physics overlaps"* (my example list included "OverlapAll"), and `anim_blueprint_compile` beat `blueprint_compile` for *"compile a blueprint"*.

Both descriptions were made more specific. The benchmark was not adjusted — it was right.

## Gate

`tsc --noEmit` clean · **1434 tests green** · `lint:legacy-wrappers` OK (123 entries). No C++ changed.

Probe assets deleted and `Content/Temp` removed from the host project — nothing of mine is left on disk there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)