### PR TITLE
Prompt cache_control breakpoints + cache-hit usage metrics

### DIFF
--- a/mcp-tools/hayba-mcp/src/agents/llm-client.test.ts
+++ b/mcp-tools/hayba-mcp/src/agents/llm-client.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createLLMClient,
+  buildAnthropicRequest,
+  type AnthropicClientLike,
+  type LLMCompleteParams,
+  type LLMTool,
+} from './llm-client.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tool(name: string): LLMTool {
+  return { name, description: `does ${name}`, input_schema: { type: 'object', properties: {} } };
+}
+
+function baseParams(over: Partial<LLMCompleteParams> = {}): LLMCompleteParams {
+  return {
+    system: 'You are the Hayba copilot.',
+    messages: [{ role: 'user', content: 'hi' }],
+    ...over,
+  };
+}
+
+const RESOLVED_CFG = { provider: 'anthropic', protocol: 'anthropic' as const, model: 'claude-x', baseURL: '', apiKey: 'k' };
+
+// ---------------------------------------------------------------------------
+// cache_control placement (Issue #30)
+// ---------------------------------------------------------------------------
+
+describe('buildAnthropicRequest — cache_control placement', () => {
+  it('marks the system block with cache_control:ephemeral', () => {
+    const req = buildAnthropicRequest(RESOLVED_CFG, baseParams({ tools: [tool('actor_spawn')] }));
+    expect(req.system).toEqual([
+      { type: 'text', text: 'You are the Hayba copilot.', cache_control: { type: 'ephemeral' } },
+    ]);
+  });
+
+  it('marks only the LAST tool in the catalog, not every tool', () => {
+    const tools = [tool('actor_spawn'), tool('actor_list'), tool('actor_delete')];
+    const req = buildAnthropicRequest(RESOLVED_CFG, baseParams({ tools }));
+    const reqTools = req.tools as Array<Record<string, unknown>>;
+    expect(reqTools).toHaveLength(3);
+    expect(reqTools[0].cache_control).toBeUndefined();
+    expect(reqTools[1].cache_control).toBeUndefined();
+    expect(reqTools[2].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('never marks messages — the volatile, per-turn-growing block', () => {
+    const req = buildAnthropicRequest(
+      RESOLVED_CFG,
+      baseParams({
+        tools: [tool('actor_spawn')],
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'hello' },
+          { role: 'user', content: [{ type: 'text', text: 'do a thing' }] },
+        ],
+      }),
+    );
+    const msgs = req.messages as Array<{ content: unknown }>;
+    for (const m of msgs) {
+      const content = m.content;
+      if (typeof content === 'string') continue; // plain string can't carry cache_control anyway
+      for (const block of content as Array<Record<string, unknown>>) {
+        expect(block.cache_control).toBeUndefined();
+      }
+    }
+  });
+
+  it('keeps the breakpoint count fixed (2: system + tools-tail) regardless of catalog size', () => {
+    const manyTools = Array.from({ length: 60 }, (_, i) => tool(`tool_${i}`));
+    const req = buildAnthropicRequest(RESOLVED_CFG, baseParams({ tools: manyTools }));
+    const reqTools = req.tools as Array<Record<string, unknown>>;
+    const toolBreakpoints = reqTools.filter((t) => t.cache_control !== undefined).length;
+    const systemBreakpoints = (req.system as Array<Record<string, unknown>>).filter(
+      (b) => b.cache_control !== undefined,
+    ).length;
+    expect(toolBreakpoints).toBe(1);
+    expect(systemBreakpoints).toBe(1);
+    // Anthropic's hard cap is 4 breakpoints per request.
+    expect(toolBreakpoints + systemBreakpoints).toBeLessThanOrEqual(4);
+  });
+
+  it('omits tools entirely when none are offered — no stray cache_control on an empty list', () => {
+    const req = buildAnthropicRequest(RESOLVED_CFG, baseParams());
+    expect(req.tools).toBeUndefined();
+    // System is still cacheable even with no tools.
+    expect((req.system as Array<Record<string, unknown>>)[0].cache_control).toEqual({
+      type: 'ephemeral',
+    });
+  });
+
+  it('does not crash and emits a plain string system when system is empty (harmless no-op)', () => {
+    const req = buildAnthropicRequest(RESOLVED_CFG, baseParams({ system: '' }));
+    expect(req.system).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Usage / cache-hit metrics
+// ---------------------------------------------------------------------------
+
+describe('cache-hit usage metrics', () => {
+  it('complete() surfaces cache_creation_input_tokens / cache_read_input_tokens from usage', async () => {
+    const fakeAnthropic: AnthropicClientLike = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ type: 'text', text: 'hi' }],
+          stop_reason: 'end_turn',
+          usage: {
+            input_tokens: 120,
+            output_tokens: 12,
+            cache_creation_input_tokens: 400,
+            cache_read_input_tokens: 3000,
+          },
+        }),
+        stream: vi.fn(),
+      },
+    };
+    const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fakeAnthropic });
+    const resp = await client.complete(baseParams());
+    expect(resp.usage).toEqual({
+      inputTokens: 120,
+      outputTokens: 12,
+      cacheCreationInputTokens: 400,
+      cacheReadInputTokens: 3000,
+    });
+  });
+
+  it('stream() merges usage from message_start (cache fields) and message_delta (output tokens)', async () => {
+    async function* fakeStream() {
+      yield {
+        type: 'message_start',
+        message: {
+          usage: { input_tokens: 500, output_tokens: 0, cache_read_input_tokens: 2500, cache_creation_input_tokens: 0 },
+        },
+      };
+      yield { type: 'content_block_start', index: 0, content_block: { type: 'text' } };
+      yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hi' } };
+      yield { type: 'content_block_stop', index: 0 };
+      yield { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 7 } };
+    }
+    const fakeAnthropic: AnthropicClientLike = {
+      messages: { create: vi.fn(), stream: vi.fn().mockReturnValue(fakeStream()) },
+    };
+    const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fakeAnthropic });
+
+    let doneUsage: unknown;
+    for await (const ev of client.stream(baseParams())) {
+      if (ev.type === 'done') doneUsage = ev.response.usage;
+    }
+    expect(doneUsage).toEqual({
+      inputTokens: 500,
+      outputTokens: 7,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 2500,
+    });
+  });
+
+  it('leaves usage undefined when the wire payload has no usage field (mock protocol, e.g.)', async () => {
+    const client = createLLMClient({ provider: 'mock' });
+    const resp = await client.complete(baseParams());
+    expect(resp.usage).toBeUndefined();
+  });
+});

