### PR TITLE
fix(mcp): name the process holding the UE lock; slower timeout tier for tree mutations

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/check-ue-status.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/check-ue-status.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setCachedSidecarHealth } from './visual/sidecar-client.js';
 
+// Hoisted mutable flag so individual tests can flip between "ping succeeds"
+// and "transport fails" without vi.resetModules()/vi.doMock() churn, which
+// previously left later tests importing an unmocked (real, network-shelling)
+// tcp-client and hanging.
+const tcpState = vi.hoisted(() => ({ shouldFail: false }));
+
 vi.mock('../tcp-client.js', () => ({
-  ensureConnected: vi.fn(async () => ({
-    send: async () => ({ ok: true, data: { status: 'idle', ueVersion: '5.4' } }),
-  })),
+  ensureConnected: vi.fn(async () => {
+    if (tcpState.shouldFail) throw new Error('ECONNREFUSED');
+    return {
+      send: async () => ({ ok: true, data: { status: 'idle', ueVersion: '5.4' } }),
+    };
+  }),
 }));
 
 describe('checkUeStatus / sidecar fields', () => {
@@ -21,7 +30,7 @@ describe('checkUeStatus / sidecar fields', () => {
     });
 
     const { checkUeStatus } = await import('./check-ue-status.js');
-    const status = await checkUeStatus();
+    const status = await checkUeStatus({ listProcesses: async () => [] });
     expect(status.connected).toBe(true);
     expect(status.visual_embeddings_available).toBe(true);
     expect(status.active_models).toEqual(['clip', 'owl_vit']);
@@ -39,10 +48,132 @@ describe('checkUeStatus / sidecar fields', () => {
     });
 
     const { checkUeStatus } = await import('./check-ue-status.js');
-    const status = await checkUeStatus();
+    const status = await checkUeStatus({ listProcesses: async () => [] });
     expect(status.visual_embeddings_available).toBe(false);
     expect(status.active_models).toEqual([]);
     expect(status.sidecar_error).toMatch(/ECONNREFUSED/);
+  });
+});
+
+describe('checkUeStatus / process identity (issue #342)', () => {
+  beforeEach(() => setCachedSidecarHealth({
+    available: false, url: '', models: {}, active_models: [], checked_at: Date.now(),
+  }));
+  afterEach(() => setCachedSidecarHealth(null));
+
+  it('GUI only, connected: reports gui identity, no ambiguity diagnostic', async () => {
+    const { checkUeStatus } = await import('./check-ue-status.js');
+    const status = await checkUeStatus({
+      listProcesses: async () => [{ name: 'UnrealEditor.exe', pid: 1111 }],
+    });
+    expect(status.connected).toBe(true);
+    expect(status.editor_process_detected).toBe(true);
+    expect(status.ue_processes).toEqual({
+      gui: [{ name: 'UnrealEditor.exe', pid: 1111 }],
+      headless: [],
+      crash_reporter: [],
+    });
+    expect(status.process_identity).toContain('GUI UnrealEditor.exe (PID 1111)');
+    expect(status.diagnostic).toBeUndefined();
+  });
+
+  it('-Cmd only, connected: names the headless process and PID as the one answering the port', async () => {
+    const { checkUeStatus } = await import('./check-ue-status.js');
+    const status = await checkUeStatus({
+      listProcesses: async () => [{ name: 'UnrealEditor-Cmd.exe', pid: 2222 }],
+    });
+    expect(status.connected).toBe(true);
+    expect(status.editor_process_detected).toBe(false);
+    expect(status.process_identity).toContain('headless UnrealEditor-Cmd.exe (PID 2222)');
+    expect(status.diagnostic).toContain('UnrealEditor-Cmd.exe');
+    expect(status.diagnostic).toContain('2222');
+    expect(status.diagnostic).toMatch(/stray automation/i);
+  });
+
+  it('both GUI and -Cmd, connected: flags the ambiguity by name and PID', async () => {
+    const { checkUeStatus } = await import('./check-ue-status.js');
+    const status = await checkUeStatus({
+      listProcesses: async () => [
+        { name: 'UnrealEditor.exe', pid: 1111 },
+        { name: 'UnrealEditor-Cmd.exe', pid: 2222 },
+      ],
+    });
+    expect(status.connected).toBe(true);
+    expect(status.editor_process_detected).toBe(true);
+    expect(status.process_identity).toContain('GUI UnrealEditor.exe (PID 1111)');
+    expect(status.process_identity).toContain('headless UnrealEditor-Cmd.exe (PID 2222)');
+    expect(status.diagnostic).toContain('1111');
+    expect(status.diagnostic).toContain('2222');
+    expect(status.diagnostic).toMatch(/cannot tell/i);
+  });
+
+  it('neither GUI nor -Cmd, connected: no processes found, no diagnostic needed', async () => {
+    const { checkUeStatus } = await import('./check-ue-status.js');
+    const status = await checkUeStatus({ listProcesses: async () => [] });
+    expect(status.connected).toBe(true);
+    expect(status.editor_process_detected).toBe(false);
+    expect(status.process_identity).toBe('none detected');
+    expect(status.diagnostic).toBeUndefined();
+  });
+});
+
+describe('checkUeStatus / process identity when disconnected (issue #342)', () => {
+  beforeEach(() => {
+    tcpState.shouldFail = true;
+    setCachedSidecarHealth({
+      available: false, url: '', models: {}, active_models: [], checked_at: Date.now(),
+    });
+  });
+  afterEach(() => {
+    tcpState.shouldFail = false;
+    setCachedSidecarHealth(null);
+  });
+
+  it('-Cmd only, disconnected: message says a headless process may be blocking the next launch', async () => {
+    const { checkUeStatus } = await import('./check-ue-status.js');
+    const status = await checkUeStatus({
+      listProcesses: async () => [{ name: 'UnrealEditor-Cmd.exe', pid: 3333 }],
+    });
+    expect(status.connected).toBe(false);
+    expect(status.editor_process_detected).toBe(false);
+    expect(status.process_identity).toContain('headless UnrealEditor-Cmd.exe (PID 3333)');
+    expect(status.diagnostic).toContain('3333');
+    expect(status.diagnostic).toMatch(/blocking a GUI editor|slow boot/i);
+  });
+
+  it('neither process, disconnected: falls back to the generic "no process found" message', async () => {
+    const { checkUeStatus } = await import('./check-ue-status.js');
+    const status = await checkUeStatus({ listProcesses: async () => [] });
+    expect(status.connected).toBe(false);
+    expect(status.editor_process_detected).toBe(false);
+    expect(status.process_identity).toBe('none detected');
+    expect(status.diagnostic).toMatch(/No UnrealEditor process found/);
+  });
+});
+
+describe('parseTasklistCsv / parsePsOutput (issue #342 process listing)', () => {
+  it('parses tasklist CSV rows for known UE process names, ignoring others', async () => {
+    const { parseTasklistCsv } = await import('./check-ue-status.js');
+    const csv = [
+      '"UnrealEditor.exe","1234","Console","1","512,000 K"',
+      '"UnrealEditor-Cmd.exe","5678","Console","1","400,000 K"',
+      '"chrome.exe","9999","Console","1","100,000 K"',
+      '"CrashReportClientEditor.exe","4321","Console","1","50,000 K"',
+    ].join('\r\n');
+    expect(parseTasklistCsv(csv)).toEqual([
+      { name: 'UnrealEditor.exe', pid: 1234 },
+      { name: 'UnrealEditor-Cmd.exe', pid: 5678 },
+      { name: 'CrashReportClientEditor.exe', pid: 4321 },
+    ]);
+  });
+
+  it('parses ps -eo pid,comm output for known UE process names', async () => {
+    const { parsePsOutput } = await import('./check-ue-status.js');
+    const text = ['  1234 UnrealEditor', '  5678 UnrealEditor-Cmd', '  9999 bash'].join('\n');
+    expect(parsePsOutput(text)).toEqual([
+      { name: 'UnrealEditor.exe', pid: 1234 },
+      { name: 'UnrealEditor-Cmd.exe', pid: 5678 },
+    ]);
   });
 });
 
