### PR TITLE
feat(cli): hayba-cli headless runner for CI

### DIFF
--- a/mcp-tools/hayba-mcp/examples/github-actions-hayba-cli.yml
+++ b/mcp-tools/hayba-mcp/examples/github-actions-hayba-cli.yml
@@ -1,0 +1,79 @@
+# EXAMPLE WORKFLOW — not wired into this repo's CI.
+#
+# This file lives in mcp-tools/hayba-mcp/examples/, NOT .github/workflows/,
+# specifically so GitHub Actions never picks it up here. This repo's own CI
+# is unreliable and is deliberately not treated as a trusted gate (see
+# docs/WORKFLOW-improving-the-mcp.md §4) — copy this into a downstream
+# project's .github/workflows/ once you have a runner that can actually
+# launch UE, and adapt the paths/secrets to that project.
+#
+# What this demonstrates: a CI job that
+#   1. builds the MCP server package,
+#   2. launches UE headless (-batchmode -Cmd) with the HaybaMCPToolkit
+#      plugin enabled, so it opens the MCP TCP port,
+#   3. runs `hayba-cli` against a spec file describing the scene to build,
+#   4. relies entirely on hayba-cli's exit code for pass/fail — see
+#      mcp-tools/hayba-mcp/src/cli/exit-codes.ts for what each code means.
+#
+# UNVERIFIED: this workflow has not been run on a real GitHub-hosted or
+# self-hosted runner, and hayba-cli has not been exercised against UE
+# launched via -batchmode -Cmd (only against an already-running GUI editor,
+# manually, during development — see the PR description). Treat the UE
+# launch step below as a sketch of the shape, not a tested command line;
+# flags/paths will need adjusting to your actual project and runner.
+
+name: hayba-cli scene build (EXAMPLE — do not enable as-is)
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  build-scene:
+    # Needs a runner with UE installed and licensed — not a hosted
+    # ubuntu-latest/windows-latest runner. Self-hosted with UE pre-installed.
+    runs-on: self-hosted
+
+    env:
+      # hayba-cli discovers the port from Saved/HaybaMCP/instances/<pid>.json
+      # when UE is launched from the workspace; set this explicitly instead
+      # when the project's Saved/ dir isn't reachable from the CI working
+      # directory, or to pin a fixed port for a headless launch.
+      UE_TCP_PORT: 52342
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install and build the MCP server
+        working-directory: mcp-tools/hayba-mcp
+        run: |
+          npm ci
+          npm run build:server
+
+      - name: Launch UE headless with the HaybaMCPToolkit plugin
+        # Sketch only — adapt UPROJECT_PATH / UE_EDITOR_CMD to the runner.
+        # This backgrounds the process; hayba-cli's own reachability check
+        # (poll + bounded retry/backoff) is what waits for the TCP port to
+        # come up, so no manual sleep is needed here.
+        run: |
+          "$UE_EDITOR_CMD" "$UPROJECT_PATH" -batchmode -Cmd -unattended -nosplash &
+        env:
+          UE_EDITOR_CMD: ${{ vars.UE_EDITOR_CMD }}
+          UPROJECT_PATH: ${{ vars.UPROJECT_PATH }}
+
+      - name: Run the scene-build spec through hayba-cli
+        working-directory: mcp-tools/hayba-mcp
+        run: node dist/cli/index.js examples/sample-spec.yaml
+        # Exit code contract (dist/cli/exit-codes.js):
+        #   0  every step in the spec succeeded  → job passes
+        #   1  the spec file was missing/malformed → job fails, fix the spec
+        #   2  UE never became reachable          → job fails, check the launch step
+        #   3  a step failed against UE           → job fails, read the step's error
+        #   4  hayba-cli itself crashed            → job fails, file a bug
+
+      - name: Tear down UE
+        if: always()
+        run: pkill -f UnrealEditor-Cmd || true

