### PR TITLE
test(crash): make the editor crash corpus executable

### DIFF
--- a/docs/audit/2026-08-10-crash-threat-model.md
+++ b/docs/audit/2026-08-10-crash-threat-model.md
@@ -1,0 +1,111 @@
+# Hayba editor-crash threat model — 2026-08-10
+
+This report turns the local crash history into an executable inventory. Its source of truth is
+[`crash-threat-model.json`](crash-threat-model.json); a contract test rejects duplicate IDs or
+signatures, missing guard/recovery/test ownership, unsourced resolved claims, arithmetic drift,
+and accidental host-private data.
+
+## Evidence boundary
+
+The inspected window is **2026-07-20 03:01:17.209 UTC through 2026-08-10 03:38:37.898 UTC**. It contains
+264 crash-report directories and 97 distinct non-empty engine `PCallStackHash` values. The counts
+below are deliberately two different measurements:
+
+- **Artifacts** count crash-report directories. Unreal writes these for ensures as well as fatal
+  process exits, so this is not an editor-death count.
+- **Signatures** count distinct engine-provided stack hashes. This is the deduplication unit. A
+  root cause may still acquire a new hash when its call site or binary changes.
+
+No report path, project asset name, source excerpt, request payload, machine/account identifier,
+or crash GUID is retained. Existing repository audit and handoff documents supply reproduction
+evidence for incidents whose crash reporter metadata does not contain a recognizable signature.
+
+## Corpus classification
+
+Classification is conservative and precedence-based: UMG GUID → PIE teardown/reference →
+transaction-buffer retention → automation execution → D3D12/RHI → constructor helper → security
+post-fault re-entry → dynamic delegates → Slate runtime collections → abstract assets → async
+imports → PIE type mismatch. First match wins, which keeps the rows disjoint.
+
+| Stable class                                                   | Artifacts | Signatures | Current disposition                                         |
+| -------------------------------------------------------------- | --------: | ---------: | ----------------------------------------------------------- |
+| `HCR-UMG-001` stale UMG variable GUID map                      |       153 |         57 | Resolved; direct compile regression                         |
+| `HCR-PIE-001` PIE world/object survives teardown               |         6 |          4 | Mitigated; survival regression still needed                 |
+| `HCR-TRANS-001` transaction buffer retains PIE object          |        68 |          3 | Mitigated; static policy exists, survival regression needed |
+| `HCR-AUTO-001` unsafe automation lifecycle/test object         |        17 |         16 | Resolved for the MCP runner; host tests remain their owners |
+| `HCR-RHI-001` RHI/render teardown fault                        |         2 |          2 | Open                                                        |
+| `HCR-CTOR-001` constructor helper used at runtime              |         2 |          1 | External host-project defect                                |
+| `HCR-SEH-001` handler fault followed by unsafe post-processing |         2 |          2 | Resolved; fault tail has an early-return contract           |
+| `HCR-DELEG-001` reflected dynamic delegate cannot bind         |         4 |          3 | External host-code defect                                   |
+| `HCR-SLATE-001` Slate collection/item lifetime corruption      |         6 |          5 | External host runtime-UI defect                             |
+| `HCR-DATA-001` abstract data-asset class reaches AssetTools    |         1 |          1 | Open; handler preflight is missing                          |
+| `HCR-IMPORT-001` async Fab/Interchange source-node failure     |         2 |          2 | External engine/third-party pipeline                        |
+| `HCR-PIETYPE-001` PIE duplication returns wrong object class   |         1 |          1 | External host asset/class defect                            |
+| **Unclassified**                                               |     **0** |      **0** | **Clear for this evidence window**                          |
+
+The classified rows reconcile exactly to 264 artifacts and 97 signatures. The release threshold
+is zero unclassified signatures, so the current manifest says `audit_threshold.met: true`.
+That is a statement about this bounded corpus, not universal coverage: the classifier emits an
+opaque one-way fingerprint for any future unknown and immediately makes the threshold fail.
+
+The original pass left 14 signatures unclassified. Mining their sibling editor logs and module
+families reduced them without guessing: three were one reflected-delegate defect; five were Slate
+list/item identity or lifetime faults; one was the second half of PIE initialization; one passed
+an abstract class to AssetTools; two belonged to the Fab/Interchange import pipeline; one was a
+PIE object-class mismatch; and one was the post-fault crash already described by `HCR-SEH-001`.
+That last signature has an unsymbolicated final stack, so its rule is intentionally narrow: it
+requires the same local incident log to show the constructor-helper fatal during `level_load`, the
+SEH guard returning control, a later successful ping, and then the Core/Engine/UnrealEd access
+violation. No single one of those markers is enough.
+
+## Reproduce the counts
+
+Run the classifier against a local Unreal crash directory; it emits no paths, messages, call
+stacks, crash GUIDs, asset names, or identity fields:
+
+```text
+node mcp-tools/hayba-mcp/scripts/audit-crash-threat-model.mjs \
+  --crash-dir <Saved/Crashes> \
+  --check-manifest docs/audit/crash-threat-model.json
+```
+
+Exit code 0 means the evidence window, first-match order, per-class artifact/signature totals,
+missing-signature count, and opaque unknown fingerprints all match the committed manifest.
+The classifier reads sibling logs only to attribute an otherwise unsymbolicated post-SEH crash;
+their contents never enter its output.
+
+## Reproduced and adversarial classes outside the classifier
+
+The manifest also owns reproduced or source-audited classes that cannot honestly inherit a corpus
+count: world switching during the MCP tick, Python callbacks/threads escaping a request, malformed
+or oversized TCP frames, partitioned foliage lookup without a level hint, self-deadlocking
+game-thread work, pathological material compilation, and non-finite/overflowing numeric input.
+Their evidence is marked `reproduced` or `inferred`, never `observed`.
+
+Every class records:
+
+- a stable ID and semantic signature;
+- the trigger and affected command/domain;
+- the layer that must refuse or contain it;
+- whether the editor remains healthy, becomes suspect, or is dead;
+- an explicit recovery action;
+- regression sources and runtime evidence; and
+- an honest status: `resolved`, `mitigated`, `open`, or `external`.
+
+“Resolved” is intentionally strict: the manifest contract requires at least one named regression
+and at least one existing source file. “Mitigated” means a guard exists but the requested
+editor-survival proof or coverage is incomplete. This report therefore makes no claim of universal
+editor-crash immunity.
+
+## Next evidence required
+
+1. Re-run the deterministic classifier whenever the evidence window advances; any opaque unknown
+   fingerprint fails the zero-unknown threshold until it receives a defensible semantic owner.
+2. Add disposable-editor survival tests for PIE teardown/transaction retention, lifetime-escaping
+   Python work, malformed frames, and every engine-assert preflight.
+3. Add the missing `data_create` abstract-class preflight and a regression before changing
+   `HCR-DATA-001` from open.
+4. Treat a caught structured exception as a suspect session forever; the safe response is a
+   minimal error and restart instruction, not continued post-processing.
+5. Never overwrite observed counts
+   with estimates from audit prose.