--- a/mcp-tools/hayba-mcp/src/agents/llm-client.ts
+++ b/mcp-tools/hayba-mcp/src/agents/llm-client.ts
@@ -53,10 +53,24 @@ export interface LLMToolCall {
 
 export type LLMStopReason = 'end_turn' | 'tool_use' | 'max_tokens';
 
+/**
+ * Token accounting for one LLM call. `cacheCreationInputTokens` /
+ * `cacheReadInputTokens` are Anthropic-specific (prompt caching); they stay
+ * `undefined` for protocols/providers that don't report them, never `0` — a
+ * real 0 vs "not reported" distinction matters for hit-rate metrics.
+ */
+export interface LLMUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+}
+
 export interface LLMResponse {
   content: string | null;
   toolCalls: LLMToolCall[];
   stopReason: LLMStopReason;
+  usage?: LLMUsage;
 }
 
 /** One normalized event type for `stream()`; both protocols normalize into it. */
@@ -194,6 +208,15 @@ function mapError(err: unknown, provider: string, apiKey: string): LLMError {
 // Tool mapping (our shape -> each wire format)
 // ---------------------------------------------------------------------------
 
+/**
+ * Anthropic prompt caching (GA, no beta header needed): a `cache_control`
+ * block marks "cache everything up to and including this block". Anthropic
+ * caps the number of active breakpoints per request at 4 — we use at most 2
+ * (system, tools), never one per tool, so the count stays fixed regardless
+ * of catalog size. See `buildAnthropicRequest` for the ordering rationale.
+ */
+const CACHE_CONTROL_EPHEMERAL = { type: 'ephemeral' as const };
+
 function toAnthropicTools(tools: LLMTool[]): Array<Record<string, unknown>> {
   return tools.map((t) => ({
     name: t.name,
@@ -229,22 +252,86 @@ function normalizeOpenAIStop(reason: unknown): LLMStopReason {
 // Anthropic protocol
 // ---------------------------------------------------------------------------
 
-function buildAnthropicRequest(cfg: ResolvedConfig, params: LLMCompleteParams): Record<string, unknown> {
+/**
+ * Build the Anthropic `messages.create`/`.stream` request body, with
+ * `cache_control` breakpoints on the two blocks that are genuinely stable
+ * across turns of one conversation:
+ *
+ *   - `system`: the same instructions are re-sent every turn verbatim.
+ *   - `tools`: the catalog is derived once per turn from the (unchanged)
+ *     registry — same names/descriptions/schemas turn after turn within a
+ *     session, so it round-trips byte-identical and is a cache HIT after the
+ *     first turn.
+ *
+ * `messages` is deliberately left unmarked — it grows every turn (new user
+ * turn + tool results appended), so marking it would make every request a
+ * cache MISS while still paying the cache-write premium: strictly worse than
+ * not caching at all.
+ *
+ * Anthropic evaluates cache breakpoints in request order — tools, then
+ * system, then messages — so placing the marked blocks first (tools, system)
+ * and the volatile block last (messages) keeps the cached prefix at the head
+ * of the prompt, which is what the API requires for a hit.
+ */
+export function buildAnthropicRequest(
+  cfg: ResolvedConfig,
+  params: LLMCompleteParams,
+): Record<string, unknown> {
   const req: Record<string, unknown> = {
     model: cfg.model,
     max_tokens: params.maxTokens ?? 4096,
-    system: params.system,
     // Block arrays map 1:1 to Anthropic content blocks; strings pass through.
     messages: params.messages.map((m) => ({ role: m.role, content: m.content })),
   };
   if (params.tools && params.tools.length > 0) {
-    req.tools = toAnthropicTools(params.tools);
+    const tools = toAnthropicTools(params.tools);
+    // One breakpoint on the LAST tool caches the whole preceding tool list as
+    // a single prefix — not one breakpoint per tool (that would blow the
+    // 4-breakpoint cap on any catalog bigger than a handful of tools).
+    tools[tools.length - 1] = {
+      ...tools[tools.length - 1],
+      cache_control: CACHE_CONTROL_EPHEMERAL,
+    };
+    req.tools = tools;
+  }
+  if (params.system.length > 0) {
+    // System-as-content-blocks (not a plain string) is what lets us attach
+    // cache_control to it at all — Anthropic only accepts the marker on a
+    // content block, never on the bare string form.
+    req.system = [{ type: 'text', text: params.system, cache_control: CACHE_CONTROL_EPHEMERAL }];
+  } else {
+    req.system = params.system;
   }
   return req;
 }
 
+/** Raw Anthropic `usage` object shape (present on non-stream responses and
+ *  on `message_start`/`message_delta` stream events). */
+interface RawAnthropicUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+function parseAnthropicUsage(raw: RawAnthropicUsage | undefined): LLMUsage | undefined {
+  if (!raw) return undefined;
+  const usage: LLMUsage = {};
+  if (typeof raw.input_tokens === 'number') usage.inputTokens = raw.input_tokens;
+  if (typeof raw.output_tokens === 'number') usage.outputTokens = raw.output_tokens;
+  if (typeof raw.cache_creation_input_tokens === 'number')
+    usage.cacheCreationInputTokens = raw.cache_creation_input_tokens;
+  if (typeof raw.cache_read_input_tokens === 'number')
+    usage.cacheReadInputTokens = raw.cache_read_input_tokens;
+  return Object.keys(usage).length > 0 ? usage : undefined;
+}
+
 function parseAnthropicResponse(resp: unknown): LLMResponse {
-  const r = resp as { content?: Array<Record<string, unknown>>; stop_reason?: unknown };
+  const r = resp as {
+    content?: Array<Record<string, unknown>>;
+    stop_reason?: unknown;
+    usage?: RawAnthropicUsage;
+  };
   const blocks = r.content ?? [];
   const textParts: string[] = [];
   const toolCalls: LLMToolCall[] = [];
@@ -263,6 +350,7 @@ function parseAnthropicResponse(resp: unknown): LLMResponse {
     content: textParts.length > 0 ? textParts.join('') : null,
     toolCalls,
     stopReason: normalizeAnthropicStop(r.stop_reason),
+    usage: parseAnthropicUsage(r.usage),
   };
 }
 
@@ -276,6 +364,14 @@ async function* streamAnthropic(
   let stopReason: LLMStopReason = 'end_turn';
   // Accumulator for the tool_use block currently being streamed, keyed by index.
   const pending = new Map<number, { id: string; name: string; json: string }>();
+  // Usage arrives in two pieces: `message_start` carries input/cache tokens,
+  // `message_delta` carries the (cumulative) output token count. Merge both.
+  let usage: LLMUsage | undefined;
+  const mergeUsage = (raw: RawAnthropicUsage | undefined): void => {
+    const parsed = parseAnthropicUsage(raw);
+    if (!parsed) return;
+    usage = { ...usage, ...parsed };
+  };
 
   let iterable: AsyncIterable<unknown>;
   try {
@@ -291,8 +387,14 @@ async function* streamAnthropic(
         index?: number;
         content_block?: Record<string, unknown>;
         delta?: Record<string, unknown>;
+        message?: { usage?: RawAnthropicUsage };
+        usage?: RawAnthropicUsage;
       };
       switch (ev.type) {
+        case 'message_start': {
+          mergeUsage(ev.message?.usage);
+          break;
+        }
         case 'content_block_start': {
           const cb = ev.content_block ?? {};
           if (cb.type === 'tool_use') {
@@ -328,6 +430,7 @@ async function* streamAnthropic(
         case 'message_delta': {
           const d = ev.delta ?? {};
           if (d.stop_reason !== undefined) stopReason = normalizeAnthropicStop(d.stop_reason);
+          mergeUsage(ev.usage);
           break;
         }
         default:
@@ -344,6 +447,7 @@ async function* streamAnthropic(
       content: textParts.length > 0 ? textParts.join('') : null,
       toolCalls,
       stopReason,
+      usage,
     },
   };
 }

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
@@ -132,6 +132,43 @@ describe('runAgentLoop', () => {
     expect(result!.content).toContain('actor_list');
   });
 
+  it('sums usage across every LLM call in the turn (Issue #30 cache-hit metrics)', async () => {
+    // Two round-trips: a tool call, then the final text answer. Each carries
+    // its own usage; the turn's final `done` must report the SUM, not just
+    // the last call's numbers — a multi-step turn genuinely spends both.
+    const client = new FakeLLMClient([
+      {
+        content: null,
+        toolCalls: [{ id: 'c1', name: 'actor_list', input: {} }],
+        stopReason: 'tool_use',
+        usage: { inputTokens: 100, outputTokens: 10, cacheReadInputTokens: 900, cacheCreationInputTokens: 0 },
+      },
+      {
+        content: 'done',
+        toolCalls: [],
+        stopReason: 'end_turn',
+        usage: { inputTokens: 150, outputTokens: 20, cacheReadInputTokens: 900, cacheCreationInputTokens: 0 },
+      },
+    ]);
+    const dispatch = vi.fn(async (name: string) => ({ ok: true, name }));
+
+    const events = await collect(runAgentLoop(baseParams({ client, dispatchTool: dispatch })));
+    const done = events.at(-1);
+    expect(done).toEqual({
+      type: 'done',
+      reason: 'end_turn',
+      stopReason: 'end_turn',
+      usage: { inputTokens: 250, outputTokens: 30, cacheReadInputTokens: 1800, cacheCreationInputTokens: 0 },
+    });
+  });
+
+  it('leaves usage undefined on the done event when the client never reports it', async () => {
+    const client = new FakeLLMClient([textResponse('hi')]);
+    const events = await collect(runAgentLoop(baseParams({ client })));
+    const done = events.at(-1) as Extract<AgentEvent, { type: 'done' }>;
+    expect(done.usage).toBeUndefined();
+  });
+
   it('refuses a filtered/disabled tool: not offered AND refused if called', async () => {
     const client = new FakeLLMClient([
       toolResponse('actor_spawn', {}, 'c1'),

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
@@ -36,6 +36,7 @@ import type {
   LLMTool,
   LLMToolCall,
   LLMStopReason,
+  LLMUsage,
 } from '../agents/llm-client.js';
 import { deriveSignature, getRawShape, listRecordedCommands } from '../tools/schema-registry.js';
 import { unwrapZod } from '../tools/zod-unwrap.js';
@@ -255,7 +256,7 @@ export type AgentEvent =
   | { type: 'tool_call'; call: LLMToolCall }
   | { type: 'tool_result'; id: string; name: string; result: unknown; isError?: boolean }
   | { type: 'plan_request'; call: LLMToolCall; hint?: string; source: 'ts' | 'ue'; argsHash?: string }
-  | { type: 'done'; reason: AgentDoneReason; stopReason?: LLMStopReason }
+  | { type: 'done'; reason: AgentDoneReason; stopReason?: LLMStopReason; usage?: LLMUsage }
   | { type: 'error'; error: string; kind?: string };
 
 export interface AgentLoopParams {
@@ -344,19 +345,34 @@ export async function* runAgentLoop(
 
   let steps = 0;
   let tokens = 0;
+  // Sums usage across every LLM call in this turn (a "turn" may make several
+  // round-trips when the model chains tool calls). Fields the client never
+  // reports stay undefined rather than defaulting to 0, so a caller can tell
+  // "no cache activity happened" apart from "this protocol doesn't report it".
+  let usage: LLMUsage | undefined;
+  const accumulateUsage = (u: LLMUsage | undefined): void => {
+    if (!u) return;
+    const next: LLMUsage = { ...usage };
+    for (const key of Object.keys(u) as Array<keyof LLMUsage>) {
+      const v = u[key];
+      if (v === undefined) continue;
+      next[key] = (next[key] ?? 0) + v;
+    }
+    usage = next;
+  };
 
   while (true) {
     if (signal?.aborted) {
       yield { type: 'error', error: 'aborted', kind: 'aborted' };
-      yield { type: 'done', reason: 'aborted' };
+      yield { type: 'done', reason: 'aborted', usage };
       return;
     }
     if (steps >= maxSteps) {
-      yield { type: 'done', reason: 'max_steps' };
+      yield { type: 'done', reason: 'max_steps', usage };
       return;
     }
     if (tokenBudget !== undefined && tokens >= tokenBudget) {
-      yield { type: 'done', reason: 'token_budget' };
+      yield { type: 'done', reason: 'token_budget', usage };
       return;
     }
 
@@ -369,7 +385,7 @@ export async function* runAgentLoop(
       for await (const ev of client.stream({ system, messages, tools, maxTokens, signal })) {
         if (signal?.aborted) {
           yield { type: 'error', error: 'aborted', kind: 'aborted' };
-          yield { type: 'done', reason: 'aborted' };
+          yield { type: 'done', reason: 'aborted', usage };
           return;
         }
         if (ev.type === 'text_delta') {
@@ -379,6 +395,7 @@ export async function* runAgentLoop(
           content = ev.response.content;
           toolCalls = ev.response.toolCalls;
           stopReason = ev.response.stopReason;
+          accumulateUsage(ev.response.usage);
         }
         // 'tool_call' stream events are consolidated in the 'done' response.
       }
@@ -405,7 +422,7 @@ export async function* runAgentLoop(
 
     // ── Halt when the model is done ──────────────────────────────────────
     if (stopReason !== 'tool_use' || toolCalls.length === 0) {
-      yield { type: 'done', reason: 'end_turn', stopReason };
+      yield { type: 'done', reason: 'end_turn', stopReason, usage };
       return;
     }
 
@@ -414,7 +431,7 @@ export async function* runAgentLoop(
     for (const call of toolCalls) {
       if (signal?.aborted) {
         yield { type: 'error', error: 'aborted', kind: 'aborted' };
-        yield { type: 'done', reason: 'aborted' };
+        yield { type: 'done', reason: 'aborted', usage };
         return;
       }
       yield { type: 'tool_call', call };

--- a/mcp-tools/hayba-mcp/src/chat/chat-server.ts
+++ b/mcp-tools/hayba-mcp/src/chat/chat-server.ts
@@ -51,7 +51,7 @@ import {
   type ApprovedCall,
   type DispatchTool,
 } from './agent-loop.js';
-import type { LLMTool } from '../agents/llm-client.js';
+import type { LLMTool, LLMUsage } from '../agents/llm-client.js';
 import { createChatDispatcher } from './tool-dispatch.js';
 
 // ---------------------------------------------------------------------------
@@ -678,6 +678,9 @@ function finalize(
 async function runTurn(session: ChatSession, params: RunTurnParams): Promise<void> {
   let finalReason: string | null = null;
   let lastError: { error: string; kind?: string } | null = null;
+  // Cache-hit metrics (cache_creation_input_tokens / cache_read_input_tokens
+  // among them) travel on the loop's own 'done' event — see agent-loop.ts.
+  let usage: LLMUsage | undefined;
 
   try {
     for await (const ev of runAgentLoop({
@@ -691,20 +694,31 @@ async function runTurn(session: ChatSession, params: RunTurnParams): Promise<voi
       planMode: true, // honour Plan Mode; UE side is authoritative, TS side gated
       approvedCall: params.approvedCall,
     })) {
-      forwardEvent(session, ev, (r) => (finalReason = r), (e) => (lastError = e));
+      forwardEvent(
+        session,
+        ev,
+        (r) => (finalReason = r),
+        (e) => (lastError = e),
+        (u) => {
+          if (u) usage = u;
+        },
+      );
       if (finalReason) break; // loop's own done/plan_request/aborted terminus
     }
   } catch (err) {
     lastError = { error: err instanceof Error ? err.message : String(err), kind: 'internal' };
   }
 
-  // Consolidated terminal frame.
+  // Consolidated terminal frame. `usage` is included whenever the loop
+  // reported any (even on an aborted/error turn — partial usage still cost
+  // real tokens and is worth surfacing).
+  const usageExtra = usage ? { usage } : {};
   if (finalReason === 'aborted') {
-    finalize(session, 'aborted');
+    finalize(session, 'aborted', usageExtra);
   } else if (lastError && !finalReason) {
-    finalize(session, 'error', { error: lastError });
+    finalize(session, 'error', { error: lastError, ...usageExtra });
   } else {
-    finalize(session, finalReason ?? 'end_turn', lastError ? { error: lastError } : {});
+    finalize(session, finalReason ?? 'end_turn', { ...(lastError ? { error: lastError } : {}), ...usageExtra });
   }
 }
 
@@ -714,6 +728,7 @@ function forwardEvent(
   ev: AgentEvent,
   setReason: (r: string) => void,
   setError: (e: { error: string; kind?: string }) => void,
+  setUsage: (u: LLMUsage | undefined) => void,
 ): void {
   switch (ev.type) {
     case 'text_delta':
@@ -757,6 +772,7 @@ function forwardEvent(
     }
     case 'done':
       setReason(ev.reason);
+      setUsage(ev.usage);
       break;
     case 'error':
       setError({ error: ev.error, kind: ev.kind });

--- a/mcp-tools/hayba-mcp/src/chat/chat-server.usage.test.ts
+++ b/mcp-tools/hayba-mcp/src/chat/chat-server.usage.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Issue #30 — cache-hit usage metrics must reach the SSE `done` frame.
+ *
+ * The frame contract in chat-server.ts's own doc comment already promises
+ * `usage?` on the `done` event; this test proves it is actually populated
+ * end-to-end: fake LLMClient reports usage -> agent loop sums it -> chat
+ * server's `done` SSE frame carries it.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { registerChatRoutes, __resetChatState } from './chat-server.js';
+import type { LLMClient, LLMResponse, LLMStreamEvent } from '../agents/llm-client.js';
+
+function usageClient(usage: LLMResponse['usage']): LLMClient {
+  return {
+    provider: 'anthropic',
+    model: 'fake',
+    protocol: 'anthropic',
+    async complete() {
+      return { content: 'hi', toolCalls: [], stopReason: 'end_turn', usage };
+    },
+    async *stream(): AsyncGenerator<LLMStreamEvent, void, unknown> {
+      yield { type: 'text_delta', text: 'hi' };
+      yield {
+        type: 'done',
+        response: { content: 'hi', toolCalls: [], stopReason: 'end_turn', usage },
+      };
+    },
+  };
+}
+
+async function collectSse(res: Response): Promise<Array<{ event: string; data: unknown }>> {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  const frames: Array<{ event: string; data: unknown }> = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx: number;
+    while ((idx = buf.indexOf('\n\n')) !== -1) {
+      const chunk = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+      const eventLine = chunk.split('\n').find((l) => l.startsWith('event: '));
+      const dataLine = chunk.split('\n').find((l) => l.startsWith('data: '));
+      if (eventLine && dataLine) {
+        frames.push({
+          event: eventLine.slice('event: '.length),
+          data: JSON.parse(dataLine.slice('data: '.length)),
+        });
+        if (eventLine.slice('event: '.length) === 'done') return frames;
+      }
+    }
+  }
+  return frames;
+}
+
+describe('chat-server SSE done frame — usage metrics (Issue #30)', () => {
+  let server: Server;
+  let url: string;
+
+  afterEach(() => {
+    server?.close();
+    __resetChatState();
+  });
+
+  it('surfaces cache_creation/cache_read token counts on the final done frame', async () => {
+    __resetChatState();
+    const app = express();
+    app.use(express.json());
+    registerChatRoutes(app, {
+      createClient: () =>
+        usageClient({
+          inputTokens: 50,
+          outputTokens: 5,
+          cacheCreationInputTokens: 300,
+          cacheReadInputTokens: 1200,
+        }),
+      dispatchTool: async () => ({ ok: true }),
+      tools: [],
+    });
+    server = app.listen(0);
+    const port = (server.address() as AddressInfo).port;
+    url = `http://127.0.0.1:${port}`;
+
+    const res = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hi', provider: 'anthropic' }),
+    });
+    const frames = await collectSse(res as unknown as Response);
+    const done = frames.find((f) => f.event === 'done');
+    expect(done).toBeDefined();
+    expect((done!.data as { usage?: unknown }).usage).toEqual({
+      inputTokens: 50,
+      outputTokens: 5,
+      cacheCreationInputTokens: 300,
+      cacheReadInputTokens: 1200,
+    });
+  });
+
+  it('omits usage when the client never reports it (no false metrics)', async () => {
+    __resetChatState();
+    const app = express();
+    app.use(express.json());
+    registerChatRoutes(app, {
+      createClient: () => usageClient(undefined),
+      dispatchTool: async () => ({ ok: true }),
+      tools: [],
+    });
+    server = app.listen(0);
+    const port = (server.address() as AddressInfo).port;
+    url = `http://127.0.0.1:${port}`;
+
+    const res = await fetch(`${url}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hi', provider: 'anthropic' }),
+    });
+    const frames = await collectSse(res as unknown as Response);
+    const done = frames.find((f) => f.event === 'done');
+    expect(done).toBeDefined();
+    expect((done!.data as { usage?: unknown }).usage).toBeUndefined();
+  });
+});

--- a/mcp-tools/hayba-mcp/tests/agents/llm-client.test.ts
+++ b/mcp-tools/hayba-mcp/tests/agents/llm-client.test.ts
@@ -45,8 +45,16 @@ describe('tool mapping', () => {
     };
     const client = createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake });
     await client.complete(BASE);
+    // Issue #30: the LAST tool in the catalog carries a `cache_control`
+    // breakpoint so the (stable, re-sent-every-turn) tool catalog is
+    // cacheable. With one tool offered, that's this one.
     expect(captured.tools).toEqual([
-      { name: 'get_weather', description: 'Get the weather', input_schema: TOOL.input_schema },
+      {
+        name: 'get_weather',
+        description: 'Get the weather',
+        input_schema: TOOL.input_schema,
+        cache_control: { type: 'ephemeral' },
+      },
     ]);
     expect(captured.model).toBe('claude-opus-4-8');
   });


### PR DESCRIPTION
Closes #30.

## What changed (TS only, `mcp-tools/hayba-mcp`)

**`src/agents/llm-client.ts`** — `buildAnthropicRequest` now places
`cache_control: {type: 'ephemeral'}` on exactly two blocks:
- the **system prompt**, as a content-block array (Anthropic only accepts the
  marker on a block, not the bare string form) — it is re-sent verbatim every
  turn of a session.
- the **last tool** in the offered catalog — one breakpoint caches the whole
  preceding tool list as a single prefix. Only the last tool is marked, not
  every tool, so the breakpoint count stays fixed at 2 regardless of catalog
  size (well under Anthropic's 4-breakpoint cap).

`messages` is deliberately left unmarked: it grows every turn (new user turn
+ tool-result blocks appended), so marking it would make every request a
cache **miss** while still paying the cache-write premium — strictly worse
than not caching.

Also added `LLMResponse.usage` (`inputTokens`, `outputTokens`,
`cacheCreationInputTokens`, `cacheReadInputTokens`), parsed from the
non-streaming response and merged from `message_start` (cache/input fields)
+ `message_delta` (output tokens) on the streaming path.

**`src/chat/agent-loop.ts`** — sums `usage` across every LLM round-trip in a
turn (a turn can make several calls when the model chains tool calls) and
attaches the total to every `AgentEvent` of type `'done'`.

**`src/chat/chat-server.ts`** — forwards that summed usage into the SSE
`done` frame's `usage` field. This field was already documented in the route
doc-comment (`... usage?, cancelled?, partial_text`) but nothing populated
it before this change.

## Stale assumptions in the issue

The issue also asked to cache-mark "level spatial index" and "sidecar
status". Neither exists on this path:

- `level_get_spatial_index` is a UE-bridged MCP tool invoked directly by
  external clients (`src/legacy-commands/sidecar.json`) — it never flows
  into the chat agent loop's system/tools/messages. It currently returns
  `status: "deferred"` and isn't even implemented
  (`src/tools/no-stub-wrappers.test.ts`).
- There is no "sidecar status" content block injected into any turn's
  prompt anywhere in `src/chat/` or `src/agents/`. "Sidecar" in this
  codebase refers to the HTTP process itself, not a status summary sent to
  the model.

So there was nothing to mark for either — the issue predates the current
chat/agent-loop architecture and those two items are stale.

## Tests

Added:
- `src/agents/llm-client.test.ts` (9 tests) — cache_control placement on
  system/tools, absence on messages and non-last tools, fixed breakpoint
  count with 60 tools, empty-system/empty-tools no-ops, usage parsing for
  both `complete()` and `stream()`.
- `src/chat/agent-loop.test.ts` (+2 tests) — usage summed across a
  multi-step turn, `undefined` when the client never reports usage.
- `src/chat/chat-server.usage.test.ts` (2 tests) — real Express app + SSE
  stream, asserts `usage` on the final `done` frame end-to-end, and that
  it's omitted (not zeroed) when unreported.
- Fixed one pre-existing test (`tests/agents/llm-client.test.ts`) that
  asserted the exact (pre-caching) tool wire shape — updated to expect the
  new `cache_control` marker, which is the intended behavior change, not a
  regression.

**Mutation-tested each new behavior** (break -> RED -> revert -> GREEN):
1. Marked every tool instead of only the last -> broke the
   "only last tool" and "fixed breakpoint count" tests.
2. Marked the last message block too -> broke the "never marks messages"
   test.
3. Made usage accumulation overwrite instead of sum across steps -> broke
   the agent-loop multi-step usage test.
4. Dropped the `setUsage(ev.usage)` forward in chat-server -> broke the SSE
   end-to-end usage test.

All four confirmed RED, then reverted to confirmed GREEN.

## Gate

- `npx tsc --noEmit` — clean
- `npm test` — 1504/1504 passing (baseline 1491 + 13 new)
- `node scripts/check-legacy-wrappers.mjs` — OK, no violations
- `search-quality.test.ts` — passed unchanged (no description touched)

## Honesty

I cannot make a real Anthropic API call from this environment, so a cache
**hit** is not proven here. What's proven: the request structure places
`cache_control` on exactly the intended stable blocks and nowhere else, the
breakpoint count is bounded independent of catalog size, and usage fields
(including the cache token counts) propagate correctly end-to-end through
fake/injected clients. Real hit-rate confirmation against the live API is
outstanding — that would need a follow-up with an actual key and two
consecutive turns compared for `cache_read_input_tokens > 0`.

Did not touch `unreal/`, did not launch the editor, did not merge.