--- a/mcp-tools/hayba-mcp/examples/sample-spec.yaml
+++ b/mcp-tools/hayba-mcp/examples/sample-spec.yaml
@@ -1,0 +1,12 @@
+# Example hayba-cli spec. Not a tested UE session — `ping` is the one
+# command guaranteed to exist across plugin versions; swap the rest of the
+# `steps:` list for whatever the target project's build actually needs
+# (actor_spawn, pcg_create_graph, landscape_import, ...). See
+# mcp-tools/hayba-mcp/src/cli/spec.ts for the full step shape:
+#   - cmd: <required, a wire command the HaybaMCPToolkit plugin implements>
+#     name: <optional, human label used only in progress/error output>
+#     params: <optional, object passed straight through to the command>
+version: 1
+steps:
+  - cmd: ping
+    name: sanity check the connection before doing real work

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -4,7 +4,8 @@
   "description": "Hayba MCP Toolkit — AI-powered terrain and PCG authoring for Unreal Engine",
   "type": "module",
   "bin": {
-    "hayba-mcp": "./dist/index.js"
+    "hayba-mcp": "./dist/index.js",
+    "hayba-cli": "./dist/cli/index.js"
   },
   "main": "./dist/index.js",
   "scripts": {

--- a/mcp-tools/hayba-mcp/src/cli/exit-codes.ts
+++ b/mcp-tools/hayba-mcp/src/cli/exit-codes.ts
@@ -1,0 +1,30 @@
+// mcp_server/src/cli/exit-codes.ts
+/**
+ * Exit code contract for `hayba-cli`. A CI job's only signal is the process
+ * exit code — stdout/stderr are for humans, the code is for the pipeline.
+ * Keep these stable; a CI script may branch on the numeric value.
+ */
+
+/** Spec ran to completion; every step reported success. */
+export const EXIT_OK = 0;
+
+/** The spec file could not be read or parsed, or failed structural
+ *  validation (missing/empty `steps`, a step without a `cmd`, etc). Nothing
+ *  was sent to UE — this is a pure input-shape failure caught before any
+ *  connection attempt. */
+export const EXIT_SPEC_ERROR = 1;
+
+/** The spec was valid but UE could not be reached before the first step
+ *  ran. Distinct from EXIT_STEP_FAILED so CI can tell "our script is wrong"
+ *  apart from "the environment wasn't ready". */
+export const EXIT_UE_UNREACHABLE = 2;
+
+/** UE was reached, but a step in the spec returned a failure (UE responded
+ *  `ok: false`, or the transport dropped mid-run). Execution stops at the
+ *  first failing step — later steps are not attempted. */
+export const EXIT_STEP_FAILED = 3;
+
+/** Anything that reached the top-level catch unclassified — a bug in the
+ *  CLI itself, not a spec or UE problem. Kept distinct from EXIT_SPEC_ERROR
+ *  so "the CLI crashed" is never confused with "your spec is malformed". */
+export const EXIT_UNEXPECTED_ERROR = 4;

--- a/mcp-tools/hayba-mcp/src/cli/index.test.ts
+++ b/mcp-tools/hayba-mcp/src/cli/index.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { main } from './index.js';
+import { EXIT_OK, EXIT_SPEC_ERROR, EXIT_STEP_FAILED, EXIT_UE_UNREACHABLE } from './exit-codes.js';
+import type { RunnerDeps } from './runner.js';
+
+// Real temp files, but a fully injected RunnerDeps — no socket, no spawn.
+// Reading a spec file off disk is the CLI's actual, in-scope job; the UE
+// seam (checkReachable/execute) is what gets faked here.
+
+let dir: string;
+const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'hayba-cli-test-'));
+  errSpy.mockClear();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeSpec(name: string, content: string): string {
+  const p = join(dir, name);
+  writeFileSync(p, content, 'utf-8');
+  return p;
+}
+
+const okDeps = (execute = vi.fn(async () => ({ ok: true }))): RunnerDeps => ({
+  checkReachable: async () => ({ reachable: true, detail: '' }),
+  execute,
+});
+
+describe('hayba-cli main()', () => {
+  it('exits EXIT_SPEC_ERROR with no arguments', async () => {
+    const code = await main([], okDeps());
+    expect(code).toBe(EXIT_SPEC_ERROR);
+  });
+
+  it('exits 0 and prints usage on --help', async () => {
+    const code = await main(['--help'], okDeps());
+    expect(code).toBe(0);
+  });
+
+  it('exits EXIT_SPEC_ERROR when the spec file does not exist', async () => {
+    const code = await main([join(dir, 'nope.json')], okDeps());
+    expect(code).toBe(EXIT_SPEC_ERROR);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringMatching(/cannot read spec file/));
+  });
+
+  it('exits EXIT_SPEC_ERROR when the spec file is malformed', async () => {
+    const p = writeSpec('bad.json', '{ this is not valid json');
+    const code = await main([p], okDeps());
+    expect(code).toBe(EXIT_SPEC_ERROR);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringMatching(/malformed spec/));
+  });
+
+  it('exits EXIT_SPEC_ERROR when steps is missing', async () => {
+    const p = writeSpec('empty.json', '{}');
+    const code = await main([p], okDeps());
+    expect(code).toBe(EXIT_SPEC_ERROR);
+  });
+
+  it('exits EXIT_UE_UNREACHABLE and never executes any step when UE is unreachable', async () => {
+    const p = writeSpec('spec.json', JSON.stringify({ steps: [{ cmd: 'ping' }] }));
+    const execute = vi.fn();
+    const code = await main([p], {
+      checkReachable: async () => ({ reachable: false, detail: 'port 52342 answered nothing' }),
+      execute,
+    });
+    expect(code).toBe(EXIT_UE_UNREACHABLE);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('exits EXIT_STEP_FAILED when a step fails', async () => {
+    const p = writeSpec('spec.json', JSON.stringify({ steps: [{ cmd: 'boom' }] }));
+    const execute = vi.fn(async () => {
+      throw new Error('nope');
+    });
+    const code = await main([p], okDeps(execute));
+    expect(code).toBe(EXIT_STEP_FAILED);
+  });
+
+  it('exits EXIT_OK and runs every step when everything succeeds', async () => {
+    const p = writeSpec(
+      'spec.yaml',
+      ['steps:', '  - cmd: ping', '  - cmd: actor_spawn', '    params:', '      class: Foo'].join('\n'),
+    );
+    const execute = vi.fn(async () => ({ ok: true }));
+    const code = await main([p], okDeps(execute));
+    expect(code).toBe(EXIT_OK);
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenNthCalledWith(1, 'ping', {});
+    expect(execute).toHaveBeenNthCalledWith(2, 'actor_spawn', { class: 'Foo' });
+  });
+
+  it('accepts a depsFactory function form, not just a plain deps object', async () => {
+    const p = writeSpec('spec.json', JSON.stringify({ steps: [{ cmd: 'ping' }] }));
+    const execute = vi.fn(async () => ({ ok: true }));
+    const code = await main([p], async () => okDeps(execute));
+    expect(code).toBe(EXIT_OK);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/cli/index.ts
+++ b/mcp-tools/hayba-mcp/src/cli/index.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// mcp_server/src/cli/index.ts
+//
+// `hayba-cli` — headless runner for CI. Reads a spec file (JSON or YAML)
+// listing wire commands to send to a running UE editor over the same TCP
+// seam every MCP tool uses (tool-executor.ts's `executeCommand`), runs them
+// in order, and exits with a code a pipeline can branch on. See
+// exit-codes.ts for the contract.
+//
+// This does NOT launch UE. It assumes an editor (GUI or `-batchmode -Cmd`
+// headless) with the HaybaMCPToolkit plugin is already running and holding
+// its MCP TCP port — same precondition every other MCP tool call has. A CI
+// job is expected to launch UE itself (its own step) before invoking this.
+import { readFileSync } from 'node:fs';
+import { parseSpec, SpecParseError } from './spec.js';
+import { runSpec, type RunnerDeps } from './runner.js';
+import { EXIT_SPEC_ERROR, EXIT_UNEXPECTED_ERROR } from './exit-codes.js';
+
+function printUsage(): void {
+  console.error(
+    [
+      'Usage: hayba-cli <spec-file.json|.yaml>',
+      '',
+      'Runs each step in the spec against a running UE editor and exits:',
+      '  0  all steps succeeded',
+      '  1  the spec file could not be read or was malformed',
+      '  2  UE was not reachable before the first step ran',
+      '  3  a step failed (later steps are not attempted)',
+      '  4  the CLI itself hit an unexpected error',
+      '',
+      'UE_TCP_PORT / UE_TCP_HOST override the target (default 127.0.0.1:52342).',
+    ].join('\n'),
+  );
+}
+
+/** Build the real (non-test) RunnerDeps: live TCP sender + hayba_check_ue_status.
+ *  Lazily imported so `parseSpec`/`runSpec` stay importable — and unit-testable
+ *  — without pulling in node:net or the process-lister. */
+async function buildLiveDeps(): Promise<RunnerDeps> {
+  const [{ installLiveSender, executeCommand }, { checkUeStatus }, { config }] = await Promise.all([
+    import('../tools/tool-executor.js'),
+    import('../tools/check-ue-status.js'),
+    import('../config.js'),
+  ]);
+
+  await installLiveSender();
+
+  return {
+    checkReachable: async () => {
+      const status = await checkUeStatus();
+      if (status.connected) return { reachable: true, detail: '' };
+      const host = config.ueTcpHost;
+      const port = config.ueTcpPort;
+      const hint =
+        status.diagnostic ??
+        status.error ??
+        'no diagnostic available — the port never answered a ping.';
+      return {
+        reachable: false,
+        detail:
+          `no UE editor answered ${host}:${port}. ${hint} ` +
+          `Check what (if anything) is holding this port with hayba_check_ue_status, ` +
+          `or override the target with UE_TCP_PORT / UE_TCP_HOST.`,
+      };
+    },
+    execute: (cmd, params) => executeCommand(cmd, params),
+    log: (msg) => console.error(msg),
+  };
+}
+
+/**
+ * Core entrypoint logic, with the UE-facing seam injectable so tests can
+ * drive every exit path (spec error, unreachable UE, step failure, success)
+ * without a real socket or a real spawned process. Production callers omit
+ * `depsFactory` and get {@link buildLiveDeps}.
+ */
+export async function main(
+  argv: string[],
+  depsFactory: (() => Promise<RunnerDeps>) | RunnerDeps = buildLiveDeps,
+): Promise<number> {
+  const specPath = argv[0];
+  if (!specPath || specPath === '--help' || specPath === '-h') {
+    printUsage();
+    return specPath ? 0 : EXIT_SPEC_ERROR;
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(specPath, 'utf-8');
+  } catch (err) {
+    console.error(`cannot read spec file "${specPath}": ${err instanceof Error ? err.message : String(err)}`);
+    return EXIT_SPEC_ERROR;
+  }
+
+  let spec;
+  try {
+    spec = parseSpec(raw, specPath);
+  } catch (err) {
+    if (err instanceof SpecParseError) {
+      console.error(`malformed spec "${specPath}": ${err.message}`);
+      return EXIT_SPEC_ERROR;
+    }
+    throw err;
+  }
+
+  const deps = typeof depsFactory === 'function' ? await depsFactory() : depsFactory;
+  const result = await runSpec(spec, deps);
+  console.error(result.message);
+  return result.exitCode;
+}
+
+/* c8 ignore start -- process wiring, exercised via buildLiveDeps/main unit tests, not this glue */
+if (process.argv[1] && (process.argv[1].endsWith('cli/index.js') || process.argv[1].endsWith('cli\\index.js'))) {
+  main(process.argv.slice(2))
+    .then((code) => {
+      // The live TCP client's socket keeps the event loop alive even after
+      // the last command's response has arrived — Node has no reason to know
+      // the CLI is "done" with it. Left alone, a fully successful run hangs
+      // forever instead of exiting 0, which is worse than any failure exit
+      // code: CI would just time out with no signal at all. Force the exit
+      // once `main` has resolved and everything has been logged.
+      process.exit(code);
+    })
+    .catch((err) => {
+      console.error(`hayba-cli crashed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+      process.exit(EXIT_UNEXPECTED_ERROR);
+    });
+}
+/* c8 ignore stop */

--- a/mcp-tools/hayba-mcp/src/cli/runner.test.ts
+++ b/mcp-tools/hayba-mcp/src/cli/runner.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runSpec } from './runner.js';
+import { EXIT_OK, EXIT_STEP_FAILED, EXIT_UE_UNREACHABLE } from './exit-codes.js';
+import type { CliSpec } from './spec.js';
+
+function spec(steps: CliSpec['steps']): CliSpec {
+  return { version: 1, steps };
+}
+
+describe('runSpec', () => {
+  it('returns EXIT_OK and runs every step in order when all succeed', async () => {
+    const calls: Array<{ cmd: string; params: Record<string, unknown> }> = [];
+    const execute = vi.fn(async (cmd: string, params: Record<string, unknown>) => {
+      calls.push({ cmd, params });
+      return { ok: true };
+    });
+
+    const result = await runSpec(spec([{ cmd: 'ping' }, { cmd: 'actor_spawn', params: { class: 'Foo' } }]), {
+      checkReachable: async () => ({ reachable: true, detail: '' }),
+      execute,
+    });
+
+    expect(result.exitCode).toBe(EXIT_OK);
+    expect(result.stepsRun).toBe(2);
+    expect(result.stepsTotal).toBe(2);
+    expect(calls).toEqual([
+      { cmd: 'ping', params: {} },
+      { cmd: 'actor_spawn', params: { class: 'Foo' } },
+    ]);
+  });
+
+  it('returns EXIT_UE_UNREACHABLE and never calls execute when UE is unreachable', async () => {
+    const execute = vi.fn();
+
+    const result = await runSpec(spec([{ cmd: 'ping' }]), {
+      checkReachable: async () => ({ reachable: false, detail: 'no editor on port 52342' }),
+      execute,
+    });
+
+    expect(result.exitCode).toBe(EXIT_UE_UNREACHABLE);
+    expect(result.message).toMatch(/no editor on port 52342/);
+    expect(result.stepsRun).toBe(0);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('returns EXIT_STEP_FAILED at the first failing step and stops — later steps never run', async () => {
+    const calls: string[] = [];
+    const execute = vi.fn(async (cmd: string) => {
+      calls.push(cmd);
+      if (cmd === 'boom') throw new Error('UE said no');
+      return { ok: true };
+    });
+
+    const result = await runSpec(spec([{ cmd: 'ping' }, { cmd: 'boom' }, { cmd: 'never_reached' }]), {
+      checkReachable: async () => ({ reachable: true, detail: '' }),
+      execute,
+    });
+
+    expect(result.exitCode).toBe(EXIT_STEP_FAILED);
+    expect(result.stepsRun).toBe(1); // one step (ping) completed before the failure
+    expect(result.failedStep).toEqual({ index: 1, cmd: 'boom', error: 'UE said no' });
+    expect(calls).toEqual(['ping', 'boom']); // never_reached must not have been called
+  });
+
+  it('includes the step name in the failure message when provided', async () => {
+    const execute = vi.fn(async () => {
+      throw new Error('nope');
+    });
+
+    const result = await runSpec(spec([{ cmd: 'weird_cmd', name: 'build lighting' }]), {
+      checkReachable: async () => ({ reachable: true, detail: '' }),
+      execute,
+    });
+
+    expect(result.message).toMatch(/build lighting/);
+    expect(result.message).toMatch(/weird_cmd/);
+  });
+
+  it('logs a progress line per step via the injected logger', async () => {
+    const lines: string[] = [];
+    const execute = vi.fn(async () => ({ ok: true }));
+
+    await runSpec(spec([{ cmd: 'a' }, { cmd: 'b' }]), {
+      checkReachable: async () => ({ reachable: true, detail: '' }),
+      execute,
+      log: (msg) => lines.push(msg),
+    });
+
+    expect(lines).toEqual(['[1/2] a', '[2/2] b']);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/cli/runner.ts
+++ b/mcp-tools/hayba-mcp/src/cli/runner.ts
@@ -1,0 +1,80 @@
+// mcp_server/src/cli/runner.ts
+import type { CliSpec } from './spec.js';
+import { EXIT_OK, EXIT_STEP_FAILED, EXIT_UE_UNREACHABLE } from './exit-codes.js';
+
+export interface ReachabilityCheck {
+  reachable: boolean;
+  /** Human-readable explanation, only meaningful when reachable === false. */
+  detail: string;
+}
+
+export interface RunnerDeps {
+  /** Pre-flight: is UE reachable at all, before spending a step on it. */
+  checkReachable: () => Promise<ReachabilityCheck>;
+  /** Send one command over the same seam every MCP tool uses
+   *  (tool-executor's `executeCommand`). Rejects on failure. */
+  execute: (cmd: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  /** Progress line per step. Defaults to a no-op so tests stay quiet. */
+  log?: (message: string) => void;
+}
+
+export interface FailedStep {
+  index: number;
+  cmd: string;
+  error: string;
+}
+
+export interface RunResult {
+  exitCode: number;
+  message: string;
+  /** Number of steps that completed successfully before stopping. */
+  stepsRun: number;
+  stepsTotal: number;
+  failedStep?: FailedStep;
+}
+
+/**
+ * Execute a validated spec's steps in order against UE, stopping at the
+ * first failure. Never throws — every outcome, including an unreachable UE
+ * or a failing step, comes back as a {@link RunResult} with an exit code the
+ * caller can hand straight to `process.exit`.
+ */
+export async function runSpec(spec: CliSpec, deps: RunnerDeps): Promise<RunResult> {
+  const log = deps.log ?? (() => {});
+  const total = spec.steps.length;
+
+  const reachability = await deps.checkReachable();
+  if (!reachability.reachable) {
+    return {
+      exitCode: EXIT_UE_UNREACHABLE,
+      message: `UE unreachable — ${reachability.detail}`,
+      stepsRun: 0,
+      stepsTotal: total,
+    };
+  }
+
+  for (let i = 0; i < total; i++) {
+    const step = spec.steps[i];
+    const label = step.name ?? step.cmd;
+    log(`[${i + 1}/${total}] ${label}`);
+    try {
+      await deps.execute(step.cmd, step.params ?? {});
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      return {
+        exitCode: EXIT_STEP_FAILED,
+        message: `step ${i + 1}/${total} ("${label}", cmd="${step.cmd}") failed: ${errMsg}`,
+        stepsRun: i,
+        stepsTotal: total,
+        failedStep: { index: i, cmd: step.cmd, error: errMsg },
+      };
+    }
+  }
+
+  return {
+    exitCode: EXIT_OK,
+    message: `all ${total} step${total === 1 ? '' : 's'} completed`,
+    stepsRun: total,
+    stepsTotal: total,
+  };
+}

--- a/mcp-tools/hayba-mcp/src/cli/spec.test.ts
+++ b/mcp-tools/hayba-mcp/src/cli/spec.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { parseSpec, SpecParseError } from './spec.js';
+
+describe('parseSpec', () => {
+  it('parses a valid JSON spec', () => {
+    const spec = parseSpec(
+      JSON.stringify({ steps: [{ cmd: 'ping' }, { cmd: 'actor_spawn', params: { class: 'Foo' }, name: 'spawn foo' }] }),
+      'spec.json',
+    );
+    expect(spec.version).toBe(1);
+    expect(spec.steps).toEqual([
+      { cmd: 'ping', params: {}, name: undefined },
+      { cmd: 'actor_spawn', params: { class: 'Foo' }, name: 'spawn foo' },
+    ]);
+  });
+
+  it('parses a valid YAML spec by .yaml extension', () => {
+    const yaml = ['steps:', '  - cmd: ping', '  - cmd: actor_spawn', '    params:', '      class: Foo'].join('\n');
+    const spec = parseSpec(yaml, 'spec.yaml');
+    expect(spec.steps).toHaveLength(2);
+    expect(spec.steps[1].cmd).toBe('actor_spawn');
+    expect(spec.steps[1].params).toEqual({ class: 'Foo' });
+  });
+
+  it('falls back from JSON to YAML when no filename hint is given (e.g. stdin)', () => {
+    const yaml = 'steps:\n  - cmd: ping\n';
+    const spec = parseSpec(yaml);
+    expect(spec.steps).toEqual([{ cmd: 'ping', params: {}, name: undefined }]);
+  });
+
+  it('rejects syntactically broken input as neither JSON nor YAML', () => {
+    // Tab characters are illegal for YAML indentation and this isn't valid
+    // JSON either — guaranteed to fail both parsers.
+    const broken = '{ steps: [\n\t"cmd": ';
+    expect(() => parseSpec(broken, 'spec.json')).toThrow(SpecParseError);
+    expect(() => parseSpec(broken, 'spec.json')).toThrow(/could not parse spec/);
+  });
+
+  it('rejects a spec that is not an object', () => {
+    expect(() => parseSpec('[1,2,3]', 'spec.json')).toThrow(/must be an object/);
+    expect(() => parseSpec('"just a string"', 'spec.json')).toThrow(/must be an object/);
+  });
+
+  it('rejects a spec missing steps', () => {
+    expect(() => parseSpec('{}', 'spec.json')).toThrow(/spec.steps must be an array/);
+  });
+
+  it('rejects a spec with an empty steps array', () => {
+    expect(() => parseSpec('{"steps": []}', 'spec.json')).toThrow(/at least one step/);
+  });
+
+  it('rejects a step with no cmd', () => {
+    expect(() => parseSpec('{"steps": [{"params": {}}]}', 'spec.json')).toThrow(/step\[0\].*"cmd"/);
+  });
+
+  it('rejects a step with an empty-string cmd', () => {
+    expect(() => parseSpec('{"steps": [{"cmd": "   "}]}', 'spec.json')).toThrow(/step\[0\].*"cmd"/);
+  });
+
+  it('rejects a step whose params is not an object', () => {
+    expect(() => parseSpec('{"steps": [{"cmd": "ping", "params": "nope"}]}', 'spec.json')).toThrow(
+      /step\[0\]\.params must be an object/,
+    );
+  });
+
+  it('rejects a step that is itself not an object', () => {
+    expect(() => parseSpec('{"steps": ["ping"]}', 'spec.json')).toThrow(/step\[0\] must be an object/);
+  });
+
+  it('reports the correct index for a later broken step', () => {
+    expect(() => parseSpec('{"steps": [{"cmd": "ping"}, {"cmd": ""}]}', 'spec.json')).toThrow(/step\[1\]/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/cli/spec.ts
+++ b/mcp-tools/hayba-mcp/src/cli/spec.ts
@@ -1,0 +1,105 @@
+// mcp_server/src/cli/spec.ts
+import { load as loadYaml } from 'js-yaml';
+
+/** One command sent over the same TCP seam every MCP tool uses
+ *  (`executeCommand` in tool-executor.ts). `cmd` is a wire command name the
+ *  plugin implements — NOT an MCP tool name (see docs/WORKFLOW-improving-the-mcp.md
+ *  §3b: tool names and command names are different namespaces). `name` is an
+ *  optional human label for log lines; it has no effect on execution. */
+export interface CliStep {
+  cmd: string;
+  params?: Record<string, unknown>;
+  name?: string;
+}
+
+export interface CliSpec {
+  version: 1;
+  steps: CliStep[];
+}
+
+export class SpecParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SpecParseError';
+  }
+}
+
+/** True when `filename` looks like YAML by extension. Content sniffing is
+ *  deliberately not attempted — JSON is valid YAML, so guessing from content
+ *  alone is ambiguous; the extension is the one unambiguous signal a caller
+ *  controls. */
+function looksLikeYaml(filename: string | undefined): boolean {
+  if (!filename) return false;
+  return /\.ya?ml$/i.test(filename);
+}
+
+/** Parse and structurally validate a CLI spec. Accepts JSON or YAML — format
+ *  is chosen by `filename` extension when given, otherwise JSON is tried
+ *  first and YAML is the fallback (a YAML document that happens to also be
+ *  valid JSON parses identically either way, so this only matters for
+ *  non-JSON YAML with no filename hint, e.g. stdin).
+ *
+ *  Throws {@link SpecParseError} with a message naming exactly what is wrong
+ *  — malformed syntax, wrong top-level shape, or a step missing `cmd` — never
+ *  a bare parser exception. */
+export function parseSpec(raw: string, filename?: string): CliSpec {
+  let parsed: unknown;
+  const yamlFirst = looksLikeYaml(filename);
+
+  const tryJson = (): unknown => JSON.parse(raw);
+  const tryYaml = (): unknown => loadYaml(raw);
+
+  try {
+    parsed = yamlFirst ? tryYaml() : tryJson();
+  } catch (firstErr) {
+    try {
+      parsed = yamlFirst ? tryJson() : tryYaml();
+    } catch {
+      const msg = firstErr instanceof Error ? firstErr.message : String(firstErr);
+      throw new SpecParseError(`could not parse spec as JSON or YAML: ${msg}`);
+    }
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new SpecParseError('spec must be an object with a "steps" array (got ' + describeType(parsed) + ')');
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  if (!Array.isArray(obj.steps)) {
+    throw new SpecParseError('spec.steps must be an array');
+  }
+  if (obj.steps.length === 0) {
+    throw new SpecParseError('spec.steps must contain at least one step');
+  }
+
+  const steps: CliStep[] = obj.steps.map((raw, i) => validateStep(raw, i));
+
+  return { version: 1, steps };
+}
+
+function describeType(v: unknown): string {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'an array';
+  return typeof v;
+}
+
+function validateStep(raw: unknown, index: number): CliStep {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new SpecParseError(`step[${index}] must be an object (got ${describeType(raw)})`);
+  }
+  const s = raw as Record<string, unknown>;
+  if (typeof s.cmd !== 'string' || s.cmd.trim().length === 0) {
+    throw new SpecParseError(`step[${index}] is missing a non-empty "cmd" string`);
+  }
+  if (s.params !== undefined && (s.params === null || typeof s.params !== 'object' || Array.isArray(s.params))) {
+    throw new SpecParseError(`step[${index}].params must be an object when present`);
+  }
+  if (s.name !== undefined && typeof s.name !== 'string') {
+    throw new SpecParseError(`step[${index}].name must be a string when present`);
+  }
+  return {
+    cmd: s.cmd,
+    params: (s.params as Record<string, unknown> | undefined) ?? {},
+    name: s.name as string | undefined,
+  };
+}


### PR DESCRIPTION
Closes #7.

## What exists vs what was added

Before this PR: `package.json` already had a `bin` (`hayba-mcp` → `dist/index.js`, the stdio MCP server) but nothing CLI-shaped for headless/scripted use — no `hayba-cli`, no spec runner, no exit-code contract. `npm run build:server` (not `build`, which chains through a `build:dashboard` nested-install that fails) was already the right build script; no change there.

Added, all TypeScript under `mcp-tools/hayba-mcp/src/cli/`:
- `spec.ts` — parses a JSON or YAML spec (`{ steps: [{ cmd, params?, name? }] }`) into a validated `CliSpec`, or throws `SpecParseError` naming exactly what's wrong.
- `runner.ts` — `runSpec(spec, deps)`: runs steps in order against injected `checkReachable`/`execute` seams, stops at the first failure, never throws — always returns a `RunResult` with an exit code.
- `exit-codes.ts` — the documented contract (below).
- `index.ts` — the actual `hayba-cli` entrypoint. Wires the real seams (`installLiveSender` + `executeCommand` from `tool-executor.ts`, `checkUeStatus` from `check-ue-status.ts` — the same seams every other MCP tool goes through) and forces `process.exit(code)` at the end (see "what I found" below).
- `package.json` gained a second `bin` entry: `"hayba-cli": "./dist/cli/index.js"`.
- `examples/github-actions-hayba-cli.yml` — the example workflow the issue asked for. Deliberately lives in `mcp-tools/hayba-mcp/examples/`, not `.github/workflows/`, so GitHub Actions never picks it up — this repo's CI is unreliable and is not being wired to anything new.
- `examples/sample-spec.yaml` — the spec the example workflow points at.

Scope note on the issue's "Drives UE in `-batchmode -Cmd`" line: that's UE launching itself, which is out of scope for a TypeScript-only change under `mcp-tools/hayba-mcp` per the task brief. `hayba-cli` assumes UE (GUI or headless) is already running and holding its MCP TCP port — the same precondition every other MCP tool call has — and connects to it. The example workflow shows a CI job launching UE as its own step before calling `hayba-cli`.

## Exit-code contract (`src/cli/exit-codes.ts`)

| Code | Meaning |
|---|---|
| 0 | every step in the spec succeeded |
| 1 | spec file missing, unreadable, or structurally invalid (caught before any connection attempt) |
| 2 | spec was valid but UE was never reachable before the first step |
| 3 | UE was reached but a step failed (execution stops at the first failure) |
| 4 | the CLI itself hit an unexpected error |

On unreachable UE, the error names the host:port and points at `hayba_check_ue_status` for what's holding it — no hang.

## What I found while verifying

Live smoke-testing against the actual dist build (not just unit tests) surfaced a real bug: on a fully successful run, the process hung instead of exiting 0 — the TCP client's socket keeps Node's event loop alive even after the last response arrives, so `process.exitCode = 0` was never enough to actually terminate. Fixed by forcing `process.exit(code)` once `main()` resolves. Left unfixed, a green CI run would just time out with zero signal, which is worse than any failure exit code.

## Tests (26 new; suite total 1517, up from the 1491 baseline)

- `spec.test.ts` (12): valid JSON, valid YAML, JSON→YAML fallback for filename-less input (e.g. piped spec), and every malformed-spec shape — broken syntax, non-object root, missing `steps`, empty `steps`, step missing `cmd`, empty-string `cmd`, non-object `params`, non-object step, and correct index reporting on a later broken step.
- `runner.test.ts` (5): success runs every step in order, unreachable UE never calls `execute`, a failing step stops immediately (later steps confirmed *not* called), failure message includes the step name, and per-step progress logging.
- `index.test.ts` (9): no-args, `--help`, missing file, malformed JSON, missing `steps`, unreachable UE, step failure, full success (JSON and YAML), and the `depsFactory`-as-function form. Spec files are real temp files on disk (that's the CLI's actual job); the UE seam (`checkReachable`/`execute`) is always injected — never a real socket or a real spawn.

All driven through the injectable `RunnerDeps` seam from `runner.ts` — no real socket, no real spawned process, anywhere in the suite.

### Mutation testing (as required)

1. **runner.ts**: swapped the step-failure branch's exit code from `EXIT_STEP_FAILED` to `EXIT_OK`. RED: 2 tests failed (`runner.test.ts` step-failure test, `index.test.ts` step-failure test) — both asserted the wrong code came back. Reverted, confirmed GREEN.
2. **spec.ts**: removed the empty-`steps`-array check. RED: `spec.test.ts`'s "rejects a spec with an empty steps array" failed — parsing silently succeeded instead of throwing. Reverted, confirmed GREEN.
3. **runner.ts**: short-circuited the unreachable-UE guard (`if (false && !reachability.reachable)`) so it never fires. RED: `runner.test.ts` and `index.test.ts` unreachable-UE tests both failed — `execute` got called and the wrong exit code came back. Reverted, confirmed GREEN.

## Gate

- `npx tsc --noEmit` — clean
- `npm test` — 1517/1517 passed (149 files)
- `node scripts/check-legacy-wrappers.mjs` — OK, 22 cpp commands / 133 sidecar entries, no violations (the new `cli/` code is outside `src/tools/`, so this check doesn't touch it)

## Honesty / what's unverified

I do have a real UE editor running in this environment, and I used it — this is rung 5 (observed), not a claim. I ran the built `dist/cli/index.js` (not just unit tests) against it directly and confirmed, live: success (`exit 0`, ran the real `ping` command and got a real reply), spec-parse error on malformed JSON (`exit 1`), missing spec file (`exit 1`), UE unreachable via a deliberately wrong `UE_TCP_PORT` (`exit 2`, with the actual "GUI editor running but port closed" diagnostic), and a failing step against a nonexistent command (`exit 3`, with UE's real "Unknown command" error). That's what caught the exit-hang bug above.

What is **not** verified:
- The example GitHub Actions workflow has never run on an actual runner (self-hosted or otherwise) — it's marked EXAMPLE ONLY in its own header, is not in `.github/workflows/`, and is not wired into this repo's CI.
- `hayba-cli` has not been exercised against UE launched fresh via `-batchmode -Cmd` — only against an already-running GUI editor. The reachability/backoff logic (`connectWithBackoff`, `ensureConnected`) is existing, already-tested code shared with every other MCP tool, but the specific "cold headless launch, CLI waits for it to come up" sequence from the issue has not been run end-to-end.
- This repo's own CI is unreliable and was not treated as a gate — the three commands above were run locally.