### PR TITLE
docs: per-add-on getting-started guides

### DIFF
--- a/docs/getting-started-memory-system.md
+++ b/docs/getting-started-memory-system.md
@@ -1,0 +1,119 @@
+# Getting started — Memory system
+
+Sibling of [`docs/getting-started.md`](getting-started.md). Covers the
+SQLite-backed shared-memory layer referenced by `hayba.agents.json`'s
+`shared_memory` field and by two of the shipped skills
+(`hayba-refine-scene` reads "shared memory... by intent"; `hayba-new-scene`
+says "Record every spatial decision to memory with a clear `intent`
+string").
+
+**Status up front:** the class and its schema exist, are implemented, and
+have a unit test — but nothing in the current codebase instantiates or calls
+this class outside its own test file. There is no MCP tool that writes to
+or reads from it, and no retention policy or export/import support exists
+at all. Treat this page as a description of the schema for someone who wants
+to wire it up, not as a working feature.
+
+## Where it lives
+
+[`mcp-tools/hayba-mcp/src/gaea/memory/hayba-memory.ts`](../mcp-tools/hayba-mcp/src/gaea/memory/hayba-memory.ts),
+class `HaybaMemory`, backed by `better-sqlite3`. It lives under `src/gaea/`
+— the Gaea tool surface, which is currently parked (its tool-registration
+block was deleted from `src/tools/index.ts`; see the comment block in
+`mcp-tools/hayba-mcp/vitest.config.ts`). Its test,
+`mcp-tools/hayba-mcp/tests/gaea/memory/hayba-memory.test.ts`, exists but is
+excluded from the active suite by the same `vitest.config.ts` exclude entry
+(`'**/tests/gaea/**'`), so it does not currently run as part of `npm test`.
+
+## Schema
+
+One table, created with `CREATE TABLE IF NOT EXISTS` on construction:
+
+```sql
+CREATE TABLE IF NOT EXISTS memory_blocks (
+  id                 TEXT PRIMARY KEY,
+  agent_role         TEXT NOT NULL,
+  scope              TEXT NOT NULL,
+  intent             TEXT NOT NULL,
+  content            TEXT NOT NULL,
+  accessed_resources TEXT,           -- JSON-encoded string[]
+  timestamp          INTEGER NOT NULL,
+  provenance         TEXT,           -- JSON-encoded object
+  token_cost         INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_scope_role ON memory_blocks(scope, agent_role);
+CREATE INDEX IF NOT EXISTS idx_timestamp  ON memory_blocks(timestamp);
+```
+
+`scope` is a free-text column but the TypeScript-side type only ever writes
+`'private' | 'shared'`. `accessed_resources` and `provenance` are stored as
+JSON strings, not native SQLite JSON — they round-trip through
+`JSON.stringify`/`JSON.parse` in the TS layer.
+
+## API
+
+```ts
+class HaybaMemory {
+  constructor(path: string)             // opens/creates a better-sqlite3 db at `path`
+  write(b: MemoryBlock): string         // returns the row id (uuid if not supplied)
+  query(opts: {
+    scope?: 'private' | 'shared';
+    agentRole?: string;
+    limit?: number;                     // default 50
+  }): MemoryBlock[]                     // ORDER BY timestamp DESC
+  clear(agentRole?: string): void       // delete all rows, or all rows for one role
+  close(): void
+}
+```
+
+`MemoryBlock`:
+
+```ts
+interface MemoryBlock {
+  id?: string;
+  agentRole: string;
+  scope: 'private' | 'shared';
+  intent: string;
+  content: string;
+  accessedResources: string[];
+  tokenCost: number;
+  provenance?: Record<string, unknown>;
+  timestamp?: number;
+}
+```
+
+## Retention policy
+
+**Not implemented.** There is no TTL, no row-count cap, no scheduled
+pruning, and no code path that ever calls `clear()` automatically — `clear`
+is available to a caller but nothing in this repo calls it. Rows accumulate
+indefinitely for as long as something is calling `write()`.
+
+## Export / import
+
+**Not implemented.** `HaybaMemory` has no export or dump method and no
+import/load method. There is no CLI script or MCP tool in this repo for
+copying a memory database in or out. Because it's a plain SQLite file, the
+generic route (`sqlite3 <path> .dump`, or copying the `.db` file while no
+process holds it open) works at the filesystem level, but that is not
+something the codebase provides or documents — it follows from "it's a
+SQLite file," not from a shipped feature.
+
+## Where the filename convention comes from
+
+`hayba.agents.json`'s `shared_memory` field (default `"hayba-memory.db"`,
+"relative to project root" per the doc comment on `AgentsManifest` in
+`src/agents/types.ts`) is presumably meant to be the path passed to
+`new HaybaMemory(path)`. No code in this repo reads that field or
+constructs a `HaybaMemory` from it — see
+[Getting started — Swarm agents](getting-started-swarm-agents.md) for the
+matching gap on the archetype-loader side.
+
+## A naming collision worth knowing about
+
+`unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPMemoryPanel.h`
+/ `.cpp` defines `SHaybaMCPMemoryPanel` — despite the name, this is the
+**PLUMB Semantic Library** panel, a tree view over profiled scene assets
+(masks, constraints, locks). It has nothing to do with `HaybaMemory` or
+agent memory. If you're looking for a UE-side view of agent memory blocks,
+this isn't it, and no such panel currently exists.

