### PR TITLE
feat(mcp): reinstate the hayba.agents.json archetype loader

### DIFF
--- a/mcp-tools/hayba-mcp/src/agents/agent-registry.test.ts
+++ b/mcp-tools/hayba-mcp/src/agents/agent-registry.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  loadAgentsManifest,
+  getAgentsManifest,
+  getArchetype,
+  defaultManifestPath,
+  __resetAgentsManifestCacheForTests,
+} from './agent-registry.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'hayba-agents-test-'));
+  __resetAgentsManifestCacheForTests();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeManifest(name: string, content: string): string {
+  const p = join(dir, name);
+  writeFileSync(p, content, 'utf-8');
+  return p;
+}
+
+const VALID_MANIFEST = {
+  version: 1,
+  shared_memory: 'hayba-memory.db',
+  archetypes: [
+    {
+      id: 'director',
+      role: 'Director',
+      system_prompt: 'Directs.',
+      tool_filter: ['*'],
+      memory_scope: 'shared',
+    },
+    {
+      id: 'asset-manager',
+      role: 'Asset Manager',
+      system_prompt: 'Manages assets.',
+      tool_filter: ['asset_*', 'scene_*'],
+      memory_scope: 'shared',
+    },
+    {
+      id: 'pattern-expert',
+      role: 'Pattern Expert',
+      system_prompt: 'Applies patterns.',
+      tool_filter: ['scene_*', 'level_*'],
+      memory_scope: 'shared',
+    },
+    {
+      id: 'node-expert',
+      role: 'Node Expert',
+      system_prompt: 'Explains nodes.',
+      tool_filter: ['docs_*', 'pcg_*'],
+      memory_scope: 'shared',
+    },
+    {
+      id: 'blueprint-generator',
+      role: 'Blueprint Generator',
+      system_prompt: 'Builds blueprints.',
+      tool_filter: ['*'],
+      memory_scope: 'private+shared',
+    },
+  ],
+};
+
+describe('agent-registry: loadAgentsManifest', () => {
+  it('the real shipped hayba.agents.json loads and exposes all five archetypes', () => {
+    // No path override: exercises the actual file at the package root, so a
+    // regression that breaks the shipped file (not just a test fixture) is
+    // caught here too.
+    const manifest = loadAgentsManifest(defaultManifestPath());
+    expect(manifest.archetypes).toHaveLength(5);
+    const ids = manifest.archetypes.map((a) => a.id).sort();
+    expect(ids).toEqual(
+      ['asset-manager', 'blueprint-generator', 'director', 'node-expert', 'pattern-expert'].sort(),
+    );
+  });
+
+  it('a valid fixture file loads all five archetypes with their tool_filter intact', () => {
+    const p = writeManifest('valid.json', JSON.stringify(VALID_MANIFEST));
+    const manifest = loadAgentsManifest(p);
+    expect(manifest.archetypes).toHaveLength(5);
+    const assetManager = manifest.archetypes.find((a) => a.id === 'asset-manager');
+    expect(assetManager?.tool_filter).toEqual(['asset_*', 'scene_*']);
+  });
+
+  it('a missing file fails loudly, naming the path', () => {
+    const p = join(dir, 'does-not-exist.json');
+    expect(() => loadAgentsManifest(p)).toThrowError(/not found at .*does-not-exist\.json/);
+  });
+
+  it('malformed JSON fails loudly, naming the file and that it is not valid JSON', () => {
+    const p = writeManifest('broken.json', '{ "version": 1, "archetypes": [ ');
+    expect(() => loadAgentsManifest(p)).toThrowError(/broken\.json.*not valid JSON/s);
+  });
+
+  it('a schema-violating entry fails loudly, naming the failing field', () => {
+    const bad = {
+      ...VALID_MANIFEST,
+      archetypes: [
+        { ...VALID_MANIFEST.archetypes[0], tool_filter: 'not-an-array' }, // wrong type
+        ...VALID_MANIFEST.archetypes.slice(1),
+      ],
+    };
+    const p = writeManifest('bad-field.json', JSON.stringify(bad));
+    expect(() => loadAgentsManifest(p)).toThrowError(/archetypes\.0\.tool_filter/);
+  });
+
+  it('an invalid memory_scope value fails loudly, naming the field', () => {
+    const bad = {
+      ...VALID_MANIFEST,
+      archetypes: [
+        { ...VALID_MANIFEST.archetypes[0], memory_scope: 'public' }, // not in the enum
+        ...VALID_MANIFEST.archetypes.slice(1),
+      ],
+    };
+    const p = writeManifest('bad-scope.json', JSON.stringify(bad));
+    expect(() => loadAgentsManifest(p)).toThrowError(/archetypes\.0\.memory_scope/);
+  });
+
+  it('a missing required field fails loudly, naming the field', () => {
+    const bad = {
+      ...VALID_MANIFEST,
+      archetypes: [
+        { id: 'director', role: 'Director', tool_filter: ['*'], memory_scope: 'shared' }, // no system_prompt
+        ...VALID_MANIFEST.archetypes.slice(1),
+      ],
+    };
+    const p = writeManifest('missing-field.json', JSON.stringify(bad));
+    expect(() => loadAgentsManifest(p)).toThrowError(/archetypes\.0\.system_prompt/);
+  });
+
+  it('a duplicate archetype id fails loudly', () => {
+    const dup = {
+      ...VALID_MANIFEST,
+      archetypes: [VALID_MANIFEST.archetypes[0], VALID_MANIFEST.archetypes[0]],
+    };
+    const p = writeManifest('dup.json', JSON.stringify(dup));
+    expect(() => loadAgentsManifest(p)).toThrowError(/archetype id "director" more than once/);
+  });
+});
+
+describe('agent-registry: getArchetype / getAgentsManifest', () => {
+  it('a known id resolves to the expected tool_filter and system_prompt', () => {
+    const p = writeManifest('valid.json', JSON.stringify(VALID_MANIFEST));
+    const archetype = getArchetype('asset-manager', p);
+    expect(archetype.tool_filter).toEqual(['asset_*', 'scene_*']);
+    expect(archetype.system_prompt).toBe('Manages assets.');
+  });
+
+  it('an unknown archetype id is a clear error naming the id and the known ids', () => {
+    const p = writeManifest('valid.json', JSON.stringify(VALID_MANIFEST));
+    expect(() => getArchetype('not-a-real-id', p)).toThrowError(
+      /unknown archetype id "not-a-real-id".*director/s,
+    );
+  });
+
+  it('getAgentsManifest caches per path — a second call does not require the file to still exist', () => {
+    const p = writeManifest('valid.json', JSON.stringify(VALID_MANIFEST));
+    const first = getAgentsManifest(p);
+    rmSync(p);
+    const second = getAgentsManifest(p);
+    expect(second).toBe(first);
+  });
+
+  it('__resetAgentsManifestCacheForTests forces a re-read', () => {
+    const p = writeManifest('valid.json', JSON.stringify(VALID_MANIFEST));
+    getAgentsManifest(p);
+    rmSync(p);
+    __resetAgentsManifestCacheForTests();
+    expect(() => getAgentsManifest(p)).toThrowError(/not found/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/agents/agent-registry.ts
+++ b/mcp-tools/hayba-mcp/src/agents/agent-registry.ts
@@ -1,0 +1,138 @@
+/**
+ * Loader for `hayba.agents.json` — the swarm-agent "archetype" manifest.
+ *
+ * Restores the piece described (but not implemented) by
+ * docs/getting-started-swarm-agents.md: something that actually reads the
+ * file, validates it, and lets an archetype id resolve to its
+ * `tool_filter` / `system_prompt`. See issue #356.
+ *
+ * Deliberately does NOT re-implement glob matching — `buildToolCatalog`
+ * (src/chat/agent-loop.ts) already owns that, so a resolved archetype's
+ * `tool_filter` is handed to it unchanged as `archetypeFilter`. Two copies
+ * of a glob matcher is exactly the "drifted duplicate" class of bug this
+ * codebase keeps finding (docs/WORKFLOW-improving-the-mcp.md, step 2).
+ *
+ * Also deliberately does NOT open a HaybaMemory instance from
+ * `shared_memory` — that plumbing is issue #355's concern
+ * (src/tools/memory/store.ts already owns the one live memory-store
+ * singleton via `config.memoryDbPath`); wiring `shared_memory` to it would
+ * be a second, competing way to pick that path.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ZodIssue } from 'zod';
+import { AgentsManifestSchema, type AgentsManifest, type ArchetypeConfig } from './types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** `<package root>/hayba.agents.json` — dist/agents/ -> dist -> package root. */
+export function defaultManifestPath(): string {
+  return resolve(__dirname, '..', '..', 'hayba.agents.json');
+}
+
+function formatIssues(issues: ZodIssue[]): string {
+  return issues
+    .map((iss) => {
+      const path = iss.path.length > 0 ? iss.path.join('.') : '(root)';
+      return `  - ${path}: ${iss.message}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Parse and validate a manifest file at `manifestPath`. Throws a specific,
+ * loud `Error` — naming the file, the failing field(s), and what was
+ * expected — on any of: missing file, unreadable file, invalid JSON, or a
+ * schema violation. There is no fallback value; a caller that wants one
+ * must catch and decide, explicitly, rather than getting silence.
+ */
+export function loadAgentsManifest(manifestPath: string = defaultManifestPath()): AgentsManifest {
+  if (!existsSync(manifestPath)) {
+    throw new Error(
+      `hayba.agents.json not found at "${manifestPath}" — the archetype loader requires ` +
+        'this file to exist (see docs/getting-started-swarm-agents.md). It is not optional ' +
+        'config with a silent no-archetypes fallback.',
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(manifestPath, 'utf-8');
+  } catch (e: unknown) {
+    throw new Error(
+      `hayba.agents.json at "${manifestPath}" could not be read: ` +
+        `${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (e: unknown) {
+    throw new Error(
+      `hayba.agents.json at "${manifestPath}" is not valid JSON: ` +
+        `${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  const result = AgentsManifestSchema.safeParse(json);
+  if (!result.success) {
+    throw new Error(
+      `hayba.agents.json at "${manifestPath}" failed schema validation:\n` +
+        formatIssues(result.error.issues),
+    );
+  }
+
+  const seen = new Set<string>();
+  for (const a of result.data.archetypes) {
+    if (seen.has(a.id)) {
+      throw new Error(
+        `hayba.agents.json at "${manifestPath}" declares archetype id "${a.id}" more than ` +
+          'once — archetype ids must be unique.',
+      );
+    }
+    seen.add(a.id);
+  }
+
+  return result.data;
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide cache — the file is read once, not on every archetype lookup.
+// ---------------------------------------------------------------------------
+
+let cache: { path: string; manifest: AgentsManifest } | null = null;
+
+/** Cached `loadAgentsManifest`. Same failure behaviour — nothing is swallowed. */
+export function getAgentsManifest(manifestPath: string = defaultManifestPath()): AgentsManifest {
+  if (cache && cache.path === manifestPath) return cache.manifest;
+  const manifest = loadAgentsManifest(manifestPath);
+  cache = { path: manifestPath, manifest };
+  return manifest;
+}
+
+/** Test-only: drop the cache so the next call re-reads the file. */
+export function __resetAgentsManifestCacheForTests(): void {
+  cache = null;
+}
+
+/**
+ * Resolve an archetype id to its config. Throws a specific error naming the
+ * unknown id and listing the ids that ARE known, rather than returning
+ * undefined for a caller to forget to check.
+ */
+export function getArchetype(
+  id: string,
+  manifestPath: string = defaultManifestPath(),
+): ArchetypeConfig {
+  const manifest = getAgentsManifest(manifestPath);
+  const found = manifest.archetypes.find((a) => a.id === id);
+  if (!found) {
+    const known = manifest.archetypes.map((a) => a.id).join(', ');
+    throw new Error(`unknown archetype id "${id}" — known archetype ids: ${known}`);
+  }
+  return found;
+}
+
+export type { ArchetypeConfig, AgentsManifest } from './types.js';

--- a/mcp-tools/hayba-mcp/src/agents/types.ts
+++ b/mcp-tools/hayba-mcp/src/agents/types.ts
@@ -1,13 +1,43 @@
-export interface ArchetypeConfig {
-  id: string;
-  role: string;
-  system_prompt: string;
-  tool_filter: string[];          // glob patterns: "*", "actor_*", "scene_*"
-  memory_scope: 'shared' | 'private+shared';
-}
+import { z } from 'zod';
 
-export interface AgentsManifest {
-  version: number;
-  shared_memory: string;          // filename for HaybaMemory db (relative to project root)
-  archetypes: ArchetypeConfig[];
-}
+/**
+ * Schema for `hayba.agents.json` (the swarm-agent "archetype" manifest —
+ * see docs/getting-started-swarm-agents.md).
+ *
+ * Validated with zod, like the rest of this codebase, so a malformed or
+ * schema-violating file fails LOUDLY — naming the file and the offending
+ * field — instead of silently falling back to "no archetypes". A silent
+ * fallback here would look identical to the bug this file exists to fix
+ * (see issue #356 and docs/WORKFLOW-improving-the-mcp.md, "the one thing to
+ * internalise": a response/state that claims success while doing nothing).
+ *
+ * `memory_scope` deliberately reuses the SAME 'private' | 'shared'
+ * vocabulary as the memory_* tools (src/tools/memory/*.ts — see
+ * `memory_write`'s `scope` param and `MemoryBlock.scope`) rather than
+ * inventing a parallel notion. `'private+shared'` means the archetype may
+ * read/write either scope.
+ */
+export const ArchetypeConfigSchema = z.object({
+  id: z.string().min(1, 'id must be a non-empty string'),
+  role: z.string().min(1, 'role must be a non-empty string'),
+  system_prompt: z.string().min(1, 'system_prompt must be a non-empty string'),
+  tool_filter: z
+    .array(z.string().min(1, 'tool_filter entries must be non-empty strings'))
+    .min(1, 'tool_filter must contain at least one glob pattern'),
+  memory_scope: z.enum(['private', 'shared', 'private+shared']),
+});
+
+export const AgentsManifestSchema = z.object({
+  version: z.number(),
+  /** Filename for the shared memory DB (relative to project root). See
+   *  docs/getting-started-memory-system.md — the memory_* tools resolve
+   *  their own db path via config.memoryDbPath; this field is metadata
+   *  about the manifest, not currently consumed to redirect that store. */
+  shared_memory: z.string().min(1, 'shared_memory must be a non-empty string'),
+  archetypes: z
+    .array(ArchetypeConfigSchema)
+    .min(1, 'archetypes must contain at least one entry'),
+});
+
+export type ArchetypeConfig = z.infer<typeof ArchetypeConfigSchema>;
+export type AgentsManifest = z.infer<typeof AgentsManifestSchema>;

--- a/mcp-tools/hayba-mcp/src/chat/chat-server.ts
+++ b/mcp-tools/hayba-mcp/src/chat/chat-server.ts
@@ -53,6 +53,7 @@ import {
 } from './agent-loop.js';
 import type { LLMTool, LLMUsage } from '../agents/llm-client.js';
 import { createChatDispatcher } from './tool-dispatch.js';
+import { getArchetype } from '../agents/agent-registry.js';
 
 // ---------------------------------------------------------------------------
 // Localhost enforcement
@@ -563,6 +564,31 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
     }
     session.messages = messages;
 
+    // Resolve `archetype` (an id into hayba.agents.json) to its tool_filter +
+    // system_prompt. Hand-passed `archetype_filter` keeps working unchanged —
+    // this is additive: if both are given, the explicit filter wins (the
+    // caller asked for something more specific than the archetype default),
+    // but the archetype's system_prompt still applies.
+    let archetypeFilter = body.archetype_filter;
+    let turnSystem = system;
+    if (body.archetype) {
+      try {
+        const archetype = getArchetype(body.archetype);
+        turnSystem = archetype.system_prompt;
+        if (!archetypeFilter) archetypeFilter = archetype.tool_filter;
+      } catch (err) {
+        emit(session, 'error', {
+          error: err instanceof Error ? err.message : String(err),
+          kind: 'config',
+        });
+        finalize(session, 'error');
+        session.running = false;
+        session.clients.delete(res);
+        cleanup();
+        return res.end();
+      }
+    }
+
     // Resolve provider/model/key: body overrides > session config > default cfg.
     const cfg = resolveSessionConfig(sessionId);
     const provider = body.provider ?? cfg?.provider ?? 'mock';
@@ -614,9 +640,9 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
     // Drive the loop server-side, independent of the HTTP connection lifetime.
     void runTurn(session, {
       client,
-      system,
+      system: turnSystem,
       messages,
-      archetypeFilter: body.archetype_filter,
+      archetypeFilter,
       tools: options.tools,
       dispatchTool,
       signal: session.abortController.signal,

--- a/mcp-tools/hayba-mcp/tests/chat/chat-server.test.ts
+++ b/mcp-tools/hayba-mcp/tests/chat/chat-server.test.ts
@@ -465,4 +465,125 @@ describe('sidecar SSE chat server', () => {
     expect(raw).not.toContain(FAKE_KEY);
     expect(raw).not.toContain('LEAK-CANARY');
   });
+
+  // ── Archetype loader wiring (issue #356) ─────────────────────────────────
+  // These exercise the REAL hayba.agents.json shipped at the package root
+  // (chat-server.ts resolves `body.archetype` via the default manifest path,
+  // there is no injection seam for a test fixture here) so the assertions
+  // below are pinned to that file's current 'asset-manager' entry.
+  describe('archetype wiring', () => {
+    /** Records the `system` prompt and tool names offered on each stream() call. */
+    function makeRecordingClientFactory(script: ScriptStep[]): {
+      factory: () => LLMClient;
+      calls: Array<{ system: string; toolNames: string[] }>;
+    } {
+      const calls: Array<{ system: string; toolNames: string[] }> = [];
+      let turn = 0;
+      const factory = () =>
+        ({
+          provider: 'mock',
+          model: 'fake',
+          protocol: 'anthropic',
+          async complete() {
+            throw new Error('not used');
+          },
+          async *stream(params: { system: string; tools?: Array<{ name: string }> }) {
+            calls.push({ system: params.system, toolNames: (params.tools ?? []).map((t) => t.name) });
+            const step = script[turn++] ?? {
+              content: null,
+              toolCalls: [],
+              stopReason: 'end_turn' as const,
+            };
+            for (const t of step.deltas ?? []) yield { type: 'text_delta' as const, text: t };
+            yield {
+              type: 'done' as const,
+              response: { content: step.content, toolCalls: step.toolCalls, stopReason: step.stopReason },
+            };
+          },
+        }) as unknown as LLMClient;
+      return { factory, calls };
+    }
+
+    it('a known archetype id applies its system_prompt (tool_filter left to the live registry)', async () => {
+      const { factory, calls } = makeRecordingClientFactory([
+        { deltas: ['ok'], content: 'ok', toolCalls: [], stopReason: 'end_turn' },
+      ]);
+      ({ server, url } = startApp({
+        createClient: factory as never,
+        dispatchTool: async () => ({}),
+        // No `tools` override here: omitting it forces the real
+        // buildToolCatalog() path, which is what archetypeFilter feeds into.
+      }));
+
+      const res = await fetch(`${url}/chat/stream`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ session_id: 'arch1', prompt: 'hi', provider: 'mock', archetype: 'asset-manager' }),
+      });
+      const frames = await readAllFrames(res.body!);
+      expect(frames.at(-1)!.event).toBe('done');
+      expect(calls).toHaveLength(1);
+      // The asset-manager system_prompt (hayba.agents.json) mentions asset mapping —
+      // distinct from DEFAULT_SYSTEM, which never does.
+      expect(calls[0].system).toMatch(/Content Browser assets/);
+      expect(calls[0].system).not.toMatch(/in-editor copilot/);
+    });
+
+    it('an unknown archetype id fails loudly with a specific error frame, not silence', async () => {
+      const { factory, calls } = makeRecordingClientFactory([
+        { deltas: ['ok'], content: 'ok', toolCalls: [], stopReason: 'end_turn' },
+      ]);
+      ({ server, url } = startApp({
+        createClient: factory as never,
+        dispatchTool: async () => ({}),
+      }));
+
+      const res = await fetch(`${url}/chat/stream`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          session_id: 'arch2',
+          prompt: 'hi',
+          provider: 'mock',
+          archetype: 'not-a-real-archetype',
+        }),
+      });
+      const frames = await readAllFrames(res.body!);
+      const err = frames.find((f) => f.event === 'error')!.data as { error: string; kind?: string };
+      expect(err.error).toMatch(/unknown archetype id "not-a-real-archetype"/);
+      expect(err.error).toMatch(/director/); // names a KNOWN id, not just "invalid"
+      expect(frames.at(-1)!.event).toBe('done');
+      // The LLM was never even called — the gate fires before dispatch.
+      expect(calls).toHaveLength(0);
+    });
+
+    it('hand-passed archetype_filter keeps working with no archetype id given', async () => {
+      const { factory, calls } = makeRecordingClientFactory([
+        { deltas: ['ok'], content: 'ok', toolCalls: [], stopReason: 'end_turn' },
+      ]);
+      ({ server, url } = startApp({
+        createClient: factory as never,
+        dispatchTool: async () => ({}),
+        tools: [
+          { name: 'get_thing', description: 'read a thing', input_schema: { type: 'object', properties: {} } },
+        ],
+      }));
+
+      const res = await fetch(`${url}/chat/stream`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          session_id: 'arch3',
+          prompt: 'hi',
+          provider: 'mock',
+          archetype_filter: ['get_thing'],
+        }),
+      });
+      const frames = await readAllFrames(res.body!);
+      expect(frames.at(-1)!.event).toBe('done');
+      expect(calls).toHaveLength(1);
+      // No archetype id supplied → the default system prompt applies unchanged.
+      expect(calls[0].system).toMatch(/in-editor copilot/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #356.

`mcp-tools/hayba-mcp/hayba.agents.json` defines five swarm-agent archetypes (director, asset-manager, pattern-expert, node-expert, blueprint-generator) and nothing read it — the loader (`AgentRegistry`) had been deleted. This takes the issue's option 2: reinstate the loader, rather than delete the file, since the file carries authored system prompts and two docs (`docs/getting-started-swarm-agents.md`, `docs/getting-started-memory-system.md`) already reference it.

- `src/agents/types.ts` — the manifest/archetype schema, now a zod schema (source of truth) instead of a hand-written interface that could silently drift from it.
- `src/agents/agent-registry.ts` — the loader: `loadAgentsManifest` / `getAgentsManifest` (cached) / `getArchetype(id)`. Fails LOUDLY on a missing file, unreadable file, invalid JSON, or a schema violation — naming the file path and the specific failing field — never falling back to "no archetypes" silently (that failure mode is indistinguishable from today's bug).
- `src/chat/chat-server.ts` — `POST /chat/stream`'s `archetype` field (declared in the request type but never read) now resolves via `getArchetype` to that archetype's `tool_filter` + `system_prompt`. An unknown id ends the turn with a specific `error` SSE frame naming the id and the known ids, not silence. Hand-passed `archetype_filter` keeps working unchanged and is not overridden by an archetype's default filter.
- `memory_scope` validates against `'private' | 'shared' | 'private+shared'` — the same vocabulary `memory_write`'s `scope` param already uses (`src/tools/memory/`), rather than inventing a parallel notion.
- Tool-filter glob matching is **not** duplicated — `buildToolCatalog` (`src/chat/agent-loop.ts`) still owns that; the loader only resolves an id to its config and hands the glob list through unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 1612/1612 passing (158 files), no regressions, no pre-existing failures observed
- [x] `node scripts/check-legacy-wrappers.mjs` — OK, no violations
- [x] New unit tests (`src/agents/agent-registry.test.ts`, 12 cases): the real shipped `hayba.agents.json` loads all five archetypes; a valid fixture loads correctly; missing file / malformed JSON / schema-violating field / invalid `memory_scope` / missing required field / duplicate id each fail with a specific, file-naming error; a known id resolves to its `tool_filter` + `system_prompt`; an unknown id errors with the known ids listed; manifest caching + cache reset behave correctly.
- [x] New wiring tests (`tests/chat/chat-server.test.ts`, 3 cases): a known `archetype` id applies its `system_prompt`; an unknown `archetype` id fails loudly via an SSE `error` frame (LLM never even called); hand-passed `archetype_filter` still works with no `archetype` id given.
- [x] Every new test mutation-tested: broke the missing-file check, the schema-validation branch (3 assertions), the unknown-id error, and the chat-server wiring itself — each confirmed RED, then reverted and confirmed GREEN (`git diff` empty against pre-mutation state each time).

Not verified: no live UE editor / C++ side involved in this change (TS-only per scope), so no editor-side check was needed or performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable agent archetypes with custom system prompts and default tool filters.
  * Added manifest loading, validation, caching, and archetype lookup.
  * Added support for private and shared memory scopes.

* **Bug Fixes**
  * Invalid archetype selections now return clear configuration errors and safely end the session.
  * Explicit tool filters continue to override archetype defaults.

* **Tests**
  * Added comprehensive coverage for manifest validation, caching, lookups, and chat-server archetype behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->