### PR TITLE
Refactor tool registration around one descriptor catalogue

### DIFF
--- a/mcp-tools/hayba-mcp/scripts/smoke-tool-registration.mjs
+++ b/mcp-tools/hayba-mcp/scripts/smoke-tool-registration.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+// Rung-5 smoke test for issue #319: exercise the built MCP server through its
+// real stdio transport. This is intentionally not a Vitest in-process server;
+// it catches import-order, startup, registration, and child-process teardown
+// failures that a fake McpServer cannot. The selected hidden tool is read-only
+// and local, so the smoke never connects to or mutates an Unreal editor.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const packageRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const scratch = mkdtempSync(join(tmpdir(), 'hayba-registration-smoke-'));
+const serverEntry = join(packageRoot, 'dist', 'index.js');
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [serverEntry],
+  cwd: packageRoot,
+  stderr: 'pipe',
+  env: {
+    ...process.env,
+    HAYBA_SETTINGS_PATH: join(scratch, 'settings.json'),
+    HAYBA_TOOL_ROUTING: 'deferred',
+  },
+});
+const stderr = [];
+transport.stderr?.on('data', (chunk) => stderr.push(String(chunk)));
+const client = new Client({ name: 'hayba-registration-smoke', version: '1.0.0' });
+let stage = 'startup';
+
+async function bounded(label, promise, timeoutMs = 20_000) {
+  stage = label;
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function textOf(result) {
+  return (result.content ?? [])
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+}
+
+try {
+  await bounded('connect', client.connect(transport));
+  const listed = await bounded('list tools', client.listTools());
+  const visible = new Set(listed.tools.map((tool) => tool.name));
+  for (const bootstrap of ['list_tool_categories', 'hayba_search_tools', 'hayba_invoke']) {
+    assert(visible.has(bootstrap), `missing bootstrap tool ${bootstrap}`);
+  }
+  assert(!visible.has('memory_recall'), 'memory_recall should start hidden in deferred mode');
+
+  const categories = await bounded('list categories', client.callTool({ name: 'list_tool_categories', arguments: {} }));
+  assert.match(textOf(categories), /memory/i, 'category catalogue did not materialize');
+
+  const search = await bounded(
+    'search hidden tool',
+    client.callTool({
+      name: 'hayba_search_tools',
+      arguments: { query: 'recall remembered project context', k: 10 },
+    }),
+  );
+  assert.match(textOf(search), /memory_recall/, 'hidden tool was not searchable');
+
+  const invoked = await bounded(
+    'invoke hidden tool',
+    client.callTool({
+      name: 'hayba_invoke',
+      arguments: {
+        name: 'memory_recall',
+        args: { text: '__hayba_registration_smoke_no_match__' },
+      },
+    }),
+  );
+  const invokedText = textOf(invoked);
+  assert(!/unknown_tool/i.test(invokedText), 'hidden tool resolved as unknown');
+  assert(!/tool_disabled/i.test(invokedText), 'hidden tool was unexpectedly disabled');
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        ok: true,
+        child_pid: transport.pid,
+        bootstrap_tools: ['list_tool_categories', 'hayba_search_tools', 'hayba_invoke'],
+        hidden_tool: 'memory_recall',
+        hidden_tool_visible_initially: false,
+        hidden_tool_searchable: true,
+        hidden_tool_invokable: true,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+} catch (error) {
+  const detail = error instanceof Error ? error.message : String(error);
+  const childDiagnostics = stderr.join('').split(/\r?\n/).slice(-20).join('\n');
+  process.stderr.write(`registration smoke failed during ${stage}: ${detail}\n${childDiagnostics}\n`);
+  process.exitCode = 1;
+} finally {
+  await bounded('close client', client.close(), 5_000).catch(async () => {
+    await transport.close().catch(() => undefined);
+  });
+  rmSync(scratch, { recursive: true, force: true });
+}

--- a/mcp-tools/hayba-mcp/src/tools/__tests__/non-idempotent-domains.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/__tests__/non-idempotent-domains.test.ts
@@ -15,8 +15,9 @@
  * hand, which the comments there say out loud ("added to tool-executor's
  * NON_IDEMPOTENT set", "Mirrors FOLIAGE_NON_IDEMPOTENT"). Importing them
  * directly would close the loop properly, but the py-tools modules reach
- * tool-executor themselves, so the import cycle is real — which is exactly why
- * legacy-tool-factory mutates the set at module load instead.
+ * tool-executor themselves, so the import cycle is real. Sidecar-derived names
+ * are therefore installed explicitly during registerTools startup; catalogue
+ * imports themselves remain side-effect free.
  *
  * Hand-copying is therefore load-bearing here. This test makes the copy
  * mechanically checked rather than merely intended: add a name to a domain
@@ -76,11 +77,11 @@ describe('per-domain non-idempotent lists are mirrored into the retry gate', () 
 });
 
 describe('sidecar-derived mutating commands reach the retry gate', () => {
-  it('generateLegacyDescriptors populates NON_IDEMPOTENT', async () => {
-    const { generateLegacyDescriptors, legacyNonIdempotentNames } =
+  it('explicit startup registration populates NON_IDEMPOTENT', async () => {
+    const { registerLegacyNonIdempotent, legacyNonIdempotentNames } =
       await import('../legacy-tool-factory.js');
 
-    generateLegacyDescriptors();
+    registerLegacyNonIdempotent();
 
     const names = legacyNonIdempotentNames();
     expect(names.length, 'the sidecar should surface some mutating commands').toBeGreaterThan(0);

--- a/mcp-tools/hayba-mcp/src/tools/__tests__/register-tools-capture.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/__tests__/register-tools-capture.test.ts
@@ -5,19 +5,28 @@
  * was the entire coverage of the code path that decides which tools exist —
  * so the whole suite could stay green while the catalogue came out empty.
  *
- * The mechanism used to be a monkey-patch: assign over `server.tool`, run
- * registration, restore the original in a `finally`. It worked, but the real
- * server object spent the window in a mutated state, and the failure mode is
- * silent — a live MCP server whose `tool` method registers into a map nobody
- * reads afterwards. These tests pin the properties that made replacing it with
- * an explicit stand-in worth doing.
+ * The mechanism used to be a monkey-patch, then an explicit fake server: run
+ * eager registration and intercept `.tool()` merely to discover the catalogue.
+ * Both made a value depend on registration timing. The catalogue is now a
+ * descriptor value converted directly into a captured map; these tests pin
+ * that distinction as behavior, not source-text shape.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { registerTools } from '../index.js';
+import { config } from '../../config.js';
+import {
+  captureStaticToolCatalogue,
+  CODE_MODE_DESCRIPTORS,
+  registerTools,
+  SPECIAL_EAGER_DESCRIPTORS,
+  STANDARD_DESCRIPTORS,
+  STATIC_TOOL_CATALOGUE,
+} from '../index.js';
+import { wrapToolHandlerForStream } from '../tool-stream-mirror.js';
+import { __resetDisabledToolsCache } from '../disabled-tools-watcher.js';
 import { __resetSettingsCache } from '../routing/settings-watcher.js';
 import { __resetConnectedLatch } from '../check-ue-status.js';
 
@@ -27,17 +36,21 @@ const NO_EMBEDDINGS = { selectBackend: async () => null };
 /** Minimal stand-in for McpServer: registration only ever calls `.tool()`. */
 function fakeServer() {
   const registered = new Map<string, unknown[]>();
+  const calls = new Map<string, number>();
   const server = {
     tool: (name: string, ...rest: unknown[]) => {
       registered.set(name, rest);
+      calls.set(name, (calls.get(name) ?? 0) + 1);
     },
   };
-  return { server, registered };
+  return { server, registered, calls };
 }
 
 let dir: string;
+let originalCodeMode: boolean;
 
 beforeEach(() => {
+  originalCodeMode = config.codeMode;
   dir = mkdtempSync(join(tmpdir(), 'hayba-cap-'));
   process.env.HAYBA_SETTINGS_PATH = join(dir, 'settings.json');
   process.env.HAYBA_TOOL_INDEX_DIR = dir;
@@ -49,12 +62,65 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  config.codeMode = originalCodeMode;
+  __resetDisabledToolsCache();
   rmSync(dir, { recursive: true, force: true });
   delete process.env.HAYBA_SETTINGS_PATH;
   delete process.env.HAYBA_TOOL_INDEX_DIR;
+  delete process.env.HAYBA_DISABLED_TOOLS_PATH;
 });
 
 describe('registerTools capture', () => {
+  it('constructs the whole static catalogue directly from unique descriptors', () => {
+    const captured = captureStaticToolCatalogue({});
+    const names = STATIC_TOOL_CATALOGUE.map((d) => d.name);
+
+    expect(new Set(names).size, 'duplicate descriptor names make routing order significant').toBe(names.length);
+    expect([...captured.keys()]).toEqual(names);
+    expect(captured.size).toBe(
+      CODE_MODE_DESCRIPTORS.length + STANDARD_DESCRIPTORS.length + SPECIAL_EAGER_DESCRIPTORS.length,
+    );
+  });
+
+  it('keeps canonical signatures separate from compatibility-only wire aliases', () => {
+    const sig = CODE_MODE_DESCRIPTORS.find((d) => d.name === 'get_tool_signature')!;
+    const python = CODE_MODE_DESCRIPTORS.find((d) => d.name === 'python_run')!;
+
+    expect(Object.keys(sig.schema)).toEqual(['command']);
+    expect(Object.keys(sig.wireSchema ?? {})).toEqual(['command', 'name']);
+    expect(Object.keys(python.schema)).toEqual(['script', 'allow_unsafe']);
+    expect(Object.keys(python.wireSchema ?? {})).toEqual(['script', 'code', 'allow_unsafe']);
+  });
+
+  it('makes deferred stream wrapping idempotent before a captured tool is pack-loaded', () => {
+    const handler = async (_params: unknown) => ({ content: [] });
+    const once = wrapToolHandlerForStream('probe', handler);
+    expect(wrapToolHandlerForStream('probe', once)).toBe(once);
+  });
+
+  it('applies the plugin advisory setting at the shared native/deferred wrapper', async () => {
+    const result = {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ error: 'keep me', warnings: ['hide me'], hint: 'hide me too' }),
+      }],
+      isError: true,
+    };
+    const settings = join(dir, 'disabled-tools.json');
+    process.env.HAYBA_DISABLED_TOOLS_PATH = settings;
+    writeFileSync(settings, JSON.stringify({ disabled: [], advisory_verbosity: 'errors_only' }));
+    __resetDisabledToolsCache();
+
+    const wrapped = wrapToolHandlerForStream('advisory_probe', async (_params: unknown) => result);
+    const filtered = await wrapped({}) as typeof result;
+    expect(JSON.parse(filtered.content[0]!.text)).toEqual({ error: 'keep me' });
+
+    writeFileSync(settings, JSON.stringify({ disabled: [], advisory_verbosity: 'errors_warnings_and_tips' }));
+    __resetDisabledToolsCache();
+    const full = await wrapped({});
+    expect(full, 'full verbosity should preserve the original result identity').toBe(result);
+  });
+
   it('leaves the real server registering, not capturing', async () => {
     const { server, registered } = fakeServer();
 
@@ -78,7 +144,7 @@ describe('registerTools capture', () => {
   });
 
   it('captures the catalogue and registers only the always-on surface', async () => {
-    const { server, registered } = fakeServer();
+    const { server, registered, calls } = fakeServer();
 
     const handle = await registerTools(server as never, {} as never, NO_EMBEDDINGS);
     expect(handle, 'deferred routing should return a handle').not.toBeNull();
@@ -91,6 +157,10 @@ describe('registerTools capture', () => {
     expect(names).toContain('hayba_invoke');
     expect(names).toContain('hayba_search_tools');
     expect(names.length).toBeLessThan(20);
+    expect(
+      calls.get('hayba_check_ue_status'),
+      'the deferred autoload-aware status replacement must register exactly once',
+    ).toBe(1);
 
     // Asserted through the public search surface rather than an internal count,
     // because "an agent can find a tool it did not register" is the actual
@@ -103,5 +173,20 @@ describe('registerTools capture', () => {
         'could produce while every other test stayed green',
     ).toBeGreaterThan(0);
     expect(names, 'a searchable tool need not be registered').not.toContain(hits[0]!.name);
+  });
+
+  it('preserves full eager registration without the deferred status replacement', async () => {
+    writeFileSync(process.env.HAYBA_SETTINGS_PATH!, JSON.stringify({
+      toolRouting: 'full', alwaysLoadPacks: [],
+    }));
+    __resetSettingsCache();
+    config.codeMode = false;
+    const { server, registered, calls } = fakeServer();
+
+    const handle = await registerTools(server as never, {} as never, NO_EMBEDDINGS);
+
+    expect(handle).toBeNull();
+    expect([...registered.keys()].sort()).toEqual(STATIC_TOOL_CATALOGUE.map((d) => d.name).sort());
+    expect(calls.get('hayba_check_ue_status')).toBe(1);
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/advisory-verbosity.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/advisory-verbosity.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { applyAdvisoryVerbosity } from './advisory-verbosity.js';
+import { __resetDisabledToolsCache, getAdvisoryVerbosity } from './disabled-tools-watcher.js';
+import { VALIDATION_NUDGE } from './hayba-tool-meta.js';
+import { UNVERIFIED_MUTATION_WARNING } from './response-evidence.js';
+import type { RichToolResult } from './types.js';
+
+const originalPath = process.env.HAYBA_DISABLED_TOOLS_PATH;
+
+afterEach(() => {
+  if (originalPath === undefined) delete process.env.HAYBA_DISABLED_TOOLS_PATH;
+  else process.env.HAYBA_DISABLED_TOOLS_PATH = originalPath;
+  __resetDisabledToolsCache();
+});
+
+function textResult(value: unknown): RichToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+
+describe('advisory verbosity mirror', () => {
+  it('reads the plugin choice and falls back safely on an unknown value', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hayba-advisory-'));
+    const file = join(dir, 'runtime.json');
+    try {
+      process.env.HAYBA_DISABLED_TOOLS_PATH = file;
+      writeFileSync(file, JSON.stringify({ disabled: [], advisory_verbosity: 'errors_only' }));
+      __resetDisabledToolsCache();
+      expect(getAdvisoryVerbosity()).toBe('errors_only');
+
+      writeFileSync(file, JSON.stringify({ disabled: [], advisory_verbosity: 'invented' }));
+      __resetDisabledToolsCache();
+      expect(getAdvisoryVerbosity()).toBe('errors_and_warnings');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Node result-boundary advisory filtering', () => {
+  it('ErrorsOnly recursively strips warning/tip prose but keeps errors and machine facts', () => {
+    const result = textResult({
+      ok: false,
+      error: 'save failed',
+      warnings: ['optional warning'],
+      tip: 'optional coaching',
+      warning_count: 1,
+      failed: 1,
+      mandatory_recovery: ['save before exit'],
+      nested: { compile_warnings: ['w'], error_detail: 'must survive', hint: 'retry' },
+    });
+    const filtered = applyAdvisoryVerbosity(result, 'errors_only');
+    const payload = JSON.parse((filtered.content[0] as { text: string }).text) as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('warnings');
+    expect(payload).not.toHaveProperty('tip');
+    expect(payload).toMatchObject({ error: 'save failed', warning_count: 1, failed: 1 });
+    expect(payload.nested).toEqual({ error_detail: 'must survive' });
+    expect(payload).toHaveProperty('mandatory_recovery');
+  });
+
+  it('warning mode keeps warnings and removes tips', () => {
+    const result = textResult({ warnings: ['w'], tips: ['t'], error: 'e' });
+    const filtered = applyAdvisoryVerbosity(result, 'errors_and_warnings');
+    expect(JSON.parse((filtered.content[0] as { text: string }).text)).toEqual({
+      warnings: ['w'],
+      error: 'e',
+    });
+  });
+
+  it('removes centrally-added optional blocks at the requested levels', () => {
+    const result: RichToolResult = {
+      content: [
+        { type: 'text', text: '{"ok":true}' },
+        { type: 'text', text: UNVERIFIED_MUTATION_WARNING },
+        { type: 'text', text: VALIDATION_NUDGE },
+      ],
+    };
+    expect(applyAdvisoryVerbosity(result, 'errors_only').content).toHaveLength(1);
+    expect(
+      applyAdvisoryVerbosity(result, 'errors_and_warnings').content.map((b) => (b.type === 'text' ? b.text : '')),
+    ).toEqual(['{"ok":true}', UNVERIFIED_MUTATION_WARNING]);
+    expect(applyAdvisoryVerbosity(result, 'errors_warnings_and_tips')).toBe(result);
+  });
+
+  it('filters validator prose and structured findings by severity without hiding errors', () => {
+    const result: RichToolResult = {
+      content: [
+        {
+          type: 'text',
+          text: '[validator:error] fatal: bad — fix\n[validator:warning] risk: maybe — inspect\n[validator:info] coach: next — try',
+        },
+        {
+          type: 'text',
+          text: JSON.stringify({
+            validator: {
+              findings: [
+                { severity: 'error', message: 'bad', hint: 'fix it' },
+                { severity: 'warning', message: 'risk', hint: 'inspect it' },
+                { severity: 'info', message: 'coach', hint: 'try it' },
+              ],
+            },
+          }),
+        },
+      ],
+      isError: true,
+    };
+    const errors = applyAdvisoryVerbosity(result, 'errors_only');
+    expect((errors.content[0] as { text: string }).text).toContain('[validator:error]');
+    expect((errors.content[0] as { text: string }).text).not.toContain('[validator:warning]');
+    const structured = JSON.parse((errors.content[1] as { text: string }).text) as {
+      validator: { findings: Array<Record<string, unknown>> };
+    };
+    expect(structured.validator.findings).toEqual([{ severity: 'error', message: 'bad' }]);
+    expect(errors.isError).toBe(true);
+  });
+
+  it('never alters image blocks', () => {
+    const result: RichToolResult = { content: [{ type: 'image', data: 'x', mimeType: 'image/png' }] };
+    expect(applyAdvisoryVerbosity(result, 'errors_only')).toBe(result);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/advisory-verbosity.ts
+++ b/mcp-tools/hayba-mcp/src/tools/advisory-verbosity.ts
@@ -1,0 +1,131 @@
+import { VALIDATION_NUDGE } from './hayba-tool-meta.js';
+import { UNVERIFIED_MUTATION_WARNING } from './response-evidence.js';
+import type { AdvisoryVerbosity } from './disabled-tools-watcher.js';
+import type { RichToolResult, ToolContent } from './types.js';
+
+function isWarningField(field: string): boolean {
+  const name = field.toLowerCase();
+  return name === 'warning' || name === 'warnings' || name.endsWith('_warning') || name.endsWith('_warnings');
+}
+
+function isTipField(field: string): boolean {
+  const name = field.toLowerCase();
+  return (
+    name === 'tip' ||
+    name === 'tips' ||
+    name === 'hint' ||
+    name === 'hints' ||
+    name === 'suggestion' ||
+    name === 'suggestions' ||
+    name.endsWith('_tip') ||
+    name.endsWith('_tips') ||
+    name.endsWith('_hint') ||
+    name.endsWith('_hints') ||
+    name.endsWith('_suggestion') ||
+    name.endsWith('_suggestions')
+  );
+}
+
+function findingAllowed(value: unknown, verbosity: AdvisoryVerbosity): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return true;
+  const severity = String((value as Record<string, unknown>).severity ?? '').toLowerCase();
+  if (severity === 'error' || severity === 'fatal') return true;
+  if (severity === 'warning') return verbosity !== 'errors_only';
+  return verbosity === 'errors_warnings_and_tips';
+}
+
+function filterJson(value: unknown, verbosity: AdvisoryVerbosity): { value: unknown; changed: boolean } {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const filtered = value.map((item) => {
+      const next = filterJson(item, verbosity);
+      changed ||= next.changed;
+      return next.value;
+    });
+    return { value: filtered, changed };
+  }
+  if (!value || typeof value !== 'object') return { value, changed: false };
+
+  let changed = false;
+  const output: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (
+      (verbosity === 'errors_only' && isWarningField(key)) ||
+      (verbosity !== 'errors_warnings_and_tips' && isTipField(key))
+    ) {
+      changed = true;
+      continue;
+    }
+
+    if (key === 'findings' && Array.isArray(raw)) {
+      const allowed = raw.filter((finding) => findingAllowed(finding, verbosity));
+      if (allowed.length !== raw.length) changed = true;
+      const next = filterJson(allowed, verbosity);
+      changed ||= next.changed;
+      output[key] = next.value;
+      continue;
+    }
+
+    const next = filterJson(raw, verbosity);
+    changed ||= next.changed;
+    output[key] = next.value;
+  }
+  return { value: output, changed };
+}
+
+function filterValidatorProse(text: string, verbosity: AdvisoryVerbosity): string | null {
+  const lines = text.split(/\r?\n/);
+  const nonEmpty = lines.filter((line) => line.trim().length > 0);
+  if (nonEmpty.length === 0 || !nonEmpty.every((line) => /^\[validator:(error|warning|info)\]/.test(line.trim()))) {
+    return text;
+  }
+  const kept = nonEmpty.filter((line) => {
+    if (/^\[validator:error\]/.test(line.trim())) return true;
+    if (/^\[validator:warning\]/.test(line.trim())) return verbosity !== 'errors_only';
+    return verbosity === 'errors_warnings_and_tips';
+  });
+  return kept.length > 0 ? kept.join('\n') : null;
+}
+
+function filterText(text: string, verbosity: AdvisoryVerbosity): string | null {
+  if (verbosity !== 'errors_warnings_and_tips' && text === VALIDATION_NUDGE) return null;
+  if (verbosity === 'errors_only' && text === UNVERIFIED_MUTATION_WARNING) return null;
+
+  const validator = filterValidatorProse(text, verbosity);
+  if (validator === null || validator !== text) return validator;
+
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    const filtered = filterJson(parsed, verbosity);
+    return filtered.changed ? JSON.stringify(filtered.value, null, 2) : text;
+  } catch {
+    // Arbitrary prose has no dependable severity. Preserve it rather than
+    // deleting real errors by guessing from words such as "warning".
+    return text;
+  }
+}
+
+/**
+ * Enforce the plugin's advisory setting at the final Node MCP result boundary.
+ * Native and TS-only tools therefore cannot disagree about warning/tip policy.
+ */
+export function applyAdvisoryVerbosity<T extends RichToolResult>(result: T, verbosity: AdvisoryVerbosity): T {
+  if (verbosity === 'errors_warnings_and_tips' || !Array.isArray(result.content)) return result;
+
+  let changed = false;
+  const content: ToolContent[] = [];
+  for (const block of result.content) {
+    if (block.type !== 'text') {
+      content.push(block);
+      continue;
+    }
+    const text = filterText(block.text, verbosity);
+    if (text === null) {
+      changed = true;
+      continue;
+    }
+    if (text !== block.text) changed = true;
+    content.push(text === block.text ? block : { ...block, text });
+  }
+  return changed ? { ...result, content } : result;
+}

--- a/mcp-tools/hayba-mcp/src/tools/disabled-tools-watcher.ts
+++ b/mcp-tools/hayba-mcp/src/tools/disabled-tools-watcher.ts
@@ -8,7 +8,7 @@
 // The UE plugin's FHaybaMCPSettings::Save() writes this file every time the
 // user toggles something in the MCP panel.
 
-import { readFileSync, watch } from 'node:fs';
+import { readFileSync, watch, type FSWatcher } from 'node:fs';
 import { resolve } from 'node:path';
 
 function disabledToolsPath(): string {
@@ -21,17 +21,30 @@ function disabledToolsPath(): string {
 }
 
 let cached: Set<string> = new Set();
+export type AdvisoryVerbosity = 'errors_only' | 'errors_and_warnings' | 'errors_warnings_and_tips';
+
+const DEFAULT_ADVISORY_VERBOSITY: AdvisoryVerbosity = 'errors_and_warnings';
+let cachedAdvisoryVerbosity: AdvisoryVerbosity = DEFAULT_ADVISORY_VERBOSITY;
 let watcherInstalled = false;
+let watcher: FSWatcher | null = null;
+
+function parseAdvisoryVerbosity(value: unknown): AdvisoryVerbosity {
+  return value === 'errors_only' || value === 'errors_and_warnings' || value === 'errors_warnings_and_tips'
+    ? value
+    : DEFAULT_ADVISORY_VERBOSITY;
+}
 
 function reload(): void {
   try {
     const path = disabledToolsPath();
     const raw = readFileSync(path, 'utf-8');
-    const json = JSON.parse(raw) as { disabled?: string[] };
+    const json = JSON.parse(raw) as { disabled?: string[]; advisory_verbosity?: unknown };
     cached = new Set(json.disabled ?? []);
+    cachedAdvisoryVerbosity = parseAdvisoryVerbosity(json.advisory_verbosity);
   } catch {
     // File missing or malformed — treat as "nothing disabled".
     cached = new Set();
+    cachedAdvisoryVerbosity = DEFAULT_ADVISORY_VERBOSITY;
   }
 }
 
@@ -41,10 +54,12 @@ function ensureWatcher(): void {
   reload();
   try {
     const path = disabledToolsPath();
-    watch(path, { persistent: false }, () => reload());
+    watcher = watch(path, { persistent: false }, () => reload());
   } catch {
-    // File doesn't exist yet — the user hasn't opened the MCP tab. We'll
-    // pick it up on the next reload() call when it does.
+    // File doesn't exist yet — retry installation on the next query so a file
+    // created after Node startup is not ignored for the whole process lifetime.
+    watcherInstalled = false;
+    watcher = null;
   }
 }
 
@@ -58,8 +73,17 @@ export function listDisabledTools(): string[] {
   return Array.from(cached).sort();
 }
 
+/** User-selected optional-guidance level mirrored by the UE plugin settings. */
+export function getAdvisoryVerbosity(): AdvisoryVerbosity {
+  ensureWatcher();
+  return cachedAdvisoryVerbosity;
+}
+
 /** Reset internal cache — used in tests. Not part of the public API. */
 export function __resetDisabledToolsCache(): void {
+  watcher?.close();
+  watcher = null;
   cached = new Set();
+  cachedAdvisoryVerbosity = DEFAULT_ADVISORY_VERBOSITY;
   watcherInstalled = false;
 }

--- a/mcp-tools/hayba-mcp/src/tools/index.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import { registerTools } from './index.js';
 
 describe('Tools index', () => {
-  it('should export registerTools function', async () => {
-    const { registerTools } = await import('./index.js');
+  it('should export registerTools function', () => {
     expect(typeof registerTools).toBe('function');
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -3,21 +3,21 @@ import { z } from 'zod';
 import { config } from '../config.js';
 import { appendMeta } from './hayba-tool-meta.js';
 import type { HaybaToolMeta } from './hayba-tool-meta.js';
-import { recordSchema, type Cost } from './schema-registry.js';
-import { installToolStreamMirror } from './tool-stream-mirror.js';
+import { installToolStreamMirror, wrapToolHandlerForStream } from './tool-stream-mirror.js';
 import { installLiveSender, executeCommand } from './tool-executor.js';
-import { registerToolMeta, getToolMeta } from './tool-meta-registry.js';
+import { registerToolMeta } from './tool-meta-registry.js';
 import { readSettings } from './routing/settings-watcher.js';
 import { registerDeferredRouting, type CapturedTool, type RoutingHandle, type DeferredRoutingOptions } from './routing/register.js';
-import { defineTool, registerTool, recordToolSchema, type ToolDescriptor } from './register-tool.js';
+import {
+  defineTool,
+  materializeTool,
+  registerTool,
+  recordToolSchema,
+  type ToolDescriptor,
+} from './register-tool.js';
 import { resolveAliases } from './param-aliases.js';
 import { TOOL_ALIASES } from './tool-aliases.js';
 import { AUDIO_DESCRIPTORS } from './audio/audio-tools.js';
-import {
-  guardHandlerWithEvidence,
-  isUnderEvidenceContract,
-  parseEffectsFromDescription,
-} from './response-evidence.js';
 import { errorResult, okResult } from './tool-result.js';
 
 // ── Code Mode meta-tools (always-on) ──────────────────────────────────────────
@@ -348,7 +348,7 @@ import { landscapePyDescriptors } from './landscape/landscape-py-tools.js';
 import { foliagePyDescriptors } from './foliage/foliage-py-tools.js';
 import { lightingPyDescriptors } from './lighting/lighting-py-tools.js';
 import { toToolDescriptor } from './py-tool-factory.js';
-import { generateLegacyDescriptors } from './legacy-tool-factory.js';
+import { generateLegacyDescriptors, registerLegacyNonIdempotent } from './legacy-tool-factory.js';
 
 // ── Zone painter tool handlers ────────────────────────────────────────────────
 import { openZonePainterHandler } from './hayba-open-zone-painter.js';
@@ -440,10 +440,10 @@ type SessionManagerStub = {
 };
 
 // ── Shared Zod coercion helpers (module scope) ───────────────────────────────
-// Hoisted so the single descriptor list (buildStandardDescriptors) is the only
+// Hoisted so the descriptor catalogue is the only
 // place each tool's shape is declared — consumed both by recordToolSchema
-// (always) and registerTool (eager block). Previously these were defined twice:
-// once in registerToolsCore and once in recordEagerSchemas, identically.
+// (always) and registerTool (eager mode). Previously these were defined twice:
+// once for native registration and once for schema seeding, identically.
 const dVec3 = z.tuple([z.number(), z.number(), z.number()]);
 // Some MCP clients (incl. Claude Code's tool harness) JSON-stringify nested
 // arrays/booleans before they hit Zod. Wrap so we accept both raw and the
@@ -464,33 +464,15 @@ const dCoerceVec3 = z.preprocess((v) => {
  * Single-source tool descriptor list.
  *
  * ## Pattern
- * Each entry is a ToolDescriptor that declares the tool ONCE. Two consumers
- * iterate this list:
- *   - recordEagerSchemas → recordToolSchema(d)   — records Zod shape + cost +
- *     returns into the schema registry so get_tool_signature can derive params
- *     at runtime, regardless of Code Mode.
- *   - registerToolsCore eager block → registerTool(server, session, d) — calls
- *     server.tool(appendMeta(desc, meta), schema, handler) + remember(name, meta),
- *     only when Code Mode is off.
- *
- * ## Eligible tools
- * A tool belongs here if:
- *   1. Its server.tool schema and its reg() entry are identical (no drift).
- *   2. The handler is a plain ToolHandler — no custom closures or side-effects
- *      baked into the eager registration block.
- *   3. The tool returns ToolResult (not RichToolResult with image blocks).
- *
- * ## Non-eligible (stay hand-written)
- *   - editor_capture_viewport: custom wait_for_shaders pre-step closure.
- *   - editor_stream_log: reg schema adds fields absent from server.tool schema.
- *   - pcg_cook_and_wait: 3-step TS orchestrator (python generate → wait_for_idle → python inspect), not a single buildScript.
- *   - PLUMB / validator / PCGEx / zone-painter / conventions: these have no
- *     meta or non-standard registration — migrate incrementally as needed.
+ * Each entry is a ToolDescriptor that declares the tool once. The complete
+ * STATIC_TOOL_CATALOGUE has three consumers: schema seeding, eager native
+ * registration, and direct deferred capture. Rich image results and small
+ * orchestration closures are valid descriptor handlers; they are behavior, not
+ * a reason to invent a sixth registration path.
  *
  * ## Adding a new tool
- * Add a ToolDescriptor entry here. Do NOT add a separate server.tool call in
- * registerToolsCore or a separate reg() call in recordEagerSchemas — those
- * are now generated automatically from this list.
+ * Add a ToolDescriptor to the appropriate catalogue shard. Do not add a
+ * separate server.tool call or schema-registry entry.
  */
 const M = 'material'; // niche domain for the material toolset
 const UI = 'ui'; // niche domain for the UMG / Widget Blueprint toolset
@@ -3410,80 +3392,188 @@ export const STANDARD_DESCRIPTORS: ToolDescriptor[] = [
   ),
 ];
 
+const ueStatusMeta: HaybaToolMeta = {
+  cost: 'low',
+  effects: [],
+  when: 'checking whether the Unreal editor bridge is reachable before an editor operation',
+  not_when: 'a just-completed editor call already proved the bridge is reachable',
+};
+
+/**
+ * Tools exposed even when the large eager catalogue is hidden by Code Mode.
+ *
+ * They used to be hand-written `server.tool(...)` calls with separate schema
+ * registry entries. `wireSchema` preserves the two compatibility aliases while
+ * `schema` remains the canonical signature shown to agents.
+ */
+export const CODE_MODE_DESCRIPTORS: ToolDescriptor[] = [
+  defineTool({
+    name: 'list_tool_categories',
+    description:
+      'List all HaybaOS command domains and their commands. Call this first to discover what is available before requesting a specific schema.',
+    meta: listMeta,
+    schema: {},
+    cost: 'low',
+    returns: '{categories:[{domain,commands:[string]}]}',
+    handler: async (_params, session) => listToolCategoriesHandler({}, session),
+  }),
+  defineTool({
+    name: 'get_tool_signature',
+    description:
+      'Return the JSON schema (params, return shape, cost) for a specific HaybaOS command. Call list_tool_categories first to find command names.',
+    meta: sigMeta,
+    schema: {
+      command: z.string().describe('Exact command name, e.g. "actor_spawn"'),
+    },
+    wireSchema: {
+      command: z.string().optional().describe('Exact command name, e.g. "actor_spawn"'),
+      name: z.string().optional().describe('Alias for "command".'),
+    },
+    cost: 'low',
+    returns: '{command, params, returns, cost} or {status:"no_schema_available", did_you_mean}',
+    handler: async (params, session) => {
+      const resolved = resolveAliases(params as Record<string, unknown>, TOOL_ALIASES.get_tool_signature);
+      if (!resolved.ok) return errorResult(`Validation error: ${resolved.error}`);
+      return getToolSignatureHandler(resolved.args, session);
+    },
+  }),
+  defineTool({
+    name: 'python_run',
+    description:
+      'Execute a Python script inside UE via PythonScriptPlugin. Universal escape hatch for invoking any UE command not otherwise exposed.',
+    meta: pyMeta,
+    schema: {
+      script: z.string().describe('Python source to execute'),
+      allow_unsafe: z
+        .boolean()
+        .optional()
+        .describe(
+          'Override only the Tier 3 filesystem/subprocess policy (DANGEROUS). It cannot bypass crash, deadlock, editor-lifetime, or execution-deadline guards.',
+        ),
+    },
+    wireSchema: {
+      script: z.string().optional().describe('Python source to execute'),
+      code: z.string().optional().describe('Alias for "script".'),
+      allow_unsafe: z
+        .boolean()
+        .optional()
+        .describe(
+          'Override only the Tier 3 filesystem/subprocess policy (DANGEROUS). It cannot bypass crash, deadlock, editor-lifetime, or execution-deadline guards.',
+        ),
+    },
+    cost: 'high',
+    returns: '{ok, tier, stdout, stderr}',
+    handler: async (params, session) => pythonRunHandler(params as Record<string, unknown>, session),
+  }),
+];
+
+/** Eager-only tools whose wrappers need a small amount of local orchestration. */
+export const SPECIAL_EAGER_DESCRIPTORS: ToolDescriptor[] = [
+  {
+    name: 'editor_capture_viewport',
+    description:
+      'Capture the active editor viewport and return it as an inline image block (plus a small text block with camera/width/height). Set HAYBA_CAPTURE_TO_FILE to also spill the image to a temp file path.',
+    meta: captureMeta,
+    schema: {
+      width: z.coerce.number().int().optional(),
+      height: z.coerce.number().int().optional(),
+      wait_for_shaders: z
+        .boolean()
+        .optional()
+        .describe('If true, calls wait_for_shaders first (max_seconds=60, poll_seconds=1).'),
+    },
+    cost: 'medium',
+    returns: '{width, height, camera, ...} + the capture as an image block',
+    handler: async (params, session) => {
+      if (params.wait_for_shaders === true) {
+        await handleWaitForShaders({ max_seconds: 60, poll_seconds: 1 });
+      }
+      return editorCaptureViewportHandler(params as Record<string, unknown>, session);
+    },
+  },
+  defineTool({
+    name: 'editor_stream_log',
+    description: 'Tail recent UE log lines (paged via since_line).',
+    meta: streamLogMeta,
+    schema: {
+      filter: z.string().optional(),
+      since_line: z.coerce.number().int().nonnegative().optional(),
+    },
+    cost: 'low',
+    returns: '{lines:[string], next_line:int}',
+    handler: async (params, session) => editorStreamLogHandler(params as Record<string, unknown>, session),
+  }),
+  defineTool({
+    name: 'hayba_check_ue_status',
+    description: 'Check whether the Unreal editor bridge is reachable and report its current identity and status.',
+    meta: ueStatusMeta,
+    schema: {},
+    cost: 'low',
+    returns: '{connected, status, ueVersion, plugin, pluginVersion}',
+    handler: async () => okResult(await checkUeStatus()),
+  }),
+];
+
+/** Every statically declared tool, independent of which routing mode exposes it. */
+export const STATIC_TOOL_CATALOGUE: ReadonlyArray<ToolDescriptor> = [
+  ...CODE_MODE_DESCRIPTORS,
+  ...STANDARD_DESCRIPTORS,
+  ...SPECIAL_EAGER_DESCRIPTORS,
+];
+
+/**
+ * Convert the static catalogue directly into the deferred-routing value map.
+ * No registration code runs and no real or fake `server.tool` is involved.
+ */
+export function captureStaticToolCatalogue(
+  session: SessionManagerStub,
+): Map<string, CapturedTool> {
+  const captured = new Map<string, CapturedTool>();
+  for (const descriptor of STATIC_TOOL_CATALOGUE) {
+    if (captured.has(descriptor.name)) {
+      throw new Error(`duplicate static tool descriptor: ${descriptor.name}`);
+    }
+    registerToolMeta(descriptor.name, descriptor.meta);
+    const tool = materializeTool(session, descriptor);
+    captured.set(tool.name, {
+      description: tool.description,
+      schema: tool.schema,
+      handler: wrapToolHandlerForStream(tool.name, tool.handler) as CapturedTool['handler'],
+      dir: inferDir(tool.name),
+    });
+  }
+  return captured;
+}
+
 export async function registerTools(
   server: McpServer,
   session: SessionManagerStub,
   /** Forwarded to registerDeferredRouting. Exists so a test can pass a
    *  lexical-only embedding backend instead of letting the default probe reach
    *  the network — without it this function is untestable, which is how the
-   *  capture shim went uncovered for as long as it did. */
+   *  catalogue-construction path went uncovered for as long as it did. */
   options: DeferredRoutingOptions = {},
 ): Promise<RoutingHandle | null> {
+  // Retry policy is startup wiring, not an import-time side effect of building
+  // the sidecar descriptor values.
+  registerLegacyNonIdempotent();
+
+  // Runtime wiring is independent of catalogue construction. In particular,
+  // neither call below is made against a capture stand-in.
+  void installLiveSender();
+  installToolStreamMirror(server);
+
+  // Signatures exist in every mode, including Code Mode where most native MCP
+  // registrations are deliberately hidden until discovered.
+  seedCatalogueSchemas();
+
   const settings = readSettings();
   if (settings.toolRouting === 'deferred') {
-    // γ-hybrid: capture every server.tool(...) call into a descriptor map
-    // without registering it. registerDeferredRouting wires the always-on
-    // meta-tools and packs against the captured set.
-    const captured = new Map<string, CapturedTool>();
-
-    const capture = (name: string, ...rest: unknown[]): void => {
-      let description: string | undefined;
-      let schema: z.ZodRawShape;
-      let handler: (...args: unknown[]) => unknown;
-      if (typeof rest[0] === 'string') {
-        description = rest[0] as string;
-        schema = rest[1] as z.ZodRawShape;
-        handler = rest[2] as (...args: unknown[]) => unknown;
-      } else {
-        schema = rest[0] as z.ZodRawShape;
-        handler = rest[1] as (...args: unknown[]) => unknown;
-      }
-      const dir = inferDir(name);
-      // Put every captured tool under the response-evidence contract, not just
-      // the ones registered through registerTool — a tool should not escape the
-      // rule because of which registration path it took.
-      //
-      // Effects come from the meta registry when the tool has one. Only the
-      // hand-rolled server.tool(...) sites, which never register a meta object,
-      // fall back to recovering them from the description string — the effects
-      // are appended there as `[effects=[...]]` by appendMeta, so parsing them
-      // back out is reading our own formatting rather than a fact. Data first,
-      // string-scraping only where there is no data.
-      //
-      // Note the `.length` check rather than `??`. A registered meta with
-      // `effects: []` is a truthy value, so `??` would accept it and suppress
-      // the description fallback — quietly dropping that tool out of the
-      // evidence contract. This can only ever add coverage, never remove it.
-      const metaEffects = getToolMeta(name)?.effects;
-      const effects = metaEffects && metaEffects.length > 0
-        ? metaEffects
-        : parseEffectsFromDescription(description);
-      const guarded = isUnderEvidenceContract(effects) ? guardHandlerWithEvidence(handler) : handler;
-      captured.set(name, { description, schema, handler: guarded, dir });
-      // Nothing is forwarded to the real server here — registerDeferredRouting
-      // registers only the always-on subset plus alwaysLoadPacks tools.
-    };
-
-    // Registration writes into this stand-in, not into the real server.
-    //
-    // It used to monkey-patch `server.tool`, run registration, and restore the
-    // original in a `finally`. Same effect, but the real object spent the
-    // window in a mutated state: anything else holding a reference to it saw
-    // the capturing implementation, the tool-stream mirror silently wrapped the
-    // shim instead of the server (which is why it had to be re-installed
-    // afterwards), and an exception anywhere in registration risked leaving a
-    // live MCP server whose `tool` method quietly registered nothing.
-    //
-    // registerToolsCore only ever calls `.tool()`, so the stand-in only needs
-    // that. If it grows another dependency, this cast stops compiling — which
-    // is the point of writing it out rather than patching in place.
-    const capturingServer = { tool: capture } as unknown as McpServer;
-
-    registerToolsCore(capturingServer, session, { forceEager: true });
-
-    // The mirror goes on the real server. registerToolsCore installed one on
-    // the stand-in, which is discarded with it.
-    installToolStreamMirror(server);
+    // γ-hybrid: the complete static catalogue is already data. Convert the
+    // descriptors straight into the captured map; registration is no longer
+    // executed for its side effects merely to discover what would register.
+    const captured = captureStaticToolCatalogue(session);
+    installToolHooks();
 
     // Now register meta-tools + alwaysLoadPacks. Awaited so the caller can
     // sequence server.connect() after every server.tool() call has happened
@@ -3493,7 +3583,21 @@ export async function registerTools(
     return handle;
   }
 
-  registerToolsCore(server, session);
+  for (const descriptor of CODE_MODE_DESCRIPTORS) {
+    registerTool(server, session, descriptor);
+  }
+
+  // Code Mode keeps the native surface small. The descriptors and signatures
+  // still exist as values above; only native registration is skipped.
+  if (config.codeMode) return null;
+
+  for (const descriptor of STANDARD_DESCRIPTORS) {
+    registerTool(server, session, descriptor);
+  }
+  for (const descriptor of SPECIAL_EAGER_DESCRIPTORS) {
+    registerTool(server, session, descriptor);
+  }
+  installToolHooks();
   return null;
 }
 
@@ -3538,691 +3642,8 @@ export function inferDir(name: string): string | null {
   return null;
 }
 
-/** Options for {@link registerToolsCore}.
- *
- *  `forceEager` exists so the deferred-routing capture can walk the *whole*
- *  catalogue. It used to be expressed by assigning `config.codeMode = false`
- *  around the call and restoring it in a `finally` — a global mutated to pass
- *  one boolean one level down, which meant anything else reading `config`
- *  during registration saw a value that was briefly a lie. */
-interface RegisterCoreOptions {
-  forceEager?: boolean;
-}
-
-function registerToolsCore(
-  server: McpServer,
-  session: SessionManagerStub,
-  { forceEager = false }: RegisterCoreOptions = {},
-): void {
-  // Fire-and-forget: dynamic import resolves in <1ms; MCP handshake takes longer
-  // so any tool call is guaranteed to find DEFAULT_SENDER set.
-  void installLiveSender();
-
-  // Local helper: pushes the tool's meta into the registry so the ToolExecutor
-  // can look up cost by command name. Keeps registration sites one-liner.
-  const remember = (name: string, meta: HaybaToolMeta | undefined): void => {
-    if (meta) registerToolMeta(name, meta);
-  };
-
-  // Wrap server.tool BEFORE any registration so every tool is captured in the
-  // UE Tool Stream panel, including pure TS-side handlers (PCGEx catalog, etc).
-  installToolStreamMirror(server);
-
-  // Record every Zod shape into the schema registry so get_tool_signature can
-  // derive parameter docs from the actual validation schema — independent of
-  // whether the tool is also eagerly registered with server.tool() under
-  // Code Mode. The registry is the source of truth; the hand-maintained dict
-  // in get-tool-signature.ts is only a fallback for un-migrated tools.
-  const reg = (name: string, shape: z.ZodRawShape, cost: Cost, returns: string) =>
-    recordSchema(name, { shape, cost, returns });
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Code Mode meta-tools — always registered. Per the HaybaOS spec (§2.4),
-  // these are Claude's progressive-discovery entry points.
-  //   list_tool_categories  → returns domain list + command counts
-  //   get_tool_signature    → returns the JSON schema for a specific command
-  //   python_run            → executes any command via UE Python (escape hatch)
-  // ──────────────────────────────────────────────────────────────────────────
-
-
-
-  server.tool(
-    'list_tool_categories',
-    appendMeta(
-      'List all HaybaOS command domains and their commands. Call this first to discover what is available before requesting a specific schema.',
-      listMeta,
-    ),
-    {},
-    async () => {
-      const r = await listToolCategoriesHandler({}, session);
-      return { content: r.content, isError: r.isError };
-    },
-  );
-  remember('list_tool_categories', listMeta);
-
-  server.tool(
-    'get_tool_signature',
-    appendMeta(
-      'Return the JSON schema (params, return shape, cost) for a specific HaybaOS command. Call list_tool_categories first to find command names.',
-      sigMeta,
-    ),
-    // Wire-level shape only — widened with `name` as an accepted alias for
-    // `command` (issue #339) so the MCP transport doesn't reject the call
-    // before it reaches getToolSignatureHandler. The DOCUMENTED signature
-    // (what get_tool_signature reports about itself, via recordEagerSchemas'
-    // separate `{command...}` literal below) is untouched — still one
-    // required field, one spelling.
-    {
-      command: z.string().optional().describe('Exact command name, e.g. "actor_spawn"'),
-      name: z.string().optional().describe('Alias for "command".'),
-    },
-    async (params) => {
-      const resolved = resolveAliases(params as Record<string, unknown>, TOOL_ALIASES.get_tool_signature);
-      if (!resolved.ok) {
-        return { content: [{ type: 'text', text: `Validation error: ${resolved.error}` }], isError: true };
-      }
-      const r = await getToolSignatureHandler(resolved.args, session);
-      return { content: r.content, isError: r.isError };
-    },
-  );
-  remember('get_tool_signature', sigMeta);
-
-  server.tool(
-    'python_run',
-    appendMeta(
-      'Execute a Python script inside UE via PythonScriptPlugin. Universal escape hatch for invoking any UE command not otherwise exposed.',
-      pyMeta,
-    ),
-    // Wire-level shape only — widened with `code` as an accepted alias for
-    // `script` (issue #339); pythonRunHandler's own schema (canonical-only)
-    // still enforces `script` is actually present after normalisation.
-    {
-      script: z.string().optional().describe('Python source to execute'),
-      code: z.string().optional().describe('Alias for "script".'),
-      allow_unsafe: z.boolean().optional().describe('Override Tier 3 filesystem/subprocess block (DANGEROUS)'),
-    },
-    async (params) => {
-      const r = await pythonRunHandler(params as Record<string, unknown>, session);
-      return { content: r.content, isError: r.isError };
-    },
-  );
-  remember('python_run', pyMeta);
-
-  // Record schemas for tools whose shapes we want get_tool_signature to derive
-  // live. Runs regardless of Code Mode so the registry stays in sync.
-  recordEagerSchemas(reg);
-
-  // When Code Mode is ON (default), stop here — full schemas are only fetched
-  // on demand via get_tool_signature. Set HAYBA_CODE_MODE=off to expose
-  // every tool eagerly (~70 tools, much larger initial tool-list payload).
-  //
-  // forceEager overrides it for the deferred-routing capture, which needs to
-  // see every tool in order to make every tool reachable through hayba_invoke.
-  if (config.codeMode && !forceEager) return;
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Eager registrations (Code Mode disabled) — every domain tool below here.
-  // ──────────────────────────────────────────────────────────────────────────
-
-  // Some MCP clients (incl. Claude Code's tool harness) JSON-stringify nested
-  // booleans before they hit Zod. Wrap so we accept both raw and the
-  // stringified form for params we know are commonly affected. (vec3/coerceVec3
-  // now live at module scope as dVec3/dCoerceVec3, used by the descriptor list.)
-  const coerceBool = z.preprocess((v) => (typeof v === 'string' ? v.toLowerCase() === 'true' : v), z.boolean());
-
-  // ── Standard tools (actor / material / scene) ───────────────────────────────
-  // Registered from the single descriptor list. Each descriptor declares the
-  // tool once; registerTool does server.tool(appendMeta(...)) + remember(...),
-  // and recordEagerSchemas already recorded the schema (always, above).
-  for (const d of STANDARD_DESCRIPTORS) registerTool(server, session, d);
-
-  // ── Editor domain ───────────────────────────────────────────────────────────
-
-  // editor_capture_viewport was hand-written only because it returns an image
-  // block and the registrar's handler type was text-only. Now that the
-  // descriptor accepts a RichToolHandler it goes through the same path as
-  // everything else, and picks up the policies it had been missing.
-  registerTool(server, session, {
-    name: 'editor_capture_viewport',
-    description:
-      'Capture the active editor viewport and return it as an inline image block (plus a small text block with camera/width/height). Set HAYBA_CAPTURE_TO_FILE to also spill the image to a temp file path.',
-    meta: captureMeta,
-    schema: {
-      width: z.coerce.number().int().optional(),
-      height: z.coerce.number().int().optional(),
-      wait_for_shaders: z
-        .boolean()
-        .optional()
-        .describe('If true, calls wait_for_shaders first (max_seconds=60, poll_seconds=1).'),
-    },
-    cost: 'medium',
-    returns: '{width, height, camera, ...} + the capture as an image block',
-    handler: async (params, sess) => {
-      if (params.wait_for_shaders === true) {
-        await handleWaitForShaders({ max_seconds: 60, poll_seconds: 1 });
-      }
-      return editorCaptureViewportHandler(params as Record<string, unknown>, sess);
-    },
-  });
-
-  // editor_start_pie is now in STANDARD_DESCRIPTORS — registered via the loop above.
-
-  server.tool(
-    'editor_stream_log',
-    appendMeta('Tail recent UE log lines (paged via since_line).', streamLogMeta),
-    {
-      filter: z.string().optional(),
-      since_line: z.coerce.number().int().nonnegative().optional(),
-    },
-    async (params) => {
-      const r = await editorStreamLogHandler(params as Record<string, unknown>, session);
-      return { content: r.content, isError: r.isError };
-    },
-  );
-  remember('editor_stream_log', streamLogMeta);
-
-  // wait_for_shaders, wait_for_idle, render_camera are now in STANDARD_DESCRIPTORS.
-
-  // ── Agent-ergonomics tools (HANDOFF postmortem) ─────────────────────────────
-  // hayba_introspect, pcg_add_node, pcg_set_prop, pcg_wire, pcg_inspect_instances
-  // are now in STANDARD_DESCRIPTORS (registered via the descriptor loop above).
-
-remember('pcg_cook_and_wait', pcgCookMeta);
-
-remember('pcg_scatter_mesh', pcgScatterMeta);
-
-  // hayba_fab_*, hayba_polyhaven_*, hayba_ambientcg_*, hayba_sketchfab_* tools
-  // are now in STANDARD_DESCRIPTORS — registered via the loop above.
-
-  // ── PCGEx tools ─────────────────────────────────────────────────────────────
-
-
-
-
-
-
-
-
-  // Two registrations of this tool exist and both are load-bearing, which is
-  // not obvious from either site.
-  //
-  // This one serves eager (non-deferred) mode, and it also puts the name and
-  // schema into the captured map so hayba_invoke can reach it. In deferred mode
-  // registerDeferredRouting then REPLACES the handler with one that wires
-  // onConnected -> maybeAutoLoad('ue_connected') (see routing/register.ts), a
-  // registry this module has no access to.
-  //
-  // The consequence worth knowing: in eager mode, confirming the editor is
-  // connected does not trigger pack autoload. That is a real difference in
-  // behaviour between the two modes, not an oversight in one of them.
-  server.tool('hayba_check_ue_status', {}, async () => {
-    const result = await checkUeStatus();
-    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-  });
-
-  // Gaea / terrain feature surface intentionally disabled — kept out of the
-  // build by removing imports + registrations. Will return when the
-  // worldbuilding-hub roadmap reaches the terrain integration phase.
-
-
-
-
-
-
-
-
-
- // end Gaea + Knowledge tool block
-
-  // ── Conventions tools ────────────────────────────────────────────────────────
-
-
-
-  // Landscape import surface intentionally disabled with the rest of the
-  // terrain features. See note above.
-
-  // ── Scene workflow ────────────────────────────────────────────────────────────
-
-  /* Disabled: depends on Gaea pipeline; will be re-added later.
-  server.tool(
-    'hayba_ue_landscape_pipeline',
-    'Full UE landscape project pipeline: guided brainstorm → zone painting → Gaea terrain generation → bake → import into Unreal Engine → foliage zones. Use this for major landscape projects that will be imported into UE5. For standalone Gaea terrain work, use hayba_brainstorm_gaea instead.',
-    {
-      step: z.enum(['start', 'biome', 'scale', 'features', 'name', 'layout', 'preview', 'bake', 'foliage', 'done'])
-        .describe('Current step in the pipeline flow. Always start with "start".'),
-      answer: z.string().optional()
-        .describe('The user\'s answer to the previous step\'s question.'),
-      projectId: z.string().optional()
-        .describe('Project ID — returned by the "layout" step, pass it through on subsequent steps.'),
-      projectName: z.string().optional()
-        .describe('Name for the project, used at the "layout" step when creating the project.'),
-      biomeAnswer: z.string().optional()
-        .describe('The biome answer from step "biome" — used for archetype search in preview.'),
-      featureAnswer: z.string().optional()
-        .describe('The feature answer from step "features" — used for archetype search in preview.'),
-    },
-    async (params) => {
-      const result = await ueLandscapePipelineHandler(params as Record<string, unknown>, session);
-      return { content: result.content, isError: result.isError };
-    }
-  );
-  */
-
-  // ── Zone Painter tools ──────────────────────────────────────────────────────
-
-
-
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // ── Validator (runtime rule system + history) ───────────────────────────
-  //
-  // The validator tools are declared as ToolDescriptors (see
-  // VALIDATOR_DESCRIPTORS) so they pass through the one registrar with every
-  // other tool. Only the evaluator-hook installation is left here, because it
-  // is a startup side-effect rather than a registration.
-  //
-  // Rule definitions live in src/validator/rules.ts; evaluators in
-  // src/validator/tool-hooks.ts (auto-installed below).
-  // ──────────────────────────────────────────────────────────────────────────
-  // Install evaluator hooks once — wires actual logic onto rules catalog.
-  installToolHooks();
-
-  // ── PLUMB constraint subsystem ──────────────────────────────────────────
-  //
-  // Quantified, directional validator + a tiny CLOSED constraint language bound
-  // to assets/tags, plus baked physical profiles. Authoring fills values; the
-  // grammar (10 primitives) never grows. See src/plumb/.
-  const j = (r: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(r, null, 2) }] });
-
-
-  // Auto-fetch StaticMesh bounds (cm) via the UE mesh_get_info command when the
-  // caller omits origin_cm/extent_cm — "point at an SM and bake".
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  // ── Landscape import (TS wrapper for UE-side landscape_import handler) ────
-}
-
-// Schema registry seeding. Mirrors the Zod shapes used by the eager
-// server.tool() calls above, but lives independently of the Code Mode gate
-// so get_tool_signature can derive params from real schemas at runtime.
-// New tools should add an entry here when first registered.
-function recordEagerSchemas(reg: (name: string, shape: z.ZodRawShape, cost: Cost, returns: string) => void): void {
-  // coerceBool still used by hayba_validate_attribute_flow below. vec3/coerceVec3
-  // moved to module scope (dVec3/dCoerceVec3) and consumed via STANDARD_DESCRIPTORS.
-  const coerceBool = z.preprocess((v) => (typeof v === 'string' ? v.toLowerCase() === 'true' : v), z.boolean());
-
-  // ── Standard tools (actor / material / scene) ──────────────────────────────
-  // Schema recording from the single descriptor list. recordToolSchema mirrors
-  // the old reg(name, shape, cost, returns) calls exactly, one per descriptor.
-  for (const d of STANDARD_DESCRIPTORS) recordToolSchema(d);
-
-  // ── Code Mode meta ────────────────────────────────────────────────────────
-  reg('list_tool_categories', {}, 'low', '{categories:[{domain,commands:[string]}]}');
-  reg(
-    'get_tool_signature',
-    { command: z.string().describe('Exact command name, e.g. "actor_spawn"') },
-    'low',
-    '{command, params, returns, cost} or {status:"no_schema_available", did_you_mean}',
-  );
-  reg(
-    'python_run',
-    {
-      script: z.string().describe('Python source to execute'),
-      allow_unsafe: z.boolean().optional().describe('Override Tier 3 filesystem/subprocess block (DANGEROUS)'),
-    },
-    'high',
-    '{ok, tier, stdout, stderr}',
-  );
-
-  // ── Editor domain ─────────────────────────────────────────────────────────
-  reg(
-    'editor_capture_viewport',
-    {
-      width: z.coerce.number().int().optional(),
-      height: z.coerce.number().int().optional(),
-    },
-    'medium',
-    '{image_base64, width, height, camera}',
-  );
-  // editor_start_pie is now in STANDARD_DESCRIPTORS — recordToolSchema(d) called above.
-  reg(
-    'editor_stream_log',
-    {
-      filter: z.string().optional().describe('Plain substring filter (legacy)'),
-      regex_filter: z.string().optional().describe('Perl-style regex applied to each line'),
-      severity_filter: z
-        .string()
-        .optional()
-        .describe('Comma-separated severities: Verbose,Display,Log,Warning,Error,Fatal'),
-      format: z
-        .enum(['raw', 'structured'])
-        .optional()
-        .describe('"structured" emits {line, category, severity, msg, raw} objects'),
-      since_line: z.coerce.number().int().min(0).optional(),
-    },
-    'low',
-    '{lines:[string|object], next_line:int, format}',
-  );
-
-  // ── Agent-ergonomics tools (HANDOFF postmortem) ───────────────────────────
-  // hayba_introspect, pcg_add_node, pcg_set_prop, pcg_wire, pcg_inspect_instances:
-  // now in STANDARD_DESCRIPTORS — recordToolSchema(d) called by the loop above.
-  reg(
-    'pcg_cook_and_wait',
-    pcgCookSchema.shape,
-    'high',
-    '{ok, cook:{components}, idle, result:{ism:[{mesh,count}], total}}',
-  );
-  reg(
-    'pcg_scatter_mesh',
-    pcgScatterSchema.shape,
-    'high',
-    '{ok, graph_asset, volume_actor, instances, result:{ism:[{mesh,count}], total}} — ok:false when instances==0',
-  );
-
-  // ── PCGEx domain ──────────────────────────────────────────────────────────
-  reg(
-    'hayba_search_node_catalog',
-    {
-      query: z.string().describe('Search query — keyword, node class, or category'),
-    },
-    'low',
-    '{results:[{class,category,description,inputs,outputs,key_properties}], matchType}',
-  );
-  reg(
-    'hayba_get_node_details',
-    {
-      class: z.string().describe('PCGEx node class name'),
-    },
-    'low',
-    '{class, category, description, inputs, outputs, properties}',
-  );
-  reg(
-    'hayba_create_pcg_graph',
-    {
-      graph: z.string().describe('JSON string of the PCGEx graph topology'),
-      name: z.string().describe('Asset name for the new PCGGraph'),
-    },
-    'high',
-    '{ok, asset_path}',
-  );
-  reg(
-    'hayba_validate_pcg_graph',
-    {
-      graph: z.string().describe('JSON string of the PCGEx graph to validate'),
-    },
-    'medium',
-    '{valid, errors:[{type,node,pin,detail}], errorCount}',
-  );
-  reg(
-    'hayba_list_pcg_assets',
-    {
-      path: z.string().optional().describe('Content path filter (default: /Game/)'),
-    },
-    'low',
-    '{assets:[{name,path,nodeCount,edgeCount}], count}',
-  );
-  reg(
-    'hayba_export_pcg_graph',
-    {
-      assetPath: z.string().describe('Full UE asset path to the PCGGraph'),
-    },
-    'medium',
-    '{graph:{version,meta,nodes,edges,metadata}}',
-  );
-  reg(
-    'hayba_execute_pcg_graph',
-    {
-      assetPath: z.string().describe('Full UE asset path to execute'),
-    },
-    'high',
-    '{ok, generated_count, duration_ms}',
-  );
-  reg('hayba_check_ue_status', {}, 'low', '{connected, status, ueVersion, plugin, pluginVersion}');
-
-  // ── Asset domain — added Initiative #6 + #10 (ref-preserving move, deps) ─
-  reg(
-    'asset_move',
-    {
-      path: z.string().describe('Source asset path, e.g. "/Game/Foo/Bar.Bar"'),
-      target_dir: z.string().describe('Target content-browser folder, e.g. "/Game/Archive"'),
-    },
-    'medium',
-    '{ok, old_path, new_path}',
-  );
-  reg(
-    'asset_fix_redirectors',
-    {
-      path: z.string().optional().describe('Content path to scan (default /Game)'),
-    },
-    'medium',
-    '{fixed_count, path}',
-  );
-  reg(
-    'asset_get_dependencies',
-    {
-      path: z.string().describe('Asset path; returns what this asset depends on'),
-    },
-    'low',
-    '{dependencies:[string], count}',
-  );
-  reg(
-    'asset_get_referencers',
-    {
-      path: z.string().describe('Asset path; returns who depends on this asset (blast radius)'),
-    },
-    'low',
-    '{referencers:[string], count}',
-  );
-  reg(
-    'hayba_scrape_node_registry',
-    {
-      pluginSourcePath: z.string().optional().describe('Path to PCGExtendedToolkit/Source/ directory'),
-      outputDbPath: z.string().optional().describe('Output SQLite DB path (default: Resources/pcgex_registry.db)'),
-      forceRescan: z.boolean().optional().describe('Force re-scan even if DB exists'),
-    },
-    'high',
-    '{nodes_scanned, pins_scanned, properties_scanned, db_path, catalog_path}',
-  );
-  reg(
-    'hayba_match_pin_names',
-    {
-      fromClass: z.string().describe('Source node class'),
-      fromPin: z.string().describe('Pin name on source node (may be approximate)'),
-      toClass: z.string().describe('Target node class to find a matching input pin on'),
-    },
-    'low',
-    '{matches:[{pin,confidence,reason}]}',
-  );
-  reg(
-    'hayba_validate_attribute_flow',
-    {
-      graph: z.string().describe('JSON string of the PCGEx graph to validate attribute flow'),
-      strictMode: coerceBool.optional().describe('If true, also flag orphan writes (written but never consumed)'),
-    },
-    'medium',
-    '{valid, errors:[{type,node,attribute,detail}]}',
-  );
-  reg(
-    'hayba_diff_against_working_asset',
-    {
-      wipGraph: z.string().describe('JSON string of the work-in-progress graph'),
-      referenceAssetPath: z.string().describe('Full UE asset path to the reference PCGGraph'),
-      diffMode: z.enum(['structural', 'properties', 'full']).optional().describe('What to diff (default: full)'),
-    },
-    'medium',
-    '{added, removed, modified, identical}',
-  );
-  reg(
-    'hayba_format_graph_topology',
-    {
-      graph: z.string().describe('JSON string of the PCGEx graph to layout'),
-      algorithm: z.enum(['layered', 'grid']).optional(),
-      nodeWidth: z.number().int().optional(),
-      nodeHeight: z.number().int().optional(),
-      horizontalSpacing: z.number().int().optional(),
-      verticalSpacing: z.number().int().optional(),
-      addCommentBlocks: z.boolean().optional(),
-    },
-    'low',
-    'JSON string of laid-out graph (nodes carry position:{x,y})',
-  );
-  reg(
-    'hayba_abstract_to_subgraph',
-    {
-      graph: z.string().describe('JSON string of the full PCGEx graph'),
-      nodeIds: z.array(z.string()).describe('Array of node IDs to extract into a subgraph'),
-      subgraphName: z.string().optional().describe('Name for the extracted subgraph (default: SubGraph)'),
-    },
-    'medium',
-    '{subgraph, mainGraph}',
-  );
-  reg(
-    'hayba_parameterize_graph_inputs',
-    {
-      graph: z.string().describe('JSON string of the PCGEx graph'),
-      targets: z.array(
-        z.object({
-          nodeId: z.string(),
-          property: z.string(),
-          parameterName: z.string().optional(),
-        }),
-      ),
-    },
-    'medium',
-    '{graph, parameters:[{name,type,defaultValue}]}',
-  );
-  reg(
-    'hayba_query_pcgex_docs',
-    {
-      query: z.string().describe('Node class name or keyword to search documentation'),
-      includeSourceSnippet: z.boolean().optional().describe('Include up to 80 lines from the header file'),
-    },
-    'low',
-    '{results:[{class,description,sourceSnippet?}]}',
-  );
-  reg(
-    'hayba_initiate_infrastructure_brainstorm',
-    {
-      topic: z.string().describe('The infrastructure or system design topic to brainstorm'),
-      context: z.string().optional(),
-      constraints: z.array(z.string()).optional(),
-    },
-    'low',
-    '{approaches:[{name,description,nodes,tradeoffs}]} — PROPOSAL ONLY',
-  );
-
-  // ── Conventions domain ────────────────────────────────────────────────────
-  reg(
-    'hayba_setup_conventions',
-    {
-      stage: z.enum(['start', 'folders', 'naming', 'workflow', 'confirm', 'save']),
-      preset: z.enum(['epic-default', 'gamedevtv', 'custom']).optional(),
-      answers: z.record(z.string(), z.unknown()).optional(),
-      target: z.enum(['global', 'project']).optional(),
-      projectRoot: z.string().optional(),
-    },
-    'low',
-    '{stage, question?, next_stage?, saved_to?}',
-  );
-  reg(
-    'hayba_analyze_conventions',
-    {
-      projectRoot: z.string().describe('Path to UE project root (contains .uproject file)'),
-      save: z.boolean().optional(),
-      target: z.enum(['global', 'project']).optional(),
-    },
-    'medium',
-    '{inferred:{folders, naming, workflow}, saved_to?}',
-  );
-
-  // ── Landscape import ──────────────────────────────────────────────────────
-  reg(
-    'hayba_import_landscape',
-    {
-      heightmapPath: z.string().describe('Absolute path to a PNG or R16 heightmap file'),
-      worldSizeKm: z.number().optional().default(8.0).describe('Landscape XY size in km'),
-      maxHeightM: z
-        .number()
-        .optional()
-        .default(600.0)
-        .describe('Maximum height in m (0..maxHeightM mapped from uint16)'),
-      actorLabel: z.string().optional().default('Hayba_Terrain').describe('Label for the spawned Landscape actor'),
-      landscapeMaterial: z.string().optional().describe('UE material path; empty = no material'),
-    },
-    'high',
-    '{actorLabel, heightmapPath, worldSizeKm, maxHeightM}',
-  );
-
-  // ── Zone painter domain ───────────────────────────────────────────────────
-  reg(
-    'hayba_open_zone_painter',
-    {
-      projectId: z.string().optional(),
-      projectName: z.string().optional(),
-      phase: z.enum(['a', 'b']).optional(),
-    },
-    'low',
-    '{ok, url, projectId}',
-  );
-  reg(
-    'hayba_read_zones',
-    {
-      projectId: z.string().optional(),
-      scratchSessionId: z.string().optional(),
-    },
-    'low',
-    '{zones:[{id,label,mask_path,bounds}]}',
-  );
-  reg(
-    'hayba_set_painter_heightmap',
-    {
-      projectId: z.string(),
-      heightmapPath: z.string(),
-    },
-    'low',
-    '{ok}',
-  );
-
-  // ── PLUMB constraint subsystem ────────────────────────────────────────────
-  reg('plumb_primitives', plumbPrimitivesSchema, 'low', '{primitives:[{id,gate,default_hard,qualitative,params,doc}]}');
-  reg('plumb_profile_bake', plumbProfileBakeSchema, 'low', '{ok, profile}');
-  reg('plumb_profile_annotate', plumbProfileAnnotateSchema, 'low', '{ok, profile|error}');
-  reg('plumb_profile_list', plumbProfileListSchema, 'low', '{profiles:[{asset_id,profile,affordances,locked}]}');
-  reg('plumb_profile_get', plumbProfileGetSchema, 'low', '{ok, profile|error}');
-  reg('plumb_constraint_define', plumbConstraintDefineSchema, 'low', '{ok, errors?}');
-  reg('plumb_constraint_list', plumbConstraintListSchema, 'low', '{constraints:[Constraint]}');
-  reg('plumb_constraint_remove', plumbConstraintRemoveSchema, 'low', '{ok, removed}');
-  reg('plumb_constraint_propose', plumbConstraintProposeSchema, 'low', '{ok, proposals:[Partial<Constraint>]|error}');
-  reg('plumb_validate', plumbValidateSchema, 'low', '{verdict:Verdict}');
-  reg('plumb_mask_add', plumbMaskAddSchema, 'low', '{ok, profile|error}');
-  reg('plumb_mask_remove', plumbMaskRemoveSchema, 'low', '{ok, removed}');
-  reg('plumb_lesson_add', plumbLessonAddSchema, 'low', '{ok, errors?}');
-  reg('plumb_lesson_list', plumbLessonListSchema, 'low', '{lessons:[{slug,title,refs}]}');
-  reg('plumb_lesson_remove', plumbLessonRemoveSchema, 'low', '{ok, removed}');
-  reg('plumb_study', plumbStudySchema, 'low', '{asset, has_profile, profile?, primitives, mask_kinds, guidance}');
-  reg('plumb_study_take', plumbStudyTakeSchema, 'low', '{requests:[{asset,ts}], note}');
-  reg('plumb_segment', plumbSegmentSchema, 'high', '{ok, added:[label], skipped?, error?}');
-  reg('plumb_production_define', plumbProductionDefineSchema, 'low', '{ok, errors?}');
-  reg('plumb_production_list', plumbProductionListSchema, 'low', '{productions:[Production]}');
-  reg('plumb_production_remove', plumbProductionRemoveSchema, 'low', '{ok, removed}');
-  reg('plumb_socket_add', plumbSocketAddSchema, 'low', '{ok, profile|error}');
-  reg('plumb_grammar_expand', plumbGrammarExpandSchema, 'low', '{plan:PlacementPlan, note}');
+// Schema registry seeding reads the same descriptors as eager registration and
+// deferred capture, independently of which routing mode exposes them.
+function seedCatalogueSchemas(): void {
+  for (const descriptor of STATIC_TOOL_CATALOGUE) recordToolSchema(descriptor);
 }

--- a/mcp-tools/hayba-mcp/src/tools/landscape-import.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/landscape-import.test.ts
@@ -45,7 +45,10 @@ describe('hayba_import_landscape wrapper', () => {
     expect(indexSrc).toMatch(declares('landscapeMaterial', 'string'));
   });
 
-  it('registers the schema in the eager schema-registry block', () => {
-    expect(indexSrc).toMatch(/reg\(\s*['"]hayba_import_landscape['"]/);
+  it('feeds its descriptor through the shared schema-seeding loop', () => {
+    expect(indexSrc).toMatch(/name:\s*['"]hayba_import_landscape['"]/);
+    expect(indexSrc).toMatch(
+      /for\s*\(\s*const\s+descriptor\s+of\s+STATIC_TOOL_CATALOGUE\s*\)\s*recordToolSchema\(/,
+    );
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/legacy-tool-factory.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/legacy-tool-factory.test.ts
@@ -5,6 +5,7 @@ import {
   isLegacyTarget,
   isNonIdempotentLegacy,
   legacyNonIdempotentNames,
+  registerLegacyNonIdempotent,
 } from './legacy-tool-factory.js';
 import { STANDARD_DESCRIPTORS } from './index.js';
 import { getSidecar } from '../legacy-commands/index.js';
@@ -115,8 +116,9 @@ describe('no duplicate names across the merged registration set', () => {
   it('generated names never collide with hand-written descriptors', () => {
     const reserved = new Set(STANDARD_DESCRIPTORS.map((d) => d.name));
     // Simulate the index.ts splice: reserve every hand-written name.
+    const generatedNames = new Set(generateLegacyDescriptors(new Set()).map((d) => d.name));
     const handwritten = STANDARD_DESCRIPTORS.filter(
-      (d) => !generateLegacyDescriptors(new Set()).some((g) => g.name === d.name),
+      (d) => !generatedNames.has(d.name),
     ).map((d) => d.name);
     const gen = generateLegacyDescriptors(new Set(handwritten));
     for (const g of gen) expect(reserved.has(g.name)).toBe(true); // all merged in
@@ -126,11 +128,15 @@ describe('no duplicate names across the merged registration set', () => {
 });
 
 describe('NON_IDEMPOTENT extension', () => {
-  it('surfaced mutating commands are registered non-idempotent', () => {
-    // Importing the factory module runs the side-effect that extends the set.
-    for (const name of legacyNonIdempotentNames()) {
-      expect(NON_IDEMPOTENT.has(name)).toBe(true);
-    }
+  it('catalogue generation is pure and startup explicitly registers mutating commands', () => {
+    const names = legacyNonIdempotentNames();
+    for (const name of names) NON_IDEMPOTENT.delete(name);
+
+    generateLegacyDescriptors();
+    expect(names.filter((name) => NON_IDEMPOTENT.has(name))).toEqual([]);
+
+    registerLegacyNonIdempotent();
+    for (const name of names) expect(NON_IDEMPOTENT.has(name)).toBe(true);
     // Spot-checks across the mutating families.
     expect(NON_IDEMPOTENT.has('spline_add_point')).toBe(true);
     expect(NON_IDEMPOTENT.has('actor_duplicate')).toBe(true);

--- a/mcp-tools/hayba-mcp/src/tools/legacy-tool-factory.ts
+++ b/mcp-tools/hayba-mcp/src/tools/legacy-tool-factory.ts
@@ -189,10 +189,6 @@ export function buildLegacyDescriptor(
 export function generateLegacyDescriptors(
   reserved: ReadonlySet<string> = new Set(),
 ): ToolDescriptor[] {
-  // The retry gate must know about these before anything can be invoked, and
-  // this is the earliest point that is a deliberate call rather than an import.
-  registerLegacyNonIdempotent();
-
   const out: ToolDescriptor[] = [];
   const skipped: string[] = [];
   const sidecar = getSidecar();
@@ -231,9 +227,10 @@ export function legacyNonIdempotentNames(): string[] {
  *  whether some unrelated import had happened yet. Nothing said so at the
  *  reading end, in tool-executor.
  *
- *  Called from generateLegacyDescriptors, which must run before any tool can be
- *  registered or invoked, so the set is complete by the time the gate reads it.
- *  Idempotent — Set.add is, and callers may run it more than once.
+ *  Called explicitly by registerTools before anything can be invoked. Catalogue
+ *  construction stays pure: importing index.ts or asking the factory for
+ *  descriptors cannot silently rewrite another module's exported state.
+ *  Idempotent — Set.add is, and startup may run it more than once in tests.
  *
  *  Exported for the drift test in __tests__/non-idempotent-domains.test.ts. */
 export function registerLegacyNonIdempotent(): void {

--- a/mcp-tools/hayba-mcp/src/tools/material/material-tools.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/material/material-tools.test.ts
@@ -13,33 +13,28 @@ import { fileURLToPath } from 'node:url';
  * - material_get_info
  *
  * Tests that all wrappers are:
- * 1. Registered in index.ts with server.tool()
+ * 1. Declared in index.ts's descriptor catalogue
  * 2. Wired to executeCommand() calls with the correct command names (in handler files)
- * 3. Registered in the schema-registry block via reg()
+ * 3. Consumed by the shared native-registration and schema-seeding loops
  * 4. Have the correct handler exports
  */
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const indexSrc = readFileSync(join(__dirname, '..', 'index.ts'), 'utf-8');
 
 // As of the registrar refactor, standard tools (incl. all material_*) are
-// declared ONCE in the STANDARD_DESCRIPTORS list and registered/recorded via
-// loops (registerTool + recordToolSchema). A descriptor `name: 'X'` is the
-// single source of truth that drives BOTH server.tool(X) and reg(X). These
-// helpers accept either the legacy literal form (for un-migrated tools) or the
-// descriptor form, so the tests assert the real guarantee, not a code shape.
-const REGISTRAR_LOOP = /for\s*\(\s*const\s+d\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*registerTool\(/;
-const SCHEMA_LOOP = /for\s*\(\s*const\s+d\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*recordToolSchema\(/;
-/** True when `name` is registered as a tool: literal server.tool OR a descriptor consumed by the registerTool loop. */
+// declared once in STANDARD_DESCRIPTORS, spliced into STATIC_TOOL_CATALOGUE,
+// and consumed by the native registration + schema-seeding loops.
+const REGISTRAR_LOOP = /for\s*\(\s*const\s+descriptor\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*\{\s*registerTool\(/;
+const SCHEMA_LOOP = /for\s*\(\s*const\s+descriptor\s+of\s+STATIC_TOOL_CATALOGUE\s*\)\s*recordToolSchema\(/;
+/** True when `name` is registered from the descriptor catalogue. */
 function isToolRegistered(name: string): boolean {
-  const literal = new RegExp(`server\\.tool\\(\\s*['"]${name}['"]`);
   const descriptor = new RegExp(`name:\\s*['"]${name}['"]`);
-  return literal.test(indexSrc) || (descriptor.test(indexSrc) && REGISTRAR_LOOP.test(indexSrc));
+  return descriptor.test(indexSrc) && REGISTRAR_LOOP.test(indexSrc);
 }
-/** True when `name`'s schema is recorded: literal reg() OR a descriptor consumed by the recordToolSchema loop. */
+/** True when `name`'s descriptor feeds the shared schema-seeding loop. */
 function isSchemaRecorded(name: string): boolean {
-  const literal = new RegExp(`reg\\(\\s*['"]${name}['"]`);
   const descriptor = new RegExp(`name:\\s*['"]${name}['"]`);
-  return literal.test(indexSrc) || (descriptor.test(indexSrc) && SCHEMA_LOOP.test(indexSrc));
+  return descriptor.test(indexSrc) && SCHEMA_LOOP.test(indexSrc);
 }
 
 // Read handler files to check for executeCommand calls

--- a/mcp-tools/hayba-mcp/src/tools/register-tool.ts
+++ b/mcp-tools/hayba-mcp/src/tools/register-tool.ts
@@ -46,6 +46,16 @@ export type ToolDescriptor = {
   description: string;
   /** Zod raw shape used both for server.tool validation and the schema registry. */
   schema: z.ZodRawShape;
+  /**
+   * Optional wire-only shape accepted by McpServer.
+   *
+   * Most tools use `schema` for both transport validation and their published
+   * signature. A very small compatibility surface accepts deprecated aliases
+   * at the wire while deliberately documenting only the canonical spelling.
+   * Keeping that exception on the descriptor makes it data too; it no longer
+   * requires a hand-written `server.tool(...)` site beside a separate `reg()`.
+   */
+  wireSchema?: z.ZodRawShape;
   /** Tool meta — drives appendMeta(description) and the cost-lookup registry. */
   meta: HaybaToolMeta;
   /**
@@ -87,6 +97,7 @@ export function defineTool<S extends z.ZodRawShape>(d: {
   name: string;
   description: string;
   schema: S;
+  wireSchema?: z.ZodRawShape;
   meta: HaybaToolMeta;
   cost: Cost;
   returns: string;
@@ -111,6 +122,44 @@ export function recordToolSchema(d: ToolDescriptor): void {
 }
 
 /**
+ * Fully materialized MCP registration produced from one descriptor.
+ *
+ * This value is consumed by both eager registration and deferred capture. The
+ * latter used to discover tools by executing the eager-registration routine
+ * against a fake server whose `.tool()` method intercepted each call. Making
+ * the registration itself a value removes that timing-sensitive shim: capture
+ * can now build its map without touching any server object at all.
+ */
+export interface MaterializedTool {
+  name: string;
+  description: string;
+  schema: z.ZodRawShape;
+  handler: (params: Record<string, unknown>) => Promise<RichToolResult>;
+}
+
+export function materializeTool(
+  session: SessionManager,
+  d: ToolDescriptor,
+): MaterializedTool {
+  const niche = d.niche;
+  const nudge = isSceneMutating(d.meta.effects);
+  const evidence = isUnderEvidenceContract(d.meta.effects);
+  return {
+    name: d.name,
+    description: appendMeta(d.description, d.meta),
+    schema: d.wireSchema ?? d.schema,
+    handler: async (params: Record<string, unknown>): Promise<RichToolResult> => {
+      const r = await d.handler(params, session);
+      const shaped = niche
+        ? appendNicheBriefing(niche, session, r)
+        : { content: r.content, isError: r.isError };
+      const checked = evidence ? withEvidenceWarning(shaped) : shaped;
+      return nudge ? withValidationNudge(checked) : checked;
+    },
+  };
+}
+
+/**
  * Eagerly register one tool from a descriptor: server.tool(...) with the
  * appendMeta'd description + the standard handler wrapper, plus remember(name).
  * Call only inside the eager (Code Mode off) block, matching the old
@@ -121,29 +170,12 @@ export function registerTool(
   session: SessionManager,
   d: ToolDescriptor,
 ): void {
-  const niche = d.niche;
-  // Scene-mutating tools get a post-mutation validation nudge appended to their
-  // successful result — see withValidationNudge. Decided ONCE here from the
-  // tool's declared effects so it's DRY across every registered tool.
-  const nudge = isSceneMutating(d.meta.effects);
-  // A tool that declares ANY effect is under the response-evidence contract:
-  // if it comes back with only ok/status/message, the caller is told "success"
-  // about a change nothing in the response describes. Decided here for the same
-  // reason as the nudge — one place, every tool, including the wrappers that
-  // pass the plugin's reply straight through.
-  const evidence = isUnderEvidenceContract(d.meta.effects);
+  const tool = materializeTool(session, d);
   server.tool(
-    d.name,
-    appendMeta(d.description, d.meta),
-    d.schema,
-    async (params: Record<string, unknown>): Promise<RichToolResult> => {
-      const r = await d.handler(params, session);
-      const shaped = niche
-        ? appendNicheBriefing(niche, session, r)
-        : { content: r.content, isError: r.isError };
-      const checked = evidence ? withEvidenceWarning(shaped) : shaped;
-      return nudge ? withValidationNudge(checked) : checked;
-    },
+    tool.name,
+    tool.description,
+    tool.schema,
+    tool.handler,
   );
   registerToolMeta(d.name, d.meta);
 }

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -1,8 +1,7 @@
 // Wiring for γ-hybrid tool routing. Called from tools/index.ts when
-// settings.toolRouting === 'deferred'. Expects the caller to have already
-// captured every original server.tool(...) registration into `captured` via
-// a shim, and to have populated `schema-registry` via the existing `reg(...)`
-// helper. We don't re-walk the tool catalog here — we read from those.
+// settings.toolRouting === 'deferred'. The caller supplies the catalogue as a
+// value map built directly from ToolDescriptors; this layer augments it with
+// the few runtime descriptors that close over retriever/DAG/sliver instances.
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -39,6 +38,7 @@ import { journalTailHandler, journalTailSchema } from '../dag/journal-tail.js';
 import { setAssetDagSink } from '../asset-sources/shared.js';
 import { registerChatCapturedTools } from '../../chat/tool-dispatch.js';
 import { buildOrientation, shouldOrient } from './orientation.js';
+import { wrapToolHandlerForStream } from '../tool-stream-mirror.js';
 
 // ── First-install surface ────────────────────────────────────────────────────
 //
@@ -84,7 +84,7 @@ export const CORE_META = new Set<string>([
  *  there is an editor to use them on. */
 export const AUTOLOAD_ON_UE_CONNECT = ['editor'] as const;
 
-/** Tools registered by registerDeferredRouting itself — skip in shim re-register.
+/** Tools registered by registerDeferredRouting itself.
  *
  *  Kept as a separate export because callers (and the routing integration test)
  *  treat it as "what is registered at startup". It is exactly CORE_META now;
@@ -126,7 +126,7 @@ const __dirname = dirname(__filename);
  * Build the deferred-mode routing layer.
  *
  * @param server          The real MCP server (used to register meta-tools + on pack load).
- * @param captured        Map of every tool name → its descriptor (filled by the shim).
+ * @param captured        Map of every static tool name → its materialized descriptor.
  * @param cacheDir        Where to persist the tool index (defaults to Saved/HaybaMCP).
  */
 /** Options for {@link registerDeferredRouting}.
@@ -164,14 +164,20 @@ export async function registerDeferredRouting(
   // index. They were simultaneously always in your face and impossible to find
   // by searching.
   //
-  // They now go through `defer`, which puts them in the captured map like every
-  // other tool. Pack discovery, the search index and hayba_invoke all read that
-  // map, so they stay searchable and callable while costing nothing until asked
-  // for. This block must stay ABOVE pack discovery for that to hold.
+  // They now produce RuntimeToolDescriptor values first. One conversion below
+  // adds that complete list to the captured map before pack discovery, so they
+  // stay searchable and callable while costing nothing until asked for.
 
-  /** Route a runtime-constructed tool through the deferred path instead of
-   *  registering it natively. */
-  /** Capture a runtime-constructed tool — one that closes over a live object
+  interface RuntimeToolDescriptor {
+    dir: string;
+    name: string;
+    description: string;
+    schema: z.ZodRawShape;
+    handler: CapturedTool['handler'];
+  }
+  const runtimeDescriptors: RuntimeToolDescriptor[] = [];
+
+  /** Declare a runtime-constructed tool — one that closes over a live object
    *  (the retriever, the DAG, the sliver loader) and so cannot be declared
    *  statically as a descriptor.
    *
@@ -188,11 +194,15 @@ export async function registerDeferredRouting(
     schema: z.ZodRawShape,
     run: (...args: never[]) => unknown,
   ): void => {
-    captured.set(name, {
+    runtimeDescriptors.push({
+      name,
       description,
       schema,
-      handler: (async (...args: never[]) =>
-        toMcpResponse(await run(...args))) as unknown as CapturedTool['handler'],
+      handler: wrapToolHandlerForStream(
+        name,
+        (async (...args: never[]) =>
+          toMcpResponse(await run(...args))) as unknown as CapturedTool['handler'],
+      ),
       dir,
     });
   };
@@ -335,6 +345,18 @@ export async function registerDeferredRouting(
   );
 
   // ── Pack discovery ─────────────────────────────────────────────────────────
+  for (const descriptor of runtimeDescriptors) {
+    if (captured.has(descriptor.name)) {
+      throw new Error(`runtime tool collides with static catalogue: ${descriptor.name}`);
+    }
+    captured.set(descriptor.name, {
+      description: descriptor.description,
+      schema: descriptor.schema,
+      handler: descriptor.handler,
+      dir: descriptor.dir,
+    });
+  }
+
   const toolDirs = new Map<string, string | null>();
   const explicitPacks = new Map<string, string>();
   for (const [name, desc] of captured) {
@@ -485,7 +507,7 @@ export async function registerDeferredRouting(
 
   // ── Re-register the always-on tools from the captured set ─────────────────
   // (list_tool_categories, get_tool_signature, hayba_check_ue_status are
-  // captured by the shim but not registered with the real server. We register
+  // present in the catalogue but not registered with the real server. We register
   // them here so they appear in the deferred always-on surface.)
   const passthrough = (name: string): void => {
     const t = captured.get(name);

--- a/mcp-tools/hayba-mcp/src/tools/tool-stream-mirror.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-stream-mirror.ts
@@ -5,7 +5,8 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ensureConnected } from '../tcp-client.js';
-import { isToolDisabled } from './disabled-tools-watcher.js';
+import { getAdvisoryVerbosity, isToolDisabled } from './disabled-tools-watcher.js';
+import { applyAdvisoryVerbosity } from './advisory-verbosity.js';
 
 function preview(value: unknown, max: number): string {
   if (value == null) return '';
@@ -25,6 +26,7 @@ function preview(value: unknown, max: number): string {
 // distinct user prompts.
 const NEW_TURN_GAP_MS = 3000;
 let lastMirrorTimestamp = 0;
+const MIRRORED_HANDLERS = new WeakSet<Function>();
 
 async function mirror(toolName: string, params: unknown, result: unknown): Promise<void> {
   try {
@@ -62,7 +64,25 @@ export function installToolStreamMirror(server: McpServer): void {
     const handler = args[args.length - 1] as Function;
     if (typeof handler !== 'function') return orig(...args);
 
-    const wrapped = async (params: unknown, ...rest: unknown[]) => {
+    args[args.length - 1] = wrapToolHandlerForStream(name, handler);
+    return orig(...args);
+  };
+}
+
+/**
+ * Apply the same disabled-tool gate and best-effort stream mirroring used by a
+ * native MCP registration to a handler stored in the deferred catalogue.
+ *
+ * Deferred tools can be invoked without ever passing through `server.tool`, so
+ * the wrapper must be expressible independently of server registration. The
+ * WeakSet makes the operation idempotent: when a captured tool is later loaded
+ * as a native pack, `installToolStreamMirror` sees the already-wrapped handler
+ * and does not mirror the same call twice.
+ */
+export function wrapToolHandlerForStream<T extends Function>(name: string, handler: T): T {
+  if (MIRRORED_HANDLERS.has(handler)) return handler;
+
+  const wrapped = async (params: unknown, ...rest: unknown[]) => {
       // MCP panel gate: if the user disabled this tool, short-circuit with a
       // clear status. Meta-tools (list_tool_categories / get_tool_signature)
       // are never gated themselves — they handle disabled-state internally.
@@ -80,11 +100,15 @@ export function installToolStreamMirror(server: McpServer): void {
         };
       }
       const result = await handler(params, ...rest);
+      const filteredResult = result && typeof result === 'object'
+        && Array.isArray((result as { content?: unknown }).content)
+        ? applyAdvisoryVerbosity(result as never, getAdvisoryVerbosity())
+        : result;
       // Extract the text content the tool returned, when available — that's
       // what users care about in the stream. Fall back to the full object.
-      let resultForMirror: unknown = result;
-      if (result && typeof result === 'object') {
-        const r = result as { content?: Array<{ type?: string; text?: string }> };
+      let resultForMirror: unknown = filteredResult;
+      if (filteredResult && typeof filteredResult === 'object') {
+        const r = filteredResult as { content?: Array<{ type?: string; text?: string }> };
         if (Array.isArray(r.content)) {
           const text = r.content
             .filter(c => c?.type === 'text' && typeof c.text === 'string')
@@ -94,10 +118,9 @@ export function installToolStreamMirror(server: McpServer): void {
         }
       }
       mirror(name, params, resultForMirror).catch(() => {});
-      return result;
-    };
-
-    args[args.length - 1] = wrapped;
-    return orig(...args);
+      return filteredResult;
   };
+
+  MIRRORED_HANDLERS.add(wrapped);
+  return wrapped as unknown as T;
 }

--- a/mcp-tools/hayba-mcp/src/tools/ui/ui-tools.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui/ui-tools.test.ts
@@ -27,8 +27,8 @@ const UI_TOOLS = ['ui_create_widget', 'ui_add_element', 'ui_query'] as const;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const indexSrc = readFileSync(join(__dirname, '..', 'index.ts'), 'utf-8');
 
-const REGISTRAR_LOOP = /for\s*\(\s*const\s+d\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*registerTool\(/;
-const SCHEMA_LOOP = /for\s*\(\s*const\s+d\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*recordToolSchema\(/;
+const REGISTRAR_LOOP = /for\s*\(\s*const\s+descriptor\s+of\s+STANDARD_DESCRIPTORS\s*\)\s*\{\s*registerTool\(/;
+const SCHEMA_LOOP = /for\s*\(\s*const\s+descriptor\s+of\s+STATIC_TOOL_CATALOGUE\s*\)\s*recordToolSchema\(/;
 function isToolRegistered(name: string): boolean {
   const descriptor = new RegExp(`name:\\s*['"]${name}['"]`);
   return descriptor.test(indexSrc) && REGISTRAR_LOOP.test(indexSrc);


### PR DESCRIPTION
## Outcome

Replaces the registration monkey-patch stack with one descriptor-driven catalogue and one materialization boundary.

- one `STATIC_TOOL_CATALOGUE` feeds schema seeding, eager registration, and deferred capture
- runtime packs collect descriptors first, then pass through the same collision-checked capture path
- canonical schemas and transport-only aliases are explicit through `wireSchema`
- deferred handlers now receive the same disabled-tool, advisory-filtering, and stream-mirroring wrapper exactly once
- watcher teardown is non-persistent and leak-free
- removes the duplicate handwritten `reg()` catalogue and fake-server/config-flip capture path

The small advisory filter included here is the output-boundary prerequisite for #371; it does not close the plugin-settings work.

## Verification

- `npm run typecheck`
- 8 focused registration/catalogue/advisory files: 101/101 tests
- full registration agent gate: 170 files / 1718 tests with 4 workers
- `npm run lint:legacy-wrappers` (22 C++ commands, 153 sidecar entries, zero violations)
- `npm run build:server`
- real stdio process smoke: bootstrap catalogue, search hidden `memory_recall`, invoke it through `hayba_invoke`, clean child teardown

Fixes #319
Related to #371