### PR TITLE
fix(unreal): make foliage mutations partition-safe

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/foliage-handler-link-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/foliage-handler-link-contract.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const handler = readFileSync(join(
+  here, '..', '..', '..', '..',
+  'unreal', 'HaybaMCPToolkit', 'Source', 'HaybaMCPToolkit',
+  'Private', 'handlers', 'HaybaMCPFoliageHandler.cpp',
+), 'utf8');
+
+describe('UE 5.8 foliage link compatibility', () => {
+  it('does not directly call the MinimalAPI-only Blueprint AddInstances helper', () => {
+    expect(handler).not.toMatch(/AInstancedFoliageActor::AddInstances\s*\(/);
+  });
+
+  it('uses the exported IFA + foliage-info append path', () => {
+    expect(handler).toMatch(/AInstancedFoliageActor::Get\s*\(/);
+    expect(handler).toMatch(/->AddFoliageType\s*\(/);
+    expect(handler).toMatch(/Info->AddInstance\s*\(/);
+    expect(handler).toMatch(/After != Before \+ 1/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/foliage/foliage-handler-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/foliage/foliage-handler-contract.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..', '..');
+const handler = readFileSync(join(
+  root, 'unreal', 'HaybaMCPToolkit', 'Source', 'HaybaMCPToolkit',
+  'Private', 'handlers', 'HaybaMCPFoliageHandler.cpp',
+), 'utf8');
+
+describe('partition-safe foliage handler contract', () => {
+  it('never asks the actor-partition subsystem for an IFA without a level hint', () => {
+    // UE 5.8 asserts InLevelHint in ActorPartitionSubsystem.cpp:184. This exact
+    // spelling survived SEH but poisoned the session during foliage_list_types.
+    expect(handler).not.toMatch(/AInstancedFoliageActor::Get\(World,\s*(?:true|false)\s*\)/);
+  });
+
+  it('enumerates loaded partition actors for read/remove operations', () => {
+    expect(handler).toContain('TActorIterator<AInstancedFoliageActor>');
+  });
+
+  it('uses the engine-supported persistence path for add and paint', () => {
+    expect(handler.match(/AInstancedFoliageActor::AddInstances/g)?.length).toBe(2);
+    expect(handler).not.toContain('foliage instance persistence is unavailable');
+  });
+
+  it('accepts the object vector spelling published by the TypeScript schemas', () => {
+    expect(handler).toContain('TryGetObjectField(Field, VectorObj)');
+    expect(handler).toContain('TryGetNumberField(TEXT("x"), X)');
+    expect(handler).toContain('IsFiniteVector');
+  });
+
+  it('bounds the paint workload before allocating or tracing', () => {
+    expect(handler).toContain('Density > 10000');
+    expect(handler).toContain('Radius > 1000000.0');
+    expect(handler.indexOf('Density > 10000')).toBeLessThan(handler.indexOf('Transforms.Reserve(Density)'));
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/foliage/foliage-handler-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/foliage/foliage-handler-contract.test.ts
@@ -21,7 +21,9 @@ describe('partition-safe foliage handler contract', () => {
   });
 
   it('uses the engine-supported persistence path for add and paint', () => {
-    expect(handler.match(/AInstancedFoliageActor::AddInstances/g)?.length).toBe(2);
+    expect(handler).not.toMatch(/AInstancedFoliageActor::AddInstances\s*\(/);
+    expect(handler.match(/AddFoliageTransforms\(World, Type, Transforms, AddError\)/g)?.length).toBe(2);
+    expect(handler).toContain('Info->AddInstance(LocalType, Instance)');
     expect(handler).not.toContain('foliage instance persistence is unavailable');
   });
 

--- a/mcp-tools/hayba-mcp/src/tools/foliage/foliage-paint-at.ts
+++ b/mcp-tools/hayba-mcp/src/tools/foliage/foliage-paint-at.ts
@@ -13,8 +13,9 @@ export const meta: HaybaToolMeta = {
 export const schema = z.object({
   foliage_type_path: z.string().min(1).describe('FoliageType asset path to scatter'),
   location: z.object({ x: z.number(), y: z.number(), z: z.number() }).describe('World-space centre of the painted area'),
-  radius: z.number().optional().describe('Brush radius in cm'),
-  density: z.number().optional().describe('Instances per unit area, as the foliage brush means it'),
+  radius: z.number().finite().positive().max(1_000_000).optional().describe('Brush radius in cm; defaults to 200'),
+  density: z.number().int().min(1).max(10_000).optional().describe('Maximum number of placement attempts; defaults to 5'),
+  seed: z.number().int().optional().describe('Deterministic scatter seed; defaults to 1337'),
 });
 
 export const foliagePaintAtHandler: ToolHandler = ueTool('foliage_paint_at', schema);

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPFoliageHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPFoliageHandler.cpp
@@ -71,6 +71,43 @@ namespace
         }
         return Count;
     }
+
+    // UE 5.8 declares AInstancedFoliageActor::AddInstances as a Blueprint
+    // helper on a MinimalAPI class but does not export the function. Calling it
+    // directly therefore compiles and then fails LNK2019 on a clean build. Use
+    // only the explicitly FOLIAGE_API-exported pieces of the same operation.
+    static bool AddFoliageTransforms(UWorld* World, UFoliageType* Type,
+        const TArray<FTransform>& Transforms, FString& OutError)
+    {
+        if (!World || !Type)
+        {
+            OutError = TEXT("invalid world or foliage type");
+            return false;
+        }
+        for (int32 Index = 0; Index < Transforms.Num(); ++Index)
+        {
+            const FTransform& Transform = Transforms[Index];
+            AInstancedFoliageActor* IFA = AInstancedFoliageActor::Get(
+                World, /*bCreateIfNone=*/true, World->GetCurrentLevel(), Transform.GetLocation());
+            if (!IFA)
+            {
+                OutError = FString::Printf(TEXT("could not resolve/create InstancedFoliageActor for transform %d"), Index);
+                return false;
+            }
+            IFA->Modify();
+            FFoliageInfo* Info = nullptr;
+            UFoliageType* LocalType = IFA->AddFoliageType(Type, &Info);
+            if (!LocalType || !Info)
+            {
+                OutError = FString::Printf(TEXT("AddFoliageType returned no usable foliage info for transform %d"), Index);
+                return false;
+            }
+            FFoliageInstance Instance;
+            Instance.SetInstanceWorldTransform(Transform);
+            Info->AddInstance(LocalType, Instance);
+        }
+        return true;
+    }
 }
 
 TArray<FString> FHaybaMCPFoliageHandler::GetCommands() const
@@ -123,7 +160,9 @@ FHaybaHandlerResult FHaybaMCPFoliageHandler::FoliageAddInstance(const TSharedPtr
 
     const int32 Before = CountInstances(World, Type);
     const TArray<FTransform> Transforms = { FTransform(Rot, Loc, Scale) };
-    AInstancedFoliageActor::AddInstances(World, Type, Transforms);
+    FString AddError;
+    if (!AddFoliageTransforms(World, Type, Transforms, AddError))
+        return FHaybaHandlerResult::Err(FString::Printf(TEXT("foliage_add_instance: %s"), *AddError));
     const int32 After = CountInstances(World, Type);
     if (After != Before + 1)
         return FHaybaHandlerResult::Err(FString::Printf(
@@ -273,7 +312,9 @@ FHaybaHandlerResult FHaybaMCPFoliageHandler::FoliagePaintAt(const TSharedPtr<FJs
         return FHaybaHandlerResult::Err(TEXT("foliage_paint_at: no WorldStatic surface was hit; no foliage was added"));
 
     const int32 Before = CountInstances(World, Type);
-    AInstancedFoliageActor::AddInstances(World, Type, Transforms);
+    FString AddError;
+    if (!AddFoliageTransforms(World, Type, Transforms, AddError))
+        return FHaybaHandlerResult::Err(FString::Printf(TEXT("foliage_paint_at: %s"), *AddError));
     const int32 After = CountInstances(World, Type);
     const int32 Added = After - Before;
     if (Added <= 0)

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPFoliageHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPFoliageHandler.cpp
@@ -1,6 +1,7 @@
 #include "HaybaMCPFoliageHandler.h"
 #include "Json.h"
 #include "Editor.h"
+#include "EngineUtils.h"
 #include "Engine/World.h"
 #include "Engine/StaticMesh.h"
 #include "InstancedFoliageActor.h"
@@ -12,12 +13,42 @@ DEFINE_LOG_CATEGORY_STATIC(LogHaybaMCPFoliage, Log, All);
 
 namespace
 {
+    static bool IsFiniteVector(const FVector& Value)
+    {
+        return FMath::IsFinite(Value.X) && FMath::IsFinite(Value.Y) && FMath::IsFinite(Value.Z);
+    }
+
     static bool ReadVec(const TSharedPtr<FJsonObject>& Obj, const TCHAR* Field, FVector& Out)
     {
-        const TArray<TSharedPtr<FJsonValue>>* Arr;
-        if (!Obj.IsValid() || !Obj->TryGetArrayField(Field, Arr) || Arr->Num() < 3) return false;
-        Out = FVector((*Arr)[0]->AsNumber(), (*Arr)[1]->AsNumber(), (*Arr)[2]->AsNumber());
-        return true;
+        if (!Obj.IsValid()) return false;
+
+        // The TypeScript tools publish vectors as {x,y,z}. Keep accepting the
+        // historic [x,y,z] spelling as well, but never call AsNumber() on an
+        // unchecked JSON value: malformed input must be an error, not an engine
+        // assertion or a silently fabricated zero.
+        const TSharedPtr<FJsonObject>* VectorObj = nullptr;
+        if (Obj->TryGetObjectField(Field, VectorObj) && VectorObj && VectorObj->IsValid())
+        {
+            double X = 0.0, Y = 0.0, Z = 0.0;
+            if (!(*VectorObj)->TryGetNumberField(TEXT("x"), X) ||
+                !(*VectorObj)->TryGetNumberField(TEXT("y"), Y) ||
+                !(*VectorObj)->TryGetNumberField(TEXT("z"), Z))
+            {
+                return false;
+            }
+            Out = FVector(X, Y, Z);
+            return IsFiniteVector(Out);
+        }
+
+        const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+        if (!Obj->TryGetArrayField(Field, Arr) || !Arr || Arr->Num() != 3) return false;
+        double Values[3] = {};
+        for (int32 Index = 0; Index < 3; ++Index)
+        {
+            if (!(*Arr)[Index].IsValid() || !(*Arr)[Index]->TryGetNumber(Values[Index])) return false;
+        }
+        Out = FVector(Values[0], Values[1], Values[2]);
+        return IsFiniteVector(Out);
     }
 
     static UWorld* EditorWorld()
@@ -25,18 +56,20 @@ namespace
         return GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
     }
 
-    static UFoliageType* ResolveFoliageType(AInstancedFoliageActor* IFA, const FString& Path)
+    static UFoliageType* ResolveFoliageType(const FString& Path)
     {
         UObject* Loaded = LoadObject<UObject>(nullptr, *Path);
-        if (!Loaded) return nullptr;
-        if (UFoliageType* AsType = Cast<UFoliageType>(Loaded)) return AsType;
-        if (UStaticMesh* SM = Cast<UStaticMesh>(Loaded))
+        return Cast<UFoliageType>(Loaded);
+    }
+
+    static int32 CountInstances(UWorld* World, const UFoliageType* Type)
+    {
+        int32 Count = 0;
+        for (TActorIterator<AInstancedFoliageActor> It(World); It; ++It)
         {
-            UFoliageType* Created = nullptr;
-            IFA->AddMesh(SM, &Created);
-            return Created;
+            if (const FFoliageInfo* Info = It->FindInfo(Type)) Count += Info->Instances.Num();
         }
-        return nullptr;
+        return Count;
     }
 }
 
@@ -84,25 +117,24 @@ FHaybaHandlerResult FHaybaMCPFoliageHandler::FoliageAddInstance(const TSharedPtr
     FVector Scale = FVector::OneVector;
     ReadVec(*TransformObj, TEXT("scale"), Scale);
 
-    AInstancedFoliageActor* IFA = AInstancedFoliageActor::Get(World, true);
-    if (!IFA) return FHaybaHandlerResult::Err(TEXT("foliage_add_instance: cannot get IFA"));
+    UFoliageType* Type = ResolveFoliageType(Path);
+    if (!Type) return FHaybaHandlerResult::Err(FString::Printf(
+        TEXT("foliage_add_instance: '%s' did not resolve to a UFoliageType asset"), *Path));
 
-    UFoliageType* Type = ResolveFoliageType(IFA, Path);
-    if (!Type) return FHaybaHandlerResult::Err(FString::Printf(TEXT("foliage_add_instance: cannot load foliage type: %s"), *Path));
+    const int32 Before = CountInstances(World, Type);
+    const TArray<FTransform> Transforms = { FTransform(Rot, Loc, Scale) };
+    AInstancedFoliageActor::AddInstances(World, Type, Transforms);
+    const int32 After = CountInstances(World, Type);
+    if (After != Before + 1)
+        return FHaybaHandlerResult::Err(FString::Printf(
+            TEXT("foliage_add_instance: engine reported no persisted instance (before=%d, after=%d)"),
+            Before, After));
 
-    FFoliageInstance Instance;
-    Instance.Location = Loc;
-    Instance.Rotation = Rot;
-    Instance.DrawScale3D = (FVector3f)Scale;
-    (void)Instance;
-
-    // Honesty: this operation is not actually implemented — the foliage add API
-    // was reworked and no instance is ever persisted. Previously this reported
-    // added:true with the PRE-EXISTING count, which lies to the caller. Report a
-    // structured error instead until real persistence is wired up.
-    return FHaybaHandlerResult::Err(
-        TEXT("foliage_add_instance: not implemented — foliage instance persistence is unavailable "
-             "on this engine version; no instance was added"));
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetBoolField(TEXT("added"), true);
+    Out->SetNumberField(TEXT("count"), After);
+    Out->SetStringField(TEXT("foliage_type_path"), Type->GetPathName());
+    return FHaybaHandlerResult::Ok(Out);
 }
 
 FHaybaHandlerResult FHaybaMCPFoliageHandler::FoliageRemoveInstances(const TSharedPtr<FJsonObject>& P)
@@ -125,16 +157,7 @@ FHaybaHandlerResult FHaybaMCPFoliageHandler::FoliageRemoveInstances(const TShare
 
     FBox Bounds(Min, Max);
 
-    AInstancedFoliageActor* IFA = AInstancedFoliageActor::Get(World, false);
-    if (!IFA)
-    {
-        TSharedPtr<FJsonObject> O = MakeShared<FJsonObject>();
-        O->SetNumberField(TEXT("removed"), 0);
-        return FHaybaHandlerResult::Ok(O);
-    }
-
-    UObject* Loaded = LoadObject<UObject>(nullptr, *Path);
-    UFoliageType* Type = Cast<UFoliageType>(Loaded);
+    UFoliageType* Type = ResolveFoliageType(Path);
     // Honesty: a path that fails to load or isn't a UFoliageType is a caller
     // error, not a successful removal of zero instances.
     if (!Type)
@@ -142,8 +165,9 @@ FHaybaHandlerResult FHaybaMCPFoliageHandler::FoliageRemoveInstances(const TShare
             TEXT("foliage_remove_instances: '%s' did not resolve to a UFoliageType"), *Path));
 
     int32 Removed = 0;
+    for (TActorIterator<AInstancedFoliageActor> It(World); It; ++It)
     {
-        if (FFoliageInfo* Info = IFA->FindInfo(Type))
+        if (FFoliageInfo* Info = It->FindInfo(Type))
         {
             TArray<int32> ToRemove;
             for (int32 i = 0; i < Info->Instances.Num(); ++i)
@@ -151,8 +175,8 @@ FHaybaHandlerResult FHaybaMCPFoliageHandler::FoliageRemoveInstances(const TShare
                 if (Bounds.IsInside(Info->Instances[i].Location))
                     ToRemove.Add(i);
             }
-            Removed = ToRemove.Num();
-            if (Removed > 0)
+            Removed += ToRemove.Num();
+            if (ToRemove.Num() > 0)
             {
                 Info->RemoveInstances(ToRemove, true);
             }
@@ -170,21 +194,25 @@ FHaybaHandlerResult FHaybaMCPFoliageHandler::FoliageListTypes(const TSharedPtr<F
     UWorld* World = EditorWorld();
     if (!World) return FHaybaHandlerResult::Err(TEXT("foliage_list_types: no editor world"));
 
-    TArray<TSharedPtr<FJsonValue>> Types;
-    AInstancedFoliageActor* IFA = AInstancedFoliageActor::Get(World, false);
-    if (IFA)
+    TMap<UFoliageType*, int32> Counts;
+    for (TActorIterator<AInstancedFoliageActor> It(World); It; ++It)
     {
-        for (const auto& Pair : IFA->GetFoliageInfos())
+        for (const auto& Pair : It->GetFoliageInfos())
         {
             UFoliageType* Type = Pair.Key;
             const auto& Info = Pair.Value;
             if (!Type) continue;
-
-            TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
-            Entry->SetStringField(TEXT("path"), Type->GetPathName());
-            Entry->SetNumberField(TEXT("count"), Info->Instances.Num());
-            Types.Add(MakeShared<FJsonValueObject>(Entry));
+            Counts.FindOrAdd(Type) += Info->Instances.Num();
         }
+    }
+
+    TArray<TSharedPtr<FJsonValue>> Types;
+    for (const auto& Pair : Counts)
+    {
+        TSharedPtr<FJsonObject> Entry = MakeShared<FJsonObject>();
+        Entry->SetStringField(TEXT("path"), Pair.Key->GetPathName());
+        Entry->SetNumberField(TEXT("count"), Pair.Value);
+        Types.Add(MakeShared<FJsonValueObject>(Entry));
     }
 
     TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
@@ -208,22 +236,54 @@ FHaybaHandlerResult FHaybaMCPFoliageHandler::FoliagePaintAt(const TSharedPtr<FJs
 
     double Radius = 200.0;
     P->TryGetNumberField(TEXT("radius"), Radius);
+    if (!FMath::IsFinite(Radius) || Radius <= 0.0 || Radius > 1000000.0)
+        return FHaybaHandlerResult::Err(TEXT("foliage_paint_at: radius must be finite and in (0, 1000000] cm"));
 
     int32 Density = 5;
     P->TryGetNumberField(TEXT("density"), Density);
-    if (Density <= 0) Density = 1;
+    if (Density <= 0 || Density > 10000)
+        return FHaybaHandlerResult::Err(TEXT("foliage_paint_at: density must be an integer in [1, 10000]"));
 
-    AInstancedFoliageActor* IFA = AInstancedFoliageActor::Get(World, true);
-    if (!IFA) return FHaybaHandlerResult::Err(TEXT("foliage_paint_at: cannot get IFA"));
+    int32 Seed = 1337;
+    P->TryGetNumberField(TEXT("seed"), Seed);
+    UFoliageType* Type = ResolveFoliageType(Path);
+    if (!Type) return FHaybaHandlerResult::Err(FString::Printf(
+        TEXT("foliage_paint_at: '%s' did not resolve to a UFoliageType asset"), *Path));
 
-    UFoliageType* Type = ResolveFoliageType(IFA, Path);
-    if (!Type) return FHaybaHandlerResult::Err(FString::Printf(TEXT("foliage_paint_at: cannot load foliage type: %s"), *Path));
+    FRandomStream Random(Seed);
+    TArray<FTransform> Transforms;
+    Transforms.Reserve(Density);
+    FCollisionQueryParams QueryParams(SCENE_QUERY_STAT(HaybaFoliagePaint), false);
+    const double TraceHalfHeight = 1000000.0;
+    for (int32 Index = 0; Index < Density; ++Index)
+    {
+        const double Angle = Random.FRandRange(0.0f, 2.0f * PI);
+        const double Distance = Radius * FMath::Sqrt(Random.FRand());
+        const FVector XYOffset(FMath::Cos(Angle) * Distance, FMath::Sin(Angle) * Distance, 0.0);
+        FHitResult Hit;
+        const FVector Start = Center + XYOffset + FVector(0.0, 0.0, TraceHalfHeight);
+        const FVector End = Center + XYOffset - FVector(0.0, 0.0, TraceHalfHeight);
+        if (World->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic, QueryParams))
+        {
+            const FRotator Rotation = FRotationMatrix::MakeFromZ(Hit.ImpactNormal).Rotator();
+            Transforms.Add(FTransform(Rotation, Hit.ImpactPoint, FVector::OneVector));
+        }
+    }
+    if (Transforms.IsEmpty())
+        return FHaybaHandlerResult::Err(TEXT("foliage_paint_at: no WorldStatic surface was hit; no foliage was added"));
 
-    // Honesty: the paint loop below builds instances but discards each one — no
-    // foliage is actually placed. Reporting painted:<density> for zero real work
-    // is a lie, so return a structured error instead of a fabricated count.
-    (void)Center; (void)Radius; (void)Density;
-    return FHaybaHandlerResult::Err(
-        TEXT("foliage_paint_at: not implemented — foliage instance persistence is unavailable "
-             "on this engine version; no foliage was painted"));
+    const int32 Before = CountInstances(World, Type);
+    AInstancedFoliageActor::AddInstances(World, Type, Transforms);
+    const int32 After = CountInstances(World, Type);
+    const int32 Added = After - Before;
+    if (Added <= 0)
+        return FHaybaHandlerResult::Err(TEXT("foliage_paint_at: engine persisted no foliage instances"));
+
+    TSharedPtr<FJsonObject> Out = MakeShared<FJsonObject>();
+    Out->SetNumberField(TEXT("painted"), Added);
+    Out->SetNumberField(TEXT("requested"), Density);
+    Out->SetNumberField(TEXT("missed_surface"), Density - Transforms.Num());
+    Out->SetNumberField(TEXT("seed"), Seed);
+    Out->SetStringField(TEXT("foliage_type_path"), Type->GetPathName());
+    return FHaybaHandlerResult::Ok(Out);
 }


### PR DESCRIPTION
## Outcome

Removes the reproducible `ActorPartitionSubsystem.cpp:184` assertion from `foliage_list_types` and rebuilds the foliage handler around UE5.8's exported persistence APIs.

## Changes

- list/remove iterate loaded foliage actors instead of calling partition lookup without a level hint
- add/paint resolve foliage actors with an explicit level and location
- persistent instances use `AInstancedFoliageActor::AddFoliageType` plus `FFoliageInfo::AddInstance`
- vector/radius/density inputs are finite and bounded
- accepts documented TS vector objects and the legacy array form

## Verification

- incremental UE build: linked successfully
- C++/TS foliage tests: green
- disposable live editor smoke: 15 passed, 0 failed, 2 intentionally skipped
- same editor survived; mutations persisted and cleanup completed

Contributes to #369 and #373. It does not close the broader audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable foliage instance placement, removal, listing, and painting across supported world configurations.
  - Added deterministic foliage scattering through an optional seed.
  - Added safeguards for painting radius, density, vector inputs, and workload size.
  - Added confirmation of successful placement and reporting of actual painting results.

- **Bug Fixes**
  - Improved foliage persistence and handling to prevent missed instances and unsupported operations.
  - Improved error reporting when foliage operations cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->