### PR TITLE
docs: consistency sweep — satellite plugins, typed seam, stale paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Hayba MCP Toolkit are documented here. Format based on [K
 
 ## [Unreleased]
 
+### Added
+- `editor_save_all_and_quit` — saves every dirty package, refuses to quit while
+  anything is still unsaved (a dirty asset otherwise parks the editor on a
+  modal save prompt with the MCP port already closed), then issues
+  `QUIT_EDITOR`.
+- Parameter-name aliasing (`src/tools/param-aliases.ts`, `resolveAliases`) — a
+  single normalisation step, routed through by every dispatch path (`ueTool`,
+  the python-tool factory, `hayba_invoke`, the two hand-registered
+  meta-tools), that folds a historical/expected param spelling (e.g.
+  `widget_blueprint_path`) onto its canonical name before the tool's own Zod
+  schema sees it. Conflicting values under two spellings fail loudly instead
+  of silently picking one.
+- `hayba-cli` — a headless runner (`mcp-tools/hayba-mcp/src/cli`) for CI. Reads
+  a JSON/YAML spec of wire commands, sends them over the same TCP seam every
+  MCP tool uses, and exits with a code a pipeline can branch on (0 ok, 1 bad
+  spec, 2 UE unreachable, 3 a step failed, 4 unexpected CLI error — see
+  `src/cli/exit-codes.ts`). Does not launch UE; assumes an editor is already
+  running and holding the port. An example (untested, not wired into this
+  repo's own CI) workflow lives at
+  `mcp-tools/hayba-mcp/examples/github-actions-hayba-cli.yml`.
+
+### Changed
+- **Satellite plugins settled** ([ADR-0008](docs/adr/0008-satellite-plugins-earn-their-place.md)).
+  `HaybaMCPGAS` and `HaybaMCPMetaSound` are installed and surfaced.
+  `HaybaMCPNiagara` and `HaybaMCPSequencer` are deleted — every command they
+  added duplicated a TS/python tool (`niagara_*`, `seq_*`) already shipping
+  under a different name, chosen deliberately not to collide with the dormant
+  C++ ones.
+- The C++ response limiter caps every string field in every reply at 512
+  characters — right for a property dump, fatal for a base64 image (the clip
+  produces a non-empty string that fails base64 validation, and the MCP SDK
+  drops the whole content block). `image_base64` is now in
+  `FHaybaMCPResponseBuilder::NeverTrimFields`, exempting it by field name (not
+  by command), so any command that returns an image is covered, including
+  ones not written yet. This was the root cause under #334.
+
 ### Fixed
 - CI on `main` had been red for 26 days, from three causes that were not the code under test: `room-grammar.test.ts` read a developer-machine absolute path (`D:/UnrealEngine/...`); `registerDeferredRouting` **created** its embedding backend instead of accepting one, so the default probe's Hugging Face model download blew a 5s test timeout on any cold cache; and `no-stub-wrappers` correctly flagged three Blueprint commands that had been implemented but left on the stub denylist. `probeOllama` also had no timeout at all.
 - **One visual sidecar.** Two FastAPI apps, both titled `hayba-visual-sidecar`, both defaulting to `:7821`, serving disjoint endpoints, with a single Node adapter calling across both — so whichever process ran, half the adapter was broken. Merged ([ADR-0006](docs/adr/0006-one-visual-sidecar.md)). The app also could not be *imported* without multi-GB weights, which took `/health` down with it; model imports are now lazy and `/health` reports real capability rather than a hardcoded `"clip": true`.
@@ -58,7 +94,12 @@ First tagged release. The repo has shipped continuously for four months without 
 
 ## Earlier history
 
-Pre-roadmap commits are summarized in the [open feat/mcp-stabilization PR](https://github.com/zajalist/hayba/pull/2). Major themes:
+**This section describes the state of the repo at the time it was written,
+not today.** It predates the satellite-plugin decision, the typed-domain-seam
+work, and most of what is listed under [Unreleased](#unreleased) above — do
+not read "34-domain" or "16 stubs" below as current counts; see
+`docs/ARCHITECTURE.md` / `CONTEXT.md` for what is true now. Pre-roadmap
+commits are summarized in the [open feat/mcp-stabilization PR](https://github.com/zajalist/hayba/pull/2). Major themes, as they stood then:
 
 - 34-domain UE plugin (Actor / Level / Scene / Asset / Blueprint / Material / Foliage / Spline / WP / ISM / Physics / Python / Editor / Docs + 16 stubs).
 - Code Mode meta-tool architecture.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,7 +27,7 @@ Agent host ──stdio──▶ Node MCP server ──TCP──▶ UE5 C++ plugi
   `mcp-tools/hayba-mcp/src/tcp-client.ts` and the UE plugin's
   `FHaybaMCPTcpServer`. They must agree on the envelope — this is the
   single most important invariant in the repo.
-- **UE plugin** — the C++ editor **adapter**: 34 command-handler domains,
+- **UE plugin** — the C++ editor **adapter**: 33 command-handler domains,
   Slate panels.
 
 ## Glossary
@@ -68,6 +68,18 @@ Agent host ──stdio──▶ Node MCP server ──TCP──▶ UE5 C++ plugi
 - **Re-emulation doctrine** — when a pre-restructure branch's behaviour
   must land on the restructured layout, reproduce its *effect* as fresh
   commits; never git-merge the old layout back in (see ADR-0001).
+- **Satellite plugin** — an optional UE module living outside
+  `unreal/HaybaMCPToolkit/`, installed into a host project only when it adds
+  capability the always-available TypeScript/python tool surface cannot
+  reach. `HaybaMCPGAS` and `HaybaMCPMetaSound` are installed; `HaybaMCPNiagara`
+  and `HaybaMCPSequencer` were deleted because their commands duplicated a
+  shipping TS tool under an older name (ADR-0008).
+- **Typed domain seam** (`HaybaActorOps` / `HaybaUIOps` / `HaybaEditorOps` /
+  `HaybaBlueprintOps`) — a per-domain split of a C++ handler into a pure
+  Parse/Shape half (unit-testable without an editor) and an Execute half
+  (still needs one). 5 of 33 handler domains have one today: Actor, UI, PIE,
+  Editor, Blueprint. See `docs/handoffs/HANDOFF-architecture-cleanup.md` for
+  the running count and the pattern to copy for the next domain.
 
 ## Repo shape
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,31 +6,39 @@ Thanks for considering a contribution. This document covers the dev loop, conven
 
 You need:
 - **Unreal Engine 5.7** (Editor with C++ toolchain, Visual Studio 2022 17.10+).
-- **Node 20+** and **npm 10+**.
-- **Python 3.11+** if you're touching the visual-embeddings sidecar.
+- **Node ≥ 22.5** (see [`.nvmrc`](.nvmrc) — the codebase uses `node:sqlite`).
+- **Python 3.10+** and [`uv`](https://docs.astral.sh/uv/) if you're touching
+  the visual sidecar.
 
 ```bash
 git clone https://github.com/zajalist/hayba.git
 cd hayba
-npm install        # installs all workspaces
-npm run build      # builds the Node MCP server (TS → dist)
+npm install                               # installs all workspaces
+npm --prefix mcp-tools/hayba-mcp test     # tsc --noEmit + vitest (the gate)
+npm --prefix mcp-tools/hayba-mcp run build:server   # TS -> dist (not `run build`, see below)
 ```
 
-The UE plugin lives under `packages/hayba/Plugins/HaybaMCPToolkit/`. Drop it into your UE project's `Plugins/` folder (or symlink), regenerate VS files, recompile.
+The UE plugin lives under `unreal/HaybaMCPToolkit/`. Copy or symlink it into
+your UE project's `Plugins/` folder, regenerate VS files, recompile.
 
 ## Repo layout
 
 ```
-packages/hayba/
-  src/                              # Node MCP server (TS)
-  Plugins/HaybaMCPToolkit/
-    Source/HaybaMCPToolkit/         # UE C++ plugin
-      Private/                      # implementation
-      Public/                       # exported headers
-    Resources/                      # icons, SVGs, HTML for cognitive map
-    ThirdParty/mcp_server/dist/     # bundled Node server
-  addons/visual-embeddings/         # Python sidecar (FastAPI + CLIP / SpatialCLIP / OWL-ViT)
+mcp-tools/
+  hayba-mcp/                        # Node MCP server (TS) — the core product
+    src/                            # tool surface, schemas, TCP client
+    addons/visual-embeddings/       # Python sidecar (FastAPI + CLIP / SpatialCLIP / OWL-ViT + SAM)
+    addons/workflows/                # Claude Code skill bundles (Tier 3)
+  pcgex/                            # PCGEx node-registry tooling
+unreal/
+  HaybaMCPToolkit/                  # UE C++ plugin (always loaded)
+    Source/HaybaMCPToolkit/
+      Private/                     # implementation, handlers/
+      Public/                      # exported headers
+    Resources/                     # icons, SVGs, HTML for cognitive map
+  HaybaMCPGAS/, HaybaMCPMetaSound/  # optional satellite plugins (ADR-0008)
 website/                            # landing page
+supabase/, infra/                   # self-host backend
 ```
 
 ## Branching
@@ -71,7 +79,10 @@ These run in CI on every push/PR. Make sure `npm run lint` passes with zero warn
 
 ## Pre-commit
 
-The `.githooks/pre-commit` hook runs `tsc` and restages `packages/hayba/dist/` whenever `packages/hayba/src/` is part of the commit. Activated by `npm install` via the `prepare` script — if your hooks aren't firing, run:
+The `.githooks/pre-commit` hook runs `tsc --noEmit` (nothing else — it does
+not restage `dist/`) whenever `mcp-tools/hayba-mcp/src/`, `tsconfig.json`, or
+`package.json` is part of the commit. Activated by `npm install` via the
+`prepare` script — if your hooks aren't firing, run:
 
 ```bash
 git config core.hooksPath .githooks
@@ -80,21 +91,23 @@ git config core.hooksPath .githooks
 ## Pull request checklist
 
 Before requesting review:
-- [ ] `npm run build` is clean.
+- [ ] `cd mcp-tools/hayba-mcp && npx tsc --noEmit && npm test` is clean — the
+      authoritative gate. CI on this repo is unreliable; don't rely on it
+      instead of running the gate locally.
 - [ ] `npm run lint` passes with zero warnings.
 - [ ] If you added a TS file, it's registered with the Zod schema registry so `get_tool_signature` returns derived params.
 - [ ] If you added a C++ command, it's listed in the handler's `GetCommands()` AND dispatched in `Handle()`.
 - [ ] If you added a destructive command, it's classified in `IsDestructiveCommand()` in `HaybaMCPCommandHandler.cpp` so transactions wrap it.
-- [ ] Tests added or updated for any new/modified TS modules.
+- [ ] Tests added or updated for any new/modified TS modules, and mutation-tested (break the code, watch the test go red, revert) — see `docs/WORKFLOW-improving-the-mcp.md`.
 - [ ] Docs updated if behaviour changes.
 - [ ] CHANGELOG.md has an entry under `[Unreleased]`.
 
 ## Adding a new MCP tool
 
-1. **Node side** — register the tool in `packages/hayba/src/tools/index.ts` with a Zod shape. The schema registry will derive its docs automatically.
+1. **Node side** — register the tool in `mcp-tools/hayba-mcp/src/tools/index.ts` with a Zod shape. The schema registry will derive its docs automatically.
 2. **UE side** — add the command name to a handler's `GetCommands()` array, route in `Handle()`, implement the method.
 3. **Changelog** — add an entry under `[Unreleased]` in `CHANGELOG.md`.
-4. **Test** — fire the tool through Claude or via the MCP CLI; verify it appears in the Tool Stream panel and (if destructive) is undoable.
+4. **Test** — fire the tool through Claude, or against a running editor via `hayba-cli` (`mcp-tools/hayba-mcp/src/cli`); verify it appears in the Tool Stream panel and (if destructive) is undoable.
 
 ## Adding a new domain handler
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repo is the UE5 MCP toolkit: the Node MCP server, the UE5 C++ editor plugin
 
 ## Features
 
-- **100+ tools across 30+ domains** — Actor / Level / Scene / Asset / Blueprint / Material / Foliage / Spline / World Partition / ISM / Physics / Python / Editor / Docs / PCG / Sequencer / Animation / Niagara / Audio / MetaSound / GAS / Behavior Tree / Input / UI / Net / Mesh / Texture / Data / Project / Build / Test / Memory / Plan / Conventions
+- **100+ tools across 30+ domains** — Actor / Level / Scene / Asset / Blueprint / Material / Foliage / Spline / World Partition / ISM / Physics / Python / Editor / Docs / PCG / Sequencer / Animation / Audio / Behavior Tree / Input / UI / Net / Mesh / Texture / Data / Project / Build / Test / Memory / Plan / Conventions, plus GAS and MetaSound as optional [satellite plugins](docs/adr/0008-satellite-plugins-earn-their-place.md)
 - **PCG SQLite registry** — 344 PCGEx nodes / 356 pins / 2270 properties scraped from C++ headers, queryable with semantic + structural intent
 - **Cognitive Map** — 2D top-down semantic clustering of every actor in the level, force-directed mindmap renderer
 - **Visual sidecar** — FastAPI + CLIP / SpatialCLIP / OWL-ViT for deep physics validation and spatial grounding, plus SAM segmentation for AI mask generation
@@ -34,7 +34,7 @@ This repo is the UE5 MCP toolkit: the Node MCP server, the UE5 C++ editor plugin
 | Path | What it is |
 |---|---|
 | [`mcp-tools/hayba-mcp`](mcp-tools/hayba-mcp) | **Core product** — the Node/TypeScript MCP server (tool surface, schema registry, TCP client to UE) |
-| [`mcp-tools/visual-sidecar`](mcp-tools/visual-sidecar) | Python FastAPI visual sidecar (CLIP / SpatialCLIP / OWL-ViT + SAM segmentation) |
+| [`mcp-tools/hayba-mcp/addons/visual-embeddings`](mcp-tools/hayba-mcp/addons/visual-embeddings) | Python FastAPI visual sidecar (CLIP / SpatialCLIP / OWL-ViT + SAM segmentation) |
 | `mcp-tools/pcgex` | PCGEx node-registry tooling (see its README) |
 | [`unreal/HaybaMCPToolkit`](unreal/HaybaMCPToolkit) | The UE5 C++ editor plugin — command-handler domains, Slate panels, the TCP server half of the protocol |
 | [`website/`](website) | Public website (static HTML/CSS/JS) — landing, waitlist, login, admin |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,6 +55,39 @@ the Node client discovers the live instance. Ports auto-allocate in
 | Website | static HTML/CSS/JS | `website/` |
 | Backend / self-host | SQL + Docker | `supabase/`, `infra/` |
 
+## Satellite plugins
+
+`unreal/HaybaMCPToolkit` is the always-present plugin — 33 handler domains,
+loaded whenever the toolkit is. Two more UE modules sit outside it and are
+installed only when they add capability the TypeScript/python tool layer
+cannot reach on its own:
+
+- `unreal/HaybaMCPGAS` — Gameplay Ability System commands.
+- `unreal/HaybaMCPMetaSound` — MetaSound graph commands (`metasound_list` /
+  `metasound_create` work; four graph-editing commands are documented but
+  `agent_callable: false`, pending MetaSound Frontend Document Builder API
+  stability).
+
+`HaybaMCPNiagara` and `HaybaMCPSequencer` **were deleted** — every command
+they added duplicated a TS/python tool already shipping under a different
+name (`niagara_*`, `seq_*`), which is the always-available surface these
+satellites exist to be an *exception* to, not a second copy of. See
+[ADR-0008](adr/0008-satellite-plugins-earn-their-place.md) for the
+command-by-command audit that motivated the deletion.
+
+## Typed domain seam
+
+A handler can split into a pure Parse/Shape half (unit-testable without an
+editor) and an Execute half (still needs one) — `HaybaActorOps`,
+`HaybaUIOps`, `HaybaEditorOps`, `HaybaBlueprintOps` in
+`unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/`, plus the PIE domain's
+`HaybaPieCoords::ToAbsolute` (in `HaybaMCPParams.h`). 5 of 33 handler domains
+have this seam today: Actor, UI, PIE, Editor, Blueprint. This is `#320`'s
+whole point — most of a handler's bugs live in parameter parsing, which
+previously required a live editor to exercise at all. See
+`docs/handoffs/HANDOFF-architecture-cleanup.md` for the pattern and the
+current count; it is worked one domain at a time, not all at once.
+
 ## Build & verify
 
 The authoritative gate is local — run it before pushing:
@@ -66,6 +99,8 @@ npm --prefix mcp-tools/hayba-mcp test    # tsc --noEmit + vitest
 
 ## Surfaced deepening opportunities
 
-Friction points flagged for future grilling (see README roadmap): the
-large tool-registration surface, the manual schema-registry bottleneck,
-and the un-versioned TCP envelope.
+Friction points flagged for future grilling — no README roadmap section
+exists to link to, this is the list itself: the large tool-registration
+surface (`docs/handoffs/HANDOFF-architecture-cleanup.md` §3 tracks it as
+#319), the manual schema-registry bottleneck, and the un-versioned TCP
+envelope.

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,12 +1,11 @@
 # Architecture
 
-The authoritative architectural orientation is
-[`../../CONTEXT.md`](../../CONTEXT.md) ("The protocol seam" section) and the
-recorded decisions in [`../adr/`](../adr/). The root
-[`../../README.md`](../../README.md) and the UE plugin README reference a
-long-form `docs/ARCHITECTURE.md`; that file is a **planned expansion** of the
-CONTEXT.md seam section and does not exist yet — use CONTEXT.md until it
-lands.
+The authoritative long-form doc is [`../ARCHITECTURE.md`](../ARCHITECTURE.md)
+(language boundaries, the TCP seam, satellite plugins, the typed domain
+seam). [`../../CONTEXT.md`](../../CONTEXT.md) ("The protocol seam" section)
+is the shorter domain-language version, and decisions are recorded in
+[`../adr/`](../adr/). This page is a summary/pointer, not a third copy —
+read the two files above for anything not covered here.
 
 ## The protocol seam (summary)
 
@@ -22,15 +21,19 @@ Agent host ──stdio──▶ Node MCP server ──TCP──▶ UE5 C++ plugi
   `src/index.ts` (stdio transport + local dashboard + visual-sidecar probe).
 - **TCP seam** — a **length-prefixed JSON envelope** `{ cmd, id, params,
   auth? }` on `:52342` (auto-fallback `:52343–52350`). A 4-byte
-  little-endian length header precedes the UTF-8 JSON body. Responses are
+  **big-endian** length header precedes the UTF-8 JSON body
+  (`buffer.readUInt32BE` in `src/tcp-frame-decoder.ts`). Responses are
   `{ id, ok, data?, error? }`, correlated by `id`.
 - **Two adapters on the seam** that must agree on the envelope:
   `mcp-tools/hayba-mcp/src/tcp-client.ts` (Node, `UETcpClient`) and the UE
   plugin's `FHaybaMCPTcpServer`. This agreement is the single most important
   invariant in the repo.
-- **UE plugin** (`unreal/HaybaMCPToolkit`) — the C++ editor adapter: 34
-  command-handler domains + Slate panels. The plugin publishes its actual
-  port to `Saved/HaybaMCP/instances/<pid>.json` for multi-editor setups.
+- **UE plugin** (`unreal/HaybaMCPToolkit`) — the C++ editor adapter: 33
+  command-handler domains + Slate panels, plus two optional satellite
+  plugins (`HaybaMCPGAS`, `HaybaMCPMetaSound` — see
+  [ADR-0008](../adr/0008-satellite-plugins-earn-their-place.md)). The plugin
+  publishes its actual port to `Saved/HaybaMCP/instances/<pid>.json` for
+  multi-editor setups.
 
 ## Key properties
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -10,7 +10,7 @@ Read [`../../CONTEXT.md`](../../CONTEXT.md) first for the domain language.
 |---|---|
 | [Getting-Started](Getting-Started.md) | Prerequisites + pointer to `docs/getting-started.md` |
 | [Architecture](Architecture.md) | The protocol seam, pointer to the architecture docs |
-| [MCP-Tool-Reference](MCP-Tool-Reference.md) | How the tool surface is derived; the 34 handler domains |
+| [MCP-Tool-Reference](MCP-Tool-Reference.md) | How the tool surface is derived; the 33 handler domains + 2 satellite plugins |
 | [UE-Plugin](UE-Plugin.md) | The UE5 C++ plugin + handler-domain table |
 | [Troubleshooting](Troubleshooting.md) | Ports, Node version, the local gate |
 | [Glossary](Glossary.md) | One-line definitions of the core terms |
@@ -29,7 +29,7 @@ Read [`../../CONTEXT.md`](../../CONTEXT.md) first for the domain language.
 
 - [`mcp-tools/hayba-mcp`](../../mcp-tools/hayba-mcp/README.md) — the core MCP
   server
-- [`mcp-tools/visual-sidecar`](../../mcp-tools/visual-sidecar/README.md) — the
+- [`mcp-tools/hayba-mcp/addons/visual-embeddings`](../../mcp-tools/hayba-mcp/addons/visual-embeddings/README.md) — the
   Python visual sidecar (CLIP / SpatialCLIP / SAM)
 - [`mcp-tools/pcgex`](../../mcp-tools/pcgex/README.md) — PCGEx debug tooling
   (parked)

--- a/docs/wiki/MCP-Tool-Reference.md
+++ b/docs/wiki/MCP-Tool-Reference.md
@@ -38,17 +38,23 @@ There is one `*Handler.cpp` per domain in
 concrete handler files**:
 
 `Actor` · `Animation` · `Asset` · `Audio` · `BehaviorTree` · `Blueprint` ·
-`Build` · `DataAsset` · `Docs` · `Editor` · `Foliage` · `GAS` · `ISM` ·
-`Input` · `Legacy` · `Level` · `Material` · `MetaSound` · `Network` ·
-`Niagara` · `PIE` · `Perf` · `Physics` · `Project` · `Python` ·
-`SceneGraph` · `Sequencer` · `Spline` · `StaticMesh` · `Test` · `Texture` ·
-`UI` · `WorldPartition`
+`Build` · `DataAsset` · `Docs` · `Editor` · `Foliage` · `ISM` · `Idle` ·
+`Input` · `Legacy` · `Level` · `Material` · `Network` · `PIE` · `Perf` ·
+`Physics` · `Project` · `Python` · `Render` · `SceneGraph` · `Spline` ·
+`StaticMesh` · `Test` · `Texture` · `UI` · `UILayout` · `Vault` ·
+`WorldPartition`
 
-The repo refers to **"34 command-handler domains"** (CONTEXT.md, root
-README, the UE plugin README) — the count is the framing used across the
-docs; the 33 files above are the concrete `IHaybaMCPHandler`
-implementations dispatched by `HaybaMCPModule`. Each implements
-`GetCommands()` / `Handle()`.
+Each implements `GetCommands()` / `Handle()`, dispatched by `HaybaMCPModule`.
+
+### Satellite plugins (not in the list above)
+
+`GAS` and `MetaSound` handlers live in their own UE modules —
+`unreal/HaybaMCPGAS` and `unreal/HaybaMCPMetaSound` — installed into a host
+project only when wanted, not part of the always-loaded `HaybaMCPToolkit`
+count above. `Niagara` and `Sequencer` handler modules **used to exist** the
+same way and were deleted: their commands duplicated `niagara_*` / `seq_*`
+tools the TS/python layer already shipped under different names. See
+[ADR-0008](../adr/0008-satellite-plugins-earn-their-place.md).
 
 > The Node-side `list_tool_categories` groups commands into agent-facing
 > categories (e.g. `actor`, `pcg`, `seq`) that map onto these handlers plus

--- a/docs/wiki/UE-Plugin.md
+++ b/docs/wiki/UE-Plugin.md
@@ -28,17 +28,32 @@ One `*Handler.cpp` per domain in
 |---|---|---|---|
 | Actor | Animation | Asset | Audio |
 | BehaviorTree | Blueprint | Build | DataAsset |
-| Docs | Editor | Foliage | GAS |
-| ISM | Input | Legacy | Level |
-| Material | MetaSound | Network | Niagara |
-| PIE | Perf | Physics | Project |
-| Python | SceneGraph | Sequencer | Spline |
-| StaticMesh | Test | Texture | UI |
+| Docs | Editor | Foliage | ISM |
+| Idle | Input | Legacy | Level |
+| Material | Network | PIE | Perf |
+| Physics | Project | Python | Render |
+| SceneGraph | Spline | StaticMesh | Test |
+| Texture | UI | UILayout | Vault |
 | WorldPartition | | | |
 
-33 concrete handler files; the repo's docs consistently frame this as
-**"34 command-handler domains"** (see [MCP-Tool-Reference](MCP-Tool-Reference.md)
-for the note on this count).
+33 concrete handler files, all inside the always-loaded `HaybaMCPToolkit`
+plugin.
+
+## Satellite plugins
+
+Two more UE modules ship optional handlers outside `HaybaMCPToolkit`,
+installed into a host project separately:
+
+- `unreal/HaybaMCPGAS` — Gameplay Ability System commands.
+- `unreal/HaybaMCPMetaSound` — MetaSound graph commands (two of six work
+  today; the rest are documented but not agent-callable, pending an
+  upstream API).
+
+`HaybaMCPNiagara` and `HaybaMCPSequencer` were deleted — their commands
+duplicated `niagara_*` / `seq_*` tools already shipped by the TS/python
+layer under different names. See
+[ADR-0008](../adr/0008-satellite-plugins-earn-their-place.md) for the
+command-by-command audit.
 
 ## Source layout
 


### PR DESCRIPTION
Docs half of #357 (test half is a separate, parallel effort — this PR does not close #357).

## Summary

Brought `docs/`, `README.md`, `CHANGELOG.md`, and `CONTRIBUTING.md` in line with what the code actually does today. Every claim below was checked against source before being written down — see `docs/WORKFLOW-improving-the-mcp.md`'s core rule, which this PR treats as applying to docs as much as code.

## Corrected (with what proved it wrong)

- **CONTEXT.md** self-contradicted its own handler-domain count — "34 command-handler domains" on one line, "33 UE-side command groups" in the glossary two lines later. `ls unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/*.h` returns 33 files. Fixed to 33 throughout.
- **docs/wiki/Architecture.md** claimed `docs/ARCHITECTURE.md` "does not exist yet" and told readers to use CONTEXT.md instead — the file exists and is current. Also had the TCP length-header endianness backwards ("little-endian"); `tcp-frame-decoder.ts:29` uses `buffer.readUInt32BE` — big-endian.
- **docs/wiki/MCP-Tool-Reference.md** and **docs/wiki/UE-Plugin.md** listed `Niagara` and `Sequencer` as handler domains inside `unreal/HaybaMCPToolkit/.../handlers/`, and `GAS`/`MetaSound` alongside them. Per ADR-0008 (2026-08-08), Niagara and Sequencer handlers were **deleted** (duplicated shipping TS tools under old names), and GAS/MetaSound live in separate satellite plugins (`unreal/HaybaMCPGAS`, `unreal/HaybaMCPMetaSound`), not in that directory. Both pages were also missing three real domains that are in the directory listing: `Idle`, `UILayout`, `Vault`.
- **README.md** and **docs/wiki/Home.md** linked `mcp-tools/visual-sidecar` — that path doesn't exist (`ls mcp-tools/` shows only `hayba-mcp` and `pcgex`). The sidecar lives at `mcp-tools/hayba-mcp/addons/visual-embeddings`, confirmed against `docs/getting-started.md` and its own README there.
- **README.md**'s feature list still named `Niagara` as a plugin domain after ADR-0008 deleted its handler.
- **docs/ARCHITECTURE.md** pointed at "README roadmap" for further reading — no such section exists in README.md.
- **CONTRIBUTING.md** described the pre-restructure `packages/hayba/` layout (ADR-0001 moved this to `mcp-tools/hayba-mcp` + `unreal/HaybaMCPToolkit`), said Node 20+ (actual `engines` field requires `>=22.5.0`), and claimed the pre-commit hook "restages `packages/hayba/dist/`" — read `.githooks/pre-commit`: it only runs `tsc --noEmit`, doesn't touch `dist/`, and gates on `mcp-tools/hayba-mcp/src/`. Rewrote dev-setup, repo-layout, pre-commit, PR-checklist, and "adding a tool" sections against current paths.
- **CHANGELOG.md**'s pre-roadmap "Earlier history" section is accurate as history but read as current state (e.g. "34-domain UE plugin"). Added an explicit disclaimer that it predates the satellite-plugin decision and the seam work.

## Added (previously undocumented anywhere)

- ADR-0008 (satellite plugins) surfaced in `docs/ARCHITECTURE.md`, `CONTEXT.md`, `CHANGELOG.md`, and the three wiki pages that list handler domains.
- The typed-domain-seam pattern (`HaybaActorOps` / `HaybaUIOps` / `HaybaEditorOps` / `HaybaBlueprintOps`, plus PIE's `HaybaPieCoords::ToAbsolute`) — 5 of 33 domains have one today, per `docs/handoffs/HANDOFF-architecture-cleanup.md`, which is now cited as the running source of truth for the count.
- CHANGELOG `[Unreleased]` entries for `editor_save_all_and_quit`, the param-alias mechanism (`resolveAliases`, routed through by every dispatch path), the response-limiter's `image_base64` field exemption (`NeverTrimFields`, fixing #334), and the `hayba-cli` headless runner (with its exit-code contract).

## Could NOT substantiate / left alone

- `unreal/HaybaMCPToolkit/README.md` has the exact same stale handler-domain list (Niagara/Sequencer/GAS/MetaSound, missing Idle/UILayout/Vault) as the wiki pages did — **not fixed**, `unreal/` is out of scope by instruction. Worth a follow-up.
- `docs/getting-started-swarm-agents.md` and `getting-started-memory-system.md` were already accurate on inspection (the "honest gap" model #351 set) — read, not changed.
- `docs/adr/README.md` was already complete and correct against `docs/adr/*.md` — no changes needed.
- The README/ARCHITECTURE "100+ tools across 30+ domains" figure is unverified against an exact current count; it's used consistently across docs and I didn't have a fast way to get an authoritative live number without the editor, so I left it as-is rather than guess a replacement.

## Verification

- `cd mcp-tools/hayba-mcp && npx tsc --noEmit` — clean.
- `git diff --stat` — no files under `mcp-tools/hayba-mcp/src/` touched; no tests added or modified (test half is a separate effort).
- Every relative link touched was checked with `ls` against the real path.