### PR TITLE
test(mcp): broaden coverage — zod-unwrap, PCG layout math, conventions ini default bug

### DIFF
--- a/mcp-tools/hayba-mcp/src/conventions.test.ts
+++ b/mcp-tools/hayba-mcp/src/conventions.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { getPreset, conventionsToIni, iniToConventions, type PresetName } from './conventions.js';
+
+describe('getPreset', () => {
+  it('returns independent copies — mutating one preset does not leak into another read', () => {
+    const a = getPreset('epic-default');
+    a.folders.pcgGraphs = '/Mutated';
+    const b = getPreset('epic-default');
+    expect(b.folders.pcgGraphs).toBe('/Game/PCG');
+  });
+
+  it.each<PresetName>(['epic-default', 'gamedevtv', 'custom'])(
+    'every preset defaults autoOpenInGaeaAfterBake to false (%s)',
+    (name) => {
+      expect(getPreset(name).workflow.autoOpenInGaeaAfterBake).toBe(false);
+    },
+  );
+});
+
+describe('conventionsToIni / iniToConventions round-trip', () => {
+  it('reconstructs an identical object for every preset', () => {
+    for (const name of ['epic-default', 'gamedevtv', 'custom'] as PresetName[]) {
+      const original = getPreset(name);
+      const ini = conventionsToIni(original);
+      const restored = iniToConventions(ini);
+      expect(restored).toEqual(original);
+    }
+  });
+
+  it('round-trips a workflow with autoOpenInGaeaAfterBake explicitly true', () => {
+    const original = getPreset('epic-default');
+    original.workflow.autoOpenInGaeaAfterBake = true;
+    original.workflow.confirmBeforeOverwrite = false;
+    const restored = iniToConventions(conventionsToIni(original));
+    expect(restored.workflow.autoOpenInGaeaAfterBake).toBe(true);
+    expect(restored.workflow.confirmBeforeOverwrite).toBe(false);
+  });
+});
+
+describe('iniToConventions defaults on a hand-authored/partial ini', () => {
+  // A human editing DefaultHayba.ini by hand, or an older ini written before a
+  // field existed, will not have every key conventionsToIni() would emit.
+  // Bug found while writing this test: autoOpenInGaeaAfterBake used
+  // `!== 'false'`, so an ABSENT key defaulted to true — the opposite of every
+  // preset's default (false) — silently turning on "auto-open in Gaea after
+  // every bake" for anyone whose ini predates the flag. Fixed in conventions.ts
+  // to `=== 'true'`, matching confirmBeforeOverwrite's intentional asymmetry
+  // (that one legitimately defaults true when absent).
+  it('defaults autoOpenInGaeaAfterBake to false when the key is entirely absent', () => {
+    const ini = '[Conventions]\npreset=custom\n';
+    const c = iniToConventions(ini);
+    expect(c.workflow.autoOpenInGaeaAfterBake).toBe(false);
+  });
+
+  it('defaults confirmBeforeOverwrite to true when the key is entirely absent', () => {
+    const ini = '[Conventions]\npreset=custom\n';
+    const c = iniToConventions(ini);
+    expect(c.workflow.confirmBeforeOverwrite).toBe(true);
+  });
+
+  it('honors an explicit workflow.autoOpenInGaeaAfterBake=true', () => {
+    const ini = '[Conventions]\npreset=custom\nworkflow.autoOpenInGaeaAfterBake=true\n';
+    expect(iniToConventions(ini).workflow.autoOpenInGaeaAfterBake).toBe(true);
+  });
+
+  it('honors an explicit workflow.confirmBeforeOverwrite=false', () => {
+    const ini = '[Conventions]\npreset=custom\nworkflow.confirmBeforeOverwrite=false\n';
+    expect(iniToConventions(ini).workflow.confirmBeforeOverwrite).toBe(false);
+  });
+
+  it('falls back to preset=custom and empty folders/naming when the ini is bare', () => {
+    const c = iniToConventions('[Conventions]\n');
+    expect(c.preset).toBe('custom');
+    expect(c.folders.pcgGraphs).toBe('');
+    expect(c.naming.folderCasing).toBe('PascalCase');
+  });
+
+  it('ignores comment/section lines and blank lines while parsing', () => {
+    const ini = [
+      '[Conventions]',
+      '',
+      'preset=epic-default',
+      'folders.pcgGraphs=/Game/PCG',
+    ].join('\n');
+    const c = iniToConventions(ini);
+    expect(c.preset).toBe('epic-default');
+    expect(c.folders.pcgGraphs).toBe('/Game/PCG');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/conventions.ts
+++ b/mcp-tools/hayba-mcp/src/conventions.ts
@@ -185,7 +185,10 @@ export function iniToConventions(ini: string): HaybaConventions {
     confirmBeforeOverwrite: flat['workflow.confirmBeforeOverwrite'] !== 'false',
     preferredLandscapeResolution: (parseInt(flat['workflow.preferredLandscapeResolution'], 10) || 1009) as 1009 | 2017 | 4033,
     defaultHeightmapFormat: (flat['workflow.defaultHeightmapFormat'] as 'r16' | 'png') || 'r16',
-    autoOpenInGaeaAfterBake: flat['workflow.autoOpenInGaeaAfterBake'] !== 'false',
+    // Unlike confirmBeforeOverwrite (defaults true), every preset defaults this
+    // to false — so a missing key (e.g. a hand-authored ini without the line)
+    // must default to false too, not silently flip the workflow on.
+    autoOpenInGaeaAfterBake: flat['workflow.autoOpenInGaeaAfterBake'] === 'true',
   };
 
   return { version: 1, preset: preset as PresetName, folders, naming, workflow };

--- a/mcp-tools/hayba-mcp/src/tools/format-graph-topology.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/format-graph-topology.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { formatGraphTopology } from './format-graph-topology.js';
+import type { PCGNode } from '../types.js';
+
+function node(id: string, cls = 'UPCGExSampleNearest'): PCGNode {
+  return { id, class: cls, label: id, position: { x: -1, y: -1 }, properties: {}, customData: {} };
+}
+
+function graph(nodes: PCGNode[], edges: Array<{ fromNode: string; toNode: string }>) {
+  return JSON.stringify({
+    version: '2',
+    meta: { sourceGraph: 'g', ueVersion: '5.7', exportedAt: '', tags: [] },
+    nodes,
+    edges: edges.map((e) => ({ fromNode: e.fromNode, fromPin: 'Out', toNode: e.toNode, toPin: 'In' })),
+    metadata: { inputSettings: {} },
+  });
+}
+
+describe('formatGraphTopology — layered algorithm', () => {
+  it('places a linear chain in successive layers along x, at the same y', async () => {
+    const g = graph([node('a'), node('b'), node('c')], [
+      { fromNode: 'a', toNode: 'b' },
+      { fromNode: 'b', toNode: 'c' },
+    ]);
+    const out = JSON.parse(await formatGraphTopology({ graph: g, algorithm: 'layered', nodeWidth: 200, nodeHeight: 100, horizontalSpacing: 150, verticalSpacing: 80, addCommentBlocks: false }));
+    const byId = Object.fromEntries(out.nodes.map((n: PCGNode) => [n.id, n.position]));
+    expect(byId.a.x).toBe(0);
+    expect(byId.b.x).toBe(350); // nodeWidth + horizontalSpacing
+    expect(byId.c.x).toBe(700);
+    expect(byId.a.y).toBe(0);
+    expect(byId.b.y).toBe(0);
+  });
+
+  it('stacks sibling nodes at the same layer vertically, ordered deterministically by id', async () => {
+    const g = graph([node('root'), node('z_child'), node('a_child')], [
+      { fromNode: 'root', toNode: 'z_child' },
+      { fromNode: 'root', toNode: 'a_child' },
+    ]);
+    const out = JSON.parse(await formatGraphTopology({ graph: g, algorithm: 'layered', nodeWidth: 200, nodeHeight: 100, horizontalSpacing: 150, verticalSpacing: 80, addCommentBlocks: false }));
+    const byId = Object.fromEntries(out.nodes.map((n: PCGNode) => [n.id, n.position]));
+    // Same layer (x) for both children.
+    expect(byId.z_child.x).toBe(byId.a_child.x);
+    // Sorted by id: 'a_child' < 'z_child', so a_child gets row 0 (y=0).
+    expect(byId.a_child.y).toBe(0);
+    expect(byId.z_child.y).toBe(180); // nodeHeight + verticalSpacing
+  });
+
+  it('does not hang or drop nodes on a cyclic graph — unvisited nodes fall back to layer 0', async () => {
+    const g = graph([node('a'), node('b')], [
+      { fromNode: 'a', toNode: 'b' },
+      { fromNode: 'b', toNode: 'a' },
+    ]);
+    const out = JSON.parse(await formatGraphTopology({ graph: g, algorithm: 'layered', nodeWidth: 200, nodeHeight: 100, horizontalSpacing: 150, verticalSpacing: 80, addCommentBlocks: false }));
+    expect(out.nodes).toHaveLength(2);
+    for (const n of out.nodes) {
+      expect(Number.isFinite(n.position.x)).toBe(true);
+      expect(Number.isFinite(n.position.y)).toBe(true);
+    }
+  });
+
+  it('accepts legacy from/to edge keys via normalizeEdges', async () => {
+    const g = JSON.stringify({
+      version: '2',
+      meta: { sourceGraph: 'g', ueVersion: '5.7', exportedAt: '', tags: [] },
+      nodes: [node('a'), node('b')],
+      edges: [{ from: 'a', to: 'b' }],
+      metadata: { inputSettings: {} },
+    });
+    const out = JSON.parse(await formatGraphTopology({ graph: g, algorithm: 'layered', nodeWidth: 200, nodeHeight: 100, horizontalSpacing: 150, verticalSpacing: 80, addCommentBlocks: false }));
+    const byId = Object.fromEntries(out.nodes.map((n: PCGNode) => [n.id, n.position]));
+    expect(byId.b.x).toBeGreaterThan(byId.a.x);
+  });
+});
+
+describe('formatGraphTopology — grid algorithm', () => {
+  it('lays nodes out in a square-ish grid using ceil(sqrt(n)) columns', async () => {
+    const nodes = ['a', 'b', 'c', 'd'].map((id) => node(id));
+    const g = graph(nodes, []);
+    const out = JSON.parse(await formatGraphTopology({ graph: g, algorithm: 'grid', nodeWidth: 200, nodeHeight: 100, horizontalSpacing: 150, verticalSpacing: 80, addCommentBlocks: false }));
+    // sqrt(4) = 2 columns exactly.
+    const byId = Object.fromEntries(out.nodes.map((n: PCGNode) => [n.id, n.position]));
+    expect(byId.a.position).toBeUndefined(); // sanity: no nested position key
+    expect(byId.a.x).toBe(0);
+    expect(byId.b.x).toBe(350);
+    expect(byId.c.x).toBe(0);
+    expect(byId.c.y).toBe(180);
+  });
+});
+
+describe('formatGraphTopology — comment blocks', () => {
+  it('adds no comment block for a lone node of a class (needs >= 2 to group)', async () => {
+    const g = graph([node('a', 'UPCGExSampleNearest')], []);
+    const out = JSON.parse(await formatGraphTopology({ graph: g, algorithm: 'grid', nodeWidth: 200, nodeHeight: 100, horizontalSpacing: 150, verticalSpacing: 80, addCommentBlocks: true }));
+    expect(out.nodes.filter((n: PCGNode) => n.class === 'PCGCommentSettings')).toHaveLength(0);
+  });
+
+  it('groups >= 2 nodes sharing a class prefix into one comment block, sized around them', async () => {
+    const g = graph([node('a', 'UPCGExSampleNearest'), node('b', 'UPCGExSampleFar')], []);
+    const out = JSON.parse(await formatGraphTopology({ graph: g, algorithm: 'grid', nodeWidth: 200, nodeHeight: 100, horizontalSpacing: 150, verticalSpacing: 80, addCommentBlocks: true }));
+    const comments = out.nodes.filter((n: PCGNode) => n.class === 'PCGCommentSettings');
+    expect(comments).toHaveLength(1);
+    expect(comments[0].properties.Width).toBeGreaterThan(0);
+    expect(comments[0].properties.Height).toBeGreaterThan(0);
+  });
+
+  it('rejects malformed JSON with a clear error, not a raw parser exception', async () => {
+    await expect(
+      formatGraphTopology({ graph: '{not json', algorithm: 'layered', nodeWidth: 200, nodeHeight: 100, horizontalSpacing: 150, verticalSpacing: 80, addCommentBlocks: false }),
+    ).rejects.toThrow('Invalid JSON graph payload');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/zod-unwrap.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/zod-unwrap.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { unwrapZod, formatDefault } from './zod-unwrap.js';
+
+// This module is the single source of truth two describers used to duplicate
+// (#322): schema-registry's tool-catalogue prose and agent-loop's JSON Schema
+// for the chat sidecar. The divergence bug was that `.default()` was treated
+// as optional in one place and required in the other. These tests pin the
+// unified contract so a future edit cannot reintroduce that split.
+
+describe('unwrapZod', () => {
+  it('a bare required schema is not optional and has no default', () => {
+    const r = unwrapZod(z.string());
+    expect(r.optional).toBe(false);
+    expect(r.hasDefault).toBe(false);
+    expect(r.defaultValue).toBeUndefined();
+    expect(r.inner).toBeInstanceOf(z.ZodString);
+  });
+
+  it('.optional() marks optional with no default', () => {
+    const r = unwrapZod(z.string().optional());
+    expect(r.optional).toBe(true);
+    expect(r.hasDefault).toBe(false);
+  });
+
+  it('.nullable() marks optional (an agent may omit it) with no default', () => {
+    const r = unwrapZod(z.string().nullable());
+    expect(r.optional).toBe(true);
+    expect(r.hasDefault).toBe(false);
+  });
+
+  it('.default() counts as optional AND carries the default value — the #322 rule', () => {
+    const r = unwrapZod(z.number().default(42));
+    expect(r.optional).toBe(true);
+    expect(r.hasDefault).toBe(true);
+    expect(r.defaultValue).toBe(42);
+  });
+
+  it('unwraps down to the innermost schema through every wrapper combination', () => {
+    const r = unwrapZod(z.boolean().default(true).optional());
+    expect(r.inner).toBeInstanceOf(z.ZodBoolean);
+  });
+
+  it('keeps the OUTERMOST default when defaults are nested', () => {
+    // z.string().default('inner') wrapped again with .default('outer') — the
+    // outer one is what actually applies when the param is omitted.
+    const inner = z.string().default('inner');
+    const outer = inner.default('outer' as never);
+    const r = unwrapZod(outer as unknown as z.ZodTypeAny);
+    expect(r.defaultValue).toBe('outer');
+  });
+
+  it('sees through a preprocess pipe to the schema being validated (the `out` side)', () => {
+    const r = unwrapZod(z.preprocess((v) => Number(v), z.number()));
+    expect(r.inner).toBeInstanceOf(z.ZodNumber);
+  });
+
+  it('sees through a .transform() pipe to the input schema (the `in` side)', () => {
+    const r = unwrapZod(z.string().transform((s) => s.length));
+    expect(r.inner).toBeInstanceOf(z.ZodString);
+  });
+});
+
+describe('formatDefault', () => {
+  it('renders a short JSON value', () => {
+    expect(formatDefault(42)).toBe('42');
+    expect(formatDefault('low')).toBe('"low"');
+    expect(formatDefault(true)).toBe('true');
+  });
+
+  it('returns null when the rendered form exceeds 40 characters — token budget guard', () => {
+    const long = 'x'.repeat(41);
+    expect(formatDefault(long)).toBeNull();
+    // 40 chars exactly (38 chars + 2 quotes) must still render.
+    const exactly40 = 'x'.repeat(38);
+    expect(formatDefault(exactly40)).toHaveLength(40);
+  });
+
+  it('returns null rather than throwing on a circular value', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(formatDefault(circular)).toBeNull();
+  });
+
+  it('renders undefined as null (JSON.stringify(undefined) is undefined)', () => {
+    expect(formatDefault(undefined)).toBe('null');
+  });
+});


### PR DESCRIPTION
## Summary

TEST-COVERAGE half of #357 (docs half is being handled separately — this PR does not touch `docs/` or `README`).

Targets chosen by risk, not ease, per the priority order in the issue:

1. **conventions.ts — real bug found and fixed.** `iniToConventions` defaulted `workflow.autoOpenInGaeaAfterBake` to `true` when the key was absent from `DefaultHayba.ini` (`!== 'false'`) — the opposite of every preset's default (`false`). A hand-authored or pre-existing ini missing that one line silently turns on "auto-open in Gaea after every bake" with no error. Fixed to `=== 'true'`; `confirmBeforeOverwrite` correctly keeps the opposite default-true pattern since its preset default really is `true`. Covered with round-trip tests across all three presets, explicit-value tests, and the missing-key case for both booleans, plus a `getPreset` independent-copy check.

2. **zod-unwrap.ts — the single source of truth for a bug class that already bit this repo once (#322).** Two describers (`schema-registry`'s tool catalogue prose, `agent-loop`'s JSON Schema for the chat sidecar) used to each carry their own unwrap loop and disagreed about whether `.default()` counts as optional. This module unifies that logic but had no test at all. Pinned: default-implies-optional, outermost-default-wins on nested defaults, the zod4 `ZodPipe` unwrap for both `preprocess` and `.transform()`, and `formatDefault`'s 40-char token-budget truncation (plus its circular-value guard).

3. **format-graph-topology.ts — pure PCG graph-layout math, carrying prior `BUG-F*` fix comments with no test ever pinning them.** Covered: layered topo-sort layer assignment, deterministic sibling ordering (`BUG-F7`'s id-sort), cycle fallback (no hang/drop), legacy `from`/`to` edge-key normalization, grid layout column count, the `>=2`-node threshold for comment-block grouping, and the malformed-JSON error path.

Every added test was mutation-tested: break the code, confirm red, revert, confirm green. Mutations exercised — outermost-default-wins short-circuit removed, pipe transform-side selection flipped, `formatDefault` boundary off-by-one, `structuredClone` removed from `getPreset`, a preset section dropped from `flattenConventions`, PCG sibling sort removed, grid column formula changed, comment-block `>=2` threshold lowered to `>=1`, and the malformed-JSON throw swapped for a silent empty-graph fallback — every one went red as expected before being reverted.

`1530 -> 1562` tests passing (32 new).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 154 files / 1562 tests passing (baseline was 1530)
- [x] `node scripts/check-legacy-wrappers.mjs` — OK, no violations
- [x] `src/tools/routing/search-quality.test.ts` — green
- [x] Every new test mutation-tested (broken -> red -> reverted -> green)

Refs #357 (standing issue, not closed — docs half still open).