### PR TITLE
feat(mcp): surface HaybaMemory via memory_* tools

### DIFF
--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -26,7 +26,6 @@
     "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "adm-zip": "^0.5.17",
-    "better-sqlite3": "^11.0.0",
     "cheerio": "^1.2.0",
     "express": "^4.21.0",
     "js-yaml": "^4.1.1",
@@ -38,7 +37,6 @@
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.5",
-    "@types/better-sqlite3": "^7.6.0",
     "@types/express": "^5.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^26.1.1",

--- a/mcp-tools/hayba-mcp/src/config.ts
+++ b/mcp-tools/hayba-mcp/src/config.ts
@@ -73,6 +73,29 @@ export const config = {
    */
   codeMode: process.env.HAYBA_CODE_MODE !== 'off',
 
+  /**
+   * Path to the agent-memory SQLite DB (override with HAYBA_MEMORY_DB).
+   * Defaults to a data/ directory next to dist/ so a plain checkout gets a
+   * writable location without requiring the caller to configure anything.
+   * The memory store creates this file (and its parent directory) lazily on
+   * first write; it is not a shipped resource like catalogPath/pcgexDbPath.
+   */
+  get memoryDbPath() {
+    return process.env.HAYBA_MEMORY_DB || resolve(__dirname, '..', 'data', 'hayba-memory.db');
+  },
+
+  /** Retention bounds applied automatically after every memory_write (override with HAYBA_MEMORY_MAX_COUNT / HAYBA_MEMORY_MAX_AGE_DAYS). */
+  get memoryMaxCount() {
+    const raw = process.env.HAYBA_MEMORY_MAX_COUNT;
+    const n = raw ? parseInt(raw, 10) : 2000;
+    return Number.isFinite(n) && n > 0 ? n : 2000;
+  },
+  get memoryMaxAgeMs() {
+    const raw = process.env.HAYBA_MEMORY_MAX_AGE_DAYS;
+    const days = raw ? parseFloat(raw) : 90;
+    return Number.isFinite(days) && days > 0 ? days * 24 * 60 * 60 * 1000 : 90 * 24 * 60 * 60 * 1000;
+  },
+
   /** Terrain critique threshold — complexity score above which self-critique triggers */
   critiqueThreshold: parseFloat(process.env.HAYBA_CRITIQUE_THRESHOLD || '15.0'),
 

--- a/mcp-tools/hayba-mcp/src/gaea/memory/hayba-memory.ts
+++ b/mcp-tools/hayba-mcp/src/gaea/memory/hayba-memory.ts
@@ -1,5 +1,17 @@
-import Database from 'better-sqlite3';
+// Agent memory store: small SQLite-backed blocks an agent writes and later
+// recalls (established biome plans, cross-agent handoffs, etc.).
+//
+// Uses node's built-in `node:sqlite` (DatabaseSync) rather than the
+// `better-sqlite3` native module this file used to depend on. Three other
+// tools in this package (match-pin-names.ts, query-pcgex-docs.ts,
+// scrape-node-registry.ts) already made that move — `node:sqlite` ships with
+// the runtime, so there is no native-binary build step to fail in a
+// CI-less/offline environment, at the cost of the "experimental" warning
+// Node prints on first use. See src/types/node-sqlite.d.ts for why the
+// typings are resolved defensively.
+import { createRequire } from 'node:module';
 import { randomUUID } from 'node:crypto';
+const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite') as typeof import('node:sqlite');
 
 export interface MemoryBlock {
   id?: string;
@@ -13,11 +25,45 @@ export interface MemoryBlock {
   timestamp?: number;
 }
 
+/** Bounded retention policy. Both bounds are optional; an unset bound is not enforced. */
+export interface RetentionPolicy {
+  /** Delete blocks older than this many milliseconds. */
+  maxAgeMs?: number;
+  /** After age-pruning, if more than this many blocks remain, delete the oldest excess. */
+  maxCount?: number;
+}
+
+export interface RetentionResult {
+  prunedByAge: number;
+  prunedByCount: number;
+  prunedTotal: number;
+  remaining: number;
+}
+
+export interface ImportOptions {
+  /** 'skip' (default) leaves an existing id untouched; 'replace' overwrites it. */
+  onConflict?: 'skip' | 'replace';
+}
+
+export interface ImportResult {
+  inserted: number;
+  skipped: number;
+  conflicted: number;
+  errors: string[];
+}
+
+/** Portable export/import envelope. */
+export interface MemoryExport {
+  version: 1;
+  exportedAt: number;
+  blocks: MemoryBlock[];
+}
+
 export class HaybaMemory {
-  private db: Database.Database;
+  private db: InstanceType<typeof DatabaseSync>;
 
   constructor(path: string) {
-    this.db = new Database(path);
+    this.db = new DatabaseSync(path);
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS memory_blocks (
         id TEXT PRIMARY KEY,
@@ -57,9 +103,15 @@ export class HaybaMemory {
     return id;
   }
 
+  /**
+   * Query blocks, most recent first. `text` (when given) filters to blocks
+   * whose intent or content contains it (case-sensitive SQL LIKE substring
+   * match) — this is the "search" half of recall; omit it for a plain list.
+   */
   query(opts: {
     scope?: 'private' | 'shared';
     agentRole?: string;
+    text?: string;
     limit?: number;
   }): MemoryBlock[] {
     const where: string[] = [];
@@ -72,21 +124,39 @@ export class HaybaMemory {
       where.push('agent_role = ?');
       args.push(opts.agentRole);
     }
+    if (opts.text) {
+      where.push('(intent LIKE ? OR content LIKE ?)');
+      const needle = `%${opts.text}%`;
+      args.push(needle, needle);
+    }
     const sql = `SELECT * FROM memory_blocks ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
                  ORDER BY timestamp DESC LIMIT ?`;
     args.push(opts.limit ?? 50);
-    const rows = this.db.prepare(sql).all(...args) as Array<Record<string, unknown>>;
-    return rows.map(r => ({
-      id: r.id as string,
-      agentRole: r.agent_role as string,
-      scope: r.scope as 'private' | 'shared',
-      intent: r.intent as string,
-      content: r.content as string,
-      accessedResources: JSON.parse((r.accessed_resources as string) ?? '[]'),
-      timestamp: r.timestamp as number,
-      provenance: JSON.parse((r.provenance as string) ?? '{}'),
-      tokenCost: r.token_cost as number,
-    }));
+    const rows = this.db.prepare(sql).all(...(args as [])) as Array<Record<string, unknown>>;
+    return rows.map(rowToBlock);
+  }
+
+  /** Total block count, optionally filtered the same way `query` is. */
+  count(opts: { scope?: 'private' | 'shared'; agentRole?: string } = {}): number {
+    const where: string[] = [];
+    const args: unknown[] = [];
+    if (opts.scope) {
+      where.push('scope = ?');
+      args.push(opts.scope);
+    }
+    if (opts.agentRole) {
+      where.push('agent_role = ?');
+      args.push(opts.agentRole);
+    }
+    const sql = `SELECT COUNT(*) AS n FROM memory_blocks ${where.length ? 'WHERE ' + where.join(' AND ') : ''}`;
+    const row = this.db.prepare(sql).get(...(args as [])) as { n: number };
+    return row.n;
+  }
+
+  /** Delete a single block by id. Returns whether a row was actually removed. */
+  deleteById(id: string): boolean {
+    const r = this.db.prepare('DELETE FROM memory_blocks WHERE id = ?').run(id);
+    return r.changes > 0;
   }
 
   clear(agentRole?: string): void {
@@ -97,7 +167,128 @@ export class HaybaMemory {
     }
   }
 
+  /**
+   * Enforce a bounded retention policy. Age-pruning runs first, then
+   * count-pruning (oldest-first) against whatever remains, so both bounds
+   * compose rather than fight. Always returns counts, including zero — the
+   * caller is expected to report this, not swallow it, so retention is never
+   * a silent side effect.
+   */
+  applyRetention(policy: RetentionPolicy): RetentionResult {
+    let prunedByAge = 0;
+    if (policy.maxAgeMs !== undefined) {
+      const cutoff = Date.now() - policy.maxAgeMs;
+      const r = this.db.prepare('DELETE FROM memory_blocks WHERE timestamp < ?').run(cutoff);
+      prunedByAge = Number(r.changes);
+    }
+
+    let prunedByCount = 0;
+    if (policy.maxCount !== undefined) {
+      const total = this.count();
+      const excess = total - policy.maxCount;
+      if (excess > 0) {
+        // Delete the oldest `excess` rows.
+        const r = this.db
+          .prepare(
+            `DELETE FROM memory_blocks WHERE id IN (
+               SELECT id FROM memory_blocks ORDER BY timestamp ASC LIMIT ?
+             )`,
+          )
+          .run(excess);
+        prunedByCount = Number(r.changes);
+      }
+    }
+
+    return {
+      prunedByAge,
+      prunedByCount,
+      prunedTotal: prunedByAge + prunedByCount,
+      remaining: this.count(),
+    };
+  }
+
+  /** All blocks matching the filter, unbounded (no LIMIT) — used for export. */
+  exportBlocks(opts: { scope?: 'private' | 'shared'; agentRole?: string } = {}): MemoryBlock[] {
+    const where: string[] = [];
+    const args: unknown[] = [];
+    if (opts.scope) {
+      where.push('scope = ?');
+      args.push(opts.scope);
+    }
+    if (opts.agentRole) {
+      where.push('agent_role = ?');
+      args.push(opts.agentRole);
+    }
+    const sql = `SELECT * FROM memory_blocks ${where.length ? 'WHERE ' + where.join(' AND ') : ''} ORDER BY timestamp ASC`;
+    const rows = this.db.prepare(sql).all(...(args as [])) as Array<Record<string, unknown>>;
+    return rows.map(rowToBlock);
+  }
+
+  /**
+   * Insert a batch of previously-exported blocks. Reports what actually
+   * happened rather than a bare "ok": how many were newly inserted, how many
+   * were malformed and skipped, and how many collided with an existing id
+   * (left alone under 'skip', overwritten under 'replace').
+   */
+  importBlocks(blocks: MemoryBlock[], opts: ImportOptions = {}): ImportResult {
+    const onConflict = opts.onConflict ?? 'skip';
+    const result: ImportResult = { inserted: 0, skipped: 0, conflicted: 0, errors: [] };
+
+    for (const [i, b] of blocks.entries()) {
+      if (!b || typeof b !== 'object' || !b.agentRole || !b.scope || !b.intent || b.content === undefined) {
+        result.skipped++;
+        result.errors.push(`block[${i}]: missing required field(s) (agentRole/scope/intent/content)`);
+        continue;
+      }
+      const id = b.id ?? randomUUID();
+      const existing = this.db.prepare('SELECT 1 FROM memory_blocks WHERE id = ?').get(id);
+      if (existing) {
+        result.conflicted++;
+        if (onConflict === 'skip') continue;
+        // 'replace': fall through and overwrite below.
+      }
+      this.db
+        .prepare(
+          `INSERT INTO memory_blocks
+            (id, agent_role, scope, intent, content, accessed_resources, timestamp, provenance, token_cost)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             agent_role=excluded.agent_role, scope=excluded.scope, intent=excluded.intent,
+             content=excluded.content, accessed_resources=excluded.accessed_resources,
+             timestamp=excluded.timestamp, provenance=excluded.provenance, token_cost=excluded.token_cost`,
+        )
+        .run(
+          id,
+          b.agentRole,
+          b.scope,
+          b.intent,
+          b.content,
+          JSON.stringify(b.accessedResources ?? []),
+          b.timestamp ?? Date.now(),
+          JSON.stringify(b.provenance ?? {}),
+          b.tokenCost ?? 0,
+        );
+      if (!existing) result.inserted++;
+    }
+
+    return result;
+  }
+
   close(): void {
     this.db.close();
   }
+}
+
+function rowToBlock(r: Record<string, unknown>): MemoryBlock {
+  return {
+    id: r.id as string,
+    agentRole: r.agent_role as string,
+    scope: r.scope as 'private' | 'shared',
+    intent: r.intent as string,
+    content: r.content as string,
+    accessedResources: JSON.parse((r.accessed_resources as string) ?? '[]'),
+    timestamp: r.timestamp as number,
+    provenance: JSON.parse((r.provenance as string) ?? '{}'),
+    tokenCost: r.token_cost as number,
+  };
 }

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -42,6 +42,15 @@ import { handleFabLibraryList, meta as fabLibraryListMeta } from './fab/library-
 import { handleFabMarketplaceSearch, meta as fabMarketplaceSearchMeta } from './fab/marketplace-search.js';
 import { handleFabDownload, meta as fabDownloadMeta } from './fab/download.js';
 
+// ── Agent memory tool handlers (issue #355) ──────────────────────────────────
+import { memoryWriteHandler, meta as memoryWriteMeta } from './memory/write.js';
+import { memoryRecallHandler, meta as memoryRecallMeta } from './memory/recall.js';
+import { memoryListHandler, meta as memoryListMeta } from './memory/list.js';
+import { memoryDeleteHandler, meta as memoryDeleteMeta } from './memory/delete.js';
+import { memoryExportHandler, meta as memoryExportMeta } from './memory/export-blocks.js';
+import { memoryImportHandler, meta as memoryImportMeta } from './memory/import-blocks.js';
+import { memoryPruneHandler, meta as memoryPruneMeta } from './memory/prune.js';
+
 // ── Material instance-layer tool handlers ───────────────────────────────────
 import { materialCreateHandler, meta as materialCreateMeta } from './material/material-create.js';
 import {
@@ -1645,6 +1654,108 @@ const HANDWRITTEN_STANDARD_DESCRIPTORS: ToolDescriptor[] = [
       location: dCoerceVec3.optional(),
       rotation: dCoerceVec3.optional(),
       scale: dCoerceVec3.optional(),
+    },
+  },
+
+  // ── Agent memory domain (issue #355) ──────────────────────────────────────
+  // Wraps HaybaMemory (src/gaea/memory/hayba-memory.ts), a SQLite-backed store
+  // of small text blocks an agent writes and later recalls. Was fully
+  // implemented, tested only by its own excluded test, and reachable by
+  // nothing — see the issue for why it is being surfaced now.
+  {
+    name: 'memory_write',
+    description: 'Write a memory block: an intent, its content, which agent role wrote it, and whether it is private or shared with other agents. Runs bounded retention (age + count) after every write and reports what (if anything) it pruned.',
+    meta: memoryWriteMeta,
+    handler: memoryWriteHandler,
+    cost: 'low',
+    returns: '{ok, id, retention:{pruned_by_age, pruned_by_count, pruned_total, remaining}}',
+    schema: {
+      agentRole: z.string().min(1).describe('Role of the writing agent, e.g. "director", "asset-manager"'),
+      scope: z.enum(['private', 'shared']).describe('"private" = only this agentRole sees it via recall/list filters; "shared" = any role can'),
+      intent: z.string().min(1).describe('Short label for what this block is about'),
+      content: z.string().min(1).describe('The memory content itself'),
+      accessedResources: z.array(z.string()).optional().describe('Resource paths/ids touched while forming this memory'),
+      tokenCost: z.number().optional().describe('Approximate token cost of the content, for budget tracking'),
+      provenance: z.record(z.string(), z.unknown()).optional().describe('Free-form provenance, e.g. {tool, cursor}'),
+      id: z.string().optional().describe('Explicit id (default: a generated UUID) — mainly for re-inserting/overwriting a known block'),
+      timestamp: z.number().optional().describe('Explicit epoch-ms timestamp (default: now) — mainly for import/migration'),
+    },
+  },
+  {
+    name: 'memory_recall',
+    description: 'Search memory blocks by keyword against their intent and content, most recent match first. Use when you remember roughly what a past block was about but not its id.',
+    meta: memoryRecallMeta,
+    handler: memoryRecallHandler,
+    cost: 'low',
+    returns: '{blocks:[MemoryBlock], count, query}',
+    schema: {
+      text: z.string().min(1).describe('Keyword/phrase to search for in intent + content'),
+      scope: z.enum(['private', 'shared']).optional(),
+      agentRole: z.string().optional().describe('Restrict to blocks written by this role'),
+      limit: z.number().int().positive().optional().describe('Max blocks to return (default 10)'),
+    },
+  },
+  {
+    name: 'memory_list',
+    description: 'List recent memory blocks for a role/scope, most-recent-first, with no keyword filter. Use to browse what has been written, not to search for something specific.',
+    meta: memoryListMeta,
+    handler: memoryListHandler,
+    cost: 'low',
+    returns: '{blocks:[MemoryBlock], count, total_matching, truncated}',
+    schema: {
+      scope: z.enum(['private', 'shared']).optional(),
+      agentRole: z.string().optional(),
+      limit: z.number().int().positive().optional().describe('Max blocks to return (default 50)'),
+    },
+  },
+  {
+    name: 'memory_delete',
+    description: 'Delete memory blocks: a single block by id, every block from one agentRole, or (with confirm_all) the entire store. Exactly one of id / agentRole / confirm_all is required.',
+    meta: memoryDeleteMeta,
+    handler: memoryDeleteHandler,
+    cost: 'low',
+    returns: '{ok, deleted_count, ...}',
+    schema: {
+      id: z.string().optional().describe('Delete exactly this block'),
+      agentRole: z.string().optional().describe('Delete every block written by this role'),
+      confirm_all: z.boolean().optional().describe('Set true to delete the entire store — required, not inferred'),
+    },
+  },
+  {
+    name: 'memory_export',
+    description: 'Dump memory blocks (optionally filtered by scope/agentRole) to a portable JSON file for backup or transfer to another store via memory_import.',
+    meta: memoryExportMeta,
+    handler: memoryExportHandler,
+    cost: 'low',
+    returns: '{ok, path, count}',
+    schema: {
+      path: z.string().min(1).describe('File path to write the export JSON to'),
+      scope: z.enum(['private', 'shared']).optional(),
+      agentRole: z.string().optional(),
+    },
+  },
+  {
+    name: 'memory_import',
+    description: 'Load a memory_export JSON file back into the store. Reports exactly what happened per row: inserted, skipped (malformed), or conflicted (id already existed — left alone under "skip", overwritten under "replace").',
+    meta: memoryImportMeta,
+    handler: memoryImportHandler,
+    cost: 'low',
+    returns: '{ok, total_read, inserted, skipped, conflicted, errors:[string]}',
+    schema: {
+      path: z.string().min(1).describe('File path previously written by memory_export'),
+      on_conflict: z.enum(['skip', 'replace']).optional().describe('How to handle an id that already exists (default "skip")'),
+    },
+  },
+  {
+    name: 'memory_prune',
+    description: 'Force retention to run now with an explicit (or default-configured) age/count bound. memory_write already does this automatically after every insert — use this only to prune on demand with a tighter one-off bound.',
+    meta: memoryPruneMeta,
+    handler: memoryPruneHandler,
+    cost: 'low',
+    returns: '{ok, pruned_by_age, pruned_by_count, pruned_total, remaining}',
+    schema: {
+      max_count: z.number().int().positive().optional().describe('Keep at most this many blocks (default: configured HAYBA_MEMORY_MAX_COUNT)'),
+      max_age_days: z.number().positive().optional().describe('Delete blocks older than this many days (default: configured HAYBA_MEMORY_MAX_AGE_DAYS)'),
     },
   },
 
@@ -3413,6 +3524,7 @@ export function inferDir(name: string): string | null {
   if (name.startsWith('scene_')) return 'scene';
   if (name.startsWith('editor_')) return 'editor';
   if (name.startsWith('material_')) return 'material';
+  if (name.startsWith('memory_')) return 'memory';
   if (name.startsWith('ui_')) return 'ui';
   if (name.startsWith('hayba_fab_')) return 'fab';
   if (name.startsWith('hayba_polyhaven_')) return 'asset-sources';

--- a/mcp-tools/hayba-mcp/src/tools/memory/delete.ts
+++ b/mcp-tools/hayba-mcp/src/tools/memory/delete.ts
@@ -1,0 +1,43 @@
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { errorResult, okResult } from '../tool-result.js';
+import { getMemoryStore } from './store.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['modifies_memory_state'],
+  when: 'removing a specific memory block by id, every block written by one agentRole, or (with explicit confirm_all) the entire store.',
+  not_when: 'you just want old entries to age out automatically — that is retention, applied on every memory_write.',
+};
+
+export const memoryDeleteHandler: ToolHandler = async (args) => {
+  const id = args.id !== undefined ? String(args.id) : undefined;
+  const agentRole = args.agentRole !== undefined ? String(args.agentRole) : undefined;
+  const confirmAll = args.confirm_all === true;
+
+  const provided = [id, agentRole, confirmAll ? 'confirm_all' : undefined].filter(Boolean).length;
+  if (provided === 0) {
+    return errorResult('one of id, agentRole, or confirm_all=true is required — memory_delete refuses to guess scope');
+  }
+  if (provided > 1) {
+    return errorResult('pass exactly one of id, agentRole, or confirm_all=true, not several at once');
+  }
+
+  const store = getMemoryStore();
+
+  if (id) {
+    const deleted = store.deleteById(id);
+    return okResult({ ok: deleted, id, deleted_count: deleted ? 1 : 0 });
+  }
+
+  if (agentRole) {
+    const before = store.count({ agentRole });
+    store.clear(agentRole);
+    return okResult({ ok: true, agentRole, deleted_count: before });
+  }
+
+  // confirm_all
+  const before = store.count();
+  store.clear();
+  return okResult({ ok: true, deleted_count: before, remaining: store.count() });
+};

--- a/mcp-tools/hayba-mcp/src/tools/memory/export-blocks.ts
+++ b/mcp-tools/hayba-mcp/src/tools/memory/export-blocks.ts
@@ -1,0 +1,36 @@
+import { writeFileSync } from 'node:fs';
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { errorResult, okResult } from '../tool-result.js';
+import { getMemoryStore } from './store.js';
+import type { MemoryExport } from '../../gaea/memory/hayba-memory.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['filesystem_write'],
+  when: 'backing up the memory store, or moving blocks to another machine/DB before memory_import there.',
+  not_when: 'you just want to read the blocks (use memory_list / memory_recall) — this writes a portable JSON file, it does not return the blocks inline.',
+};
+
+export const memoryExportHandler: ToolHandler = async (args) => {
+  const path = args.path !== undefined ? String(args.path) : undefined;
+  if (!path) return errorResult('path is required — file to write the export to');
+
+  const scope = args.scope as 'private' | 'shared' | undefined;
+  if (scope !== undefined && scope !== 'private' && scope !== 'shared') {
+    return errorResult('scope must be "private" or "shared" when given');
+  }
+  const agentRole = args.agentRole !== undefined ? String(args.agentRole) : undefined;
+
+  const store = getMemoryStore();
+  const blocks = store.exportBlocks({ scope, agentRole });
+  const payload: MemoryExport = { version: 1, exportedAt: Date.now(), blocks };
+
+  try {
+    writeFileSync(path, JSON.stringify(payload, null, 2), 'utf-8');
+  } catch (e) {
+    return errorResult(`failed to write export file: ${(e as Error).message}`);
+  }
+
+  return okResult({ ok: true, path, count: blocks.length });
+};

--- a/mcp-tools/hayba-mcp/src/tools/memory/import-blocks.ts
+++ b/mcp-tools/hayba-mcp/src/tools/memory/import-blocks.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs';
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { errorResult, okResult } from '../tool-result.js';
+import { getMemoryStore } from './store.js';
+import type { MemoryBlock, MemoryExport } from '../../gaea/memory/hayba-memory.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['modifies_memory_state'],
+  when: 'loading a memory_export JSON file back into the store — restoring a backup or merging another agent\'s export.',
+  not_when: 'writing a single new memory block (use memory_write) — this is for the portable export/import file format specifically.',
+};
+
+function isExportEnvelope(v: unknown): v is MemoryExport {
+  return (
+    !!v &&
+    typeof v === 'object' &&
+    Array.isArray((v as MemoryExport).blocks) &&
+    (v as MemoryExport).version === 1
+  );
+}
+
+export const memoryImportHandler: ToolHandler = async (args) => {
+  const path = args.path !== undefined ? String(args.path) : undefined;
+  if (!path) return errorResult('path is required — file previously written by memory_export');
+
+  const onConflict = args.on_conflict === 'replace' ? 'replace' : 'skip';
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch (e) {
+    return errorResult(`failed to read import file: ${(e as Error).message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return errorResult(`import file is not valid JSON: ${(e as Error).message}`);
+  }
+
+  let blocks: MemoryBlock[];
+  if (isExportEnvelope(parsed)) {
+    blocks = parsed.blocks;
+  } else if (Array.isArray(parsed)) {
+    // Tolerate a bare array of blocks too, not just the {version, blocks} envelope.
+    blocks = parsed as MemoryBlock[];
+  } else {
+    return errorResult('import file must be a memory_export envelope ({version:1, blocks:[...]}) or a bare array of blocks');
+  }
+
+  const store = getMemoryStore();
+  const result = store.importBlocks(blocks, { onConflict });
+
+  return okResult({
+    ok: true,
+    path,
+    on_conflict: onConflict,
+    total_read: blocks.length,
+    inserted: result.inserted,
+    skipped: result.skipped,
+    conflicted: result.conflicted,
+    errors: result.errors,
+  });
+};

--- a/mcp-tools/hayba-mcp/src/tools/memory/list.ts
+++ b/mcp-tools/hayba-mcp/src/tools/memory/list.ts
@@ -1,0 +1,26 @@
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { errorResult, okResult } from '../tool-result.js';
+import { getMemoryStore } from './store.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'browsing recent memory blocks for a role/scope, most-recent-first, with no keyword in mind.',
+  not_when: 'you are looking for a specific block by keyword (use memory_recall) — that filters, this just paginates.',
+};
+
+export const memoryListHandler: ToolHandler = async (args) => {
+  const scope = args.scope as 'private' | 'shared' | undefined;
+  if (scope !== undefined && scope !== 'private' && scope !== 'shared') {
+    return errorResult('scope must be "private" or "shared" when given');
+  }
+  const agentRole = args.agentRole !== undefined ? String(args.agentRole) : undefined;
+  const limit = typeof args.limit === 'number' ? args.limit : 50;
+
+  const store = getMemoryStore();
+  const blocks = store.query({ scope, agentRole, limit });
+  const total = store.count({ scope, agentRole });
+
+  return okResult({ blocks, count: blocks.length, total_matching: total, truncated: total > blocks.length });
+};

--- a/mcp-tools/hayba-mcp/src/tools/memory/memory-tools.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/memory/memory-tools.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { __resetMemoryStoreForTests } from './store.js';
+import { memoryWriteHandler } from './write.js';
+import { memoryRecallHandler } from './recall.js';
+import { memoryListHandler } from './list.js';
+import { memoryDeleteHandler } from './delete.js';
+import { memoryExportHandler } from './export-blocks.js';
+import { memoryImportHandler } from './import-blocks.js';
+import { memoryPruneHandler } from './prune.js';
+
+// Every memory_* tool goes through getMemoryStore(), which reads
+// config.memoryDbPath (HAYBA_MEMORY_DB) lazily. Point it at a fresh in-memory
+// DB per test so tests can't see each other's writes, and force the singleton
+// to reopen even though the literal path string (':memory:') repeats.
+let tmpDir: string;
+
+beforeEach(() => {
+  process.env.HAYBA_MEMORY_DB = ':memory:';
+  process.env.HAYBA_MEMORY_MAX_COUNT = '2000';
+  process.env.HAYBA_MEMORY_MAX_AGE_DAYS = '90';
+  __resetMemoryStoreForTests();
+  tmpDir = mkdtempSync(join(tmpdir(), 'hayba-memory-test-'));
+});
+
+afterEach(() => {
+  __resetMemoryStoreForTests();
+  delete process.env.HAYBA_MEMORY_DB;
+  delete process.env.HAYBA_MEMORY_MAX_COUNT;
+  delete process.env.HAYBA_MEMORY_MAX_AGE_DAYS;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function parse(result: { content: Array<{ type: 'text'; text: string }> }): any {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('memory_write', () => {
+  it('writes a block and returns its id plus an explicit (zero) retention report', async () => {
+    const r = await memoryWriteHandler(
+      { agentRole: 'director', scope: 'shared', intent: 'plan', content: 'forest -> river', tokenCost: 5 },
+      {},
+    );
+    const body = parse(r);
+    expect(body.ok).toBe(true);
+    expect(typeof body.id).toBe('string');
+    expect(body.retention).toEqual({ pruned_by_age: 0, pruned_by_count: 0, pruned_total: 0, remaining: 1 });
+  });
+
+  it('rejects a missing required field', async () => {
+    const r = await memoryWriteHandler({ agentRole: 'director', scope: 'shared', content: 'x' }, {});
+    expect(r.isError).toBe(true);
+    expect(parse(r).error).toMatch(/intent/);
+  });
+
+  it('rejects an invalid scope', async () => {
+    const r = await memoryWriteHandler({ agentRole: 'd', scope: 'public', intent: 'i', content: 'c' }, {});
+    expect(r.isError).toBe(true);
+  });
+});
+
+describe('memory_recall', () => {
+  it('finds a block by keyword in intent/content and misses on an unrelated keyword', async () => {
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'establish biome plan', content: 'forest -> river -> ruins' }, {});
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'unrelated', content: 'nothing to do with rivers' }, {});
+
+    const hit = parse(await memoryRecallHandler({ text: 'river' }, {}));
+    expect(hit.count).toBe(2);
+
+    const miss = parse(await memoryRecallHandler({ text: 'volcano' }, {}));
+    expect(miss.count).toBe(0);
+  });
+
+  it('requires text', async () => {
+    const r = await memoryRecallHandler({}, {});
+    expect(r.isError).toBe(true);
+  });
+});
+
+describe('memory_list', () => {
+  it('lists most-recent-first without a keyword filter', async () => {
+    // Both timestamps are recent (well inside the 90-day retention window) —
+    // only their relative order matters here, not how old they are.
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'old', content: 'c', timestamp: Date.now() - 1000 } as any, {});
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'new', content: 'c' }, {});
+    const body = parse(await memoryListHandler({}, {}));
+    expect(body.count).toBe(2);
+    expect(body.blocks[0].intent).toBe('new');
+  });
+
+  it('filters by agentRole', async () => {
+    await memoryWriteHandler({ agentRole: 'a', scope: 'shared', intent: 'x', content: 'c' }, {});
+    await memoryWriteHandler({ agentRole: 'b', scope: 'shared', intent: 'y', content: 'c' }, {});
+    const body = parse(await memoryListHandler({ agentRole: 'a' }, {}));
+    expect(body.count).toBe(1);
+    expect(body.blocks[0].agentRole).toBe('a');
+  });
+});
+
+describe('memory_delete', () => {
+  it('deletes a single block by id', async () => {
+    const w = parse(await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'x', content: 'c' }, {}));
+    const del = parse(await memoryDeleteHandler({ id: w.id }, {}));
+    expect(del.ok).toBe(true);
+    expect(del.deleted_count).toBe(1);
+    expect(parse(await memoryListHandler({}, {})).count).toBe(0);
+  });
+
+  it('reports ok:false and deleted_count:0 for an id that does not exist', async () => {
+    const del = parse(await memoryDeleteHandler({ id: 'nonexistent' }, {}));
+    expect(del.ok).toBe(false);
+    expect(del.deleted_count).toBe(0);
+  });
+
+  it('deletes every block for one agentRole and leaves others', async () => {
+    await memoryWriteHandler({ agentRole: 'a', scope: 'shared', intent: 'x', content: 'c' }, {});
+    await memoryWriteHandler({ agentRole: 'b', scope: 'shared', intent: 'y', content: 'c' }, {});
+    const del = parse(await memoryDeleteHandler({ agentRole: 'a' }, {}));
+    expect(del.deleted_count).toBe(1);
+    const remaining = parse(await memoryListHandler({}, {}));
+    expect(remaining.count).toBe(1);
+    expect(remaining.blocks[0].agentRole).toBe('b');
+  });
+
+  it('refuses to guess: no id/agentRole/confirm_all is an error', async () => {
+    const r = await memoryDeleteHandler({}, {});
+    expect(r.isError).toBe(true);
+  });
+
+  it('confirm_all wipes the whole store', async () => {
+    await memoryWriteHandler({ agentRole: 'a', scope: 'shared', intent: 'x', content: 'c' }, {});
+    await memoryWriteHandler({ agentRole: 'b', scope: 'shared', intent: 'y', content: 'c' }, {});
+    const del = parse(await memoryDeleteHandler({ confirm_all: true }, {}));
+    expect(del.deleted_count).toBe(2);
+    expect(del.remaining).toBe(0);
+  });
+});
+
+describe('retention actually bounds the store', () => {
+  it('memory_write prunes down to max_count after exceeding it', async () => {
+    process.env.HAYBA_MEMORY_MAX_COUNT = '3';
+    let last: any;
+    for (let i = 0; i < 5; i++) {
+      last = parse(await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: `i${i}`, content: 'c' }, {}));
+    }
+    // 5 writes against a bound of 3: the last write's own retention report
+    // must show pruning happened, and the store must actually be at the bound.
+    expect(last.retention.remaining).toBe(3);
+    expect(parse(await memoryListHandler({ limit: 100 }, {})).count).toBe(3);
+  });
+
+  it('memory_prune enforces max_age_days and reports the exact count removed', async () => {
+    // Two blocks: one 200 days old, one fresh. Write with a huge age bound so
+    // memory_write's own automatic retention doesn't pre-empt the ancient one —
+    // this test is isolating memory_prune's explicit bound, not the write path.
+    process.env.HAYBA_MEMORY_MAX_AGE_DAYS = '99999';
+    const twoHundredDaysAgo = Date.now() - 200 * 24 * 60 * 60 * 1000;
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'ancient', content: 'c', timestamp: twoHundredDaysAgo } as any, {});
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'fresh', content: 'c' }, {});
+
+    const pruned = parse(await memoryPruneHandler({ max_age_days: 90 }, {}));
+    expect(pruned.pruned_by_age).toBe(1);
+    expect(pruned.remaining).toBe(1);
+    const left = parse(await memoryListHandler({}, {}));
+    expect(left.blocks[0].intent).toBe('fresh');
+  });
+});
+
+describe('export -> import round trip', () => {
+  it('round-trips blocks through a file and reports inserted/skipped/conflicted', async () => {
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'a', content: 'c1' }, {});
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'b', content: 'c2' }, {});
+    const path = join(tmpDir, 'export.json');
+
+    const exp = parse(await memoryExportHandler({ path }, {}));
+    expect(exp.ok).toBe(true);
+    expect(exp.count).toBe(2);
+
+    // Wipe the store, then import back from the file.
+    await memoryDeleteHandler({ confirm_all: true }, {});
+    expect(parse(await memoryListHandler({}, {})).count).toBe(0);
+
+    const imp = parse(await memoryImportHandler({ path }, {}));
+    expect(imp.ok).toBe(true);
+    expect(imp.total_read).toBe(2);
+    expect(imp.inserted).toBe(2);
+    expect(imp.skipped).toBe(0);
+    expect(imp.conflicted).toBe(0);
+
+    const after = parse(await memoryListHandler({ limit: 100 }, {}));
+    expect(after.count).toBe(2);
+    expect(after.blocks.map((b: any) => b.intent).sort()).toEqual(['a', 'b']);
+  });
+
+  it('re-importing the same file reports every row as conflicted and skipped (not duplicated)', async () => {
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'a', content: 'c1' }, {});
+    const path = join(tmpDir, 'export.json');
+    await memoryExportHandler({ path }, {});
+
+    const imp = parse(await memoryImportHandler({ path }, {}));
+    expect(imp.inserted).toBe(0);
+    expect(imp.conflicted).toBe(1);
+    expect(parse(await memoryListHandler({}, {})).count).toBe(1);
+  });
+
+  it('on_conflict=replace overwrites the existing row instead of skipping it', async () => {
+    const w = parse(await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'original', content: 'c1' }, {}));
+    const path = join(tmpDir, 'export.json');
+    await memoryExportHandler({ path }, {});
+
+    // Mutate the live block, then import the (stale) export with replace.
+    await memoryDeleteHandler({ id: w.id }, {});
+    await memoryWriteHandler({ agentRole: 'd', scope: 'shared', intent: 'changed', content: 'c2', id: w.id } as any, {});
+
+    const imp = parse(await memoryImportHandler({ path, on_conflict: 'replace' }, {}));
+    expect(imp.conflicted).toBe(1);
+    expect(imp.inserted).toBe(0);
+
+    const after = parse(await memoryListHandler({}, {}));
+    expect(after.blocks[0].intent).toBe('original');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/memory/prune.ts
+++ b/mcp-tools/hayba-mcp/src/tools/memory/prune.ts
@@ -1,0 +1,32 @@
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { errorResult, okResult } from '../tool-result.js';
+import { getMemoryStore } from './store.js';
+import { config } from '../../config.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['modifies_memory_state'],
+  when: 'forcing retention to run now (e.g. with a tighter one-off bound) instead of waiting for the next memory_write, which applies it automatically.',
+  not_when: 'normal usage — memory_write already runs retention with the configured bounds after every insert, so this is rarely needed.',
+};
+
+export const memoryPruneHandler: ToolHandler = async (args) => {
+  const maxCount = typeof args.max_count === 'number' ? args.max_count : config.memoryMaxCount;
+  const maxAgeDays = typeof args.max_age_days === 'number' ? args.max_age_days : undefined;
+  const maxAgeMs = maxAgeDays !== undefined ? maxAgeDays * 24 * 60 * 60 * 1000 : config.memoryMaxAgeMs;
+
+  if (maxCount !== undefined && maxCount <= 0) return errorResult('max_count must be positive when given');
+  if (maxAgeMs !== undefined && maxAgeMs <= 0) return errorResult('max_age_days must be positive when given');
+
+  const store = getMemoryStore();
+  const result = store.applyRetention({ maxCount, maxAgeMs });
+
+  return okResult({
+    ok: true,
+    pruned_by_age: result.prunedByAge,
+    pruned_by_count: result.prunedByCount,
+    pruned_total: result.prunedTotal,
+    remaining: result.remaining,
+  });
+};

--- a/mcp-tools/hayba-mcp/src/tools/memory/recall.ts
+++ b/mcp-tools/hayba-mcp/src/tools/memory/recall.ts
@@ -1,0 +1,30 @@
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { errorResult, okResult } from '../tool-result.js';
+import { getMemoryStore } from './store.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when:
+    'looking for a specific past memory block by keyword — "what did we decide about X", "find the handoff about Y". Searches intent and content text.',
+  not_when:
+    'you want everything a role has written with no keyword (use memory_list instead), or you are searching UE content/assets (use asset_search / docs_search).',
+};
+
+export const memoryRecallHandler: ToolHandler = async (args) => {
+  const text = args.text !== undefined ? String(args.text) : undefined;
+  if (!text) return errorResult('text is required — memory_recall searches for a keyword; use memory_list to browse without one');
+
+  const scope = args.scope as 'private' | 'shared' | undefined;
+  if (scope !== undefined && scope !== 'private' && scope !== 'shared') {
+    return errorResult('scope must be "private" or "shared" when given');
+  }
+  const agentRole = args.agentRole !== undefined ? String(args.agentRole) : undefined;
+  const limit = typeof args.limit === 'number' ? args.limit : 10;
+
+  const store = getMemoryStore();
+  const blocks = store.query({ text, scope, agentRole, limit });
+
+  return okResult({ blocks, count: blocks.length, query: { text, scope, agentRole, limit } });
+};

--- a/mcp-tools/hayba-mcp/src/tools/memory/store.ts
+++ b/mcp-tools/hayba-mcp/src/tools/memory/store.ts
@@ -1,0 +1,39 @@
+// Lazy singleton wiring for the agent memory store (issue #355).
+//
+// HaybaMemory (src/gaea/memory/hayba-memory.ts) is a plain class with no
+// opinion on where its DB file lives or when it's opened — this module is
+// the one place that decides both, so every memory_* tool shares one
+// connection instead of racing to open the file.
+import { mkdirSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { HaybaMemory } from '../../gaea/memory/hayba-memory.js';
+import { config } from '../../config.js';
+
+let instance: HaybaMemory | null = null;
+let instancePath: string | null = null;
+
+/**
+ * Return the process-wide HaybaMemory instance, opening it on first call.
+ * Re-opens if `config.memoryDbPath` changes between calls (tests set
+ * HAYBA_MEMORY_DB per-case) so nothing stays pinned to a stale path.
+ */
+export function getMemoryStore(): HaybaMemory {
+  const path = config.memoryDbPath;
+  if (instance && instancePath === path) return instance;
+  if (instance) instance.close();
+
+  if (path !== ':memory:') {
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+  instance = new HaybaMemory(path);
+  instancePath = path;
+  return instance;
+}
+
+/** Test-only: force the next getMemoryStore() call to open a fresh instance. */
+export function __resetMemoryStoreForTests(): void {
+  if (instance) instance.close();
+  instance = null;
+  instancePath = null;
+}

--- a/mcp-tools/hayba-mcp/src/tools/memory/write.ts
+++ b/mcp-tools/hayba-mcp/src/tools/memory/write.ts
@@ -1,0 +1,58 @@
+import type { ToolHandler } from '../types.js';
+import type { HaybaToolMeta } from '../hayba-tool-meta.js';
+import { errorResult, okResult } from '../tool-result.js';
+import { getMemoryStore } from './store.js';
+import { config } from '../../config.js';
+
+export const meta: HaybaToolMeta = {
+  cost: 'low',
+  effects: ['modifies_memory_state'],
+  when:
+    'you have something worth handing to a future turn or another agent — an established plan, a decision and why it was made, a handoff — and want it retrievable later by role/scope/text.',
+  not_when:
+    'the information belongs in the conversation only, or you want durable cross-session notes about the USER\'S preferences/workflow (that is Claude\'s own memory file, not this store). Not a substitute for a written plan doc.',
+};
+
+export const memoryWriteHandler: ToolHandler = async (args) => {
+  const agentRole = String(args.agentRole ?? '').trim();
+  const scope = args.scope as 'private' | 'shared';
+  const intent = String(args.intent ?? '').trim();
+  const content = args.content as string;
+
+  if (!agentRole) return errorResult('agentRole is required');
+  if (scope !== 'private' && scope !== 'shared') return errorResult('scope must be "private" or "shared"');
+  if (!intent) return errorResult('intent is required');
+  if (typeof content !== 'string' || content.length === 0) return errorResult('content is required');
+
+  const accessedResources = Array.isArray(args.accessedResources)
+    ? (args.accessedResources as unknown[]).map(String)
+    : [];
+  const tokenCost = typeof args.tokenCost === 'number' ? args.tokenCost : 0;
+  const provenance =
+    args.provenance && typeof args.provenance === 'object' ? (args.provenance as Record<string, unknown>) : undefined;
+
+  const explicitId = args.id !== undefined ? String(args.id) : undefined;
+  const timestamp = typeof args.timestamp === 'number' ? args.timestamp : undefined;
+
+  const store = getMemoryStore();
+  const id = store.write({ id: explicitId, agentRole, scope, intent, content, accessedResources, tokenCost, provenance, timestamp });
+
+  // Retention is applied on every write, never silently: the response always
+  // names what (if anything) was pruned, using the bounds from config
+  // (HAYBA_MEMORY_MAX_COUNT / HAYBA_MEMORY_MAX_AGE_DAYS).
+  const retention = store.applyRetention({
+    maxCount: config.memoryMaxCount,
+    maxAgeMs: config.memoryMaxAgeMs,
+  });
+
+  return okResult({
+    ok: true,
+    id,
+    retention: {
+      pruned_by_age: retention.prunedByAge,
+      pruned_by_count: retention.prunedByCount,
+      pruned_total: retention.prunedTotal,
+      remaining: retention.remaining,
+    },
+  });
+};

--- a/mcp-tools/hayba-mcp/vitest.config.ts
+++ b/mcp-tools/hayba-mcp/vitest.config.ts
@@ -20,11 +20,23 @@ export default defineConfig({
       '**/node_modules/**',
       '**/dist/**',
       // The Gaea *tool* surface is parked: its registration block was commented
-      // out in src/tools/index.ts and has since been deleted, so these 18 files
+      // out in src/tools/index.ts and has since been deleted, so these files
       // test handlers that nothing can reach. They stay until the terrain
-      // integration phase brings the surface back — at which point delete this
-      // line rather than adding names to it.
-      '**/tests/gaea/**',
+      // integration phase brings the surface back — at which point delete these
+      // lines rather than adding to them.
+      //
+      // `tests/gaea/memory/**` is carved OUT of this list (issue #355): HaybaMemory
+      // is no longer parked-and-unreachable — it backs the memory_* tools
+      // registered in src/tools/memory/index.ts — so its test now runs like any
+      // other live test. A blanket '**/tests/gaea/**' would silently re-exclude it.
+      'tests/gaea/gaea-launcher.test.ts',
+      'tests/gaea/session.test.ts',
+      'tests/gaea/swarmhost-mutations.test.ts',
+      'tests/gaea/swarmhost-variables.test.ts',
+      'tests/gaea/swarmhost.test.ts',
+      'tests/gaea/templates.test.ts',
+      'tests/gaea/tools/**',
+      'tests/gaea/types.test.ts',
     ],
   },
 })


### PR DESCRIPTION
## Summary

Closes #355. `HaybaMemory` (`src/gaea/memory/hayba-memory.ts`) was a complete SQLite-backed memory implementation nothing could reach: no MCP tool wrapped it, nothing instantiated it outside its own test, and that test was excluded from the suite (`vitest.config.ts`). This takes option 1 from the issue: surface it.

- **Tools**: `memory_write`, `memory_recall` (keyword search over intent+content), `memory_list` (browse, no keyword), `memory_delete` (by id / by agentRole / confirm_all), `memory_export`, `memory_import`, `memory_prune` — registered in `src/tools/index.ts`, backed by a lazy singleton in `src/tools/memory/store.ts`.
- **SQLite dependency**: rewrote `hayba-memory.ts` on node's built-in `node:sqlite` (`DatabaseSync`) instead of the `better-sqlite3` native module — matching the pattern already used by `match-pin-names.ts` / `query-pcgex-docs.ts` / `scrape-node-registry.ts`, so there's no native build step to fail in a CI-less/offline environment (just the "experimental" warning Node already prints elsewhere in this repo). Dropped the now-unused `better-sqlite3` + `@types/better-sqlite3` deps.
- **Retention**: bounded by age and count (`HAYBA_MEMORY_MAX_COUNT` / `HAYBA_MEMORY_MAX_AGE_DAYS`, defaults 2000 / 90 days), applied automatically after every `memory_write` and always reported in the response (`pruned_by_age` / `pruned_by_count` / `remaining`, even when zero) — never silent. `memory_prune` exposes the same mechanism for an explicit one-off bound.
- **Export/import**: `memory_export` dumps to a portable `{version, exportedAt, blocks}` JSON file; `memory_import` reports `inserted` / `skipped` (malformed rows) / `conflicted` (id already present — left alone under `skip`, overwritten under `replace`) rather than a bare "ok".
- **Test**: un-excluded `tests/gaea/memory/hayba-memory.test.ts` in `vitest.config.ts` (its assumptions about `write`/`query`/`clear` needed no changes against the `node:sqlite` rewrite — verified green) and added `src/tools/memory/memory-tools.test.ts` (17 tests) covering write/recall/list/delete, retention actually bounding the store, and export→import round-tripping.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 1553/1553 passing (baseline 1530 + 6 un-excluded + 17 new)
- [x] `node scripts/check-legacy-wrappers.mjs` — OK, no violations
- [x] Mutation-tested: text search filter, DESC ordering, `deleteById` success flag, count-based retention bound, and import conflict detection — each broken, confirmed RED, reverted, confirmed GREEN