### PR TITLE
fix(ue): a screenshot says what it photographed, and a bad slot key builds nothing

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPIEHandler.cpp
@@ -601,7 +601,15 @@ FHaybaHandlerResult FHaybaMCPPIEHandler::PIEScreenshot(const TSharedPtr<FJsonObj
         TSharedPtr<FJsonObject> R = MakeShared<FJsonObject>();
         R->SetStringField(TEXT("filename"), Filename);
         R->SetBoolField(TEXT("captured"), FPaths::FileExists(Filename));
+        // `requested:false` here means "this call did not ask for a new
+        // capture" — it is a statement about THIS call, not about the earlier
+        // one. Read as "your request was dropped" it sends a caller into
+        // re-requesting instead of looking on disk, which is exactly what
+        // happened in the field. Say which it is.
         R->SetBoolField(TEXT("requested"), false);
+        R->SetStringField(TEXT("requested_meaning"),
+            TEXT("false because check_only does not issue a capture. It says nothing about the earlier request; "
+                 "'captured' is the answer to whether the file exists."));
         return FHaybaHandlerResult::Ok(R);
     }
 
@@ -632,6 +640,47 @@ FHaybaHandlerResult FHaybaMCPPIEHandler::PIEScreenshot(const TSharedPtr<FJsonObj
     R->SetBoolField(TEXT("captured"), FPaths::FileExists(Filename));
     R->SetStringField(TEXT("note"), TEXT("Capture requested. The engine writes the file on a later frame — ")
                                     TEXT("call again with check_only:true (and the same filename) to see when it lands."));
+
+    // Name what is being photographed.
+    //
+    // FScreenshotRequest is GLOBAL: it captures whatever viewport the engine
+    // renders next, not a viewport this command chose. With a stale standalone
+    // PIE window left open beside a docked session, that was the DEAD window —
+    // and the capture came back as a plausible, correctly-rendered picture of
+    // the game that simply never changed. editor_pie_widget_tree meanwhile read
+    // the live session, so the two disagreed and the obvious reading was "the
+    // widget is laid out but paints nothing", which is a real UMG bug and a
+    // long detour. A verification tool that cannot say WHAT it photographed is
+    // unfalsifiable.
+    R->SetStringField(TEXT("world_name"), World->GetName());
+    if (UGameViewportClient* ShotGVC = World->GetGameViewport())
+    {
+        if (FViewport* ShotVP = ShotGVC->Viewport)
+        {
+            const FIntPoint Size = ShotVP->GetSizeXY();
+            R->SetStringField(TEXT("viewport_size"), FString::Printf(TEXT("%dx%d"), Size.X, Size.Y));
+        }
+    }
+
+    // More than one live PIE world is the condition under which the global
+    // request can pick the wrong one. Say so rather than let the caller find out
+    // by disbelieving a screenshot.
+    int32 PieWorldCount = 0;
+    for (const FWorldContext& Ctx : GEngine->GetWorldContexts())
+    {
+        if (Ctx.WorldType == EWorldType::PIE && Ctx.World()) ++PieWorldCount;
+    }
+    R->SetNumberField(TEXT("pie_world_count"), PieWorldCount);
+    if (PieWorldCount > 1)
+    {
+        R->SetStringField(TEXT("ambiguous_target_warning"),
+            FString::Printf(
+                TEXT("%d live PIE worlds. This capture is a global screenshot request, so it may photograph a "
+                     "window other than '%s' — including a stale standalone window left from an earlier session, "
+                     "which renders a convincing frame that never changes. Cross-check against "
+                     "editor_pie_widget_tree before trusting the image, or stop the extra session."),
+                PieWorldCount, *World->GetName()));
+    }
     return FHaybaHandlerResult::Ok(R);
 }
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -2261,10 +2261,26 @@ namespace
         if (Spec->TryGetObjectField(TEXT("slot_props"), SlotProps) && SlotProps && SlotProps->IsValid())
         {
             const FSlotApplyResult R = ApplySlotPropsChecked(Slot, *SlotProps);
-            for (const FString& K : R.Unknown)
+            if (R.Unknown.Num() > 0)
             {
-                Stats.Warnings.Add(FString::Printf(TEXT("%s: slot key '%s' is not valid for a %s"),
-                    *New->GetName(), *K, *Slot->GetClass()->GetName()));
+                // A slot key is LAYOUT-CRITICAL: ignoring one does not degrade
+                // the result, it changes it. This used to warn and build the
+                // tree anyway, so a misspelled key (`size_rule`, which is what
+                // the UMG details panel calls it) produced 17 warnings, a
+                // reported `created: 26`, and a ScrollBox that sized to content
+                // instead of filling its parent — discovered much later, in a
+                // layout snapshot. Silent-but-wrong layout is worse than a
+                // failed call.
+                TArray<FString> Valid = ApplicableSlotKeys(Slot).Array();
+                Valid.Sort();
+                return FString::Printf(
+                    TEXT("ui_build_tree: '%s' — slot key%s %s not valid for a %s. Valid keys for that slot: %s. ")
+                    TEXT("Nothing was built; fix the key and call again."),
+                    *New->GetName(),
+                    R.Unknown.Num() == 1 ? TEXT("") : TEXT("s"),
+                    *FString::Join(R.Unknown, TEXT(", ")),
+                    *Slot->GetClass()->GetName(),
+                    Valid.Num() > 0 ? *FString::Join(Valid, TEXT(", ")) : TEXT("(none)"));
             }
         }
 