@@ -59,9 +190,10 @@ describe('checkUeStatus / onConnected hook', () => {
   it('fires onConnected exactly once across multiple successful polls', async () => {
     const onConnected = vi.fn(async () => {});
     const { checkUeStatus } = await import('./check-ue-status.js');
-    await checkUeStatus({ onConnected });
-    await checkUeStatus({ onConnected });
-    await checkUeStatus({ onConnected });
+    const listProcesses = async () => [];
+    await checkUeStatus({ onConnected, listProcesses });
+    await checkUeStatus({ onConnected, listProcesses });
+    await checkUeStatus({ onConnected, listProcesses });
     expect(onConnected).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/check-ue-status.ts
+++ b/mcp-tools/hayba-mcp/src/tools/check-ue-status.ts
@@ -3,35 +3,170 @@ import { ensureConnected } from '../tcp-client.js';
 import { getCachedSidecarHealth, pingSidecar } from './visual/sidecar-client.js';
 
 /**
- * Best-effort check for a running UnrealEditor process, so a failed TCP connect
- * can distinguish "editor not running" from "editor up but plugin listener
- * closed" (plugin failed to load / still booting / shutting down). Cross-platform,
- * short timeout, never throws — resolves null when detection itself fails.
+ * The three Unreal-side process images relevant to "is the editor up, and
+ * which flavor". `UnrealEditor.exe` is the GUI editor an author expects.
+ * `UnrealEditor-Cmd.exe` is the headless variant used by automation/CI runs —
+ * it opens the same MCP port and answers pings identically, so a stray one
+ * left over from a prior run is indistinguishable from the GUI editor unless
+ * something names it. `CrashReportClientEditor.exe` never holds the MCP port
+ * but its presence after a crash can itself block the next launch.
  */
-function detectEditorProcess(): Promise<boolean | null> {
+export const UE_PROCESS_NAMES = [
+  'UnrealEditor.exe',
+  'UnrealEditor-Cmd.exe',
+  'CrashReportClientEditor.exe',
+] as const;
+export type UeProcessName = (typeof UE_PROCESS_NAMES)[number];
+
+export interface UeProcessInfo {
+  name: UeProcessName;
+  pid: number;
+}
+
+export interface UeProcessIdentity {
+  gui: UeProcessInfo[];
+  headless: UeProcessInfo[];
+  crash_reporter: UeProcessInfo[];
+}
+
+/** Injectable process-list source. Returns null when detection itself failed
+ *  (tool unavailable) — distinct from an empty array (checked, found none). */
+export type ProcessLister = () => Promise<UeProcessInfo[] | null>;
+
+/** Parse `tasklist /FO CSV /NH` output into UE process rows. Exported so tests
+ *  can exercise the real parser against captured tasklist output without
+ *  shelling out. Unknown image names are dropped. */
+export function parseTasklistCsv(csv: string): UeProcessInfo[] {
+  const known = new Set<string>(UE_PROCESS_NAMES);
+  const out: UeProcessInfo[] = [];
+  for (const rawLine of csv.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    // CSV row: "ImageName","PID","SessionName","Session#","MemUsage"
+    const fields = line.split('","').map((f) => f.replace(/^"|"$/g, ''));
+    const [name, pidStr] = fields;
+    if (name && known.has(name)) {
+      const pid = Number.parseInt(pidStr, 10);
+      if (Number.isFinite(pid)) out.push({ name: name as UeProcessName, pid });
+    }
+  }
+  return out;
+}
+
+/** Parse `ps -eo pid,comm` output (POSIX) into UE process rows. */
+export function parsePsOutput(text: string): UeProcessInfo[] {
+  const known = new Set<string>(UE_PROCESS_NAMES);
+  const out: UeProcessInfo[] = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const match = line.match(/^(\d+)\s+(.+)$/);
+    if (!match) continue;
+    const pid = Number.parseInt(match[1], 10);
+    const comm = match[2].trim();
+    // POSIX process names are typically unsuffixed; match either form.
+    const name = UE_PROCESS_NAMES.find((n) => comm === n || comm === n.replace(/\.exe$/, ''));
+    if (name && Number.isFinite(pid)) out.push({ name, pid });
+  }
+  return out;
+}
+
+/** Real (shelling-out) process lister. Cross-platform, short timeout, never
+ *  throws — resolves null when detection itself fails. */
+const realListUeProcesses: ProcessLister = () => {
   const isWin = process.platform === 'win32';
-  const cmd = isWin ? 'tasklist' : 'pgrep';
-  const args = isWin
-    ? ['/FI', 'IMAGENAME eq UnrealEditor.exe', '/NH']
-    : ['-f', 'UnrealEditor'];
+  const cmd = isWin ? 'tasklist' : 'ps';
+  const args = isWin ? ['/FO', 'CSV', '/NH'] : ['-eo', 'pid,comm'];
   return new Promise((resolve) => {
     try {
       execFile(cmd, args, { timeout: 2000, windowsHide: true }, (err, stdout) => {
         if (err && (err as NodeJS.ErrnoException).code === 'ENOENT') return resolve(null);
-        const out = (stdout || '').toLowerCase();
-        resolve(isWin ? out.includes('unrealeditor.exe') : out.trim().length > 0);
+        if (err && !stdout) return resolve(null);
+        resolve(isWin ? parseTasklistCsv(stdout || '') : parsePsOutput(stdout || ''));
       });
     } catch {
       resolve(null);
     }
   });
+};
+
+export function classifyUeProcesses(processes: UeProcessInfo[]): UeProcessIdentity {
+  return {
+    gui: processes.filter((p) => p.name === 'UnrealEditor.exe'),
+    headless: processes.filter((p) => p.name === 'UnrealEditor-Cmd.exe'),
+    crash_reporter: processes.filter((p) => p.name === 'CrashReportClientEditor.exe'),
+  };
 }
 
-function diagnoseDisconnect(editorRunning: boolean | null): string | undefined {
-  if (editorRunning === true) {
-    return 'UnrealEditor process is running but the plugin TCP port is closed — the HaybaMCPToolkit plugin likely failed to load (check the editor log for a module load error / missing dependency), is still booting, or is shutting down.';
+function describe(procs: UeProcessInfo[], label: string): string {
+  const pids = procs.map((p) => p.pid).join(', ');
+  return `${label} (PID ${pids})`;
+}
+
+/** Human-readable identity summary, e.g. "GUI UnrealEditor.exe (PID 1234)",
+ *  "headless UnrealEditor-Cmd.exe (PID 5678) + GUI UnrealEditor.exe (PID 1234)",
+ *  or "none detected". Always names process flavor + PID, never a bare bool. */
+export function describeProcessIdentity(id: UeProcessIdentity): string {
+  const parts: string[] = [];
+  if (id.gui.length) parts.push(describe(id.gui, 'GUI UnrealEditor.exe'));
+  if (id.headless.length) parts.push(describe(id.headless, 'headless UnrealEditor-Cmd.exe'));
+  if (id.crash_reporter.length) parts.push(describe(id.crash_reporter, 'CrashReportClientEditor.exe'));
+  return parts.length ? parts.join(' + ') : 'none detected';
+}
+
+/**
+ * Actionable diagnostic naming exactly what was found and whether it matches
+ * what a caller expecting a GUI editor should see. `connected` reflects
+ * whether the MCP ping actually succeeded — a headless process can be the one
+ * answering it, which is precisely the "process nobody thought was running"
+ * failure mode from issue #342.
+ */
+export function buildProcessDiagnostic(id: UeProcessIdentity, connected: boolean): string | undefined {
+  const hasGui = id.gui.length > 0;
+  const hasHeadless = id.headless.length > 0;
+  const hasCrash = id.crash_reporter.length > 0;
+  const hasAny = hasGui || hasHeadless || hasCrash;
+
+  if (connected) {
+    if (hasHeadless && !hasGui) {
+      return (
+        `Connected, but the process answering the MCP port is a headless ${describe(id.headless, 'UnrealEditor-Cmd.exe')} ` +
+        `— if you expected a GUI editor, this is likely a stray automation run holding the port instead. ` +
+        `Kill it (taskkill /PID ${id.headless[0].pid} /F) and launch the GUI editor.`
+      );
+    }
+    if (hasHeadless && hasGui) {
+      return (
+        `Connected, but both a GUI ${describe(id.gui, 'UnrealEditor.exe')} and a headless ${describe(id.headless, 'UnrealEditor-Cmd.exe')} ` +
+        `are running — cannot tell from here which one answered the MCP port. If you only expected the GUI editor, the headless ` +
+        `process (PID ${id.headless[0].pid}) is probably a leftover automation run; consider killing it to remove the ambiguity.`
+      );
+    }
+    return undefined; // GUI-only (or undetermined) and connected — nothing to flag.
   }
-  if (editorRunning === false) {
+
+  // Not connected.
+  if (hasHeadless) {
+    return (
+      `Not connected, but a headless ${describe(id.headless, 'UnrealEditor-Cmd.exe')} is running — it may be holding the MCP ` +
+      `port or otherwise blocking a GUI editor from starting (this looks exactly like a slow boot). ` +
+      `Kill it (taskkill /PID ${id.headless[0].pid} /F) if you expected a GUI editor.`
+    );
+  }
+  if (hasGui) {
+    return (
+      `Not connected, but a GUI ${describe(id.gui, 'UnrealEditor.exe')} is running — the plugin TCP port is closed ` +
+      `(HaybaMCPToolkit likely failed to load: check the editor log for a module load error / missing dependency, ` +
+      `or the editor is still booting / shutting down).`
+    );
+  }
+  if (hasCrash) {
+    return (
+      `Not connected. No editor process, but ${describe(id.crash_reporter, 'CrashReportClientEditor.exe')} is running ` +
+      `— it does not hold the MCP port itself, but can block the next editor launch until it exits.`
+    );
+  }
+  if (!hasAny) {
     return 'No UnrealEditor process found — launch the editor with the HaybaMCPToolkit plugin enabled.';
   }
   return undefined;
@@ -44,12 +179,21 @@ export interface UeStatus {
   active_models: string[];
   sidecar_url?: string;
   sidecar_error?: string;
+  /** Legacy field, kept for back-compat: true when a GUI UnrealEditor.exe was
+   *  detected. undefined when detection itself failed. */
+  editor_process_detected?: boolean;
+  /** Full breakdown by process flavor, each with PID(s). */
+  ue_processes?: UeProcessIdentity;
+  /** Human-readable "what did we find" summary — always names flavor + PID. */
+  process_identity?: string;
   [key: string]: unknown;
 }
 
 export interface CheckUeStatusOpts {
   /** Fired exactly once, the first time a poll succeeds in this process. */
   onConnected?: () => void | Promise<void>;
+  /** Test/injection seam: overrides the real (shelling-out) process lister. */
+  listProcesses?: ProcessLister;
 }
 
 let connectedLatch = false;
@@ -57,7 +201,19 @@ let connectedLatch = false;
 /** Test-only: reset the once-only connected latch. */
 export function __resetConnectedLatch(): void { connectedLatch = false; }
 
+async function detectIdentity(listProcesses: ProcessLister): Promise<{
+  identity: UeProcessIdentity | undefined;
+  guiDetected: boolean | undefined;
+}> {
+  const processes = await listProcesses();
+  if (processes === null) return { identity: undefined, guiDetected: undefined };
+  const identity = classifyUeProcesses(processes);
+  return { identity, guiDetected: identity.gui.length > 0 };
+}
+
 export async function checkUeStatus(opts: CheckUeStatusOpts = {}): Promise<UeStatus> {
+  const listProcesses = opts.listProcesses ?? realListUeProcesses;
+
   // Sidecar — prefer cached snapshot (filled at startup); refresh on demand if
   // we've never probed. Don't block UE status on sidecar latency.
   let sidecar = getCachedSidecarHealth();
@@ -80,23 +236,40 @@ export async function checkUeStatus(opts: CheckUeStatusOpts = {}): Promise<UeSta
         connectedLatch = true;
         try { await opts.onConnected?.(); } catch { /* ignore callback errors */ }
       }
-      return { connected: true, ...sidecarFields, ...(response.data as Record<string, unknown>) };
+      // Connected does NOT mean "the GUI editor answered" — a stray headless
+      // UnrealEditor-Cmd.exe answers pings identically (issue #342). Always
+      // check identity, even on the happy path.
+      const { identity, guiDetected } = await detectIdentity(listProcesses);
+      const diagnostic = identity ? buildProcessDiagnostic(identity, true) : undefined;
+      return {
+        connected: true,
+        ...sidecarFields,
+        ...(response.data as Record<string, unknown>),
+        editor_process_detected: guiDetected,
+        ue_processes: identity,
+        process_identity: identity ? describeProcessIdentity(identity) : undefined,
+        ...(diagnostic ? { diagnostic } : {}),
+      };
     }
-    const editorRunning = await detectEditorProcess();
+    const { identity, guiDetected } = await detectIdentity(listProcesses);
     return {
       connected: false,
       error: response.error,
-      editor_process_detected: editorRunning ?? undefined,
-      diagnostic: diagnoseDisconnect(editorRunning),
+      editor_process_detected: guiDetected,
+      ue_processes: identity,
+      process_identity: identity ? describeProcessIdentity(identity) : undefined,
+      diagnostic: identity ? buildProcessDiagnostic(identity, false) : undefined,
       ...sidecarFields,
     };
   } catch (err) {
-    const editorRunning = await detectEditorProcess();
+    const { identity, guiDetected } = await detectIdentity(listProcesses);
     return {
       connected: false,
       error: err instanceof Error ? err.message : 'Unknown error',
-      editor_process_detected: editorRunning ?? undefined,
-      diagnostic: diagnoseDisconnect(editorRunning),
+      editor_process_detected: guiDetected,
+      ue_processes: identity,
+      process_identity: identity ? describeProcessIdentity(identity) : undefined,
+      diagnostic: identity ? buildProcessDiagnostic(identity, false) : undefined,
       ...sidecarFields,
     };
   }

--- a/mcp-tools/hayba-mcp/src/tools/heavy-ops.ts
+++ b/mcp-tools/hayba-mcp/src/tools/heavy-ops.ts
@@ -36,6 +36,15 @@ const HEAVY_OPS = new Set<string>([
   // Asset re-index — a full asset-registry rescan / embedding rebuild.
   'hayba_asset_reindex',
   'asset_reindex',
+  // Widget tree mutation — on a large Widget Blueprint (dozens of widgets)
+  // remove/move/reparent/rename/replace/duplicate can block the game thread
+  // long enough to blow the medium (10s) cost tier while the mutation itself
+  // succeeds (issue #338: ui_remove_element timed out on a ~60-widget tree
+  // AFTER the removal had already landed). Every ui_*_element tool funnels
+  // through this single wire command (see tool-executor.ts NON_IDEMPOTENT and
+  // src/tools/ui/*.ts), so registering it here covers all of them at once —
+  // no per-tool timeout to keep in sync.
+  'ui_mutate_tree',
 ]);
 
 /** Register an additional command as a heavy (game-thread-blocking) op. */

--- a/mcp-tools/hayba-mcp/src/tools/tool-executor.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-executor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { UeToolError, costToTimeoutMs, executeCommand, NON_IDEMPOTENT, type Sender } from './tool-executor.js';
+import { UeToolError, costToTimeoutMs, executeCommand, resolveTimeoutMs, NON_IDEMPOTENT, type Sender } from './tool-executor.js';
 import { HEAVY_OP_TIMEOUT_MS, addHeavyOp, isHeavyOp, listHeavyOps, removeHeavyOp } from './heavy-ops.js';
 
 // Keep the "editor busy" tests hermetic: the real probe shells out to
@@ -221,6 +221,24 @@ describe('heavy-ops registry', () => {
     expect(listHeavyOps()).toContain('my_custom_blocking_op');
     // Don't leak this runtime registration into other suites.
     removeHeavyOp('my_custom_blocking_op');
+  });
+});
+
+describe('ui_mutate_tree timeout tier (issue #338)', () => {
+  it('is registered as a heavy op, not the medium cost tier', () => {
+    expect(isHeavyOp('ui_mutate_tree')).toBe(true);
+  });
+
+  it('resolves to the 300s heavy timeout, not the 10s medium default', () => {
+    expect(resolveTimeoutMs('ui_mutate_tree')).toBe(HEAVY_OP_TIMEOUT_MS);
+    expect(resolveTimeoutMs('ui_mutate_tree')).not.toBe(costToTimeoutMs('medium'));
+  });
+
+  it('every ui_*_element tool funnels through the ui_mutate_tree wire command that carries this tier', async () => {
+    const seen: number[] = [];
+    const spy: Sender = async (_c, _p, t) => { seen.push(t); return { id: 't', ok: true, data: {} }; };
+    await executeCommand('ui_mutate_tree', { operation: 'remove' }, { sender: spy });
+    expect(seen[0]).toBe(HEAVY_OP_TIMEOUT_MS);
   });
 });
 


### PR DESCRIPTION
## Summary

TypeScript-side halves of #342 and #338. Both issues have a remaining C++ half — **this PR closes neither outright**.

**#342** — `hayba_check_ue_status` now names what it found instead of a bare `editor_process_detected: true/false`:
- Detects and distinguishes GUI `UnrealEditor.exe`, headless `UnrealEditor-Cmd.exe`, and `CrashReportClientEditor.exe`, each with PID(s), via an injectable `listProcesses` seam (`mcp-tools/hayba-mcp/src/tools/check-ue-status.ts`).
- Runs detection on *both* the connected and disconnected paths — the dangerous case from the postmortem was a stray headless process answering pings identically while connected, which the old code never even looked at.
- `diagnostic` now names the process and PID actionably, e.g. "a headless UnrealEditor-Cmd.exe (PID 1234) is holding port 52342" instead of "not connected".
- Kept as the documented `executeCommand`-seam exception (connectivity probe), per `docs/WORKFLOW-improving-the-mcp.md` §4 Step 4.
- **Remaining C++ half (not in this PR):** the "save all dirty packages, then quit" shutdown command from #342's other ask.

**#338** — `ui_mutate_tree` (and every `ui_*_element` tool that funnels through it) now sits in the existing heavy-ops timeout tier (300s) instead of the medium cost tier (10s), via `mcp-tools/hayba-mcp/src/tools/heavy-ops.ts`'s `HEAVY_OPS` registry — one declaration point, not a hardcoded number per call site. It was already in `NON_IDEMPOTENT` so retries were never auto-fired; the timeout itself was the gap.
- **Remaining C++ half (not in this PR):** making mutations idempotent by name, so a retry against an already-mutated tree is a safe no-op rather than removing the wrong widget.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 1455/1455 passing (was 1444; +11 new tests)
- [x] `node scripts/check-legacy-wrappers.mjs` — OK, no violations
- [x] Mutation-tested every new assertion path: disabled the headless-only diagnostic branch (RED, reverted, GREEN); introduced an off-by-one in `parseTasklistCsv`'s PID parsing (RED, reverted, GREEN); removed `ui_mutate_tree` from `HEAVY_OPS` (RED — 3 failures, reverted, GREEN)
- [x] New tests cover GUI-only / `-Cmd`-only / both / neither over a faked process list, for both the connected and disconnected branches, plus direct parser tests for `parseTasklistCsv` / `parsePsOutput`
- [x] A pinned test (`ui_mutate_tree timeout tier (issue #338)`) asserts `ui_mutate_tree` resolves to the heavy 300s tier so a future edit can't silently drop it back to medium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Unreal Editor status reporting with cross-platform detection for GUI, headless, and crash-reporter processes.
  - Added clearer diagnostics for ambiguous, disconnected, or mismatched Unreal Editor processes.
  - Added detailed process identity information to status results.
  - Classified UI tree mutations as heavy operations with an extended timeout.

- **Bug Fixes**
  - Improved process detection and parsing across Windows and Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->