--- a/docs/getting-started-skills-bundle.md
+++ b/docs/getting-started-skills-bundle.md
@@ -1,0 +1,86 @@
+# Getting started — Skills bundle
+
+Sibling of [`docs/getting-started.md`](getting-started.md). Covers Tier 3:
+the shipped `SKILL.md` workflow guides.
+
+## Install
+
+```bash
+cp -r mcp-tools/hayba-mcp/addons/workflows/* ~/.claude/skills/
+```
+
+Each subdirectory under
+[`mcp-tools/hayba-mcp/addons/workflows/`](../mcp-tools/hayba-mcp/addons/workflows)
+is a self-contained skill: a folder named after the skill, containing one
+`SKILL.md` with YAML frontmatter (`name`, `description`) and a body Claude
+Code reads when deciding whether the skill applies. There are four:
+
+## The four skills
+
+### `hayba-new-scene`
+
+> "Use when the user asks to generate a new scene from scratch — coordinates
+> moodboard → references → spatial planning → asset placement → physics
+> validation → CLIP scoring."
+
+Workflow (from the file): generate a moodboard, fetch reference embeddings,
+pull the level's spatial index, assign biome zones per World Partition cell,
+build/execute a PCG graph and paint foliage per zone, dress hero areas from
+Content Browser search results, validate physics (shallow first, deep only
+for hero shots), capture the viewport and CLIP-score it against the
+moodboard, and hand off to `hayba-refine-scene` if the score is below 0.65.
+
+### `hayba-refine-scene`
+
+> "Use when the user wants to improve an existing scene — captures viewport,
+> scores against references, and applies targeted edits to low-score
+> regions."
+
+Workflow: capture the current viewport, pull reference embeddings from
+shared memory, CLIP-score per actor to find the worst-scoring elements, try
+one of lighting / material swap / displacement / foliage-density change per
+low scorer, and iterate — stop on a score delta under 0.02 or after 5
+rounds.
+
+### `hayba-debug-level`
+
+> "Use when a level has performance, physics, or layout problems — combines
+> `editor_stream_log`, `scene_validate_physics`, and `scene_export`
+> hierarchical mode to find issues."
+
+Workflow: baseline FPS/draw-calls/memory, tail the editor log filtered to
+`LogStreaming|LogPhysics|LogPCG`, run a shallow physics validation, export
+the scene hierarchically to spot over-dense cells, snap floating actors to
+ground (validating placement first), resolve interpenetration by transform
+or visibility, and check World Partition cells for ISM-consolidation
+opportunities on perf hotspots.
+
+### `hayba-pcg-build`
+
+> "Use when the user wants to build a PCG/PCGEx graph — guides through node
+> selection, validation, and execution."
+
+Workflow: list available PCG node classes, confirm pin types per candidate
+node, sketch the graph as JSON, validate it (must pass all 5 validation
+layers), create the graph from the validated JSON, execute it on a target
+component, and read back the generated node output to verify.
+
+## What this page does and doesn't verify
+
+These four descriptions are read directly from the shipped `SKILL.md` files
+— the workflow steps and the tool names inside them (`hayba_generate_moodboard`,
+`pcg_validate_graph`, `scene_validate_physics`, etc.) are quoted as written,
+not independently re-verified against the current tool registry here. Some
+referenced tools may live in domains that have moved or been reorganized
+since a given skill was last touched (see `docs/handoffs/HANDOFF-architecture-cleanup.md`
+for the current state of tool availability). If a skill references a tool
+that no longer resolves, that's a bug in the skill file, not something this
+page can catch — check with `list_tool_categories` / `hayba_search_tools` if
+a step in one of these workflows fails to find its tool.
+
+## Discoverability
+
+Once copied into `~/.claude/skills/`, Claude Code surfaces the matching
+skill automatically based on the `description` frontmatter — no explicit
+invocation needed, per the existing "Tier 3" note in
+[`docs/getting-started.md`](getting-started.md).