@@ -2361,6 +2377,24 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleBuildTree(const TSharedPtr<FJsonOb
         if (!Error.IsEmpty()) break;
     }
 
+    // A failed build leaves nothing behind. Aborting halfway used to hand back
+    // a partial tree with an error, which is the worst of both: the call failed
+    // AND the blueprint changed, so a retry stacks a second partial tree on top
+    // of the first. Remove what this call created, newest first so parents go
+    // after their children.
+    int32 RolledBack = 0;
+    if (!Error.IsEmpty() && Stats.Names.Num() > 0)
+    {
+        for (int32 i = Stats.Names.Num() - 1; i >= 0; --i)
+        {
+            if (UWidget* Created = FindWidgetByName(WBP->WidgetTree, Stats.Names[i]))
+            {
+                WBP->WidgetTree->RemoveWidget(Created);
+                ++RolledBack;
+            }
+        }
+    }
+
     FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WBP);
     WBP->MarkPackageDirty();
 
@@ -2382,15 +2416,25 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleBuildTree(const TSharedPtr<FJsonOb
 
     if (!Error.IsEmpty())
     {
-        // Partial builds are kept, not rolled back — the widgets that landed are
-        // usually the ones the caller wanted, and silently discarding them would
-        // hide how far the spec got. The error names where it stopped and the
-        // response lists exactly what exists now.
+        // Partial builds USED to be kept, on the reasoning that the widgets
+        // which landed are usually the ones the caller wanted. Reversed
+        // deliberately: the caller's next move after a failed build is to fix
+        // the spec and call again, and a retry on top of a kept partial stacks
+        // a SECOND copy of everything that succeeded the first time. A field
+        // session hit exactly that shape from the other direction — a tree
+        // mutation that timed out after succeeding, where the natural retry was
+        // the dangerous act. Failing clean is the only answer that makes retry
+        // safe, which is the operation a failure invites.
         Out->SetStringField(TEXT("error"), Error);
-        Out->SetBoolField(TEXT("partial"), true);
+        Out->SetBoolField(TEXT("partial"), false);
+        Out->SetNumberField(TEXT("rolled_back"), RolledBack);
         return FHaybaHandlerResult::Err(FString::Printf(
-            TEXT("%s — %d widget(s) were created before the failure: %s"),
-            *Error, Stats.Created, *FString::Join(Stats.Names, TEXT(", "))));
+            TEXT("%s%s"),
+            *Error,
+            RolledBack > 0
+                ? *FString::Printf(TEXT(" %d widget(s) created before the failure were removed, so the blueprint "
+                                        "is as it was and a corrected call will not duplicate them."), RolledBack)
+                : TEXT("")));
     }
 
     return FHaybaHandlerResult::Ok(Out);


### PR DESCRIPTION
Closes #335. Closes #336. Closes #337.

## #335 — the screenshot could photograph a dead window and report success

With a stale standalone PIE window left open beside a docked session, `editor_pie_screenshot` returned frames of the **dead** window: a plausible, correctly-rendered picture of the game that never changed no matter what was clicked. `editor_pie_widget_tree` meanwhile read the live session, so the two disagreed — and the obvious reading was *"the widget is laid out but paints nothing"*, a real and scary class of UMG bug. Cost ~40 minutes and nearly a bug report against innocent code.

`FScreenshotRequest` is **global** — it captures whatever viewport renders next, not one this command picked. Rather than pretend otherwise, the reply now names what it is photographing:

- `world_name`, `viewport_size`
- `pie_world_count`, and an `ambiguous_target_warning` when more than one live PIE world exists, pointing at the `editor_pie_widget_tree` cross-check

A verification tool that cannot say **what it photographed** is unfalsifiable. This one now can, which turns the detour into a ten-second comparison.

## #336 — `requested: false` read as "your request was dropped"

It is a statement about *this* call (check_only issues no capture), not about the earlier one. It now says so in `requested_meaning`, so a caller looks at `captured` — and at the disk — instead of re-requesting.

## #337 — `ui_build_tree` warned on unknown slot keys and built anyway

Passing `size_rule` (what the UMG details panel calls it) produced 17 warnings, a reported `created: 26`, and a ScrollBox that sized to content instead of filling its parent — surfacing much later in a layout snapshot.

A slot key is **layout-critical**: ignoring one does not degrade the result, it changes it. It is now an error naming the offending keys, the slot class, and **the valid keys for that class** — the last part borrowed from `ui_set_slot_layout`, which the report singles out as excellent for exactly this.

### This reverses a recorded decision, deliberately

Partial builds were previously **kept**, on the reasoning that the widgets which landed are usually the ones the caller wanted. Reversed, and the comment now explains why: the move a failed build invites is *fix the spec and call again*, and a retry on top of a kept partial stacks a second copy of everything that already succeeded. Failing clean is what makes retry safe. Rollback removes children before parents and reports `rolled_back`.

## Verification

Build `Result: Succeeded`. `Hayba.MCP`: **17 of 18**, unchanged — the failure is `UI.RenderWidgetToPng`, `-NullRHI`-only.

These are behavioural changes in editor-only paths; live confirmation with two PIE windows open is still worth doing next session.

## Incidental

The `"0 tests passed"` trap from `WORKFLOW-improving-the-mcp.md` bit during this work, and the cause was the *other* half of #342: a stray `UnrealEditor-Cmd.exe` blocking the next launch, log stopping mid-startup with zero plugin lines. Killing it fixed the run — more evidence for that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)