### PR TITLE
fix(ue): a base64 image is never trimmed — the root cause under #334

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPResponseBuilder.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPResponseBuilder.cpp
@@ -25,6 +25,11 @@ bool FHaybaMCPResponseBuilder::TrimString(FString& InOutValue) const
     return false;
 }
 
+bool FHaybaMCPResponseBuilder::IsFieldExempt(const FString& Key) const
+{
+    return Limits.NeverTrimFields.Contains(Key);
+}
+
 int32 FHaybaMCPResponseBuilder::TrimArray(TArray<TSharedPtr<FJsonValue>>& InOutItems) const
 {
     if (Limits.MaxArrayItems < 0)
@@ -158,6 +163,12 @@ namespace
             {
             case EJson::String:
             {
+                // An exempt field passes through whole. Clipping a base64 image
+                // does not shorten it, it invalidates it — see NeverTrimFields.
+                if (Builder.IsFieldExempt(Key))
+                {
+                    break;
+                }
                 FString Str = Value->AsString();
                 const int32 OriginalLen = Str.Len();
                 if (Builder.TrimString(Str))

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPResponseBuilder.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPResponseBuilder.h
@@ -7,6 +7,24 @@ struct FHaybaResponseLimits
     int32 MaxArrayItems = 50;
     int32 MaxStringChars = 512;
     int32 MaxTopLevelFields = 20;
+
+    /**
+     * Fields whose value must never be trimmed, by key name.
+     *
+     * A base64 image is always over the string cap, and clipping it does not
+     * produce a shorter image — it produces a NON-EMPTY string that is not
+     * valid base64. The MCP SDK then rejects the whole content block
+     * ("Invalid Base64 string"), so the reply is lost entirely, metadata
+     * included, and ui_render_widget_to_png has been unusable for at least a
+     * week. editor_capture_viewport was reported failing the same way earlier,
+     * with a "_truncated: image_base64" marker that named the culprit.
+     *
+     * Exempting by FIELD rather than by command on purpose: the previous
+     * mechanism was a per-command override (python_run), which protects only
+     * the commands somebody remembered. Any command that returns an image is
+     * covered by this, including ones not written yet.
+     */
+    TSet<FString> NeverTrimFields { TEXT("image_base64") };
 };
 
 class FHaybaMCPResponseBuilder
@@ -16,6 +34,9 @@ public:
 
     /** Trim string in place, returning whether trimmed. */
     bool TrimString(FString& InOutValue) const;
+
+    /** Whether a field carrying this key is exempt from string trimming. */
+    bool IsFieldExempt(const FString& Key) const;
 
     /** Trim array in place, returning number of items removed. */
     int32 TrimArray(TArray<TSharedPtr<FJsonValue>>& InOutItems) const;

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaResponseBuilderTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaResponseBuilderTest.cpp
@@ -1,0 +1,76 @@
+// The response limiter, and the field it must never touch.
+//
+// FHaybaMCPResponseBuilder caps every string in every reply at 512 characters.
+// That is right for a property dump and catastrophic for a base64 image: the
+// clip does not produce a smaller image, it produces a non-empty string that is
+// not valid base64. The MCP SDK rejects the content block outright ("Invalid
+// Base64 string") and the WHOLE reply is lost, metadata included.
+//
+// ui_render_widget_to_png was unusable for at least a week because of this, and
+// editor_capture_viewport was reported failing the same way earlier with a
+// "_truncated: image_base64" marker naming the culprit. The exemption is by
+// FIELD, not by command, because the previous mechanism was a per-command
+// override that only protected the command somebody remembered.
+
+#include "Misc/AutomationTest.h"
+#include "HaybaMCPResponseBuilder.h"
+#include "Dom/JsonObject.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+namespace
+{
+    /** A base64-ish payload comfortably over the 512-char cap. */
+    FString FakeImagePayload()
+    {
+        FString S;
+        while (S.Len() < 4000) S += TEXT("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk");
+        return S;
+    }
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaResponseBuilderImageExemptionTest,
+    "Hayba.MCP.ResponseBuilder.ImageIsNeverTrimmed",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaResponseBuilderImageExemptionTest::RunTest(const FString&)
+{
+    const FString Payload = FakeImagePayload();
+
+    {
+        TSharedRef<FJsonObject> In = MakeShared<FJsonObject>();
+        In->SetStringField(TEXT("image_base64"), Payload);
+        In->SetStringField(TEXT("note"), Payload);   // control: not exempt
+
+        FHaybaMCPResponseBuilder Builder{FHaybaResponseLimits()};
+        TSharedRef<FJsonObject> Out = Builder.Build(In);
+
+        TestEqual(TEXT("the image survives byte for byte"),
+                  Out->GetStringField(TEXT("image_base64")), Payload);
+        TestTrue(TEXT("an ordinary field is still capped, so the limiter still works"),
+                 Out->GetStringField(TEXT("note")).Len() <= 512);
+        TestTrue(TEXT("and the trimmed one is marked as such"),
+                 Out->GetStringField(TEXT("note")).EndsWith(TEXT("...")));
+    }
+
+    {
+        // The exact failure shape: a clipped payload is NON-EMPTY, which is why
+        // an empty-string guard on the TS side never caught it.
+        FHaybaResponseLimits Limits;
+        Limits.NeverTrimFields.Empty();          // simulate the old behaviour
+        TSharedRef<FJsonObject> In = MakeShared<FJsonObject>();
+        In->SetStringField(TEXT("image_base64"), Payload);
+
+        FHaybaMCPResponseBuilder Builder{Limits};
+        TSharedRef<FJsonObject> Out = Builder.Build(In);
+        const FString Clipped = Out->GetStringField(TEXT("image_base64"));
+
+        TestTrue(TEXT("without the exemption it IS clipped"), Clipped.Len() < Payload.Len());
+        TestFalse(TEXT("and clipping leaves it non-empty — which is why it read as valid"), Clipped.IsEmpty());
+    }
+
+    return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
The C++ half of #334. #344 mitigated it in TypeScript; this removes the corruption at source.

## The bug

`HaybaMCPCommandHandler.cpp:1024` caps **every string in every reply** at 512 characters. Right for a property dump, catastrophic for a base64 image:

> The clip does not produce a smaller image. It produces a **non-empty string that is not valid base64.**

The MCP SDK rejects the content block outright — `Invalid Base64 string` — and the entire reply is lost, metadata included. That is why `ui_render_widget_to_png` failed on *every* call for at least a week.

It is also why the TypeScript guard never caught it: the guard tests for an **empty** payload, and a truncated one is not empty.

And it explains the older `editor_capture_viewport` report, whose own reply named the culprit in a `"_truncated": [{"path": "image_base64", "removed": 19524}]` marker that nobody followed up.

## The fix, and why it is by field

There was already a per-command override — `python_run` raises the cap to 64K because the same clip was cutting its JSON mid-string. That mechanism protects exactly the commands somebody remembered to add, which is how images were left out.

`image_base64` now lives in `NeverTrimFields`, so **any** command returning an image is covered, including ones not written yet.

## Verification

- Build `Result: Succeeded`.
- `Hayba.MCP`: **17 of 18 pass**, up from 16 of 17. The failure is `UI.RenderWidgetToPng`, `-NullRHI`-only, as it has been all along.
- **Mutation-tested:** making `IsFieldExempt` always return false fails `ResponseBuilder.ImageIsNeverTrimmed`. Reverted, rebuilt, green.

The new test also pins the *shape* of the original bug — that a clipped payload is non-empty — because that property is what let it slip past a guard written to catch it.

## Not verified

Live end-to-end confirmation that a real widget now renders. That needs an editor with a widget to photograph, and should be the first thing anyone checks next session.

Credit: the root cause was located by an agent working #334, which is why this PR exists rather than another TS-side patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)