--- a/docs/getting-started-swarm-agents.md
+++ b/docs/getting-started-swarm-agents.md
@@ -1,0 +1,125 @@
+# Getting started — Swarm agents (archetypes)
+
+Sibling of [`docs/getting-started.md`](getting-started.md). Covers the
+multi-agent "archetype" concept referenced by the in-editor onboarding
+wizard and by `mcp-tools/hayba-mcp/hayba.agents.json`.
+
+**Read this whole page before relying on archetypes for anything.** The
+config file and its schema exist and are real; the loader that was supposed
+to read the file at runtime does not currently exist in this repo. What
+*is* wired up is a lower-level mechanism you drive by hand.
+
+## The config file and its schema
+
+`mcp-tools/hayba-mcp/hayba.agents.json` — a single file, checked into the
+repo, not templated per project:
+
+```json
+{
+  "version": 1,
+  "shared_memory": "hayba-memory.db",
+  "archetypes": [
+    { "id": "director", "role": "Director", "tool_filter": ["*"], "memory_scope": "shared", ... },
+    { "id": "asset-manager", "role": "Asset Manager", "tool_filter": ["asset_*", "scene_*", "mesh_*", "texture_*", "material_*"], "memory_scope": "shared", ... },
+    { "id": "pattern-expert", "role": "Pattern Expert", "tool_filter": ["scene_*", "level_*", "pcg_*", "wp_*", "spline_*"], "memory_scope": "shared", ... },
+    { "id": "node-expert", "role": "Node Expert", "tool_filter": ["docs_*", "pcg_*", "python_*"], "memory_scope": "shared", ... },
+    { "id": "blueprint-generator", "role": "Blueprint Generator", "tool_filter": ["*"], "memory_scope": "private+shared", ... }
+  ]
+}
+```
+
+(Trimmed for space — each archetype also carries a `system_prompt` string.
+See the file itself for the full text.)
+
+The matching TypeScript type is
+[`mcp-tools/hayba-mcp/src/agents/types.ts`](../mcp-tools/hayba-mcp/src/agents/types.ts):
+
+```ts
+export interface ArchetypeConfig {
+  id: string;
+  role: string;
+  system_prompt: string;
+  tool_filter: string[];          // glob patterns: "*", "actor_*", "scene_*"
+  memory_scope: 'shared' | 'private+shared';
+}
+
+export interface AgentsManifest {
+  version: number;
+  shared_memory: string;          // filename for HaybaMemory db (relative to project root)
+  archetypes: ArchetypeConfig[];
+}
+```
+
+The onboarding wizard describes the file to new users as user-editable:
+
+> "hayba.agents.json defines specialist roles (Director, Asset Manager,
+> Pattern Expert, Node Expert, Blueprint Generator). Edit it to customize
+> tool filters and system prompts."
+> — `HaybaMCPOnboardingWidget.cpp`
+
+## What is NOT wired up
+
+Nothing in this repository currently loads `hayba.agents.json`. There is no
+`AgentRegistry` class, no `agent-registry.ts`, no C++ code that opens the
+file. A comment in `mcp-tools/hayba-mcp/vitest.config.ts` documents that an
+earlier version of the test suite carried an `agent-registry` test entry
+"for source that no longer exists" — i.e. the loader was built at one point
+(the v0.3.0 entry in `CHANGELOG.md` describes it: "`AgentRegistry` — loads
+`hayba.agents.json`, instantiates per-archetype runtimes with glob
+`tool_filter` matching") and has since been removed.
+
+Concretely: `system_prompt` and `memory_scope` in the file are not consumed
+by any code path found in this repo. `shared_memory` is likewise not read —
+see [Getting started — Memory system](getting-started-memory-system.md) for
+why the SQLite layer it's meant to point at isn't reachable either.
+
+## What is actually wired up
+
+The chat API accepts a raw glob list per request — it does not read the
+archetype file at all. `POST /chat/stream`
+(`mcp-tools/hayba-mcp/src/chat/chat-server.ts`) takes an optional
+`archetype_filter: string[]` field in the request body and threads it
+through to `runAgentLoop` → `buildToolCatalog` in
+[`mcp-tools/hayba-mcp/src/chat/agent-loop.ts`](../mcp-tools/hayba-mcp/src/chat/agent-loop.ts):
+
+```ts
+export interface ToolCatalogOptions {
+  disabledTools?: Iterable<string>;
+  /** Archetype `tool_filter` globs (agent-registry.ts). Omit = allow all. */
+  archetypeFilter?: string[];
+  ...
+}
+```
+
+`buildToolCatalog` glob-matches (`*` only) every name against the tool
+registry and only offers the LLM the tools that pass, in addition to
+whatever the disabled-tools list already excludes. This is the real,
+tested mechanism — see `agent-loop.test.ts`, `'filters by archetype
+tool_filter and disabled list'`.
+
+**So today, "configuring an archetype per project" means:** copy the
+`tool_filter` array for the archetype you want out of `hayba.agents.json`
+by hand, and pass it as `archetype_filter` in the `POST /chat/stream` body
+yourself (or wire up a client that does this — none of the shipped UE panel
+code does it, as far as this search found). Editing `hayba.agents.json`
+alone changes nothing at runtime.
+
+## A separate, actually-wired gating mechanism: disabled tools
+
+Distinct from archetypes, but easy to confuse with them: the MCP panel's
+"capability gating" UI writes to `FHaybaMCPSettings::DisabledTools`
+(`HaybaMCPSettings.h`/`.cpp`), which is persisted both to the project `.ini`
+and to `Saved/HaybaMCP/disabled-tools.json`. The Node MCP server watches
+that JSON file and hides/rejects matching tool names
+(`list_tool_categories`, `get_tool_signature`, and the `tool_disabled`
+error). This one works out of the box, per-project, with no manual API
+calls — but it disables tools globally for every session, not per
+archetype.
+
+## Bottom line
+
+If your workflow needs distinct tool subsets per agent role today, drive
+`archetype_filter` directly against `/chat/stream`. If you want a durable,
+per-project on-disk config that a client automatically honours, that piece
+(the archetype loader) is not implemented — treat `hayba.agents.json` as
+documentation of an intended shape, not a working config file.

--- a/docs/getting-started-visual-sidecar.md
+++ b/docs/getting-started-visual-sidecar.md
@@ -1,0 +1,144 @@
+# Getting started — Visual Sidecar
+
+Sibling of [`docs/getting-started.md`](getting-started.md). Covers Tier 2 in
+more depth: what the sidecar is, how to install it for GPU vs. CPU, and how
+the "model preset" and per-capability toggles actually work.
+
+## What it is
+
+One FastAPI process, source at
+[`mcp-tools/hayba-mcp/addons/visual-embeddings`](../mcp-tools/hayba-mcp/addons/visual-embeddings),
+listening on `localhost:7821` by default. It serves CLIP image embeddings
+(always on), SpatialCLIP depth-aware embeddings (opt-in), OWL-ViT
+open-vocabulary detection (opt-in), and SAM segmentation with world-position
+back-projection for the PLUMB Semantic Studio. Source:
+[`addons/visual-embeddings/README.md`](../mcp-tools/hayba-mcp/addons/visual-embeddings/README.md).
+
+There used to be a second, differently-scoped sidecar at
+`mcp-tools/visual-sidecar/`, also on port 7821. It was merged into this one —
+see [ADR-0006](adr/0006-one-visual-sidecar.md). If you find docs or scripts
+referencing the old path, they're stale; this is the only sidecar now.
+
+The UE plugin does **not** launch this process for you. You start it by hand
+(see Run, below); the plugin only calls into it once it's listening.
+
+## Install
+
+From `mcp-tools/hayba-mcp/addons/visual-embeddings`:
+
+```bash
+# GPU (CUDA, recommended)
+uv sync --extra gpu
+
+# CPU only
+uv sync --extra cpu
+
+# Add OWL-ViT detection to either
+uv sync --extra cpu --extra owlvit
+```
+
+The `gpu` and `cpu` extras both pull `torch>=2.3`; the difference is which
+CUDA/CPU wheel `uv` resolves. This choice is made once, at install time — it
+is **not** the same thing as the in-editor "Model Preset" described below,
+which only decides which already-installed capabilities are turned on and
+never changes what got installed.
+
+Base dependencies (`fastapi`, `uvicorn`, `pillow`, `numpy`, `trimesh`,
+`rtree`, `scipy`, `imageio[freeimage]`) are deliberately torch-free — every
+model loader imports its heavy dependency inside the function that needs it,
+so the process starts, and `/health` answers honestly, even with zero model
+weights installed. Source: `pyproject.toml` header comment.
+
+## Run
+
+```bash
+uv run hayba-visual-sidecar
+```
+
+Environment variables (from the addon's README):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `HAYBA_SIDECAR_PORT` | `7821` | TCP port |
+| `HAYBA_ENABLE_SPATIAL_CLIP` | unset | Set `1` to enable the spatial endpoint |
+| `HAYBA_ENABLE_OWL_VIT` | unset | Set `1` to enable the detection endpoint |
+| `HAYBA_SPATIAL_CLIP_CHECKPOINT` | unset | Path to the spatial adapter `.pt` |
+| `HAYBA_SAM_CACHE` | `~/.cache/hayba-sam` | Where SAM weights are looked up |
+| `HAYBA_SAM_CHECKPOINT` | `<cache>/sam_vit_b_01ec64.pth` | Explicit checkpoint path |
+| `HAYBA_SAM_MODEL` | `vit_b` | SAM model type |
+
+SAM weights are lazy-loaded on the first `/segment_project` call; `models.sam`
+in `/health` reports whether segmentation *could* run (import resolves +
+checkpoint on disk), `model_loaded` reports whether it has actually been
+warmed up.
+
+Verify it's alive:
+
+```bash
+curl http://localhost:7821/health
+# {"ok":true,"models":{"clip":true,"spatial_clip":false,"owl_vit":false,"sam":false},"model_loaded":false}
+```
+
+## Profile selection
+
+There are two separate, only loosely connected knobs. Neither one installs
+anything or starts the process for you.
+
+### 1. UE Project Settings → Plugins → Hayba MCP Toolkit → Visual Sidecar
+
+This is `UHaybaMCPDeveloperSettings`, source
+[`unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPDeveloperSettings.h`](../unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPDeveloperSettings.h).
+It exposes:
+
+- `ModelPreset` — enum `Minimal` / `Balanced` / `Full` (default `Minimal`).
+- `bEnableSpatialCLIP`, `bEnableOWLViT` — bool toggles.
+- `bEnableContinuousCapture` — bool, streams the viewport to the sidecar
+  continuously. Default off; the plugin's own tooltip warns it causes
+  "ongoing GPU load."
+- `VRAMEstimate` — a read-only computed string, e.g. `"~2000 MB VRAM"`.
+
+Changing any of these recomputes `VRAMEstimate` via
+`RecomputeVRAMEstimate()` (`HaybaMCPDeveloperSettings.cpp`):
+
+| Preset | Base | + SpatialCLIP | + OWL-ViT |
+|---|---|---|---|
+| Minimal | 1000 MB | +200 MB | +600 MB |
+| Balanced | 2000 MB | +200 MB | +600 MB |
+| Full | 12000 MB | +200 MB | +600 MB |
+
+This matches the "Model presets" table in the addon's README (Minimal ≈1 GB
+CLIP-only, Balanced ≈2 GB with SpatialCLIP, Full ≈12 GB+ with OWL-ViT too).
+
+**Important:** this panel is a display/estimate only. It does not install
+extras, does not set environment variables on the Python process, and does
+not start or stop it. It exists so you can see the VRAM cost of a
+configuration before you commit to running it.
+
+### 2. What actually turns a capability on
+
+Per the toggle tooltips in
+[`HaybaMCPSettingsPanel.cpp`](../unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettingsPanel.cpp):
+
+> "Requires the sidecar to be started with `HAYBA_ENABLE_SPATIAL_CLIP=1`."
+> "Requires the sidecar to be started with `HAYBA_ENABLE_OWL_VIT=1`."
+
+So to actually get SpatialCLIP or OWL-ViT, you need both: the corresponding
+`uv sync --extra ...` at install time, and the matching environment variable
+set when you run `uv run hayba-visual-sidecar`. The Project Settings toggles
+tell the *client* which calls to attempt; they don't configure the *server*.
+
+The toolbar Settings panel (a different UI from Project Settings) also has a
+plain "Sidecar URL" field, defaulting to `http://localhost:7821`, for pointing
+the plugin at a sidecar running somewhere other than localhost.
+
+## Test
+
+```bash
+uv sync --extra cpu --extra test
+uv run pytest
+```
+
+## Caution
+
+Continuous capture mode causes ongoing GPU load — leave it off unless you're
+actively iterating on it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,11 +61,27 @@ uv run hayba-visual-sidecar  # listens on :7821
 iterating. Configure via Project Settings → Plugins → Hayba MCP Toolkit →
 Visual Sidecar.
 
+See [Getting started — Visual Sidecar](getting-started-visual-sidecar.md)
+for install details, environment variables, and how the "Model Preset" /
+per-capability toggles relate to what you actually installed.
+
 ### Tier 3 — Workflow skills (optional)
 
 Copy `mcp-tools/hayba-mcp/addons/workflows/*` to `~/.claude/skills/`.
 Skills: `hayba-new-scene`, `hayba-refine-scene`, `hayba-debug-level`,
 `hayba-pcg-build` — SKILL.md guides Claude Code surfaces automatically.
+
+See [Getting started — Skills bundle](getting-started-skills-bundle.md) for
+what each skill's workflow actually does.
+
+### Swarm agents and shared memory
+
+Two more add-on pieces referenced by `hayba.agents.json` and the onboarding
+wizard, with an honest look at what's wired up today versus what's still a
+config template:
+
+- [Getting started — Swarm agents](getting-started-swarm-agents.md)
+- [Getting started — Memory system](getting-started-memory-system.md)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Adds four sibling pages to `docs/getting-started.md`, one per add-on named in spec §11: Visual Sidecar, Swarm agents, Skills bundle, Memory system.
- Every claim traces to source (file paths cited inline); no invented flags or instructions.
- Two of the four add-ons turn out to be partially unwired — documented as such rather than glossed over:
  - **Swarm agents**: `hayba.agents.json` and its `ArchetypeConfig`/`AgentsManifest` types exist, but no loader (`AgentRegistry`) reads the file — it was removed at some point (`vitest.config.ts` comment: "source that no longer exists"). What's actually wired is `POST /chat/stream`'s raw `archetype_filter: string[]` body param, consumed by `buildToolCatalog` in `agent-loop.ts`.
  - **Memory system**: `HaybaMemory` (better-sqlite3, `memory_blocks` table) is fully implemented with a passing-when-run unit test, but lives under the parked `src/gaea/` tree, its test is excluded from `vitest.config.ts`, and nothing instantiates the class outside its own test. No retention policy, no export/import exist anywhere in the codebase.
- Also flags a naming collision: `SHaybaMCPMemoryPanel` (C++) is the PLUMB Semantic Library asset panel, unrelated to `HaybaMemory`.
- Linked from `docs/getting-started.md` under Tier 2/3 and a new "Swarm agents and shared memory" section.
- Does not describe CI as green (per repo instruction — CI is unreliable).

## Test plan
- [x] `npx tsc --noEmit` in `mcp-tools/hayba-mcp` — clean (no code changes; docs-only PR)
- [x] All relative links in the new/edited docs resolve to real files in the repo

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added getting-started guides for the SQLite-backed memory system, skills bundle, swarm agents, and Visual Sidecar.
  * Documented setup, configuration, supported capabilities, workflows, schemas, health checks, and known limitations.
  * Updated the main getting-started guide with links to the new resources and shared memory information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->