--- a/docs/audit/crash-threat-model.json
+++ b/docs/audit/crash-threat-model.json
@@ -1,0 +1,646 @@
+{
+  "schema_version": 1,
+  "model_id": "hayba-editor-crash-threats-v1",
+  "generated_utc": "2026-08-10T00:00:00Z",
+  "corpus": {
+    "evidence_window": {
+      "start_utc": "2026-07-20T03:01:17.209Z",
+      "end_utc": "2026-08-10T03:38:37.898Z"
+    },
+    "raw_artifact_count": 264,
+    "missing_signature_artifact_count": 0,
+    "deduplication_key": "CrashContext.RuntimeProperties.PCallStackHash",
+    "distinct_signature_count": 97,
+    "classification_semantics": "First matching rule wins. Counts are observed crash-report artifacts; distinct counts are unique non-empty engine stack hashes. Reproduced and source-audit threats have no corpus count unless the classifier also matched them.",
+    "classification_order": [
+      "stale-umg-guid-map",
+      "pie-teardown-reference",
+      "transaction-buffer-pie-retention",
+      "unsafe-automation-execution",
+      "rhi-render-teardown",
+      "illegal-constructor-helper",
+      "security-audit-reentrancy",
+      "dynamic-delegate-bind-failure",
+      "slate-runtime-collection-corruption",
+      "abstract-data-asset-instantiation",
+      "asynchronous-import-pipeline-fault",
+      "pie-object-class-mismatch"
+    ],
+    "classified": [
+      {
+        "category": "stale-umg-guid-map",
+        "threat_id": "HCR-UMG-001",
+        "observed_artifact_count": 153,
+        "observed_distinct_signature_count": 57
+      },
+      {
+        "category": "pie-teardown-reference",
+        "threat_id": "HCR-PIE-001",
+        "observed_artifact_count": 6,
+        "observed_distinct_signature_count": 4
+      },
+      {
+        "category": "transaction-buffer-pie-retention",
+        "threat_id": "HCR-TRANS-001",
+        "observed_artifact_count": 68,
+        "observed_distinct_signature_count": 3
+      },
+      {
+        "category": "unsafe-automation-execution",
+        "threat_id": "HCR-AUTO-001",
+        "observed_artifact_count": 17,
+        "observed_distinct_signature_count": 16
+      },
+      {
+        "category": "rhi-render-teardown",
+        "threat_id": "HCR-RHI-001",
+        "observed_artifact_count": 2,
+        "observed_distinct_signature_count": 2
+      },
+      {
+        "category": "illegal-constructor-helper",
+        "threat_id": "HCR-CTOR-001",
+        "observed_artifact_count": 2,
+        "observed_distinct_signature_count": 1
+      },
+      {
+        "category": "security-audit-reentrancy",
+        "threat_id": "HCR-SEH-001",
+        "observed_artifact_count": 2,
+        "observed_distinct_signature_count": 2
+      },
+      {
+        "category": "dynamic-delegate-bind-failure",
+        "threat_id": "HCR-DELEG-001",
+        "observed_artifact_count": 4,
+        "observed_distinct_signature_count": 3
+      },
+      {
+        "category": "slate-runtime-collection-corruption",
+        "threat_id": "HCR-SLATE-001",
+        "observed_artifact_count": 6,
+        "observed_distinct_signature_count": 5
+      },
+      {
+        "category": "abstract-data-asset-instantiation",
+        "threat_id": "HCR-DATA-001",
+        "observed_artifact_count": 1,
+        "observed_distinct_signature_count": 1
+      },
+      {
+        "category": "asynchronous-import-pipeline-fault",
+        "threat_id": "HCR-IMPORT-001",
+        "observed_artifact_count": 2,
+        "observed_distinct_signature_count": 2
+      },
+      {
+        "category": "pie-object-class-mismatch",
+        "threat_id": "HCR-PIETYPE-001",
+        "observed_artifact_count": 1,
+        "observed_distinct_signature_count": 1
+      }
+    ],
+    "unclassified": {
+      "observed_artifact_count": 0,
+      "observed_distinct_signature_count": 0,
+      "opaque_signature_fingerprints": [],
+      "status": "clear",
+      "disposition": "Every signature in this evidence window matched a deterministic semantic rule. Any future unmatched signature reopens the audit automatically."
+    },
+    "audit_threshold": {
+      "max_unclassified_distinct_signatures": 0,
+      "met": true
+    },
+    "limitations": [
+      "Crash reports include ensures as well as fatal process exits; an artifact count is not an editor-death count.",
+      "One root cause can produce multiple engine stack hashes after code or call-site changes.",
+      "The corpus belongs to one host project and one evidence window; it cannot prove universal crash immunity.",
+      "No crash payload, user content, machine identifier, account identifier, or absolute host path is retained here."
+    ]
+  },
+  "threats": [
+    {
+      "id": "HCR-UMG-001",
+      "signature": "widget-blueprint-variable-guid-map-desynchronization",
+      "category": "stale-umg-guid-map",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 153,
+        "observed_distinct_signature_count": 57,
+        "source_refs": ["docs/handoffs/HANDOFF-umg-validation.md"]
+      },
+      "trigger": "A UI tree mutation adds, removes, renames, duplicates, or reparents a variable widget without keeping the blueprint variable-name-to-GUID map synchronized.",
+      "affected_commands": ["ui_create_widget", "ui_add_element", "ui_mutate_tree", "ui_build_tree"],
+      "guard_layer": [
+        "ui-handler structural mutation seam",
+        "widget GUID registration and subtree purge",
+        "compile postcondition"
+      ],
+      "recovery": {
+        "session_health": "suspect",
+        "action": "Stop further UI mutation, discard the malformed transient blueprint if possible, and restart before retrying from a clean asset."
+      },
+      "test_evidence": {
+        "regressions": ["Hayba.MCP.UI.WidgetGuidRegistration"],
+        "sources": ["unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPUIHandlerTest.cpp"],
+        "runtime": ["docs/handoffs/HANDOFF-umg-validation.md"]
+      },
+      "status": "resolved"
+    },
+    {
+      "id": "HCR-PIE-001",
+      "signature": "pie-world-or-object-survives-teardown",
+      "category": "pie-teardown-reference",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 6,
+        "observed_distinct_signature_count": 4,
+        "source_refs": ["docs/handoffs/HANDOFF-umg-validation.md"]
+      },
+      "trigger": "A command creates or retains an object outered to a PIE world, then PIE teardown finds the old world or object still referenced.",
+      "affected_commands": ["ui_layout_snapshot", "ui_render_widget_to_png", "editor_start_pie", "editor_stop_pie"],
+      "guard_layer": ["PIE-state preflight", "transient-object ownership", "post-PIE survival test"],
+      "recovery": {
+        "session_health": "suspect",
+        "action": "Stop PIE, release transient widget/world references, and restart if teardown emitted an assertion or the world identity changed unexpectedly."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": ["mcp-tools/hayba-mcp/src/tools/ui/ui-render-widget-to-png.test.ts"],
+        "runtime": ["docs/handoffs/HANDOFF-umg-validation.md"]
+      },
+      "status": "mitigated"
+    },
+    {
+      "id": "HCR-TRANS-001",
+      "signature": "editor-transaction-buffer-retains-pie-world",
+      "category": "transaction-buffer-pie-retention",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 68,
+        "observed_distinct_signature_count": 3,
+        "source_refs": ["docs/handoffs/HANDOFF-umg-validation.md"]
+      },
+      "trigger": "An automation edit records a PIE-owned world, game instance, or widget in the global editor transaction buffer.",
+      "affected_commands": ["ui_set_widget_properties", "ui_mutate_tree", "ui_build_tree"],
+      "guard_layer": ["transaction policy", "PIE-state transaction suppression", "ownership-safe UI mutation"],
+      "recovery": {
+        "session_health": "suspect",
+        "action": "Do not continue mutating the retained world. Stop PIE and restart the editor so the transaction buffer cannot keep stale objects alive."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": ["unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp"],
+        "runtime": ["docs/handoffs/HANDOFF-umg-validation.md"]
+      },
+      "status": "mitigated"
+    },
+    {
+      "id": "HCR-AUTO-001",
+      "signature": "automation-runner-invalid-lifecycle-or-test-object",
+      "category": "unsafe-automation-execution",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 17,
+        "observed_distinct_signature_count": 16,
+        "source_refs": ["docs/audit/2026-08-09-test-run-seh-double-fault.md"]
+      },
+      "trigger": "The MCP runner re-enters discovery, advances or stops a test outside the framework lifecycle, or a selected test constructs an engine object with an invalid owner.",
+      "affected_commands": ["test_list", "test_run", "build_status"],
+      "guard_layer": [
+        "test selector purity",
+        "single-flight async runner",
+        "framework-state validation",
+        "structured result boundary"
+      ],
+      "recovery": {
+        "session_health": "suspect",
+        "action": "Cancel the job, do not re-enter discovery from an executing automation test, and restart after any native runner fault."
+      },
+      "test_evidence": {
+        "regressions": ["Hayba.MCP.TestSelection.SelectorsAndFailuresAreTruthful", "test-run command contract"],
+        "sources": [
+          "unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPTestSelectionTest.cpp",
+          "mcp-tools/hayba-mcp/src/legacy-commands/test-run-contract.test.ts"
+        ],
+        "runtime": ["docs/audit/2026-08-09-test-run-seh-double-fault.md"]
+      },
+      "status": "resolved"
+    },
+    {
+      "id": "HCR-RHI-001",
+      "signature": "render-or-rhi-teardown-access-violation",
+      "category": "rhi-render-teardown",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 2,
+        "observed_distinct_signature_count": 2,
+        "source_refs": ["docs/handoffs/HANDOFF-architecture-cleanup.md"]
+      },
+      "trigger": "Rendering or editor shutdown overlaps an RHI/render-thread lifetime boundary; NullRHI also cannot prove real render behavior.",
+      "affected_commands": ["render_camera", "ui_render_widget_to_png", "editor_save_all_and_quit"],
+      "guard_layer": ["render capability preflight", "async render completion", "shutdown state machine"],
+      "recovery": {
+        "session_health": "dead",
+        "action": "Restart with a real RHI, inspect the new crash signature, and do not classify a NullRHI-only result as render success or failure."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": [
+          "mcp-tools/hayba-mcp/src/tools/render-camera.test.ts",
+          "mcp-tools/hayba-mcp/src/tools/ui/ui-render-widget-to-png.test.ts"
+        ],
+        "runtime": ["docs/handoffs/HANDOFF-architecture-cleanup.md"]
+      },
+      "status": "open"
+    },
+    {
+      "id": "HCR-CTOR-001",
+      "signature": "constructor-helper-used-after-construction",
+      "category": "illegal-constructor-helper",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 2,
+        "observed_distinct_signature_count": 1,
+        "source_refs": []
+      },
+      "trigger": "Host-project code invokes an Unreal ConstructorHelpers object finder outside a UObject constructor while an MCP-driven workflow reaches that code.",
+      "affected_commands": ["python_run", "editor_start_pie", "test_run"],
+      "guard_layer": ["host-project source review", "host-project regression test", "native fault containment"],
+      "recovery": {
+        "session_health": "dead",
+        "action": "Move the asset lookup into a constructor or use a runtime load API, rebuild the host project, and relaunch."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": [],
+        "runtime": []
+      },
+      "status": "external"
+    },
+    {
+      "id": "HCR-SEH-001",
+      "signature": "native-handler-fault-followed-by-unsafe-postprocessing",
+      "category": "security-audit-reentrancy",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 2,
+        "observed_distinct_signature_count": 2,
+        "source_refs": ["docs/audit/2026-08-09-test-run-seh-double-fault.md"]
+      },
+      "trigger": "A native handler raises a structured exception, the guard regains control, and normal hashing, transaction, UI, or serialization post-processing touches corrupted state.",
+      "affected_commands": ["all native commands"],
+      "guard_layer": [
+        "global native dispatch seam",
+        "pre-dispatch parameter hash",
+        "fault-only early return",
+        "minimal fault journal"
+      ],
+      "recovery": {
+        "session_health": "suspect",
+        "action": "Return immediately, cancel any open transaction, tell the caller to restart, and never retry in the same editor process."
+      },
+      "test_evidence": {
+        "regressions": ["native handler SEH containment"],
+        "sources": ["mcp-tools/hayba-mcp/src/tools/__tests__/seh-postprocessing-gate.test.ts"],
+        "runtime": ["docs/audit/2026-08-09-test-run-seh-double-fault.md"]
+      },
+      "status": "resolved"
+    },
+    {
+      "id": "HCR-DELEG-001",
+      "signature": "dynamic-delegate-target-is-not-bindable-at-pie-start",
+      "category": "dynamic-delegate-bind-failure",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 4,
+        "observed_distinct_signature_count": 3,
+        "source_refs": ["mcp-tools/hayba-mcp/scripts/audit-crash-threat-model.mjs"]
+      },
+      "trigger": "PIE begins and host game code binds a dynamic delegate to a missing, non-UFUNCTION, or pending-kill target.",
+      "affected_commands": ["editor_start_pie", "python_run"],
+      "guard_layer": [
+        "host player-controller delegate registration",
+        "PIE startup validation",
+        "post-start ensure monitoring"
+      ],
+      "recovery": {
+        "session_health": "healthy",
+        "action": "Stop PIE, correct the reflected delegate target in host code, rebuild, and retry only after a clean startup."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": [],
+        "runtime": []
+      },
+      "status": "external"
+    },
+    {
+      "id": "HCR-SLATE-001",
+      "signature": "slate-list-item-identity-or-lifetime-corruption",
+      "category": "slate-runtime-collection-corruption",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 6,
+        "observed_distinct_signature_count": 5,
+        "source_refs": ["mcp-tools/hayba-mcp/scripts/audit-crash-threat-model.mjs"]
+      },
+      "trigger": "Runtime UI code duplicates list items, removes an item without scheduling refresh, or dispatches PIE input through a row whose UObject identity or Slate lifetime is already stale.",
+      "affected_commands": ["python_run", "editor_pie_click_widget", "editor_pie_mouse", "editor_pie_press_key"],
+      "guard_layer": [
+        "host list-model identity invariant",
+        "PIE input target revalidation",
+        "fatal Slate diagnostic monitor"
+      ],
+      "recovery": {
+        "session_health": "dead",
+        "action": "Relaunch, rebuild the runtime collection with unique live item objects, and never retry input against a cached widget path."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": [],
+        "runtime": []
+      },
+      "status": "external"
+    },
+    {
+      "id": "HCR-DATA-001",
+      "signature": "abstract-data-asset-class-reaches-asset-tools",
+      "category": "abstract-data-asset-instantiation",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 1,
+        "observed_distinct_signature_count": 1,
+        "source_refs": ["mcp-tools/hayba-mcp/scripts/audit-crash-threat-model.mjs"]
+      },
+      "trigger": "data_create accepts a UDataAsset-derived class that is abstract and passes it into AssetTools::CreateAsset.",
+      "affected_commands": ["data_create"],
+      "guard_layer": [
+        "data asset class preflight",
+        "abstract/deprecated/newer-version class flags",
+        "pre-AssetTools refusal"
+      ],
+      "recovery": {
+        "session_health": "healthy",
+        "action": "Reject the class before asset creation and retry with a concrete UDataAsset subclass; remove any transient package shell left by the failed call."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": ["unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPDataAssetHandler.cpp"],
+        "runtime": []
+      },
+      "status": "open"
+    },
+    {
+      "id": "HCR-IMPORT-001",
+      "signature": "asynchronous-fab-or-interchange-import-invalidates-source-node",
+      "category": "asynchronous-import-pipeline-fault",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 2,
+        "observed_distinct_signature_count": 2,
+        "source_refs": ["mcp-tools/hayba-mcp/scripts/audit-crash-threat-model.mjs"]
+      },
+      "trigger": "A Fab or Interchange import continues asynchronously with an invalid source node, unsupported skeletal layout, or source lifetime that ended before the import task.",
+      "affected_commands": ["python_run", "asset_import"],
+      "guard_layer": [
+        "import source validation",
+        "single-flight async import ownership",
+        "engine/third-party import completion monitor"
+      ],
+      "recovery": {
+        "session_health": "dead",
+        "action": "Relaunch, validate the source through the import pipeline UI, and do not start a second import or world transition until completion."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": [],
+        "runtime": []
+      },
+      "status": "external"
+    },
+    {
+      "id": "HCR-PIETYPE-001",
+      "signature": "pie-world-duplication-returns-unexpected-object-class",
+      "category": "pie-object-class-mismatch",
+      "evidence": {
+        "classification": "observed",
+        "kind": "crash_corpus",
+        "observed_artifact_count": 1,
+        "observed_distinct_signature_count": 1,
+        "source_refs": ["mcp-tools/hayba-mcp/scripts/audit-crash-threat-model.mjs"]
+      },
+      "trigger": "PIE world duplication resolves a host-project object or class path to an object that does not have the requested reflected type.",
+      "affected_commands": ["editor_start_pie"],
+      "guard_layer": ["host asset/class reference validation", "PIE startup preflight", "failed-start cleanup"],
+      "recovery": {
+        "session_health": "dead",
+        "action": "Relaunch, repair the host asset or class reference, resave the map/defaults, and retry PIE from a clean editor."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": [],
+        "runtime": []
+      },
+      "status": "external"
+    },
+    {
+      "id": "HCR-WORLD-001",
+      "signature": "world-switch-during-mcp-tick-desynchronizes-gworld",
+      "category": "world-switch-during-request",
+      "evidence": {
+        "classification": "reproduced",
+        "kind": "reproduced_incident",
+        "source_refs": ["docs/handoffs/HANDOFF-mcp-worldswitch-crash-guardrail.md"]
+      },
+      "trigger": "python_run or a synchronous level command loads or creates a world while the TCP drain tick still owns the previous editor world context.",
+      "affected_commands": ["python_run", "level_create", "level_load"],
+      "guard_layer": ["TypeScript preflight", "authoritative C++ python guard", "deferred editor map command"],
+      "recovery": {
+        "session_health": "suspect",
+        "action": "Reject before execution. If a world switch began, stop issuing commands and restart even if the first access violation was caught."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": [
+          "mcp-tools/hayba-mcp/src/tools/guards/known-crashers.test.ts",
+          "mcp-tools/hayba-mcp/src/tools/python/python-run.test.ts"
+        ],
+        "runtime": ["docs/handoffs/HANDOFF-mcp-worldswitch-crash-guardrail.md"]
+      },
+      "status": "mitigated"
+    },
+    {
+      "id": "HCR-LIFE-001",
+      "signature": "python-work-escapes-request-lifetime",
+      "category": "lifetime-escaping-callback-or-thread",
+      "evidence": {
+        "classification": "inferred",
+        "kind": "adversarial_model",
+        "source_refs": ["unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPythonHandler.cpp"]
+      },
+      "trigger": "A Python script registers an engine-lifetime callback, starts a thread/task, sleeps on the game thread, or leaves work running after the framed response returns.",
+      "affected_commands": ["python_run"],
+      "guard_layer": ["authoritative C++ deny policy", "TypeScript early refusal", "editor-survival harness"],
+      "recovery": {
+        "session_health": "suspect",
+        "action": "Reject the script before Python execution. If work escaped, restart rather than assuming callbacks or threads were cancelled."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": ["mcp-tools/hayba-mcp/src/tools/python/python-run.test.ts"],
+        "runtime": []
+      },
+      "status": "mitigated"
+    },
+    {
+      "id": "HCR-TCP-001",
+      "signature": "malformed-oversized-or-stalled-tcp-frame",
+      "category": "tcp-framing-and-resource-exhaustion",
+      "evidence": {
+        "classification": "inferred",
+        "kind": "adversarial_model",
+        "source_refs": ["docs/audit/2026-06-22-crash-and-architecture-audit.md"]
+      },
+      "trigger": "A loopback client declares a zero, oversized, truncated, malformed, or indefinitely stalled frame, floods the pending queue, or closes during a partial response send.",
+      "affected_commands": ["transport boundary"],
+      "guard_layer": [
+        "TCP frame decoder",
+        "request and response allocation ceilings",
+        "connection and queue backpressure",
+        "worker lifetime join"
+      ],
+      "recovery": {
+        "session_health": "healthy",
+        "action": "Close only the offending connection, retain editor liveness, and require a fresh framed ping before accepting more work from that client."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": [
+          "mcp-tools/hayba-mcp/src/tcp-client.test.ts",
+          "unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPTcpServer.cpp"
+        ],
+        "runtime": []
+      },
+      "status": "mitigated"
+    },
+    {
+      "id": "HCR-FOL-001",
+      "signature": "partitioned-foliage-lookup-without-level-hint",
+      "category": "engine-assert-precondition",
+      "evidence": {
+        "classification": "reproduced",
+        "kind": "reproduced_incident",
+        "source_refs": ["mcp-tools/hayba-mcp/src/tools/foliage/foliage-handler-contract.test.ts"]
+      },
+      "trigger": "A foliage command asks the actor-partition subsystem for an instanced foliage actor without a valid level/location hint in a partitioned world.",
+      "affected_commands": [
+        "foliage_list_types",
+        "foliage_remove_instances",
+        "foliage_add_instance",
+        "foliage_paint_at"
+      ],
+      "guard_layer": [
+        "partition-safe actor enumeration",
+        "level and location aware foliage lookup",
+        "finite bounded transform validation"
+      ],
+      "recovery": {
+        "session_health": "dead",
+        "action": "Relaunch, then use the partition-safe handler path; do not retry the unhinted actor-partition lookup."
+      },
+      "test_evidence": {
+        "regressions": ["foliage handler partition-safe contract", "foliage exported persistence API link contract"],
+        "sources": [
+          "mcp-tools/hayba-mcp/src/tools/foliage/foliage-handler-contract.test.ts",
+          "mcp-tools/hayba-mcp/src/tools/foliage-handler-link-contract.test.ts"
+        ],
+        "runtime": []
+      },
+      "status": "resolved"
+    },
+    {
+      "id": "HCR-BLOCK-001",
+      "signature": "game-thread-waits-on-work-that-requires-game-thread",
+      "category": "game-thread-deadlock-or-starvation",
+      "evidence": {
+        "classification": "inferred",
+        "kind": "source_audit",
+        "source_refs": [
+          "docs/audit/2026-06-22-crash-and-architecture-audit.md",
+          "docs/audit/2026-06-22-mcp-async-command-conversions.md"
+        ]
+      },
+      "trigger": "A handler running in the TCP drain tick waits, sleeps, or queues work back to the same game thread and then waits for it.",
+      "affected_commands": ["wait_for_idle", "wait_for_shaders", "build_project", "test_run", "render_camera"],
+      "guard_layer": ["game-thread execution seam", "asynchronous job registry", "bounded per-frame pump"],
+      "recovery": {
+        "session_health": "suspect",
+        "action": "Cancel or expire the job without waiting on the game thread; if frame progress stopped, restart and inspect the last accepted command."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": ["mcp-tools/hayba-mcp/src/legacy-commands/test-run-contract.test.ts"],
+        "runtime": []
+      },
+      "status": "mitigated"
+    },
+    {
+      "id": "HCR-MAT-001",
+      "signature": "material-compiler-engine-check-on-incomplete-graph",
+      "category": "engine-assert-precondition",
+      "evidence": {
+        "classification": "inferred",
+        "kind": "source_audit",
+        "source_refs": ["docs/audit/2026-06-22-crash-and-architecture-audit.md"]
+      },
+      "trigger": "material_compile sends an incomplete or pathological material graph into an engine compiler path containing fatal check assertions.",
+      "affected_commands": ["material_compile"],
+      "guard_layer": ["material graph preflight", "safe compile capability gate", "editor-survival test"],
+      "recovery": {
+        "session_health": "dead",
+        "action": "Relaunch, repair required material inputs before compiling, and retain unsaved graph edits only if they were persisted before the compile."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": ["mcp-tools/hayba-mcp/src/tools/material/material-compile.test.ts"],
+        "runtime": []
+      },
+      "status": "open"
+    },
+    {
+      "id": "HCR-NUM-001",
+      "signature": "nonfinite-overflowing-or-unbounded-numeric-input",
+      "category": "input-resource-exhaustion-or-engine-precondition",
+      "evidence": {
+        "classification": "inferred",
+        "kind": "source_audit",
+        "source_refs": ["docs/audit/2026-06-22-crash-and-architecture-audit.md"]
+      },
+      "trigger": "JSON numeric values become NaN, infinity, fractional integers, overflowed timeouts, huge allocations, or invalid engine vectors before a domain handler validates them.",
+      "affected_commands": ["all numeric and vector parameters"],
+      "guard_layer": ["shared parameter reader", "domain-specific bounds", "pre-allocation and pre-engine validation"],
+      "recovery": {
+        "session_health": "healthy",
+        "action": "Reject the request with the field name and accepted range before allocating memory or calling an engine API."
+      },
+      "test_evidence": {
+        "regressions": [],
+        "sources": ["unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPParamsTest.cpp"],
+        "runtime": []
+      },
+      "status": "mitigated"
+    }
+  ]
+}

