### PR TITLE
feat(ue): a seam under the blueprint domain, and the two bugs it pins

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaBlueprintOps.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaBlueprintOps.cpp
@@ -1,0 +1,49 @@
+#include "HaybaBlueprintOps.h"
+#include "Misc/PackageName.h"
+
+namespace HaybaBlueprintOps
+{
+    FResolvedPackage ResolvePackage(const FString& PackagePath, const FString& AssetName)
+    {
+        FResolvedPackage Out;
+        Out.Directory = FPackageName::GetLongPackagePath(PackagePath);
+        Out.PackageName = Out.Directory / AssetName;
+
+        // The component that was thrown away. If it is not the asset name, the
+        // caller probably passed a folder and expected the asset inside it.
+        FString Trailing = PackagePath;
+        int32 Slash = INDEX_NONE;
+        if (PackagePath.FindLastChar(TEXT('/'), Slash) && Slash != INDEX_NONE)
+        {
+            Trailing = PackagePath.Mid(Slash + 1);
+        }
+        Out.bTrailingIsNotName = !Trailing.IsEmpty() && !Trailing.Equals(AssetName, ESearchCase::IgnoreCase);
+        return Out;
+    }
+
+    FString PackagePathNote(const FResolvedPackage& Resolved, const FString& PackagePath)
+    {
+        if (!Resolved.bTrailingIsNotName) return FString();
+        return FString::Printf(
+            TEXT("'package_path' is the full intended asset path and its last component is discarded, so \"%s\" "
+                 "resolved to the folder \"%s\" and the asset was created at \"%s\". If you meant the folder "
+                 "\"%s\", pass package_path=\"%s/<name>\"."),
+            *PackagePath, *Resolved.Directory, *Resolved.PackageName, *PackagePath, *PackagePath);
+    }
+
+    FString FunctionNameConflict(const TArray<FString>& ExistingGraphNames, const FString& Requested)
+    {
+        for (const FString& Existing : ExistingGraphNames)
+        {
+            if (Existing.Equals(Requested, ESearchCase::IgnoreCase))
+            {
+                return FString::Printf(
+                    TEXT("blueprint_add_function: '%s' already exists on this blueprint (as '%s'). "
+                         "Adding it again compiles to \"Found more than one function with the same name\" and leaves "
+                         "the blueprint broken, so nothing was changed. Pick another name, or edit the existing graph."),
+                    *Requested, *Existing);
+            }
+        }
+        return FString();
+    }
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaBlueprintOpsTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaBlueprintOpsTest.cpp
@@ -1,0 +1,96 @@
+// Blueprint rules that decide things, tested without an editor.
+//
+// Both were found by calling the commands against a live editor while writing
+// their descriptions, and both had the same shape: the command answered ok for
+// work that had gone somewhere the caller did not intend.
+
+#include "Misc/AutomationTest.h"
+#include "HaybaBlueprintOps.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaBlueprintOpsResolvePackageTest,
+    "Hayba.MCP.BlueprintOps.ResolvePackage",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaBlueprintOpsResolvePackageTest::RunTest(const FString&)
+{
+    using namespace HaybaBlueprintOps;
+
+    {
+        // The documented usage: package_path IS the intended asset path.
+        const FResolvedPackage R = ResolvePackage(TEXT("/Game/UI/BP_Menu"), TEXT("BP_Menu"));
+        TestEqual(TEXT("lands where the caller said"), R.PackageName, FString(TEXT("/Game/UI/BP_Menu")));
+        TestFalse(TEXT("nothing surprising to report"), R.bTrailingIsNotName);
+        TestTrue(TEXT("so no note"), PackagePathNote(R, TEXT("/Game/UI/BP_Menu")).IsEmpty());
+    }
+
+    {
+        // The trap. A caller reading the parameter name passes a FOLDER, and the
+        // asset is created one directory up from where they meant. This put a
+        // probe asset at the content root twice in one afternoon.
+        const FResolvedPackage R = ResolvePackage(TEXT("/Game/Temp"), TEXT("BP_Probe"));
+        TestEqual(TEXT("the trailing component is discarded, not treated as a folder"),
+                  R.PackageName, FString(TEXT("/Game/BP_Probe")));
+        TestTrue(TEXT("and that is flagged"), R.bTrailingIsNotName);
+
+        const FString Note = PackagePathNote(R, TEXT("/Game/Temp"));
+        TestFalse(TEXT("a note is produced"), Note.IsEmpty());
+        TestTrue(TEXT("naming where it actually went"), Note.Contains(TEXT("/Game/BP_Probe")));
+        TestTrue(TEXT("and how to get what was meant"), Note.Contains(TEXT("/Game/Temp/<name>")));
+    }
+
+    {
+        // Case should not decide whether the caller gets a warning.
+        const FResolvedPackage R = ResolvePackage(TEXT("/Game/UI/bp_menu"), TEXT("BP_Menu"));
+        TestFalse(TEXT("trailing matches the name case-insensitively"), R.bTrailingIsNotName);
+    }
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaBlueprintOpsFunctionNameTest,
+    "Hayba.MCP.BlueprintOps.FunctionNameConflict",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaBlueprintOpsFunctionNameTest::RunTest(const FString&)
+{
+    using namespace HaybaBlueprintOps;
+
+    const TArray<FString> Existing = { TEXT("EventGraph"), TEXT("ProbeFunc"), TEXT("ConstructionScript") };
+
+    {
+        TestTrue(TEXT("a free name is free"),
+                 FunctionNameConflict(Existing, TEXT("NewThing")).IsEmpty());
+    }
+
+    {
+        // The bug this exists for: adding a duplicate compiled to "Found more
+        // than one function with the same name", left the blueprint broken, and
+        // still answered ok.
+        const FString Err = FunctionNameConflict(Existing, TEXT("ProbeFunc"));
+        TestFalse(TEXT("a taken name is refused"), Err.IsEmpty());
+        TestTrue(TEXT("the message names the collision"), Err.Contains(TEXT("ProbeFunc")));
+        TestTrue(TEXT("and says nothing was changed, because nothing was"),
+                 Err.Contains(TEXT("nothing was changed")));
+    }
+
+    {
+        // FName comparison is case-insensitive, so "probefunc" collides too —
+        // letting it through would produce the same broken blueprint by a route
+        // the check appeared to cover.
+        TestFalse(TEXT("case does not create a second slot"),
+                  FunctionNameConflict(Existing, TEXT("probefunc")).IsEmpty());
+    }
+
+    {
+        TestTrue(TEXT("no graphs, no conflict"),
+                 FunctionNameConflict({}, TEXT("Anything")).IsEmpty());
+    }
+
+    return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPBlueprintHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPBlueprintHandler.cpp
@@ -1,4 +1,5 @@
 #include "HaybaMCPBlueprintHandler.h"
+#include "HaybaBlueprintOps.h"
 #include "HaybaMCPParams.h"
 #include "HaybaMCPReflection.h"
 #include "Json.h"
@@ -184,8 +185,11 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::Create(const TSharedPtr<FJsonObje
     // the standard /Game/Dir/Name.Name — NOT the malformed /Game/Dir.Name that
     // results from using package_path directly as the package and Name as a
     // sub-object inside it.
-    const FString Dir = FPackageName::GetLongPackagePath(PkgPath);
-    const FString FullPackageName = Dir / Name;
+    // Composed in HaybaBlueprintOps so the rule — and the case where a caller
+    // passed a folder and lands one directory up — is testable without an editor.
+    const HaybaBlueprintOps::FResolvedPackage Resolved =
+        HaybaBlueprintOps::ResolvePackage(PkgPath, Name);
+    const FString FullPackageName = Resolved.PackageName;
     UPackage* Package = CreatePackage(*FullPackageName);
     if (!Package)
         return FHaybaHandlerResult::Err(TEXT("blueprint_create: CreatePackage failed"));
@@ -215,6 +219,11 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::Create(const TSharedPtr<FJsonObje
     Out->SetStringField(TEXT("path"), BP->GetPathName());
     Out->SetStringField(TEXT("name"), Name);
     Out->SetBoolField(TEXT("saved"), bSaved);
+    // Say where it went when that is probably not where the caller meant. The
+    // path above has always been accurate; nobody reads it until something is
+    // missing, and by then the asset is sitting a directory up.
+    const FString PathNote = HaybaBlueprintOps::PackagePathNote(Resolved, PkgPath);
+    if (!PathNote.IsEmpty()) Out->SetStringField(TEXT("package_path_note"), PathNote);
     return FHaybaHandlerResult::Ok(Out);
 }
 
@@ -338,6 +347,24 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::AddFunction(const TSharedPtr<FJso
 
     UBlueprint* BP = LoadBPByPath(Path);
     if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_add_function: blueprint not found"));
+
+    // Refuse a name the blueprint already has, BEFORE creating anything. Adding
+    // a second graph with the same name compiles to "Found more than one
+    // function with the same name" and is not rolled back, so the old behaviour
+    // left the asset broken and still answered ok. The rule itself is pure and
+    // lives in HaybaBlueprintOps where a test can reach it.
+    {
+        TArray<UEdGraph*> AllGraphs;
+        BP->GetAllGraphs(AllGraphs);
+        TArray<FString> Names;
+        Names.Reserve(AllGraphs.Num());
+        for (const UEdGraph* G : AllGraphs)
+        {
+            if (G) Names.Add(G->GetName());
+        }
+        const FString Conflict = HaybaBlueprintOps::FunctionNameConflict(Names, FuncName);
+        if (!Conflict.IsEmpty()) return FHaybaHandlerResult::Err(Conflict);
+    }
 
     UEdGraph* NewGraph = FBlueprintEditorUtils::CreateNewGraph(
         BP, FName(*FuncName), UEdGraph::StaticClass(), UEdGraphSchema_K2::StaticClass());

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaBlueprintOps.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaBlueprintOps.h
@@ -1,0 +1,54 @@
+#pragma once
+
+// The blueprint domain's decidable rules, taken out of the editor.
+//
+// Same split as HaybaActorOps.h and HaybaUIOps.h: the parts that decide things
+// are pure and tested here, the parts that touch UBlueprint stay in the handler.
+// Both rules below were found by calling the commands against a live editor and
+// watching them answer ok for work that had gone wrong. See #320.
+
+#include "CoreMinimal.h"
+#include "Dom/JsonObject.h"
+#include "HaybaMCPParams.h"
+
+namespace HaybaBlueprintOps
+{
+    // ── Where a created asset actually lands ─────────────────────────────────
+
+    struct FResolvedPackage
+    {
+        /** The package that will be created, e.g. /Game/UI/BP_Menu */
+        FString PackageName;
+        /** The directory the trailing component was stripped to. */
+        FString Directory;
+        /** True when `package_path`'s last component is NOT the asset name.
+         *
+         *  The contract is that package_path is the FULL intended asset path and
+         *  its trailing component is discarded — so "/Game/Temp" + name "BP_X"
+         *  silently produces /Game/BP_X, one directory up from where a caller
+         *  reading the parameter name would expect. That happened twice while
+         *  writing these descriptions, once leaving an asset at the content
+         *  root. The command cannot know which was meant, so it says so. */
+        bool bTrailingIsNotName = false;
+    };
+
+    /** Compose the package a create command will write to, and notice when the
+     *  caller most likely passed a folder. Pure: no packages are touched. */
+    FResolvedPackage ResolvePackage(const FString& PackagePath, const FString& AssetName);
+
+    /** The note to attach when the trailing component was not the asset name.
+     *  Empty when there is nothing worth saying. */
+    FString PackagePathNote(const FResolvedPackage& Resolved, const FString& PackagePath);
+
+    // ── Whether a function name is free ──────────────────────────────────────
+
+    /** An error message if `Requested` collides with an existing graph, empty
+     *  otherwise.
+     *
+     *  blueprint_add_function had no such check. It created a second graph with
+     *  the same name, the blueprint stopped compiling with "Found more than one
+     *  function with the same name", nothing was rolled back, and the reply was
+     *  ok:true carrying compile_errors — verified live. Graph names compare
+     *  case-insensitively, because FName does. */
+    FString FunctionNameConflict(const TArray<FString>& ExistingGraphNames, const FString& Requested);
+}


### PR DESCRIPTION
Continues #320. Fifth typed domain seam — and the first written to hold rules that were **already known to be broken**. Both were found by calling the commands against a live editor while writing their descriptions, and both had the same shape: `ok` for work that went somewhere the caller did not intend.

## `blueprint_add_function` accepted a name the blueprint already had

It created a second graph, the compile failed with *"Found more than one function with the same name"*, **nothing was rolled back**, and the reply was `ok: true` carrying `compile_errors`. A call that reported success left the asset broken.

The name is now checked *before* anything is created. The check is case-insensitive because `FName` comparison is — letting `probefunc` through would have produced the same broken blueprint by a route the check appeared to cover.

## `blueprint_create` put assets one directory up

`package_path` is the full intended asset path and its trailing component is **discarded**. Passing a folder — the obvious reading of the parameter name — writes the asset one level up. It did exactly that twice during this work, once leaving an asset at the content root.

The contract is shared with `material_create` and `metasound_create`, so it is **not** changed here. Instead the reply now carries `package_path_note` naming where the asset actually landed and what to pass to get the folder that was meant:

> `package_path` is the full intended asset path and its last component is discarded, so "/Game/Temp" resolved to the folder "/Game" and the asset was created at "/Game/BP_Probe". If you meant the folder "/Game/Temp", pass package_path="/Game/Temp/&lt;name&gt;".

The `path` field was always accurate. Nobody reads it until something is missing.

## The seam

Both rules are pure and live in `HaybaBlueprintOps`, where a test reaches them without an editor. Execute stays in the handler — same split as `HaybaActorOps` and `HaybaUIOps`.

**Mutation-tested:** disabling the trailing-component check fails `ResolvePackage`; making the name comparison never match fails `FunctionNameConflict`. Reverted, rebuilt, both green.

## Gate

`Hayba.MCP`: **16 of 17 pass** (was 14 of 15). The failure is `UI.RenderWidgetToPng`, `-NullRHI`-only, as before.
TS: 1444 green, `tsc --noEmit` clean. Full build `Result: Succeeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)