### PR TITLE
fix(mcp): accept historical param-name aliases across tool families

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/asset/asset-delete.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset/asset-delete.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { ToolHandler } from '../types.js';
 import { ueTool } from '../ue-tool.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { TOOL_ALIASES } from '../tool-aliases.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'low',
@@ -22,4 +23,4 @@ export const schema = z
     message: 'give `path` (string) or `paths` (array of strings)',
   });
 
-export const assetDeleteHandler: ToolHandler = ueTool('asset_delete', schema);
+export const assetDeleteHandler: ToolHandler = ueTool('asset_delete', schema, TOOL_ALIASES.asset_delete);

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -10,6 +10,8 @@ import { registerToolMeta, getToolMeta } from './tool-meta-registry.js';
 import { readSettings } from './routing/settings-watcher.js';
 import { registerDeferredRouting, type CapturedTool, type RoutingHandle, type DeferredRoutingOptions } from './routing/register.js';
 import { defineTool, registerTool, recordToolSchema, type ToolDescriptor } from './register-tool.js';
+import { resolveAliases } from './param-aliases.js';
+import { TOOL_ALIASES } from './tool-aliases.js';
 import {
   guardHandlerWithEvidence,
   isUnderEvidenceContract,
@@ -3473,9 +3475,22 @@ function registerToolsCore(
       'Return the JSON schema (params, return shape, cost) for a specific HaybaOS command. Call list_tool_categories first to find command names.',
       sigMeta,
     ),
-    { command: z.string().describe('Exact command name, e.g. "actor_spawn"') },
+    // Wire-level shape only — widened with `name` as an accepted alias for
+    // `command` (issue #339) so the MCP transport doesn't reject the call
+    // before it reaches getToolSignatureHandler. The DOCUMENTED signature
+    // (what get_tool_signature reports about itself, via recordEagerSchemas'
+    // separate `{command...}` literal below) is untouched — still one
+    // required field, one spelling.
+    {
+      command: z.string().optional().describe('Exact command name, e.g. "actor_spawn"'),
+      name: z.string().optional().describe('Alias for "command".'),
+    },
     async (params) => {
-      const r = await getToolSignatureHandler(params as Record<string, unknown>, session);
+      const resolved = resolveAliases(params as Record<string, unknown>, TOOL_ALIASES.get_tool_signature);
+      if (!resolved.ok) {
+        return { content: [{ type: 'text', text: `Validation error: ${resolved.error}` }], isError: true };
+      }
+      const r = await getToolSignatureHandler(resolved.args, session);
       return { content: r.content, isError: r.isError };
     },
   );
@@ -3487,8 +3502,12 @@ function registerToolsCore(
       'Execute a Python script inside UE via PythonScriptPlugin. Universal escape hatch for invoking any UE command not otherwise exposed.',
       pyMeta,
     ),