--- a/mcp-tools/hayba-mcp/scripts/audit-crash-threat-model.mjs
+++ b/mcp-tools/hayba-mcp/scripts/audit-crash-threat-model.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+
+// Deterministic, privacy-preserving classifier for Unreal CrashContext files.
+//
+// It deliberately emits aggregates and one-way fingerprints only. Error text,
+// call stacks, crash GUIDs, paths, user/project names and request payloads never
+// leave the local process. Rules use stable engine assertions/modules instead
+// of artifact directory names, timestamps or machine-specific addresses.
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WINDOWS_EPOCH_TICKS = 621355968000000000n;
+
+const RULES = [
+  {
+    category: 'stale-umg-guid-map',
+    threat_id: 'HCR-UMG-001',
+    test: (evidence) =>
+      /WidgetVariableNameToGuidMap|SeenVariableNames|Ensure condition failed: WidgetProperty/.test(evidence),
+  },
+  {
+    category: 'pie-teardown-reference',
+    threat_id: 'HCR-PIE-001',
+    test: (evidence) =>
+      /from PIE level still referenced|!NewPIEWorld->bIsWorldInitialized|!bIsWorldInitialized/.test(evidence),
+  },
+  {
+    category: 'transaction-buffer-pie-retention',
+    threat_id: 'HCR-TRANS-001',
+    test: (evidence) => /is being referenced by TransBuffer/.test(evidence),
+  },
+  {
+    category: 'unsafe-automation-execution',
+    threat_id: 'HCR-AUTO-001',
+    test: (evidence) => /(?:Test\.cpp|Test::RunTest|TestHandler|Automation|GIsAutomationTesting)/i.test(evidence),
+  },
+  {
+    category: 'rhi-render-teardown',
+    threat_id: 'HCR-RHI-001',
+    test: (evidence) => /D3D12|FD3D12DynamicRHI|UnrealEditor_RHI/i.test(evidence),
+  },
+  {
+    category: 'illegal-constructor-helper',
+    threat_id: 'HCR-CTOR-001',
+    test: (evidence) => /FObjectFinders can't be used outside of constructors/.test(evidence),
+  },
+  {
+    category: 'security-audit-reentrancy',
+    threat_id: 'HCR-SEH-001',
+    test: (evidence, incidentLog) =>
+      /FHaybaMCPSecurityManager::HashParams/.test(evidence) ||
+      (/EXCEPTION_ACCESS_VIOLATION/.test(evidence) &&
+        /^UnrealEditor_Core\s+UnrealEditor_Core[\s\S]*UnrealEditor_Engine[\s\S]*UnrealEditor_UnrealEd/m.test(
+          evidence,
+        ) &&
+        /FObjectFinders can't be used outside of constructors/.test(incidentLog) &&
+        /SEH guard caught a structured exception in handler for command 'level_load'[\s\S]*Processing command: ping/.test(
+          incidentLog,
+        )),
+  },
+  {
+    category: 'dynamic-delegate-bind-failure',
+    threat_id: 'HCR-DELEG-001',
+    test: (evidence) => /Ensure condition failed: this->IsBound\(\).*Unable to bind delegate/s.test(evidence),
+  },
+  {
+    category: 'slate-runtime-collection-corruption',
+    threat_id: 'HCR-SLATE-001',
+    test: (evidence) =>
+      /OwnerTable->Private_IsPendingRefresh|TileViewT<ItemType>.*detected a critical error/s.test(evidence) ||
+      (/EXCEPTION_ACCESS_VIOLATION/.test(evidence) && /UnrealEditor_(?:Slate|SlateCore)/.test(evidence)),
+  },
+  {
+    category: 'abstract-data-asset-instantiation',
+    threat_id: 'HCR-DATA-001',
+    test: (evidence) => /Class which was marked abstract was trying to be loaded/.test(evidence),
+  },
+  {
+    category: 'asynchronous-import-pipeline-fault',
+    threat_id: 'HCR-IMPORT-001',
+    test: (evidence) => /UnrealEditor_(?:Fab|InterchangeImport|InterchangeEngine)/.test(evidence),
+  },
+  {
+    category: 'pie-object-class-mismatch',
+    threat_id: 'HCR-PIETYPE-001',
+    test: (evidence) => /Assertion failed: Ret->IsA\(T::StaticClass\(\)\)/.test(evidence),
+  },
+];
+
+function decodeXml(value) {
+  return value
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function tag(xml, name) {
+  const match = new RegExp(`<${name}>([\\s\\S]*?)</${name}>`).exec(xml);
+  return match ? decodeXml(match[1]).trim() : '';
+}
+
+function collectContexts(directory) {
+  const result = [];
+  const visit = (current) => {
+    const entries = readdirSync(current, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const child = resolve(current, entry.name);
+      if (entry.isDirectory()) visit(child);
+      else if (entry.isFile() && entry.name === 'CrashContext.runtime-xml') result.push(child);
+    }
+  };
+  visit(directory);
+  return result;
+}
+
+function ticksToIso(raw) {
+  if (!/^\d+$/.test(raw)) return null;
+  const ticks = BigInt(raw);
+  if (ticks < WINDOWS_EPOCH_TICKS) return null;
+  return new Date(Number((ticks - WINDOWS_EPOCH_TICKS) / 10000n)).toISOString();
+}
+
+function fingerprint(signature) {
+  return createHash('sha256').update(`hayba-crash-signature-v1\0${signature}`).digest('hex');
+}
+
+function readIncidentLogs(context) {
+  const logs = readdirSync(dirname(context), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.log'))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return logs.map((entry) => readFileSync(resolve(dirname(context), entry.name), 'utf8')).join('\n');
+}
+
+function safeUnclassifiedEvidence(context, xml) {
+  const safeEngineFamilies = new Set([
+    'Core',
+    'CoreUObject',
+    'Engine',
+    'UnrealEd',
+    'Slate',
+    'SlateCore',
+    'RHI',
+    'D3D12RHI',
+    'RenderCore',
+    'kernel32',
+    'ntdll',
+  ]);
+  const moduleFamilies = [];
+  for (const raw of tag(xml, 'CallStack').split(/\r?\n/)) {
+    const candidate = raw.trim().replace(/^UnrealEditor[_-]?/, '');
+    if (!/^[A-Za-z0-9]+$/.test(candidate)) continue;
+    const family = safeEngineFamilies.has(candidate) ? candidate : 'other';
+    if (moduleFamilies.includes(family)) continue;
+    moduleFamilies.push(family);
+    if (moduleFamilies.length === 5) break;
+  }
+  const secondsRaw = tag(xml, 'SecondsSinceStart');
+  const crashTypeRaw = tag(xml, 'CrashType');
+  return {
+    crash_type: /^(?:Crash|Ensure|Assert|Stall)$/.test(crashTypeRaw) ? crashTypeRaw : 'unknown',
+    seconds_since_start: /^\d+$/.test(secondsRaw) ? Number(secondsRaw) : null,
+    top_module_families: moduleFamilies,
+    sibling_log_present: readdirSync(dirname(context), { withFileTypes: true }).some(
+      (entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.log'),
+    ),
+    attribution_blocker: 'no deterministic rule matched the available sanitized CrashContext evidence',
+  };
+}
+
+function classifyCrashContexts(directory) {
+  const contexts = collectContexts(directory);
+  const bySignature = new Map();
+  const times = [];
+  let missingSignatureArtifactCount = 0;
+
+  for (const context of contexts) {
+    const xml = readFileSync(context, 'utf8');
+    const signature = tag(xml, 'PCallStackHash');
+    const time = ticksToIso(tag(xml, 'TimeOfCrash'));
+    if (time) times.push(time);
+    if (!signature) {
+      missingSignatureArtifactCount += 1;
+      continue;
+    }
+
+    // Only the fields needed by semantic rules enter memory. None are emitted.
+    const evidence = [
+      tag(xml, 'ErrorMessage'),
+      tag(xml, 'CallStack'),
+      tag(xml, 'PCallStack'),
+      tag(xml, 'SourceContext'),
+    ].join('\n');
+    // One historical post-SEH crash is only attributable in the incident log:
+    // its final CrashContext is unsymbolicated. Read logs locally, but never
+    // retain or print them. All other rules are CrashContext-only.
+    const incidentLog = readIncidentLogs(context);
+    const matched = RULES.find((rule) => rule.test(evidence, incidentLog));
+    const classification = matched ? { category: matched.category, threat_id: matched.threat_id } : null;
+    const prior = bySignature.get(signature);
+    if (prior && JSON.stringify(prior.classification) !== JSON.stringify(classification)) {
+      throw new Error('one engine stack signature produced conflicting semantic classifications');
+    }
+    if (prior) prior.artifacts += 1;
+    else {
+      bySignature.set(signature, {
+        artifacts: 1,
+        classification,
+        unclassified_evidence: classification ? null : safeUnclassifiedEvidence(context, xml),
+      });
+    }
+  }
+
+  const categoryMap = new Map();
+  const unclassified = [];
+  for (const [signature, group] of bySignature) {
+    if (!group.classification) {
+      unclassified.push({
+        fingerprint: fingerprint(signature),
+        artifacts: group.artifacts,
+        ...group.unclassified_evidence,
+      });
+      continue;
+    }
+    const key = `${group.classification.category}\0${group.classification.threat_id}`;
+    const aggregate = categoryMap.get(key) ?? {
+      category: group.classification.category,
+      threat_id: group.classification.threat_id,
+      observed_artifact_count: 0,
+      observed_distinct_signature_count: 0,
+    };
+    aggregate.observed_artifact_count += group.artifacts;
+    aggregate.observed_distinct_signature_count += 1;
+    categoryMap.set(key, aggregate);
+  }
+
+  const classified = RULES.map((rule) => categoryMap.get(`${rule.category}\0${rule.threat_id}`)).filter(Boolean);
+  unclassified.sort((a, b) => a.fingerprint.localeCompare(b.fingerprint));
+  return {
+    evidence_window: {
+      start_utc: times.length ? [...times].sort()[0] : null,
+      end_utc: times.length ? [...times].sort().at(-1) : null,
+    },
+    raw_artifact_count: contexts.length,
+    missing_signature_artifact_count: missingSignatureArtifactCount,
+    deduplication_key: 'CrashContext.RuntimeProperties.PCallStackHash',
+    distinct_signature_count: bySignature.size,
+    classification_order: RULES.map((rule) => rule.category),
+    classified,
+    unclassified: {
+      observed_artifact_count: unclassified.reduce((sum, row) => sum + row.artifacts, 0),
+      observed_distinct_signature_count: unclassified.length,
+      opaque_signature_fingerprints: unclassified,
+    },
+  };
+}
+
+function parseArguments(argv) {
+  const args = { crashDir: '', manifest: '' };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--crash-dir') args.crashDir = argv[++index] ?? '';
+    else if (argv[index] === '--check-manifest') args.manifest = argv[++index] ?? '';
+    else throw new Error('unknown argument');
+  }
+  if (!args.crashDir)
+    throw new Error('usage: audit-crash-threat-model.mjs --crash-dir <Saved/Crashes> [--check-manifest <json>]');
+  return args;
+}
+
+function comparableCorpus(value) {
+  return {
+    evidence_window: value.evidence_window,
+    raw_artifact_count: value.raw_artifact_count,
+    missing_signature_artifact_count: value.missing_signature_artifact_count ?? 0,
+    deduplication_key: value.deduplication_key,
+    distinct_signature_count: value.distinct_signature_count,
+    classification_order: value.classification_order,
+    classified: value.classified,
+    unclassified: {
+      observed_artifact_count: value.unclassified.observed_artifact_count,
+      observed_distinct_signature_count: value.unclassified.observed_distinct_signature_count,
+      opaque_signature_fingerprints: value.unclassified.opaque_signature_fingerprints,
+    },
+  };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  try {
+    const args = parseArguments(process.argv.slice(2));
+    if (!existsSync(args.crashDir)) throw new Error('crash directory does not exist');
+    const result = classifyCrashContexts(resolve(args.crashDir));
+    if (args.manifest) {
+      const manifest = JSON.parse(readFileSync(args.manifest, 'utf8'));
+      const expected = comparableCorpus(manifest.corpus);
+      const actual = comparableCorpus(result);
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        process.stderr.write('crash threat model manifest drifted from the classified corpus\n');
+        process.exitCode = 1;
+      }
+    }
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    // Filesystem/parser errors often embed the absolute input path or a snippet
+    // of malformed XML/JSON. Even failure output stays privacy-preserving.
+    const rawCode = error && typeof error === 'object' && 'code' in error ? String(error.code) : '';
+    const safeCode = /^[A-Z0-9_-]+$/.test(rawCode) ? rawCode : 'INVALID_INPUT';
+    process.stderr.write(`crash threat model audit failed: ${safeCode}\n`);
+    process.exitCode = 2;
+  }
+}
+
+export { RULES, classifyCrashContexts };

--- a/mcp-tools/hayba-mcp/src/tools/crash-threat-model-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/crash-threat-model-contract.test.ts
@@ -1,0 +1,278 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+type Status = 'resolved' | 'mitigated' | 'open' | 'external';
+type EvidenceClass = 'observed' | 'reproduced' | 'inferred';
+
+interface Threat {
+  id: string;
+  signature: string;
+  category: string;
+  evidence: {
+    classification: EvidenceClass;
+    kind: string;
+    observed_artifact_count?: number;
+    observed_distinct_signature_count?: number;
+    source_refs: string[];
+  };
+  trigger: string;
+  affected_commands: string[];
+  guard_layer: string[];
+  recovery: { session_health: string; action: string };
+  test_evidence: { regressions: string[]; sources: string[]; runtime: string[] };
+  status: Status;
+}
+
+interface Model {
+  schema_version: number;
+  model_id: string;
+  corpus: {
+    raw_artifact_count: number;
+    missing_signature_artifact_count: number;
+    distinct_signature_count: number;
+    classification_order: string[];
+    classified: Array<{
+      category: string;
+      threat_id: string;
+      observed_artifact_count: number;
+      observed_distinct_signature_count: number;
+    }>;
+    unclassified: {
+      observed_artifact_count: number;
+      observed_distinct_signature_count: number;
+      opaque_signature_fingerprints: Array<{ fingerprint: string; artifacts: number }>;
+      status: string;
+    };
+    audit_threshold: {
+      max_unclassified_distinct_signatures: number;
+      met: boolean;
+    };
+  };
+  threats: Threat[];
+}
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = resolve(here, '..', '..', '..', '..');
+const manifestPath = join(repoRoot, 'docs', 'audit', 'crash-threat-model.json');
+const reportPath = join(repoRoot, 'docs', 'audit', '2026-08-10-crash-threat-model.md');
+const classifierPath = join(repoRoot, 'mcp-tools', 'hayba-mcp', 'scripts', 'audit-crash-threat-model.mjs');
+const manifestText = readFileSync(manifestPath, 'utf8');
+const reportText = readFileSync(reportPath, 'utf8');
+const model = JSON.parse(manifestText) as Model;
+
+const nonEmpty = (value: unknown): boolean => typeof value === 'string' && value.trim().length > 0;
+
+describe('executable editor-crash threat model', () => {
+  it('uses unique stable IDs and semantic signatures', () => {
+    expect(model.schema_version).toBe(1);
+    expect(model.model_id).toBe('hayba-editor-crash-threats-v1');
+    expect(model.threats.length).toBeGreaterThanOrEqual(10);
+
+    const ids = model.threats.map((threat) => threat.id);
+    const signatures = model.threats.map((threat) => threat.signature);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(signatures).size).toBe(signatures.length);
+    for (const id of ids) expect(id).toMatch(/^HCR-[A-Z]+-\d{3}$/);
+  });
+
+  it('requires ownership, guard, recovery, evidence, and status for every class', () => {
+    const statuses: Status[] = ['resolved', 'mitigated', 'open', 'external'];
+    const evidenceClasses: EvidenceClass[] = ['observed', 'reproduced', 'inferred'];
+
+    for (const threat of model.threats) {
+      expect(nonEmpty(threat.signature), `${threat.id} signature`).toBe(true);
+      expect(nonEmpty(threat.category), `${threat.id} category`).toBe(true);
+      expect(nonEmpty(threat.trigger), `${threat.id} trigger`).toBe(true);
+      expect(threat.affected_commands.length, `${threat.id} affected commands`).toBeGreaterThan(0);
+      expect(threat.guard_layer.length, `${threat.id} guard layer`).toBeGreaterThan(0);
+      expect(nonEmpty(threat.recovery.session_health), `${threat.id} session health`).toBe(true);
+      expect(nonEmpty(threat.recovery.action), `${threat.id} recovery action`).toBe(true);
+      expect(statuses, `${threat.id} status`).toContain(threat.status);
+      expect(evidenceClasses, `${threat.id} evidence classification`).toContain(threat.evidence.classification);
+      expect(Array.isArray(threat.test_evidence.regressions)).toBe(true);
+      expect(Array.isArray(threat.test_evidence.sources)).toBe(true);
+      expect(Array.isArray(threat.test_evidence.runtime)).toBe(true);
+    }
+  });
+
+  it('never lets a resolved class lose its named regression and source', () => {
+    for (const threat of model.threats.filter((candidate) => candidate.status === 'resolved')) {
+      expect(threat.test_evidence.regressions.length, `${threat.id} regression`).toBeGreaterThan(0);
+      expect(threat.test_evidence.sources.length, `${threat.id} regression source`).toBeGreaterThan(0);
+      for (const regression of threat.test_evidence.regressions) {
+        expect(nonEmpty(regression), `${threat.id} empty regression`).toBe(true);
+        expect(regression.toLowerCase(), `${threat.id} planned regression`).not.toContain('planned');
+      }
+    }
+  });
+
+  it('keeps observed counts separate from reproduction and inference', () => {
+    for (const threat of model.threats) {
+      if (threat.evidence.classification === 'observed') {
+        expect(threat.evidence.kind, threat.id).toBe('crash_corpus');
+        expect(threat.evidence.observed_artifact_count, threat.id).toBeGreaterThan(0);
+        expect(threat.evidence.observed_distinct_signature_count, threat.id).toBeGreaterThan(0);
+      } else {
+        expect(threat.evidence.observed_artifact_count, threat.id).toBeUndefined();
+        expect(threat.evidence.observed_distinct_signature_count, threat.id).toBeUndefined();
+      }
+    }
+  });
+
+  it('reconciles classified and unknown counts without hiding the unknown tail', () => {
+    const classifiedArtifacts = model.corpus.classified.reduce((sum, row) => sum + row.observed_artifact_count, 0);
+    const classifiedSignatures = model.corpus.classified.reduce(
+      (sum, row) => sum + row.observed_distinct_signature_count,
+      0,
+    );
+    expect(classifiedArtifacts + model.corpus.unclassified.observed_artifact_count).toBe(
+      model.corpus.raw_artifact_count,
+    );
+    expect(classifiedSignatures + model.corpus.unclassified.observed_distinct_signature_count).toBe(
+      model.corpus.distinct_signature_count,
+    );
+    expect(model.corpus.missing_signature_artifact_count).toBe(0);
+    expect(model.corpus.unclassified.opaque_signature_fingerprints).toHaveLength(
+      model.corpus.unclassified.observed_distinct_signature_count,
+    );
+    for (const unknown of model.corpus.unclassified.opaque_signature_fingerprints) {
+      expect(unknown.fingerprint).toMatch(/^[a-f0-9]{64}$/);
+      expect(unknown.artifacts).toBeGreaterThan(0);
+    }
+
+    const thresholdShouldPass =
+      model.corpus.unclassified.observed_distinct_signature_count <=
+      model.corpus.audit_threshold.max_unclassified_distinct_signatures;
+    expect(model.corpus.audit_threshold.met).toBe(thresholdShouldPass);
+    if (model.corpus.unclassified.observed_distinct_signature_count > 0) {
+      expect(model.corpus.unclassified.status).toBe('open');
+      expect(model.corpus.audit_threshold.met).toBe(false);
+    } else {
+      expect(model.corpus.unclassified.status).toBe('clear');
+      expect(model.corpus.audit_threshold.met).toBe(true);
+    }
+  });
+
+  it('reproduces first-match deduplication without emitting private crash evidence', () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'hayba-crash-model-'));
+    const context = (hash: string, error: string, callStack: string, ticks: string): string => `
+<FGenericCrashContext><RuntimeProperties>
+<PCallStackHash>${hash}</PCallStackHash><TimeOfCrash>${ticks}</TimeOfCrash>
+<CrashType>Ensure</CrashType><SecondsSinceStart>7</SecondsSinceStart>
+<ErrorMessage><![CDATA[${error}]]></ErrorMessage><CallStack>${callStack}</CallStack>
+<PCallStack></PCallStack><SourceContext></SourceContext>
+</RuntimeProperties></FGenericCrashContext>`;
+    try {
+      for (const name of ['a', 'b', 'c']) mkdirSync(join(scratch, name));
+      writeFileSync(
+        join(scratch, 'a', 'CrashContext.runtime-xml'),
+        context(
+          'raw-shared-signature',
+          'WidgetVariableNameToGuidMap private-asset-name',
+          'UnrealEditor_UMGEditor',
+          '639212698003530000',
+        ),
+      );
+      writeFileSync(
+        join(scratch, 'b', 'CrashContext.runtime-xml'),
+        context(
+          'raw-shared-signature',
+          'SeenVariableNames second-private-asset',
+          'UnrealEditor_UMGEditor',
+          '639212698013530000',
+        ),
+      );
+      writeFileSync(
+        join(scratch, 'c', 'CrashContext.runtime-xml'),
+        context('raw-unknown-signature', 'secret request payload', 'PrivateHostModule', '639212698023530000'),
+      );
+      writeFileSync(join(scratch, 'c', 'PrivateProject.log'), 'private path and secret request payload');
+
+      const run = () => spawnSync(process.execPath, [classifierPath, '--crash-dir', scratch], { encoding: 'utf8' });
+      const first = run();
+      const second = run();
+      expect(first.status, first.stderr).toBe(0);
+      expect(second.status, second.stderr).toBe(0);
+      expect(second.stdout).toBe(first.stdout);
+
+      const result = JSON.parse(first.stdout) as Model['corpus'];
+      expect(result.raw_artifact_count).toBe(3);
+      expect(result.distinct_signature_count).toBe(2);
+      expect(result.classified).toEqual([
+        {
+          category: 'stale-umg-guid-map',
+          threat_id: 'HCR-UMG-001',
+          observed_artifact_count: 2,
+          observed_distinct_signature_count: 1,
+        },
+      ]);
+      expect(result.unclassified.observed_artifact_count).toBe(1);
+      expect(result.unclassified.observed_distinct_signature_count).toBe(1);
+      expect(result.unclassified.opaque_signature_fingerprints[0].fingerprint).toMatch(/^[a-f0-9]{64}$/);
+      expect(first.stdout).not.toContain(scratch);
+      expect(first.stdout).not.toContain('raw-shared-signature');
+      expect(first.stdout).not.toContain('raw-unknown-signature');
+      expect(first.stdout).not.toContain('private-asset');
+      expect(first.stdout).not.toContain('secret request payload');
+      expect(first.stdout).not.toContain('PrivateHostModule');
+      expect(first.stdout).not.toContain('PrivateProject.log');
+
+      const privateMissingPath = join(scratch, 'private-missing-corpus');
+      const failure = spawnSync(process.execPath, [classifierPath, '--crash-dir', privateMissingPath], {
+        encoding: 'utf8',
+      });
+      expect(failure.status).toBe(2);
+      expect(failure.stderr).not.toContain(privateMissingPath);
+      expect(failure.stderr).not.toContain(scratch);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  it('maps every classified corpus row to exactly one matching observed threat', () => {
+    for (const row of model.corpus.classified) {
+      const matches = model.threats.filter((threat) => threat.id === row.threat_id);
+      expect(matches, row.threat_id).toHaveLength(1);
+      const threat = matches[0];
+      expect(threat.category).toBe(row.category);
+      expect(threat.evidence.classification).toBe('observed');
+      expect(threat.evidence.observed_artifact_count).toBe(row.observed_artifact_count);
+      expect(threat.evidence.observed_distinct_signature_count).toBe(row.observed_distinct_signature_count);
+    }
+  });
+
+  it('keeps every referenced repository evidence file present', () => {
+    for (const threat of model.threats) {
+      const refs = [...threat.evidence.source_refs, ...threat.test_evidence.sources, ...threat.test_evidence.runtime];
+      for (const ref of refs) {
+        expect(ref, `${threat.id} relative evidence path`).not.toMatch(/^(?:[A-Za-z]:[\\/]|\/)/);
+        expect(existsSync(join(repoRoot, ref)), `${threat.id}: ${ref}`).toBe(true);
+      }
+    }
+  });
+
+  it('does not commit host paths, crash IDs, identity fields, or raw context payloads', () => {
+    const publicAudit = `${manifestText}\n${reportText}`;
+    expect(publicAudit).not.toMatch(/[A-Za-z]:[\\/]/);
+    expect(publicAudit).not.toMatch(/(?:\/Users\/|\\Users\\)/i);
+    expect(publicAudit).not.toMatch(/UECC-(?:Windows|Mac|Linux)-[A-F0-9_-]+/i);
+    expect(publicAudit).not.toMatch(/"(?:MachineId|LoginId|EpicAccountId|UserName|CommandLine)"\s*:/i);
+    expect(publicAudit).not.toContain('CrashContext.runtime-xml');
+  });
+
+  it('ships the deterministic classifier and documents its drift check', () => {
+    expect(existsSync(classifierPath)).toBe(true);
+    expect(reportText).toContain('audit-crash-threat-model.mjs');
+    expect(reportText).toContain('--check-manifest docs/audit/crash-threat-model.json');
+    const source = readFileSync(classifierPath, 'utf8');
+    for (const category of model.corpus.classification_order) expect(source).toContain(`category: '${category}'`);
+    expect(source).toContain("createHash('sha256')");
+    expect(source).not.toContain('MachineId');
+    expect(source).not.toContain('LoginId');
+    expect(source).not.toContain('EpicAccountId');
+  });
+});


