### PR TITLE
fix(mcp): errors that name the accepted form, and the font size copy_style lost

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-copy-style.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-copy-style.test.ts
@@ -116,6 +116,29 @@ describe('ui_copy_style', () => {
     });
   });
 
+  // The field the layout snapshot ACTUALLY emits is `font_size`; this reader
+  // looked for `size`, so a real copy transferred font, typeface and colour and
+  // silently left the size behind. A 26pt source left the target at 24pt, which
+  // inflated a row from 40px to 57px and was only caught by a layout snapshot.
+  //
+  // The test above passes `size`, which is why it stayed green through all of
+  // that: it asserted the author's model of the payload rather than the payload
+  // the C++ sends. Both spellings are pinned now.
+  it('copies the size the snapshot really reports (font_size)', async () => {
+    const src = { name: 'GoodLabel', class: 'TextBlock', text_info: { font_object: '/Game/F_Body', typeface: 'Regular', font_size: 26 } };
+    const dst = { name: 'BadLabel', class: 'TextBlock', text_info: { font_object: '/Game/F_Body', typeface: 'Regular', font_size: 24 } };
+    ue = scriptedUe()
+      .replies('ui_layout_snapshot', { layout_resolved: true, widgets: [src, dst] })
+      .replies('ui_set_widget_properties', { succeeded: 1, failed: 0 });
+
+    await uiCopyStyleHandler(
+      { widget_blueprint_path: BP, from_widget: 'GoodLabel', to_widget: 'BadLabel', include: ['text'] },
+      {} as never,
+    );
+    const props = ue.paramsFor('ui_set_widget_properties').properties as { Font: { Size?: number } };
+    expect(props.Font.Size, 'the source was 26pt; copying text style must carry the size').toBe(26);
+  });
+
   it('never copies slot layout or text content', async () => {
     const src = {
       name: 'GoodLabel',

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-copy-style.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-copy-style.ts
@@ -51,6 +51,13 @@ interface BrushInfo {
 interface TextInfo {
   font_object?: string;
   typeface?: string;
+  /** What the layout snapshot actually emits. The C++ writes `font_size`
+   *  (HaybaMCPUIHandler, text_info); this reader looked for `size` and so
+   *  silently copied everything about a text style EXCEPT its size. A 26pt
+   *  source left the target on its default 24pt, which inflated one row from
+   *  40px to 57px and was only caught by a layout snapshot. */
+  font_size?: number;
+  /** Historical spelling, kept so an older snapshot still copies. */
   size?: number;
   color?: number[];
 }
@@ -125,7 +132,9 @@ export const uiCopyStyleHandler: ToolHandler = async (args, session) => {
     // the target on whatever face it had, which is usually the engine Bold.
     values.font_asset = t.font_object;
     values.typeface = t.typeface ?? 'Regular';
-    if (typeof t.size === 'number') values.size = t.size;
+    // font_size first — that is the field the snapshot emits.
+    const sourceSize = typeof t.font_size === 'number' ? t.font_size : t.size;
+    if (typeof sourceSize === 'number') values.size = sourceSize;
     if (Array.isArray(t.color)) values.color = t.color;
     planned.push({ aspect: 'text', values });
   }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPBlueprintHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPBlueprintHandler.cpp
@@ -160,9 +160,65 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::Handle(const FString& Cmd, const 
     return FHaybaHandlerResult::Err(FString::Printf(TEXT("BlueprintHandler: unknown command %s"), *Cmd));
 }
 
-static UBlueprint* LoadBPByPath(const FString& Path)
+/**
+ * Load a blueprint by any of the spellings a caller reasonably arrives with.
+ *
+ * The asset path must NOT carry `_C`, while class VALUES inside `properties`
+ * must — so a caller holding one class path naturally pastes it into `path` and
+ * gets "blueprint not found", which sends them hunting for a missing asset that
+ * is sitting right there. Accept both and normalise.
+ *
+ * Tries, in order: the path as given; the same path with a trailing `_C`
+ * stripped from the object name; and the package-only form `/Game/X/WBP_A`
+ * expanded to `/Game/X/WBP_A.WBP_A`.
+ */
+static UBlueprint* LoadBPByPath(const FString& Path, FString* OutResolvedPath = nullptr)
 {
-    return LoadObject<UBlueprint>(nullptr, *Path);
+    auto Try = [OutResolvedPath](const FString& Candidate) -> UBlueprint*
+    {
+        if (Candidate.IsEmpty()) return nullptr;
+        if (UBlueprint* BP = LoadObject<UBlueprint>(nullptr, *Candidate))
+        {
+            if (OutResolvedPath) *OutResolvedPath = Candidate;
+            return BP;
+        }
+        return nullptr;
+    };
+
+    if (UBlueprint* BP = Try(Path)) return BP;
+
+    // "/Game/X/WBP_A.WBP_A_C" -> "/Game/X/WBP_A.WBP_A"
+    if (Path.EndsWith(TEXT("_C")))
+    {
+        if (UBlueprint* BP = Try(Path.LeftChop(2))) return BP;
+    }
+
+    // "/Game/X/WBP_A" -> "/Game/X/WBP_A.WBP_A"
+    if (!Path.Contains(TEXT(".")))
+    {
+        FString Leaf = Path;
+        int32 Slash = INDEX_NONE;
+        if (Path.FindLastChar(TEXT('/'), Slash) && Slash != INDEX_NONE)
+        {
+            Leaf = Path.Mid(Slash + 1);
+        }
+        if (UBlueprint* BP = Try(Path + TEXT(".") + Leaf)) return BP;
+    }
+
+    return nullptr;
+}
+
+/** The error to hand back when none of the spellings resolved. Names the forms
+ *  that work, because "not found" alone sends the caller looking for the wrong
+ *  problem — the asset usually exists and the path shape is what is wrong. */
+static FString BlueprintNotFoundError(const TCHAR* Command, const FString& Path)
+{
+    return FString::Printf(
+        TEXT("%s: no blueprint at '%s'. Accepted forms: '/Game/Dir/WBP_Name', "
+             "'/Game/Dir/WBP_Name.WBP_Name', or the class path '/Game/Dir/WBP_Name.WBP_Name_C' "
+             "(the '_C' is stripped for you). Note the asset must have been SAVED at least once — "
+             "a freshly created, never-saved blueprint cannot be loaded by path."),
+        Command, *Path);
 }
 
 FHaybaHandlerResult FHaybaMCPBlueprintHandler::Create(const TSharedPtr<FJsonObject>& P)
@@ -233,7 +289,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::GetInfo(const TSharedPtr<FJsonObj
     if (!P->TryGetStringField(TEXT("path"), Path) || Path.IsEmpty())
         return FHaybaHandlerResult::Err(TEXT("blueprint_get_info: missing path"));
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_get_info: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_get_info"), Path));
 
     TArray<TSharedPtr<FJsonValue>> Vars;
     for (const FBPVariableDescription& V : BP->NewVariables)
@@ -282,7 +338,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::AddComponent(const TSharedPtr<FJs
     if (ParamR.HasErrors()) return FHaybaHandlerResult::Err(ParamR.ErrorMessage());
 
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_add_component: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_add_component"), Path));
     UClass* CompClass = LoadClass<UActorComponent>(nullptr, *CompClassPath);
     if (!CompClass) return FHaybaHandlerResult::Err(TEXT("blueprint_add_component: component class not found"));
     if (!BP->SimpleConstructionScript)
@@ -312,7 +368,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::AddVariable(const TSharedPtr<FJso
     if (ParamR.HasErrors()) return FHaybaHandlerResult::Err(ParamR.ErrorMessage());
 
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_add_variable: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_add_variable"), Path));
 
     FEdGraphPinType PinType;
     FString L = VarType.ToLower();
@@ -346,7 +402,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::AddFunction(const TSharedPtr<FJso
     if (ParamR.HasErrors()) return FHaybaHandlerResult::Err(ParamR.ErrorMessage());
 
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_add_function: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_add_function"), Path));
 
     // Refuse a name the blueprint already has, BEFORE creating anything. Adding
     // a second graph with the same name compiles to "Found more than one
@@ -451,7 +507,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::AddNode(const TSharedPtr<FJsonObj
     if (NodeType.IsEmpty()) { NodeType = TEXT("call_function"); }
 
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_add_node: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_add_node"), Path));
 
     UEdGraph* Graph = HaybaFindGraph(BP, GraphName);
     if (!Graph) return FHaybaHandlerResult::Err(TEXT("blueprint_add_node: graph not found"));
@@ -594,7 +650,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::SetPinDefault(const TSharedPtr<FJ
     P->TryGetStringField(TEXT("graph_name"), GraphName);
 
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_set_pin_default: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_set_pin_default"), Path));
     UEdGraph* Graph = HaybaFindGraph(BP, GraphName);
     if (!Graph) return FHaybaHandlerResult::Err(TEXT("blueprint_set_pin_default: graph not found"));
     UEdGraphNode* Node = HaybaFindNode(Graph, NodeId);
@@ -675,7 +731,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::ConnectNodes(const TSharedPtr<FJs
     P->TryGetStringField(TEXT("graph_name"), GraphName);
 
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_connect_nodes: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_connect_nodes"), Path));
     UEdGraph* Graph = HaybaFindGraph(BP, GraphName);
     if (!Graph) return FHaybaHandlerResult::Err(TEXT("blueprint_connect_nodes: graph not found"));
 
@@ -730,7 +786,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::Compile(const TSharedPtr<FJsonObj
     Path = ParamR.RequiredString(TEXT("path"));
     if (ParamR.HasErrors()) return FHaybaHandlerResult::Err(ParamR.ErrorMessage());
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_compile: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_compile"), Path));
 
     FCompilerResultsLog ResultsLog;
     ResultsLog.SetSourcePath(BP->GetPathName());
@@ -788,7 +844,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::Document(const TSharedPtr<FJsonOb
     Path = ParamR.RequiredString(TEXT("path"));
     if (ParamR.HasErrors()) return FHaybaHandlerResult::Err(ParamR.ErrorMessage());
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_document: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_document"), Path));
 
     FString Doc;
     for (UEdGraph* Graph : BP->UbergraphPages)
@@ -851,7 +907,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::AddEvent(const TSharedPtr<FJsonOb
     P->TryGetStringField(TEXT("graph_name"), GraphName);
 
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_add_event: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_add_event"), Path));
     UEdGraph* Graph = HaybaFindGraph(BP, GraphName);
     if (!Graph) return FHaybaHandlerResult::Err(TEXT("blueprint_add_event: graph not found"));
 
@@ -910,7 +966,7 @@ FHaybaHandlerResult FHaybaMCPBlueprintHandler::SetDefaults(const TSharedPtr<FJso
         return FHaybaHandlerResult::Err(TEXT("blueprint_set_defaults: missing properties"));
 
     UBlueprint* BP = LoadBPByPath(Path);
-    if (!BP) return FHaybaHandlerResult::Err(TEXT("blueprint_set_defaults: blueprint not found"));
+    if (!BP) return FHaybaHandlerResult::Err(BlueprintNotFoundError(TEXT("blueprint_set_defaults"), Path));
     if (!BP->GeneratedClass)
         return FHaybaHandlerResult::Err(TEXT("blueprint_set_defaults: GeneratedClass missing — compile first"));
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -1231,7 +1231,35 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleAddElement(const TSharedPtr<FJsonO
 
     UPanelSlot* NewSlot = Parent->AddChild(NewChild);
     if (!NewSlot)
-        return FHaybaHandlerResult::Err(TEXT("ui_add_element: AddChild rejected (panel may be full or incompatible)"));
+    {
+        // "panel may be full or incompatible" is accurate and useless: it names
+        // the failure and withholds the remedy, in a system where the caller
+        // cannot see the editor. The overwhelmingly common case is a
+        // single-child container that already has its one child, and the fix is
+        // always the same — wrap what is there in an Overlay. Say that.
+        WBP->WidgetTree->RemoveWidget(NewChild);   // do not leave the orphan behind
+
+        const int32 ChildCount = Parent->GetChildrenCount();
+        const int32 MaxChildren = Parent->GetClass()->GetDefaultObject<UPanelWidget>()
+            ? (Parent->CanHaveMultipleChildren() ? -1 : 1)
+            : -1;
+
+        if (MaxChildren == 1 && ChildCount >= 1)
+        {
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("ui_add_element: '%s' is a %s, which accepts ONE child and already has '%s'. "
+                     "To put two things inside it: add an Overlay to a panel that takes several children, "
+                     "reparent '%s' into the Overlay with ui_reparent_element, then reparent the Overlay "
+                     "into '%s'."),
+                *Parent->GetName(), *Parent->GetClass()->GetName(),
+                *Parent->GetChildAt(0)->GetName(), *Parent->GetChildAt(0)->GetName(), *Parent->GetName()));
+        }
+
+        return FHaybaHandlerResult::Err(FString::Printf(
+            TEXT("ui_add_element: '%s' (a %s) refused a %s. It currently holds %d child(ren). "
+                 "Some panels accept only specific child types; check the panel's class."),
+            *Parent->GetName(), *Parent->GetClass()->GetName(), *ChildClass->GetName(), ChildCount));
+    }
 
     RegisterWidgetVariable(WBP, NewChild);
 


### PR DESCRIPTION
Closes #340. Closes #341.

Three messages named the failure and withheld the remedy, in a system where the caller cannot see the editor.

## `blueprint_*` said "blueprint not found" for an asset sitting right there

The asset path must **not** carry `_C`; class values inside `properties` **must**. So a caller holding one class path pastes it into `path` and goes hunting for a missing asset.

All eleven not-found sites now share one loader that accepts:
- the path as given
- the same path with a trailing `_C` stripped
- the package-only form `/Game/Dir/WBP_Name` expanded

…and one error listing those forms, plus the save-at-least-once requirement, which fails identically for an entirely different reason.

## `ui_add_element` said "AddChild rejected (panel may be full or incompatible)"

Accurate, useless. The common case is a single-child container that already has its child, and the remedy is always the same three-call Overlay dance. It now names the parent, its class, the child already occupying it, and the dance. It also **removes the widget it had already constructed** rather than leaving an orphan in the tree.

## `ui_copy_style` dropped font size — and the reason is the interesting part

The C++ emits **`font_size`**; the copier read **`size`**. So it transferred font, typeface and colour and silently left the size behind. A 26pt source left a target at 24pt, inflating a row from 40px to 57px — caught only by a layout snapshot.

**Its existing test passed the whole time**, because it fed the reader `size` — a spelling the snapshot never sends. That is exactly the `ScriptedUe` trap `WORKFLOW-improving-the-mcp.md` warns about:

> a test can assert the author's model of the payload instead of the payload the system actually produces

and then green-light the bug forever. The new test uses `font_size`, the real shape; the old one stays to pin the fallback.

**Mutation-tested:** reading only `size` fails the new test. Reverted, green.

## Gate

TS **1487 pass** · C++ `Hayba.MCP` **17 of 18** (`UI.RenderWidgetToPng`, `-NullRHI`-only) · build `Result: Succeeded`.

Not verified live — these are error paths and a field rename. Worth exercising against a running editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)