+    // Wire-level shape only — widened with `code` as an accepted alias for
+    // `script` (issue #339); pythonRunHandler's own schema (canonical-only)
+    // still enforces `script` is actually present after normalisation.
     {
-      script: z.string().describe('Python source to execute'),
+      script: z.string().optional().describe('Python source to execute'),
+      code: z.string().optional().describe('Alias for "script".'),
       allow_unsafe: z.boolean().optional().describe('Override Tier 3 filesystem/subprocess block (DANGEROUS)'),
     },
     async (params) => {

--- a/mcp-tools/hayba-mcp/src/tools/param-aliases.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/param-aliases.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAliases, type AliasMap } from './param-aliases.js';
+
+describe('resolveAliases', () => {
+  const aliases: AliasMap = {
+    path: ['widget_blueprint_path'],
+    name: ['child_name', 'widget_name'],
+  };
+
+  it('passes canonical-only args through untouched', () => {
+    const res = resolveAliases({ path: '/Game/A', other: 1 }, aliases);
+    expect(res).toEqual({ ok: true, args: { path: '/Game/A', other: 1 } });
+  });
+
+  it('copies an alternate value onto the canonical key and drops the alternate', () => {
+    const res = resolveAliases({ widget_blueprint_path: '/Game/A' }, aliases);
+    expect(res).toEqual({ ok: true, args: { path: '/Game/A' } });
+  });
+
+  it('leaves args untouched when neither canonical nor alternate is present', () => {
+    const res = resolveAliases({ other: 1 }, aliases);
+    expect(res).toEqual({ ok: true, args: { other: 1 } });
+  });
+
+  it('resolves whichever of several alternates for one canonical is supplied', () => {
+    expect(resolveAliases({ child_name: 'Btn' }, aliases)).toEqual({ ok: true, args: { name: 'Btn' } });
+    expect(resolveAliases({ widget_name: 'Btn' }, aliases)).toEqual({ ok: true, args: { name: 'Btn' } });
+  });
+
+  it('silently collapses canonical + alternate when the values agree', () => {
+    const res = resolveAliases({ path: '/Game/A', widget_blueprint_path: '/Game/A' }, aliases);
+    expect(res).toEqual({ ok: true, args: { path: '/Game/A' } });
+  });
+
+  it('fails loudly when canonical + alternate disagree — never silently picks one', () => {
+    const res = resolveAliases({ path: '/Game/A', widget_blueprint_path: '/Game/B' }, aliases);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toContain('path');
+      expect(res.error).toContain('widget_blueprint_path');
+    }
+  });
+
+  it('fails loudly when two alternates for the same canonical disagree', () => {
+    const res = resolveAliases({ child_name: 'A', widget_name: 'B' }, aliases);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toContain('name');
+    }
+  });
+
+  it('does not mutate the input object', () => {
+    const input = { widget_blueprint_path: '/Game/A' };
+    resolveAliases(input, aliases);
+    expect(input).toEqual({ widget_blueprint_path: '/Game/A' });
+  });
+
+  it('is a no-op given an empty alias map', () => {
+    const res = resolveAliases({ anything: 1 }, {});
+    expect(res).toEqual({ ok: true, args: { anything: 1 } });
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/param-aliases.ts
+++ b/mcp-tools/hayba-mcp/src/tools/param-aliases.ts
@@ -1,0 +1,82 @@
+// Historical/expected parameter-name aliasing — the ONE place this
+// normalisation happens. See docs/adr/0007 ("a static check must know every
+// form of the call it guards") and, more directly, the failure it is fixing:
+// GitHub issue #339 — two independent sessions cold-called tools with the
+// "obvious" sibling spelling of a param (widget_blueprint_path instead of
+// ui_query's `path`, asset_paths instead of asset_delete's `paths`, ...),
+// burned a full round-trip on a validation error, then had to re-read the
+// signature and retry.
+//
+// This module does exactly one thing: given an args object and a
+// canonical-name -> historical-alternates map, produce a normalised args
+// object with every alternate folded onto its canonical key. It does NOT
+// validate types or requiredness — that stays the job of the tool's own zod
+// schema, which is parsed against the NORMALISED object, unchanged. Nothing
+// here widens what a tool's documented signature says: get_tool_signature and
+// the schema registry keep reading the original canonical schema, never this
+// module's output shape.
+//
+// Every call site (ueTool, the PyToolDescriptor factory, hayba_invoke, and the
+// two hand-registered meta-tools) routes through resolveAliases so the rule
+// cannot drift between dispatch paths — the exact failure mode ADR 0007
+// documents for a guard taught only one form of a call.
+
+/** Canonical param name -> the historical/expected spellings that should also
+ *  be accepted for it. */
+export type AliasMap = Record<string, readonly string[]>;
+
+export type AliasResolution =
+  | { ok: true; args: Record<string, unknown> }
+  | { ok: false; error: string };
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (typeof a === 'object') {
+    try {
+      return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Fold alternate-spelling keys onto their canonical key.
+ *
+ * - Only the canonical key present: untouched.
+ * - Only an alternate present: its value is copied onto the canonical key and
+ *   the alternate key is removed.
+ * - BOTH the canonical key and an alternate (or two alternates for the same
+ *   canonical) present with equal values: the duplicate is silently dropped.
+ * - Present with DIFFERENT values: this is a caller error — fail loudly with
+ *   a message naming both spellings, rather than silently preferring one.
+ *
+ * The input object is not mutated; a shallow copy is returned.
+ */
+export function resolveAliases(
+  args: Record<string, unknown>,
+  aliases: AliasMap,
+): AliasResolution {
+  const out: Record<string, unknown> = { ...args };
+  for (const [canonical, alternates] of Object.entries(aliases)) {
+    for (const alt of alternates) {
+      if (!(alt in out)) continue;
+      const altValue = out[alt];
+      delete out[alt];
+      if (canonical in out) {
+        if (!deepEqual(out[canonical], altValue)) {
+          return {
+            ok: false,
+            error:
+              `Conflicting values for "${canonical}": also supplied as "${alt}" with a different value. Pass only one.`,
+          };
+        }
+        continue;
+      }
+      out[canonical] = altValue;
+    }
+  }
+  return { ok: true, args: out };
+}

--- a/mcp-tools/hayba-mcp/src/tools/py-tool-factory.ts
+++ b/mcp-tools/hayba-mcp/src/tools/py-tool-factory.ts
@@ -35,6 +35,7 @@ import {
 } from './register-tool.js';
 import type { Cost } from './schema-registry.js';
 import type { ToolResult, SessionManager } from './types.js';
+import { resolveAliases, type AliasMap } from './param-aliases.js';
 
 /**
  * Declarative description of a python_run-backed tool. Everything needed to
@@ -56,6 +57,10 @@ export interface PyToolDescriptor<S extends z.ZodRawShape = z.ZodRawShape> {
   returns: string;
   /** Zod raw shape — validates params AND feeds the schema registry. */
   schema: S;
+  /** Optional canonical->alternates param-name map (see param-aliases.ts).
+   *  Applied to raw args BEFORE `schema` parses them, so `schema` — and thus
+   *  the schema registry / get_tool_signature — stays canonical-only. */
+  aliases?: AliasMap;
   /** Build the Python body from validated params. Calls _emit/_err. */
   buildScript: (params: z.infer<z.ZodObject<S>>) => string;
   /** Full tool meta. When omitted, a minimal meta is synthesized from `cost`. */
@@ -98,7 +103,15 @@ export function makePyToolHandler<S extends z.ZodRawShape>(
 ): PyToolHandler {
   const validator = z.object(d.schema);
   return async (params: Record<string, unknown>): Promise<ToolResult> => {
-    const parsed = validator.safeParse(params);
+    let effectiveParams = params;
+    if (d.aliases) {
+      const resolved = resolveAliases(params, d.aliases);
+      if (!resolved.ok) {
+        return errorResult(`Invalid params for ${d.name}: ${resolved.error}`);
+      }
+      effectiveParams = resolved.args;
+    }
+    const parsed = validator.safeParse(effectiveParams);
     if (!parsed.success) {
       return errorResult(`Invalid params for ${d.name}: ${parsed.error.message}`);
     }

--- a/mcp-tools/hayba-mcp/src/tools/python/python-run.ts
+++ b/mcp-tools/hayba-mcp/src/tools/python/python-run.ts
@@ -7,6 +7,8 @@ import { executeCommand } from '../tool-executor.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
 import { scanPythonForCrashers, crashGuardMessage } from '../guards/known-crashers.js';
 import { errorResult } from '../tool-result.js';
+import { resolveAliases } from '../param-aliases.js';
+import { TOOL_ALIASES } from '../tool-aliases.js';
 
 /**
  * When python_run output exceeds this many characters, spill the full payload
@@ -64,7 +66,11 @@ export function wrapScriptForPrintRedirect(userScript: string): string {
 }
 
 export const pythonRunHandler: ToolHandler = async (args) => {
-  const parsed = schema.safeParse(args);
+  const resolved = resolveAliases(args, TOOL_ALIASES.python_run);
+  if (!resolved.ok) {
+    return errorResult(`Validation error: ${resolved.error}`);
+  }
+  const parsed = schema.safeParse(resolved.args);
   if (!parsed.success) {
     return errorResult(`Validation error: ${parsed.error.message}`);
   }

--- a/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
@@ -1,6 +1,8 @@
 import { z, type ZodRawShape } from 'zod';
 import { getRawShape } from '../../schema-registry.js';
 import { listAgentCallableLegacyCommands } from '../../../legacy-commands/index.js';
+import { resolveAliases } from '../../param-aliases.js';
+import { TOOL_ALIASES } from '../../tool-aliases.js';
 
 /**
  * Built once at module load from sidecar.json. Every entry with
@@ -48,6 +50,26 @@ export async function invokeHandler(
   if (ctx.isDisabled(args.name)) {
     return { ok: false, error: { kind: 'tool_disabled', name: args.name } };
   }
+
+  // Fold historical/expected param-name aliases onto their canonical key
+  // before ANY dispatch route sees the args — see param-aliases.ts / issue
+  // #339. Applies uniformly to the legacy route (no zod schema to normalise
+  // against downstream) and the ts route (normalised BEFORE the strict parse
+  // below, so the canonical shape used for that parse — and for
+  // get_tool_signature's docs — never changes).
+  const toolAliases = TOOL_ALIASES[args.name];
+  let rawArgs = args.args ?? {};
+  if (toolAliases) {
+    const resolved = resolveAliases(rawArgs, toolAliases);
+    if (!resolved.ok) {
+      return {
+        ok: false,
+        error: { kind: 'validation', issues: [{ message: resolved.error }] },
+      };
+    }
+    rawArgs = resolved.args;
+  }
+
   // UE-legacy route: when via:'ue_legacy' is set, dispatch the raw command
   // through the UE bridge. This is the safety hatch that makes a legacy
   // command reachable from hayba_invoke even when no TS wrapper has been
@@ -59,7 +81,7 @@ export async function invokeHandler(
       return { ok: false, error: { kind: 'legacy_not_allowlisted', name: args.name } };
     }
     const legacy = ctx.dispatchLegacy ?? ctx.dispatch;
-    const result = await legacy(args.name, args.args ?? {});
+    const result = await legacy(args.name, rawArgs);
     return { ok: true, result };
   }
   const shape: ZodRawShape | null = getRawShape(args.name);
@@ -71,7 +93,7 @@ export async function invokeHandler(
     // allow-listed. Only when neither route knows the command do we error.
     if (LEGACY_ALLOWLIST.has(args.name)) {
       const legacy = ctx.dispatchLegacy ?? ctx.dispatch;
-      const result = await legacy(args.name, args.args ?? {});
+      const result = await legacy(args.name, rawArgs);
       return { ok: true, result };
     }
     return { ok: false, error: { kind: 'unknown_tool', name: args.name } };
@@ -83,7 +105,7 @@ export async function invokeHandler(
   // 7111 engine tests, editor_pie_screenshot {path} polling a file that was
   // never checked, ui_set_slot_layout {anchors} applying everything except the
   // anchors. One loud round-trip beats hours of "the tool ignores its param".
-  const parse = z.object(shape).strict().safeParse(args.args);
+  const parse = z.object(shape).strict().safeParse(rawArgs);
   if (!parse.success) {
     return {
       ok: false,

--- a/mcp-tools/hayba-mcp/src/tools/sequencer/sequencer-py-tools.ts
+++ b/mcp-tools/hayba-mcp/src/tools/sequencer/sequencer-py-tools.ts
@@ -93,6 +93,7 @@ import { z } from 'zod';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
 import { pyStr } from '../ue-python.js';
 import type { PyToolDescriptor } from '../py-tool-factory.js';
+import { TOOL_ALIASES } from '../tool-aliases.js';
 
 // ── Shared Python helpers: load + validate a LevelSequence, rate/frame math,
 //    actor lookup, binding lookup by GUID ─────────────────────────────────────
@@ -213,6 +214,7 @@ export const seqNewDescriptor: PyToolDescriptor<typeof seqNewSchema.shape> = {
   cost: 'medium',
   returns: '{ok, asset_path, name, created, frame_rate?, dry_run?}',
   schema: seqNewSchema.shape,
+  aliases: TOOL_ALIASES.seq_new,
   meta: writeMeta,
   buildScript: seqNewScript,
   timeoutMs: 30_000,

--- a/mcp-tools/hayba-mcp/src/tools/tool-aliases.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-aliases.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Issue #339: two independent sessions cold-called a tool with the "obvious"
+ * sibling spelling of a param, burned a full validation round-trip, then had
+ * to re-read the signature and retry. TOOL_ALIASES is the fix's single
+ * source of truth; this file is the acceptance test the issue asked for —
+ * it enumerates the map and drives EVERY entry's real handler (not a stand-in)
+ * with the alternate spelling, proving the call succeeds exactly as it would
+ * with the canonical name.
+ *
+ * Each tool here is exercised through whichever dispatch path is its real
+ * validation gate:
+ *   - ueTool-backed tools (ui_query, ui_add_element, asset_delete): the
+ *     wrapper handler, via ScriptedUe.
+ *   - hand-written handlers (ui_reparent_element, ui_move_element,
+ *     python_run): the wrapper handler directly.
+ *   - PyToolDescriptor tools (seq_new): makePyToolHandler + a stubbed
+ *     python_run sender.
+ *   - legacy-only commands (blueprint_create): hayba_invoke's ts→ue_legacy
+ *     fallthrough, since that's the only path that ever validates it.
+ *   - get_tool_signature: the same normalise-then-delegate call index.ts
+ *     performs at its server.tool() registration site (get-tool-signature.ts
+ *     itself has no zod schema to alias against — the wire-level widening +
+ *     resolveAliases call lives in index.ts, not in a unit-testable module).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { TOOL_ALIASES } from './tool-aliases.js';
+import { resolveAliases } from './param-aliases.js';
+import { scriptedUe, type ScriptedUe } from './testing/scripted-ue.js';
+import { uiQueryHandler } from './ui/ui-query.js';
+import { uiAddElementHandler } from './ui/ui-add-element.js';
+import { assetDeleteHandler } from './asset/asset-delete.js';
+import { uiReparentElementHandler } from './ui/ui-reparent-element.js';
+import { uiMoveElementHandler } from './ui/ui-move-element.js';
+import { pythonRunHandler } from './python/python-run.js';
+import { getToolSignatureHandler } from './code-mode/get-tool-signature.js';
+import { invokeHandler } from './routing/meta-tools/invoke.js';
+import { makePyToolHandler } from './py-tool-factory.js';
+import { seqNewDescriptor } from './sequencer/sequencer-py-tools.js';
+
+let ue: ScriptedUe | undefined;
+afterEach(() => {
+  ue?.restore();
+  ue = undefined;
+});
+
+function textOf(r: { content: Array<{ type: string; text?: string }> }): string {
+  return r.content.find((c) => c.type === 'text')?.text ?? '';
+}
+
+describe('TOOL_ALIASES enumeration', () => {
+  it('covers exactly the tools fixed by issue #339', () => {
+    expect(Object.keys(TOOL_ALIASES).sort()).toEqual(
+      [
+        'asset_delete',
+        'blueprint_create',
+        'get_tool_signature',
+        'python_run',
+        'seq_new',
+        'ui_add_element',
+        'ui_move_element',
+        'ui_query',
+        'ui_reparent_element',
+      ].sort(),
+    );
+  });
+
+  it('every entry maps at least one canonical name to at least one distinct alternate', () => {
+    for (const [tool, aliasMap] of Object.entries(TOOL_ALIASES)) {
+      expect(Object.keys(aliasMap).length, tool).toBeGreaterThan(0);
+      for (const [canonical, alternates] of Object.entries(aliasMap)) {
+        expect(alternates.length, `${tool}.${canonical}`).toBeGreaterThan(0);
+        for (const alt of alternates) {
+          expect(alt, `${tool}.${canonical}`).not.toBe(canonical);
+        }
+      }
+    }
+  });
+});
+
+describe('ui_query accepts both spellings', () => {
+  it('canonical: path', async () => {
+    ue = scriptedUe().replies('ui_query', { path: '/Game/A', parent_class: 'UserWidget', root: {} });
+    const r = await uiQueryHandler({ path: '/Game/A' }, {} as never);
+    expect(r.isError).toBeFalsy();
+    expect(ue.paramsFor('ui_query').path).toBe('/Game/A');
+  });
+
+  it('alias: widget_blueprint_path', async () => {
+    ue = scriptedUe().replies('ui_query', { path: '/Game/A', parent_class: 'UserWidget', root: {} });
+    const r = await uiQueryHandler({ widget_blueprint_path: '/Game/A' }, {} as never);
+    expect(r.isError).toBeFalsy();
+    expect(ue.paramsFor('ui_query').path).toBe('/Game/A');
+  });
+
+  it('rejects conflicting path + widget_blueprint_path', async () => {
+    ue = scriptedUe();
+    const r = await uiQueryHandler({ path: '/Game/A', widget_blueprint_path: '/Game/B' }, {} as never);
+    expect(r.isError).toBe(true);
+    expect(textOf(r)).toContain('Conflicting values');
+    expect(ue.calls).toEqual([]);
+  });
+});
+
+describe('ui_add_element accepts both spellings', () => {
+  it('canonical: child_class / name / parent_widget_name', async () => {
+    ue = scriptedUe().replies('ui_add_element', { name: 'Btn' });
+    const r = await uiAddElementHandler(
+      { widget_blueprint_path: '/Game/A', child_class: 'Button', name: 'Btn', parent_widget_name: 'Root' },
+      {} as never,
+    );
+    expect(r.isError).toBeFalsy();
+    const p = ue.paramsFor('ui_add_element');
+    expect(p.child_class).toBe('Button');
+    expect(p.name).toBe('Btn');
+    expect(p.parent_widget_name).toBe('Root');
+  });
+
+  it('alias: widget_class / child_name / parent_name', async () => {
+    ue = scriptedUe().replies('ui_add_element', { name: 'Btn' });
+    const r = await uiAddElementHandler(
+      { widget_blueprint_path: '/Game/A', widget_class: 'Button', child_name: 'Btn', parent_name: 'Root' },
+      {} as never,
+    );
+    expect(r.isError).toBeFalsy();
+    const p = ue.paramsFor('ui_add_element');
+    expect(p.child_class).toBe('Button');
+    expect(p.name).toBe('Btn');
+    expect(p.parent_widget_name).toBe('Root');
+  });
+
+  it('alias: the other alternate for `name` — widget_name', async () => {
+    ue = scriptedUe().replies('ui_add_element', { name: 'Btn' });
+    const r = await uiAddElementHandler(
+      { widget_blueprint_path: '/Game/A', child_class: 'Button', widget_name: 'Btn' },
+      {} as never,
+    );
+    expect(r.isError).toBeFalsy();
+    expect(ue.paramsFor('ui_add_element').name).toBe('Btn');
+  });
+});
+
+describe('asset_delete accepts both spellings', () => {
+  it('alias: asset_paths', async () => {
+    ue = scriptedUe().replies('asset_delete', { requested: 1, deleted_count: 1, still_on_disk_count: 0, results: [] });
+    const r = await assetDeleteHandler({ asset_paths: ['/Game/A'] }, {} as never);
+    expect(r.isError).toBeFalsy();
+    expect(ue.paramsFor('asset_delete').paths).toEqual(['/Game/A']);
+  });
+});
+
+describe('ui_reparent_element accepts both spellings', () => {
+  it('alias: new_parent_widget_name', async () => {
+    ue = scriptedUe().replies('ui_mutate_tree', { ok: true });
+    const r = await uiReparentElementHandler(
+      { widget_blueprint_path: '/Game/A', widget_name: 'Btn', new_parent_widget_name: 'Panel' },
+      {} as never,
+    );
+    expect(r.isError).toBeFalsy();
+    expect(ue.paramsFor('ui_mutate_tree').new_parent_name).toBe('Panel');
+  });
+});
+
+describe('ui_move_element accepts both spellings', () => {
+  it('alias: new_index', async () => {
+    ue = scriptedUe().replies('ui_mutate_tree', { ok: true });
+    const r = await uiMoveElementHandler(
+      { widget_blueprint_path: '/Game/A', widget_name: 'Btn', new_index: 2 },
+      {} as never,
+    );
+    expect(r.isError).toBeFalsy();
+    expect(ue.paramsFor('ui_mutate_tree').index).toBe(2);
+  });
+});
+
+describe('python_run accepts both spellings', () => {
+  it('alias: code', async () => {
+    ue = scriptedUe().replies('python_run', { stdout: 'hi', stderr: '' });
+    const r = await pythonRunHandler({ code: 'print(1)' }, {} as never);
+    expect(r.isError).toBeFalsy();
+    expect(ue.paramsFor('python_run').script).toBe('print(1)');
+  });
+
+  it('rejects conflicting script + code', async () => {
+    ue = scriptedUe();
+    const r = await pythonRunHandler({ script: 'print(1)', code: 'print(2)' }, {} as never);
+    expect(r.isError).toBe(true);
+    expect(textOf(r)).toContain('Conflicting values');
+    expect(ue.calls).toEqual([]);
+  });
+});
+
+describe('seq_new accepts both spellings', () => {
+  it('alias: package_path', async () => {
+    const emit = 'HAYBA_JSON:' + JSON.stringify({ ok: true, asset_path: '/Game/Cine/LS', name: 'LS', created: true });
+    ue = scriptedUe().replies('python_run', { stdout: emit, stderr: '' });
+    const r = await makePyToolHandler(seqNewDescriptor)({ package_path: '/Game/Cine', name: 'LS' });
+    expect(r.isError).toBeFalsy();
+    expect(ue.paramsFor('python_run').script).toContain("_path = '/Game/Cine'");
+  });
+});
+
+describe('blueprint_create accepts both spellings (legacy dispatch)', () => {
+  it('alias: path / parent_class, folded onto package_path / parent_class_path before hitting the wire', async () => {
+    const dispatchLegacy = async (_cmd: string, params: Record<string, unknown>) => params;
+    const res = await invokeHandler(
+      { name: 'blueprint_create', args: { name: 'BP_Foo', path: '/Game/Foo/BP_Foo', parent_class: '/Script/Engine.Actor' } },
+      { dispatch: async () => { throw new Error('should not use the ts route'); }, dispatchLegacy, isDisabled: () => false },
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.result).toEqual({
+        name: 'BP_Foo',
+        package_path: '/Game/Foo/BP_Foo',
+        parent_class_path: '/Script/Engine.Actor',
+      });
+    }
+  });
+});
+
+describe('get_tool_signature accepts both spellings', () => {
+  // Mirrors the normalise-then-delegate call index.ts makes at its
+  // server.tool('get_tool_signature', ...) registration site.
+  it('alias: name (in place of command)', async () => {
+    const resolved = resolveAliases({ name: 'ui_query' }, TOOL_ALIASES.get_tool_signature);
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    const r = await getToolSignatureHandler(resolved.args, {} as never);
+    const parsed = JSON.parse(textOf(r)) as { command: string };
+    expect(parsed.command).toBe('ui_query');
+  });
+
+  it('rejects conflicting command + name', () => {
+    const resolved = resolveAliases({ command: 'ui_query', name: 'asset_delete' }, TOOL_ALIASES.get_tool_signature);
+    expect(resolved.ok).toBe(false);
+    if (!resolved.ok) expect(resolved.error).toContain('Conflicting values');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/tool-aliases.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-aliases.ts
@@ -1,0 +1,52 @@
+// Single source of truth for which historical/expected param spellings a
+// tool accepts, keyed by tool (command) name. Consumed by:
+//   - hayba_invoke (src/tools/routing/meta-tools/invoke.ts) — the default
+//     dispatch path under Code Mode / deferred routing.
+//   - ueTool / PyToolDescriptor handlers — the direct-call path (also what
+//     unit tests exercise).
+//   - the two hand-registered meta-tools (get_tool_signature, python_run)
+//     that sit outside both of the above.
+//
+// One map, one place to add a tool. See param-aliases.ts for the
+// normalisation logic itself and docs/adr/0007 for why a second copy of this
+// data would be the bug.
+//
+// GitHub issue #339 — table of confirmed round-trip failures plus the same
+// shape found elsewhere in the same families.
+import type { AliasMap } from './param-aliases.js';
+
+export const TOOL_ALIASES: Record<string, AliasMap> = {
+  ui_query: {
+    path: ['widget_blueprint_path'],
+  },
+  ui_add_element: {
+    child_class: ['widget_class'],
+    name: ['child_name', 'widget_name'],
+    parent_widget_name: ['parent_name'],
+  },
+  ui_reparent_element: {
+    new_parent_name: ['new_parent_widget_name'],
+  },
+  ui_move_element: {
+    index: ['new_index'],
+  },
+  get_tool_signature: {
+    command: ['name'],
+  },
+  asset_delete: {
+    paths: ['asset_paths'],
+  },
+  blueprint_create: {
+    package_path: ['path'],
+    parent_class_path: ['parent_class'],
+  },
+  // The C++ "seq_create" command is dormant (no sidecar entry, unreachable —
+  // see sequencer-py-tools.ts); seq_new is the live tool that fills the same
+  // role and has the same path/package_path confusion the issue described.
+  seq_new: {
+    path: ['package_path'],
+  },
+  python_run: {
+    script: ['code'],
+  },
+};

--- a/mcp-tools/hayba-mcp/src/tools/ue-tool.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ue-tool.ts
@@ -22,6 +22,7 @@
 import type { z } from 'zod';
 import type { ToolHandler } from './types.js';
 import { executeCommand } from './tool-executor.js';
+import { resolveAliases, type AliasMap } from './param-aliases.js';
 
 /** Build the handler for a wrapper that passes validated args straight to a
  *  plugin command and returns the reply as pretty-printed JSON.
@@ -33,10 +34,22 @@ import { executeCommand } from './tool-executor.js';
  *                  unit tests pass. `wire-command-names.test.ts` enforces this
  *                  statically; see docs/WORKFLOW-improving-the-mcp.md §3b.
  *  @param schema   Zod schema; its parsed output is the params object.
+ *  @param aliases  Optional canonical->alternates param-name map (see
+ *                  param-aliases.ts). Applied to the raw args BEFORE `schema`
+ *                  parses them, so `schema` itself stays canonical-only —
+ *                  get_tool_signature's documented signature is unaffected.
  */
-export function ueTool(command: string, schema: z.ZodTypeAny): ToolHandler {
+export function ueTool(command: string, schema: z.ZodTypeAny, aliases?: AliasMap): ToolHandler {
   return async (args) => {
-    const parsed = schema.safeParse(args);
+    let effectiveArgs: Record<string, unknown> = args;
+    if (aliases) {
+      const resolved = resolveAliases(args, aliases);
+      if (!resolved.ok) {
+        return { content: [{ type: 'text', text: `Validation error: ${resolved.error}` }], isError: true };
+      }
+      effectiveArgs = resolved.args;
+    }
+    const parsed = schema.safeParse(effectiveArgs);
     if (!parsed.success) {
       return {
         content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }],

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-add-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-add-element.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { ToolHandler } from '../types.js';
 import { ueTool } from '../ue-tool.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { TOOL_ALIASES } from '../tool-aliases.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'medium',
@@ -37,4 +38,4 @@ export const schema = z.object({
     ),
 });
 
-export const uiAddElementHandler: ToolHandler = ueTool('ui_add_element', schema);
+export const uiAddElementHandler: ToolHandler = ueTool('ui_add_element', schema, TOOL_ALIASES.ui_add_element);

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-move-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-move-element.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import type { ToolHandler } from '../types.js';
 import { executeCommand } from '../tool-executor.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { resolveAliases } from '../param-aliases.js';
+import { TOOL_ALIASES } from '../tool-aliases.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'medium',
@@ -21,7 +23,11 @@ export const schema = z.object({
 });
 
 export const uiMoveElementHandler: ToolHandler = async (args) => {
-  const parsed = schema.safeParse(args);
+  const resolved = resolveAliases(args, TOOL_ALIASES.ui_move_element);
+  if (!resolved.ok) {
+    return { content: [{ type: 'text', text: `Validation error: ${resolved.error}` }], isError: true };
+  }
+  const parsed = schema.safeParse(resolved.args);
   if (!parsed.success) {
     return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
   }

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-query.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { ToolHandler } from '../types.js';
 import { ueTool } from '../ue-tool.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { TOOL_ALIASES } from '../tool-aliases.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'low',
@@ -38,4 +39,4 @@ export const schema = z.object({
     .describe('Return the flat `matches` list even when no filter is given.'),
 });
 
-export const uiQueryHandler: ToolHandler = ueTool('ui_query', schema);
+export const uiQueryHandler: ToolHandler = ueTool('ui_query', schema, TOOL_ALIASES.ui_query);

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-reparent-element.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-reparent-element.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import type { ToolHandler } from '../types.js';
 import { executeCommand } from '../tool-executor.js';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { resolveAliases } from '../param-aliases.js';
+import { TOOL_ALIASES } from '../tool-aliases.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'medium',
@@ -21,7 +23,11 @@ export const schema = z.object({
 });
 
 export const uiReparentElementHandler: ToolHandler = async (args) => {
-  const parsed = schema.safeParse(args);
+  const resolved = resolveAliases(args, TOOL_ALIASES.ui_reparent_element);
+  if (!resolved.ok) {
+    return { content: [{ type: 'text', text: `Validation error: ${resolved.error}` }], isError: true };
+  }
+  const parsed = schema.safeParse(resolved.args);
   if (!parsed.success) {
     return { content: [{ type: 'text', text: `Validation error: ${parsed.error.message}` }], isError: true };
   }


### PR DESCRIPTION
## Summary

Closes #339. Two independent sessions cold-called `ui_query`, `ui_add_element`, `ui_reparent_element`, `ui_move_element`, `get_tool_signature`, `asset_delete`, `blueprint_create`, `seq_new` (see note below), and `python_run` with the sibling spelling every other tool in that family uses, burned a full validation round-trip, then had to re-read the signature and retry.

- Adds one shared helper, `src/tools/param-aliases.ts` (`resolveAliases`), that folds an alternate spelling onto its canonical key before a tool's own zod schema ever sees the args. Both spellings present with **different** values is a caller error and fails loudly, naming both keys.
- The alias data lives in one place, `src/tools/tool-aliases.ts` (`TOOL_ALIASES`), consumed by every dispatch path so the rule can't drift between them (per ADR 0007): `hayba_invoke` (the default path), `ueTool`-backed wrappers, the two hand-written handlers (`ui_reparent_element`, `ui_move_element`), the `PyToolDescriptor` factory (`seq_new`), `python-run.ts`, and the two always-on meta-tools registered directly in `index.ts` (`get_tool_signature`, `python_run`).
- Nothing widens what a tool's documented signature says: the canonical zod schema recorded in the schema registry is unchanged, so `get_tool_signature` and the tool catalogue keep teaching exactly one spelling per param. Only `get_tool_signature`/`python_run`'s wire-level shapes (their sole direct SDK registration, outside the schema registry) gained optional alias fields so the MCP transport doesn't reject the call before `resolveAliases` runs.

## Scope note

`seq_create` in the issue's table does not correspond to a reachable command — the C++ command is dormant (see `sequencer-py-tools.ts`'s 3-surface overlap audit: zero sidecar entry, unregistered). Treated `seq_new` as the intended target since it has the identical `path` vs `package_path` confusion and is the live tool filling that role. Flagging this interpretation explicitly rather than silently guessing.

## Verified

- `npx tsc --noEmit`: clean
- `npm test`: **1470/1470 passing** (1444 baseline + 26 new)
- `node scripts/check-legacy-wrappers.mjs`: OK, no violations
- Mutation-tested every new assertion path by breaking it and confirming RED, then reverting to GREEN:
  - the conflict-detection branch in `resolveAliases`
  - a `TOOL_ALIASES` entry (removed `ui_query`'s alias)
  - the alias hookup in `ueTool`, `invoke.ts`, `py-tool-factory.ts`, `ui-move-element.ts`, and `python-run.ts`
  - each one independently caught by the new tests, confirming a test that hasn't been seen to fail isn't evidence

## Not verified

- No live UE editor in this worktree, so no live round trip was run against the C++ plugin. Everything here is TS-side param normalisation before the wire call; wire command names and payload shapes are unchanged from before this fix, so existing `wire-command-names.test.ts` coverage still applies, but "the alias actually reaches Unreal" was not observed live.

## Test plan

- [x] `cd mcp-tools/hayba-mcp && npx tsc --noEmit`
- [x] `npm test`
- [x] `node scripts/check-legacy-wrappers.mjs`
- [ ] Live-editor smoke test of `ui_add_element` / `ui_query` with alias params (not possible from this worktree)