### PR TITLE
feat(ue): how long one plan approval lasts is a setting, not a commented-out line

### DIFF
--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp
@@ -832,12 +832,34 @@ FString FHaybaMCPCommandHandler::ProcessCommand(const FString& CommandJson)
                 auto Data = MakeShared<FJsonObject>();
                 Data->SetStringField(TEXT("status"), TEXT("plan_mode_required"));
                 Data->SetStringField(TEXT("hint"), TEXT("Plan Mode is ON. Call hayba_propose_plan with a steps[] array, then the user must click Approve in the Plan tab before destructive commands run."));
+                // Under strict consume the previous Approve was SPENT by the
+                // last destructive command. Without saying so, the second call
+                // in a sequence looks exactly like Approve never worked, and
+                // the user clicks it again wondering what broke.
+                Data->SetStringField(TEXT("approval_mode"),
+                    S.bPlanApprovalStrictConsume ? TEXT("per_call_consume") : TEXT("per_plan_persist"));
+                if (S.bPlanApprovalStrictConsume)
+                {
+                    Data->SetStringField(TEXT("approval_mode_note"),
+                        TEXT("Strict consume is on: each Approve authorises exactly ONE destructive command, so an "
+                             "earlier approval in this sequence has already been used. Set "
+                             "bPlanApprovalStrictConsume=false in the Hayba settings for one Approve to cover a whole plan."));
+                }
                 return MakeOkResponse(Id, Data);
             }
-            // Consume the approval: subsequent destructive calls need a fresh plan.
-            // Comment out the next line if you want approval to persist across
-            // a multi-step destructive sequence.
-            // M->bPlanApproved = false;
+            // How long one Approve lasts is now a SETTING rather than a
+            // commented-out line, because both answers are right for different
+            // sessions and the choice was previously made by editing source.
+            //
+            // Default (false) keeps the existing per-plan behaviour: a plan
+            // whose steps are "delete these six assets" must not stop dead
+            // after the first one. Strict consume spends the approval on the
+            // first destructive command, which is what an unattended agent
+            // against content that matters wants.
+            if (S.bPlanApprovalStrictConsume && M)
+            {
+                M->bPlanApproved = false;
+            }
         }
         S.PlanModeToolCallCount++;
         S.Save();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettings.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettings.cpp
@@ -261,6 +261,7 @@ void FHaybaMCPSettings::Load()
     GConfig->GetBool(Section, TEXT("bHasSeenWizard"), bHasSeenWizard, GEditorPerProjectIni);
     GConfig->GetBool(Section, TEXT("bHasSeenOnboarding"), bHasSeenOnboarding, GEditorPerProjectIni);
     GConfig->GetBool(Section, TEXT("bPlanModeEnabled"), bPlanModeEnabled, GEditorPerProjectIni);
+    GConfig->GetBool(Section, TEXT("bPlanApprovalStrictConsume"), bPlanApprovalStrictConsume, GEditorPerProjectIni);
     GConfig->GetInt(Section, TEXT("PlanModeToolCallCount"), PlanModeToolCallCount, GEditorPerProjectIni);
     GConfig->GetBool(Section, TEXT("bShownPlanModePrompt"), bShownPlanModePrompt, GEditorPerProjectIni);
     {
@@ -312,6 +313,7 @@ void FHaybaMCPSettings::Save() const
     GConfig->SetBool(Section, TEXT("bHasSeenWizard"), bHasSeenWizard, GEditorPerProjectIni);
     GConfig->SetBool(Section, TEXT("bHasSeenOnboarding"), bHasSeenOnboarding, GEditorPerProjectIni);
     GConfig->SetBool(Section, TEXT("bPlanModeEnabled"), bPlanModeEnabled, GEditorPerProjectIni);
+    GConfig->SetBool(Section, TEXT("bPlanApprovalStrictConsume"), bPlanApprovalStrictConsume, GEditorPerProjectIni);
     GConfig->SetInt(Section, TEXT("PlanModeToolCallCount"), PlanModeToolCallCount, GEditorPerProjectIni);
     GConfig->SetBool(Section, TEXT("bShownPlanModePrompt"), bShownPlanModePrompt, GEditorPerProjectIni);
     GConfig->SetString(Section, TEXT("PlanModeFirstUseDate"), *PlanModeFirstUseDate.ToIso8601(), GEditorPerProjectIni);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettings.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPSettings.h
@@ -59,6 +59,24 @@ public:
     int32 PlanModeToolCallCount = 0;
     bool bShownPlanModePrompt = false;
 
+    /**
+     * How long one Approve lasts.
+     *
+     * false (default) — PER-PLAN PERSIST. One Approve covers every destructive
+     *   command until the user rejects or proposes a new plan. This is what the
+     *   gate has always done, and it is what a multi-step plan needs: a plan
+     *   whose steps are "delete these 6 assets" would otherwise stop dead after
+     *   the first one.
+     * true — PER-CALL CONSUME. The approval is spent by the first destructive
+     *   command, so each one needs its own plan. Appropriate when an agent is
+     *   running unattended against content that matters.
+     *
+     * Default is the existing behaviour deliberately: flipping the meaning of an
+     * approval under someone who is mid-session is a worse surprise than the
+     * looser default they already have.
+     */
+    bool bPlanApprovalStrictConsume = false;
+
     // Security
     // Optional. When set, every TCP request must include matching `auth` field.
     FString CapabilityToken;


### PR DESCRIPTION
Closes #12.

The destructive-op gate carried the choice as **dead code**:

```cpp
// Consume the approval: subsequent destructive calls need a fresh plan.
// Comment out the next line if you want approval to persist ...
// M->bPlanApproved = false;
```

Picking a policy meant editing source and rebuilding the plugin. Both answers are right for different sessions, which is what a setting is for.

## `bPlanApprovalStrictConsume`

Persisted to `GEditorPerProjectIni` alongside `bPlanModeEnabled`.

- **`false` (default) — per-plan persist.** One Approve covers every destructive command until Reject or a new plan. A plan whose steps are *"delete these six assets"* must not stop dead after the first one.
- **`true` — per-call consume.** The approval is spent by the first destructive command. For an agent running unattended against content that matters.

Default is the existing behaviour deliberately: changing what an approval *means* under someone mid-session is a worse surprise than the looser default they already have. The issue reached the same conclusion.

## The refusal message is now mode-aware

This matters more than it sounds. Under strict consume, the second destructive call in a sequence is refused **because the earlier Approve was spent** — and without saying so, that is indistinguishable from Approve never having worked. The user clicks it again wondering what broke.

The reply now carries `approval_mode`, and under strict consume a note explaining that an approval has already been used and how to change the policy.

## Gate

C++ `Hayba.MCP`: **17 of 18**, unchanged (`UI.RenderWidgetToPng`, `-NullRHI`-only). Build `Result: Succeeded`.

Not verified live: the gate needs Plan Mode on, a proposed plan, and a human clicking Approve, so both branches are reasoned and compiled rather than exercised. The strict path is one boolean and one assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)