### PR DESCRIPTION
## Outcome

Turns the historical Unreal editor crash corpus into an executable, privacy-preserving threat model.

- classifies 264 CrashContext artifacts / 97 distinct engine stack signatures
- leaves zero unknown signatures in the bounded 2026-07-20 through 2026-08-10 evidence window
- separates observed corpus counts from reproduced/inferred threats
- records guard owner, recovery, evidence and disposition for every threat class
- adds a deterministic drift checker that emits only aggregates and one-way fingerprints
- fails future drift when a new unknown signature appears

## Verification

- `node scripts/audit-crash-threat-model.mjs --crash-dir D:\Projects\aphrosia\Saved\Crashes --check-manifest ..\..\docs\audit\crash-threat-model.json`
- focused Vitest: 10/10
- `npm run typecheck`
- `npm run lint:legacy-wrappers`
- diff/format checks clean

This closes the inventory issue only. Open/mitigated threats remain owned by #365-#369 and the epic.

Fixes #364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a privacy-preserving crash audit capability that categorizes crash evidence, identifies recurring failure patterns, and highlights unknown signatures.
  * Added structured threat-model reporting covering observed, reproduced, and inferred crash risks.
* **Documentation**
  * Documented evidence handling, classification rules, audit thresholds, recovery guidance, and known limitations.
* **Tests**
  * Added automated validation for deterministic results, privacy redaction, corpus reconciliation, threat coverage, and regression detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->