### PR TITLE
fix(ui): guard ui_render_widget_to_png against corrupted image_base64

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-render-widget-to-png.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-render-widget-to-png.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { scriptedUe, type ScriptedUe } from '../testing/scripted-ue.js';
-import { uiRenderWidgetToPngHandler } from './ui-render-widget-to-png.js';
+import { isValidBase64, uiRenderWidgetToPngHandler } from './ui-render-widget-to-png.js';
 
 let ue: ScriptedUe | undefined;
 afterEach(() => {
@@ -91,5 +91,100 @@ describe('ui_render_widget_to_png', () => {
     const r = await uiRenderWidgetToPngHandler({}, {} as never);
     expect(r.isError).toBe(true);
     expect(ue.calls).toEqual([]);
+  });
+
+  // --- Regression coverage for #334 ------------------------------------
+  //
+  // Root cause: the response-shaping layer between UE and this handler (a
+  // generic per-field string cap applied to every command's JSON response,
+  // unreal/HaybaMCPToolkit/.../HaybaMCPCommandHandler.cpp ~line 1024,
+  // `Limits.MaxStringChars = 512`) has no exemption for image-carrying
+  // commands the way python_run does (line 1034). A base64 PNG is almost
+  // always over 512 chars, so it gets clipped mid-string and a non-base64
+  // "..." marker appended — producing a field that is non-empty but not
+  // valid base64. Handing that straight to the MCP SDK as an `image` content
+  // block throws inside the SDK's own response validation ("Invalid Base64
+  // string"), which kills the WHOLE tool response — metadata and path
+  // included, even though both were fine.
+  //
+  // unreal/ is out of scope for this fix (cannot be verified without the
+  // editor). These tests instead harden the TS handler: (1) a large,
+  // well-formed base64 payload must survive completely unmodified through
+  // this handler, and (2) a payload matching the observed corruption
+  // signature (clipped, non-multiple-of-4, trailing "...") must never reach
+  // an `image` content block, and must never take `path` down with it.
+
+  it('a large, well-formed base64 payload survives the handler byte-identical', async () => {
+    // ~1.3MB of base64 — comfortably past the 512-char cap that corrupts
+    // real screenshots, so this pins that OUR code does not add its own
+    // truncation on top of (or instead of) the one already diagnosed.
+    const bigPng = 'A'.repeat(1_000_000); // 1,000,000 chars — multiple of 4, len % 4 === 0
+    expect(isValidBase64(bigPng)).toBe(true);
+
+    ue = scriptedUe().replies('ui_render_widget_to_png', {
+      out_path: 'D:/big.png',
+      image_base64: bigPng,
+    });
+
+    const r = await uiRenderWidgetToPngHandler({ widget_blueprint_path: BP }, {} as never);
+    const { image } = blocks(r);
+    expect(image?.data).toBe(bigPng);
+    expect(image?.data?.length).toBe(bigPng.length);
+  });
+
+  it('drops a clipped/invalid base64 payload instead of building a broken image block', async () => {
+    // Mirrors the exact corruption shape: a 512-char field cap keeping the
+    // first 509 chars of valid base64 and appending "...". 509 is not a
+    // multiple of 4, and "..." is not base64 alphabet — this is what UE
+    // currently sends back for any real render.
+    const validPrefix = 'A'.repeat(509);
+    const clipped = validPrefix + '...';
+    expect(isValidBase64(clipped)).toBe(false);
+
+    ue = scriptedUe().replies('ui_render_widget_to_png', {
+      out_path: 'D:/x.png',
+      image_base64: clipped,
+    });
+
+    const r = await uiRenderWidgetToPngHandler({ widget_blueprint_path: BP }, {} as never);
+    const { image, text } = blocks(r);
+    // No image block was built from the corrupt string — that would have
+    // thrown inside the SDK and destroyed this entire response.
+    expect(image).toBeUndefined();
+    // The corruption is surfaced as text, not silently dropped.
+    expect(r.content.some((c) => c.type === 'text' && c.text?.includes('not valid base64'))).toBe(true);
+    // And the metadata / path are still intact — the whole point of not
+    // routing the bad string through the image block.
+    expect(JSON.parse(text).path).toBe('D:/x.png');
+  });
+
+  it('always carries a usable "path" the caller can read from disk', async () => {
+    ue = scriptedUe().replies('ui_render_widget_to_png', {
+      out_path: 'D:/only-metadata.png',
+      inline_image_skipped: 'too big',
+    });
+    const r = await uiRenderWidgetToPngHandler(
+      { widget_blueprint_path: BP, inline_image: false },
+      {} as never,
+    );
+    const { text } = blocks(r);
+    const parsed = JSON.parse(text);
+    expect(parsed.path).toBe('D:/only-metadata.png');
+    expect(parsed.out_path).toBe('D:/only-metadata.png');
+  });
+});
+
+describe('isValidBase64', () => {
+  it('accepts valid, correctly padded base64', () => {
+    expect(isValidBase64('AAAA')).toBe(true);
+    expect(isValidBase64('AAA=')).toBe(true);
+    expect(isValidBase64('AA==')).toBe(true);
+  });
+
+  it('rejects empty strings, non-multiple-of-4 lengths, and non-base64 characters', () => {
+    expect(isValidBase64('')).toBe(false);
+    expect(isValidBase64('AAAAA')).toBe(false); // length 5, not a multiple of 4
+    expect(isValidBase64('AAA...')).toBe(false); // trailing ellipsis — the observed corruption
+    expect(isValidBase64('not base64!!')).toBe(false);
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-render-widget-to-png.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-render-widget-to-png.ts
@@ -32,6 +32,29 @@ export const schema = z.object({
     .describe('Return the PNG inline so you can actually look at it (default true). Skipped automatically above ~3MB; read out_path in that case.'),
 });
 
+/**
+ * True only for a well-formed, complete base64 string (correct charset, and a
+ * length that is a multiple of 4 once padding is accounted for).
+ *
+ * Why this matters here: the response-shaping layer between UE and this
+ * handler (a generic string-length cap applied to every field in every
+ * command's JSON response) can clip a long string field before it reaches
+ * this handler — see docs/handoffs/HANDOFF-mcp-agent-ergonomics-postmortem.md
+ * for the `_truncated`/`removed` signature this produces on a sibling tool.
+ * A clipped base64 string is non-empty but invalid: cutting it mid-stream
+ * both breaks the 4-char alignment and appends a non-base64 "..." marker.
+ *
+ * Handing an invalid string to the MCP SDK as an `image` content block throws
+ * deep inside the SDK's own result validation ("Invalid Base64 string") —
+ * which fails the ENTIRE tool response, taking the metadata and `path` down
+ * with it even though both are fine. Validating first means a corrupted
+ * field degrades to "no inline image" instead of "no response at all".
+ */
+export function isValidBase64(s: string): boolean {
+  if (s.length === 0 || s.length % 4 !== 0) return false;
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(s);
+}
+
 // Rich rather than plain: this tool returns an image block, which the text-only
 // ToolResult cannot carry. Signature otherwise matches every other handler.
 export const uiRenderWidgetToPngHandler: RichToolHandler = async (args) => {
@@ -50,10 +73,33 @@ export const uiRenderWidgetToPngHandler: RichToolHandler = async (args) => {
   // into the text block is what destroyed every screenshot the last time —
   // the transport length-caps text. See editor_capture_viewport.
   const { image_base64, ...metaFields } = data as { image_base64?: unknown } & Record<string, unknown>;
-  const content: RichToolResult['content'] = [{ type: 'text', text: JSON.stringify(metaFields, null, 2) }];
+
+  // Always surface a `path` a caller can read from disk. A file path cannot be
+  // corrupted by a response-shaping layer the way an inline base64 string
+  // can, so it is the robust fallback regardless of what happened to
+  // image_base64. `out_path` is UE's field name; `path` is the stable alias
+  // callers should prefer.
+  const rawPath = (metaFields as Record<string, unknown>).out_path;
+  const path = typeof rawPath === 'string' && rawPath.length > 0 ? rawPath : undefined;
+  const meta: Record<string, unknown> = path !== undefined ? { ...metaFields, path } : { ...metaFields };
+
+  const content: RichToolResult['content'] = [{ type: 'text', text: JSON.stringify(meta, null, 2) }];
 
   if (typeof image_base64 === 'string' && image_base64.length > 0) {
-    content.unshift({ type: 'image', data: image_base64, mimeType: 'image/png' });
+    if (isValidBase64(image_base64)) {
+      content.unshift({ type: 'image', data: image_base64, mimeType: 'image/png' });
+    } else {
+      // Corrupted/clipped payload — never construct an image block from it.
+      // Report the problem as text instead so the caller still gets metadata
+      // and `path`, and knows to fall back to reading the file.
+      content.push({
+        type: 'text',
+        text:
+          `image_base64 was present but not valid base64 (length ${image_base64.length}) — ` +
+          `it was likely clipped by response shaping before reaching this tool. ` +
+          `Read the PNG from "path" instead.`,
+      });
+    }
   }
 
   return { content };


### PR DESCRIPTION
Closes #334.

## Root cause (verified, not just diagnosed from the report)

The response-shaping layer that runs on **every** command's reply, `FHaybaMCPResponseBuilder`, applies a blanket 512-char cap to every string field in the response — `unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp` around line 1024 (`Limits.MaxStringChars = 512`). `python_run` has an explicit exemption right below it (line 1034, bumped to 64K) because its stdout carries a JSON result line that a 512-char cap breaks mid-JSON. **No equivalent exemption exists for image-carrying commands** — `ui_render_widget_to_png` or `editor_capture_viewport`.

A base64 PNG is almost always over 512 characters, so `image_base64` gets clipped mid-string and a non-base64 `"..."` marker appended (see `TrimString` in `HaybaMCPResponseBuilder.cpp`). The result is a field that is **non-empty but not valid base64**: wrong length (not a multiple of 4) and a trailing sequence outside the base64 alphabet. Handing that straight to the MCP SDK as an `image` content block throws deep inside the SDK's own response validation (`Invalid Base64 string`) — which fails the **entire** tool response, taking the metadata and `out_path` down with it even though both were fine.

This matches the `_truncated`/`removed` signature the old ergonomics postmortem recorded for `editor_capture_viewport` (`docs/handoffs/HANDOFF-mcp-agent-ergonomics-postmortem.md`) — same mechanism, same generic response-shaping layer, just not previously traced to the exact 512-char cap and the missing exemption.

## What this PR changes

`unreal/` is out of scope here — no editor available to build or verify a C++ fix against, per the task constraints. So this fixes the TS side of the seam instead of the true source:

- `src/tools/ui/ui-render-widget-to-png.ts`: validates `image_base64` (charset + `length % 4 === 0`) **before** ever constructing an `image` content block. A corrupted payload is now reported as a text note (`"not valid base64 ... read path instead"`) rather than handed to the SDK, so metadata and the file path survive even when the image doesn't.
- The response now always carries a `path` field aliasing UE's `out_path`. A file already on disk can't be corrupted by a response-shaping layer the way an inline base64 string can, so it's the reliable fallback a caller can use regardless of what happened to `image_base64` — this is the "also worth doing" ask from the issue.

## Tests (1449 total, up from 1444 baseline)

- a well-formed ~1MB base64 payload survives the handler byte-identical (regression pin)
- a payload matching the observed corruption shape (509 valid base64 chars + `"..."`, exactly what the 512-char cap produces) is dropped instead of becoming a broken image block, and `path`/metadata still come through intact
- the response always carries a usable `path`
- `isValidBase64` unit coverage for the accept/reject boundary

### Mutation testing (both broken and confirmed red, then reverted and confirmed green)

- Stubbed `isValidBase64` to always return `true` (disabling the guard) → 2 tests went red (the corruption-drop test and the `isValidBase64` boundary test). Reverted → green.
- Dropped the `out_path` → `path` alias (`meta = { ...metaFields }`) → 2 tests went red (`always carries a usable "path"` and the corruption test, which also asserts `path`). Reverted → green.

## Gate

```
npx tsc --noEmit   # clean
npm test           # 1449/1449 passing
node scripts/check-legacy-wrappers.mjs   # OK — 22 cpp commands, 133 sidecar entries, no violations
```

## Honesty / what's NOT verified

I cannot run the Unreal editor, so I did **not**:
- Build or exercise the C++ `FHaybaMCPResponseBuilder` code that is the actual root cause — read and reasoned about it, not modified or compiled.
- Render a real Widget Blueprint end-to-end and confirm a viewable PNG comes back through a live editor.

What's verified: the TS handler compiles, is routed through the same `executeCommand`/`ScriptedUe` seam every other tool uses, and its response-splitting/validation logic is pinned by tests that were red before the fix and green after (mutation-confirmed both ways). Live verification against a running editor is the outstanding gap.