### PR TITLE
security: harden asset archives and gate production dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
     branches: [main]
 
 jobs:
+  production-dependency-audit:
+    name: Production dependency audit — reachability + expiry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # The audit needs the resolved lock graph, not lifecycle scripts. In
+      # particular, onnxruntime-node's vulnerable AdmZip path is postinstall-
+      # only; an audit job must not execute the parser it is assessing.
+      - name: Install without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      # The script invokes `npm audit --omit=dev --json` itself, parses raw JSON
+      # in memory, and emits only sanitized package/advisory policy codes.
+      - name: Reject unassessed or expired production risk
+        run: npm run audit:production
+
   lint:
     name: TypeScript lint + format check (mcp-tools/hayba-mcp)
     runs-on: ubuntu-latest
@@ -104,4 +125,4 @@ jobs:
         run: pytest -q
 
       - name: Lint
-        run: ruff check . || true   # non-blocking until a style baseline is adopted
+        run: ruff check . || true # non-blocking until a style baseline is adopted

--- a/.github/workflows/production-dependency-audit.yml
+++ b/.github/workflows/production-dependency-audit.yml
@@ -1,0 +1,64 @@
+name: Scheduled production dependency audit
+
+on:
+  schedule:
+    - cron: '23 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Run sanitized production audit
+        id: audit
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          npm run --silent audit:production > "$RUNNER_TEMP/production-audit.md" 2>&1
+          status=$?
+          set -e
+          cat "$RUNNER_TEMP/production-audit.md"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Open, update, or resolve the single drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUDIT_STATUS: ${{ steps.audit.outputs.status }}
+        shell: bash
+        run: |
+          title='[security] Production dependency audit drift'
+          issue="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          if [ "$AUDIT_STATUS" != '0' ]; then
+            {
+              printf '%s\n\n' 'The scheduled production-only dependency gate found policy drift.'
+              printf '%s\n\n' 'Sanitized report:'
+              printf '%s\n' '```text'
+              cat "$RUNNER_TEMP/production-audit.md"
+              printf '%s\n\n' '```'
+              printf '%s\n' 'This issue is maintained by `.github/workflows/production-dependency-audit.yml`.'
+            } > "$RUNNER_TEMP/issue-body.md"
+            if [ -n "$issue" ]; then
+              gh issue edit "$issue" --body-file "$RUNNER_TEMP/issue-body.md"
+            else
+              gh issue create --title "$title" --body-file "$RUNNER_TEMP/issue-body.md"
+            fi
+            exit 1
+          fi
+          if [ -n "$issue" ]; then
+            gh issue comment "$issue" --body 'Production audit is green again; closing the automated drift issue.'
+            gh issue close "$issue" --reason completed
+          fi

--- a/docs/audit/2026-08-10-asset-archive-ingestion.md
+++ b/docs/audit/2026-08-10-asset-archive-ingestion.md
@@ -1,0 +1,102 @@
+# Asset archive ingestion boundary — 2026-08-10
+
+Issue: [#377](https://github.com/zajalist/hayba/issues/377)
+
+## Outcome
+
+Marketplace ZIPs no longer enter `adm-zip` or an eager `extractAllTo` path.
+AmbientCG and Sketchfab now cross one fail-closed boundary:
+
+`bounded download -> complete lazy metadata preflight -> private streamed extraction -> atomic promotion -> UE import`
+
+The import continuation is structurally after all four filesystem stages. Any
+download, metadata, path, inflation, checksum, deadline, or promotion rejection
+deletes the request-owned cache and cannot call `python_run`.
+
+Poly Haven does not consume archives, but now shares the bounded downloader,
+uses a unique request cache, rejects provider-supplied unsafe/colliding leaf
+names, and deletes a partial request cache if any file fails.
+
+## Non-disableable ceilings
+
+Defaults are centralized in `DEFAULT_ARCHIVE_LIMITS`. A caller may lower them;
+zero, negative, fractional, non-finite, or unsafe-integer values are rejected.
+
+| Boundary | Default |
+|---|---:|
+| compressed download/archive | 512 MiB |
+| download deadline | 120 s |
+| provider lookup metadata | 8 MiB |
+| provider lookup deadline | 30 s |
+| validation + extraction deadline | 120 s |
+| central directory | 16 MiB |
+| entries | 4,096 |
+| filename | 1,024 UTF-8 bytes |
+| extra field | 4,096 bytes per entry |
+| path depth | 32 components |
+| compressed bytes per entry | 512 MiB |
+| uncompressed bytes per entry | 256 MiB |
+| total uncompressed bytes | 2 GiB |
+| compression ratio | 200:1 |
+
+Download size is enforced once from `Content-Length` when present and again on
+the actual response stream. Both download and extraction deadlines abort their
+active pipelines and remove private staging directories. Provider lookup JSON
+is also decoded only after a bounded stream completes; invalid UTF-8/JSON and
+network errors never echo response bodies, signed URLs, or authorization data.
+
+## ZIP policy
+
+The parser reads the EOCD and central directory with bounded positional reads;
+declared entry sizes never drive allocation. It accepts only single-disk,
+non-ZIP64, unencrypted stored/deflated regular files and directories. It rejects:
+
+- absolute, drive, UNC, device, ADS, NUL, control, Win32-invalid, dot,
+  traversal, backslash, trailing-dot/space, reserved-device, non-NFC, and
+  compatibility-normalizing names;
+- filename/depth/metadata, entry-count, entry-size, total-size, ratio, and
+  wall-clock overruns;
+- symlink, special-file, reparse, NTFS, and ASi Unix metadata; extraction only
+  creates new regular files/directories, so no hardlink primitive exists;
+- duplicate normalized names, case collisions, file/directory collisions,
+  duplicate local offsets, overlapping local records, and local/central
+  metadata disagreement;
+- unsupported compression, empty/directory-only archives, malformed extra
+  fields, truncation, inflated-size mismatch, and CRC mismatch.
+
+All entries are planned before the first output byte. Each file is opened with
+exclusive creation inside a private `mkdtemp` root. Every resolved destination
+must remain under that root, and each existing parent is rechecked as a real
+directory rather than a link. The final destination is never opened for write
+and is not replaced if already present.
+
+## Path-replacement / TOCTOU posture
+
+Preflight and extraction use one open read-only file handle. Entry streams use
+positional reads from that handle rather than reopening the archive pathname,
+so renaming or replacing the path after inspection cannot substitute different
+bytes. The immutable plan still enforces output byte limits and CRC on every
+entry, failing closed if the underlying file is concurrently corrupted.
+
+## Deterministic proof
+
+`secure-archive.test.ts` builds ZIP bytes directly, without the production
+parser or `adm-zip`, and covers:
+
+- valid stored/deflated/empty files and CRC verification;
+- declared 4 GB size, ratio bomb, entry flood, per-entry and total size,
+  filename and depth ceilings;
+- zip slip, backslash traversal, absolute/drive/device/ADS paths, reserved and
+  trailing-dot/space names;
+- symlink/reparse metadata, duplicate/case/file-parent collisions, overlapping
+  publication targets, truncation, and an inflation-time CRC failure after an
+  earlier file was staged;
+- response-stream overrun, stalled-response deadline, extraction deadline,
+  existing download/extraction targets, and private-root cleanup;
+- zero UE-import continuation calls after both archive rejection and download
+  rejection.
+
+The production dependency manifest is intentionally outside this change because
+#380 owns dependency updates. Once that change removes direct `adm-zip`, only
+the separately assessed optional ONNX installation path may remain in the
+lockfile; there is no Hayba runtime import or use of `adm-zip` after #377.

--- a/docs/audit/2026-08-10-production-dependency-reachability.md
+++ b/docs/audit/2026-08-10-production-dependency-reachability.md
@@ -1,0 +1,76 @@
+# Production dependency reachability — 2026-08-10
+
+Issue #380 turns the production dependency audit from a point-in-time command
+into an executable, expiring policy. The machine authority is
+[`production-dependency-assessments.json`](production-dependency-assessments.json).
+
+## Outcome
+
+Compatible updates removed every currently fixable production finding:
+
+- `js-yaml` 4.1.1 → 4.3.1;
+- `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0;
+- compatible transitive updates for Hono/Node Server, Axios/FormData,
+  Fast-URI, BodyParser, IP Address, Undici, and ProtobufJS.
+
+`npm audit --omit=dev --json` fell from 15 production vulnerability nodes (12
+high) to four high nodes. The gate expands transitive `via` chains into five
+distinct package/advisory paths so an aggregate package cannot silently inherit
+another package's exception.
+
+#377 removed the reachable direct `adm-zip` path and the direct dependency.
+External asset archives now use the bounded streaming extractor, and an `rg`
+audit finds zero runtime `adm-zip`/`AdmZip`/`extractAllTo` references. The
+package still appears transitively under ONNX Runtime, so the production audit
+correctly remains non-zero rather than hiding it.
+
+The other paths come from the optional Transformers text-embedding backend:
+
+- ONNX Runtime's residual `adm-zip` path is installation-only. Hayba never
+  invokes it at runtime; audit jobs install with scripts disabled and the
+  lockfile pins integrity.
+- Sharp's vulnerable image/SVG parser is outside Hayba's text-only
+  `feature-extraction` call path. The backend accepts only strings.
+
+Those decisions expire on 2026-09-09. Expiry fails CI even when the inventory
+file is otherwise unchanged.
+
+## Executable policy
+
+Run from the repository root:
+
+```powershell
+npm run audit:production
+```
+
+The script itself launches `npm audit --omit=dev --json`; callers cannot
+accidentally broaden it to a dev audit or weaken it with `--audit-level`. Raw
+npm JSON is parsed in memory and never emitted. Output contains only stable
+policy codes, package names, GHSA IDs, counts, and no dependency paths, request
+data, environment, registry credentials, or raw advisory prose.
+
+The policy fails on:
+
+- any new/unassessed critical or high package/advisory path;
+- an unresolved/cyclic npm `via` chain;
+- malformed, duplicate, future-dated, expired, or stale assessments;
+- severity or installed-version drift.
+
+Moderate/low findings are reported as non-blocking warnings. The current report
+contains none; every remaining current finding has an assessed high record.
+Dev-only advisories do not enter this lane because the executable collector
+always supplies `--omit=dev`.
+
+CI runs the gate on every push/PR. A weekly scheduled workflow uses the same
+script and creates or updates exactly one issue named
+`[security] Production dependency audit drift`; it closes that issue when the
+lane returns green.
+
+## Reproducibility and install ordering
+
+Dependency installation mutates the shared root `node_modules`, so install,
+typecheck, test, and audit must be serialized. A transient typecheck executed
+while npm was replacing SDK files observed missing declarations; the identical
+typecheck passed after installation completed. CI naturally serializes these
+steps, and local evidence for this change was collected only after the final
+install process exited.

--- a/docs/audit/production-dependency-assessments.json
+++ b/docs/audit/production-dependency-assessments.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 1,
+  "policy_id": "hayba-production-dependencies-v1",
+  "generated_on": "2026-08-10",
+  "source_command": "npm audit --omit=dev --json",
+  "blocking_severities": ["critical", "high"],
+  "assessments": [
+    {
+      "finding_key": "@huggingface/transformers|GHSA-f88m-g3jw-g9cj",
+      "package": "@huggingface/transformers",
+      "advisory": "GHSA-f88m-g3jw-g9cj",
+      "severity": "high",
+      "installed_versions": ["4.0.1"],
+      "importing_feature": "Optional local text-embedding fallback for MCP tool search",
+      "reachability": "unreachable_code_path",
+      "decision": "time_bounded_exception",
+      "mitigation": "Hayba calls only the feature-extraction text pipeline with strings; it never supplies image/SVG input to Sharp. Ollama is attempted first and lexical search remains available when the optional backend fails.",
+      "owner": "Hayba security maintainers",
+      "tracking_issue": "#380",
+      "reviewed_on": "2026-08-10",
+      "expires_on": "2026-09-09",
+      "evidence": [
+        "mcp-tools/hayba-mcp/src/tools/routing/embedding-backends.ts:47-55",
+        "docs/research/2026-08-10-unreal-mcp-comparison.md"
+      ]
+    },
+    {
+      "finding_key": "@huggingface/transformers|GHSA-xcpc-8h2w-3j85",
+      "package": "@huggingface/transformers",
+      "advisory": "GHSA-xcpc-8h2w-3j85",
+      "severity": "high",
+      "installed_versions": ["4.0.1"],
+      "importing_feature": "Optional local text embeddings backed by ONNX Runtime",
+      "reachability": "install_time_only",
+      "decision": "time_bounded_exception",
+      "mitigation": "The transitive AdmZip reference belongs to ONNX Runtime's package installation script, not Hayba's runtime embedding calls. Installs are lockfile-integrity-pinned; CI audit jobs use --ignore-scripts. Runtime archive extraction remains separately reachable and blocking under #377.",
+      "owner": "Hayba security maintainers",
+      "tracking_issue": "#380",
+      "reviewed_on": "2026-08-10",
+      "expires_on": "2026-09-09",
+      "evidence": ["mcp-tools/hayba-mcp/src/tools/routing/embedding-backends.ts:47-55", "package-lock.json"]
+    },
+    {
+      "finding_key": "adm-zip|GHSA-xcpc-8h2w-3j85",
+      "package": "adm-zip",
+      "advisory": "GHSA-xcpc-8h2w-3j85",
+      "severity": "high",
+      "installed_versions": ["0.5.17"],
+      "importing_feature": "ONNX Runtime installation for the optional local text-embedding fallback",
+      "reachability": "install_time_only",
+      "decision": "time_bounded_exception",
+      "mitigation": "#377 removed every Hayba runtime AdmZip import and replaced external archive handling with bounded streaming extraction. The sole remaining package is transitive to ONNX Runtime's postinstall binary installer; security workflows use --ignore-scripts and the lockfile pins integrity.",
+      "owner": "Hayba security maintainers",
+      "tracking_issue": "#380",
+      "reviewed_on": "2026-08-10",
+      "expires_on": "2026-09-09",
+      "evidence": ["mcp-tools/hayba-mcp/src/tools/asset-sources/secure-archive.ts", "package-lock.json"]
+    },
+    {
+      "finding_key": "onnxruntime-node|GHSA-xcpc-8h2w-3j85",
+      "package": "onnxruntime-node",
+      "advisory": "GHSA-xcpc-8h2w-3j85",
+      "severity": "high",
+      "installed_versions": ["1.24.3"],
+      "importing_feature": "Native inference runtime for the optional local text-embedding fallback",
+      "reachability": "install_time_only",
+      "decision": "time_bounded_exception",
+      "mitigation": "ONNX Runtime declares AdmZip for its postinstall binary installer; Hayba does not invoke that archive reader at runtime. Lockfile integrity pins the package and security workflows install with lifecycle scripts disabled.",
+      "owner": "Hayba security maintainers",
+      "tracking_issue": "#380",
+      "reviewed_on": "2026-08-10",
+      "expires_on": "2026-09-09",
+      "evidence": ["package-lock.json", "mcp-tools/hayba-mcp/src/tools/routing/embedding-backends.ts:47-55"]
+    },
+    {
+      "finding_key": "sharp|GHSA-f88m-g3jw-g9cj",
+      "package": "sharp",
+      "advisory": "GHSA-f88m-g3jw-g9cj",
+      "severity": "high",
+      "installed_versions": ["0.34.5"],
+      "importing_feature": "Image-processing dependency shipped by the optional Transformers backend",
+      "reachability": "unreachable_code_path",
+      "decision": "time_bounded_exception",
+      "mitigation": "The Hayba backend accepts text strings only and selects a text feature-extraction model. It does not expose Transformers image processors or pass SVG/image bytes to Sharp.",
+      "owner": "Hayba security maintainers",
+      "tracking_issue": "#380",
+      "reviewed_on": "2026-08-10",
+      "expires_on": "2026-09-09",
+      "evidence": ["mcp-tools/hayba-mcp/src/tools/routing/embedding-backends.ts:47-55", "package-lock.json"]
+    }
+  ]
+}

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -24,11 +24,10 @@
     "@anthropic-ai/sdk": "^0.110.0",
     "@distube/ytdl-core": "^4.16.12",
     "@huggingface/transformers": "^4.0.1",
-    "@modelcontextprotocol/sdk": "^1.0.0",
-    "adm-zip": "^0.5.17",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "cheerio": "^1.2.0",
     "express": "^4.21.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.1",
     "lru-cache": "^11.3.6",
     "minisearch": "^7.2.0",
     "openai": "^6.45.0",
@@ -36,7 +35,6 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/adm-zip": "^0.5.5",
     "@types/express": "^5.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^26.1.1",

--- a/mcp-tools/hayba-mcp/scripts/audit-production-dependencies.mjs
+++ b/mcp-tools/hayba-mcp/scripts/audit-production-dependencies.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+
+/* global process */
+
+// Production dependency policy for #380.
+//
+// The live path invokes `npm audit --omit=dev --json` itself. That makes the
+// production-only scope part of the executable policy instead of a convention
+// a workflow author can accidentally omit. Raw npm output is parsed in memory
+// and never printed; reports contain stable package/advisory keys and policy
+// codes only.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..', '..');
+const DEFAULT_INVENTORY = resolve(REPO_ROOT, 'docs', 'audit', 'production-dependency-assessments.json');
+const DEFAULT_LOCKFILE = resolve(REPO_ROOT, 'package-lock.json');
+const BLOCKING_SEVERITIES = new Set(['critical', 'high']);
+const ALLOWED_REACHABILITY = new Set(['reachable', 'install_time_only', 'unreachable_code_path']);
+const ALLOWED_DECISIONS = new Set(['temporary_blocking_exception', 'time_bounded_exception']);
+const MAX_TEXT = 500;
+const MAX_EXCEPTION_DAYS = 30;
+
+function parseArgs(argv) {
+  const out = {
+    inventory: DEFAULT_INVENTORY,
+    lockfile: DEFAULT_LOCKFILE,
+    auditFixture: null,
+    today: new Date().toISOString().slice(0, 10),
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--inventory' && next) {
+      out.inventory = resolve(next);
+      i += 1;
+    } else if (arg === '--lockfile' && next) {
+      out.lockfile = resolve(next);
+      i += 1;
+    } else if (arg === '--audit-fixture' && next) {
+      out.auditFixture = resolve(next);
+      i += 1;
+    } else if (arg === '--today' && next) {
+      out.today = next;
+      i += 1;
+    } else {
+      throw new Error('PDA-USAGE');
+    }
+  }
+  return out;
+}
+
+function readJson(path, code) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    throw new Error(code);
+  }
+}
+
+function runProductionAudit() {
+  // npm scripts expose the exact npm-cli entry point. Invoking it through the
+  // current Node binary avoids Windows' inability to spawn a .cmd shim without
+  // a command shell (and avoids quoting user-controlled shell text).
+  const npmExecPath = process.env.npm_execpath;
+  const command = npmExecPath ? process.execPath : 'npm';
+  const args = npmExecPath ? [npmExecPath, 'audit', '--omit=dev', '--json'] : ['audit', '--omit=dev', '--json'];
+  const result = spawnSync(command, args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    windowsHide: true,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  // npm exits non-zero when findings exist; valid JSON is the authority.
+  if (result.error || !result.stdout) throw new Error('PDA-AUDIT-UNAVAILABLE');
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new Error('PDA-AUDIT-MALFORMED');
+  }
+}
+
+function isDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function safeText(value) {
+  if (typeof value !== 'string' || value.trim().length === 0 || value.length > MAX_TEXT) return false;
+  for (let i = 0; i < value.length; i += 1) {
+    if (value.charCodeAt(i) <= 0x1f) return false;
+  }
+  return true;
+}
+
+function isPackageName(value) {
+  return (
+    typeof value === 'string' &&
+    value.length <= 214 &&
+    /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/i.test(value)
+  );
+}
+
+function isAdvisory(value) {
+  return typeof value === 'string' && /^(?:GHSA-[A-Za-z0-9-]+|NPM-\d+)$/.test(value);
+}
+
+function daysBetween(start, end) {
+  return (Date.parse(`${end}T00:00:00Z`) - Date.parse(`${start}T00:00:00Z`)) / 86_400_000;
+}
+
+function advisoryId(via) {
+  const urlMatch = typeof via.url === 'string' ? /\/advisories\/(GHSA-[A-Za-z0-9-]+)\/?$/.exec(via.url) : null;
+  if (urlMatch) return urlMatch[1];
+  if (Number.isSafeInteger(via.source) && via.source > 0) return `NPM-${via.source}`;
+  return null;
+}
+
+function leavesFor(packageName, vulnerabilities, seen = new Set()) {
+  if (seen.has(packageName)) return { leaves: [], unresolved: true };
+  const entry = vulnerabilities[packageName];
+  if (!entry || !Array.isArray(entry.via)) return { leaves: [], unresolved: true };
+  const nextSeen = new Set(seen).add(packageName);
+  const leaves = [];
+  let unresolved = false;
+  for (const via of entry.via) {
+    if (typeof via === 'string') {
+      const nested = leavesFor(via, vulnerabilities, nextSeen);
+      leaves.push(...nested.leaves);
+      unresolved ||= nested.unresolved;
+    } else if (via && typeof via === 'object') {
+      const id = advisoryId(via);
+      if (!id) unresolved = true;
+      else leaves.push({ advisory: id, advisoryPackage: String(via.name ?? packageName) });
+    } else {
+      unresolved = true;
+    }
+  }
+  const unique = new Map(leaves.map((leaf) => [`${leaf.advisory}\0${leaf.advisoryPackage}`, leaf]));
+  return { leaves: [...unique.values()], unresolved };
+}
+
+function installedVersions(lockfile, packageName) {
+  const suffix = `node_modules/${packageName}`;
+  const versions = new Set();
+  for (const [path, value] of Object.entries(lockfile.packages ?? {})) {
+    if ((path === suffix || path.endsWith(`/${suffix}`)) && safeText(value?.version)) versions.add(value.version);
+  }
+  return [...versions].sort();
+}
+
+function currentFindings(audit, lockfile) {
+  const vulnerabilities = audit?.vulnerabilities;
+  if (!vulnerabilities || typeof vulnerabilities !== 'object' || Array.isArray(vulnerabilities)) {
+    throw new Error('PDA-AUDIT-SHAPE');
+  }
+  const findings = [];
+  const unresolved = [];
+  for (const packageName of Object.keys(vulnerabilities).sort()) {
+    if (!isPackageName(packageName)) {
+      unresolved.push('UNSAFE-PACKAGE-NAME');
+      continue;
+    }
+    const entry = vulnerabilities[packageName];
+    const severity = String(entry?.severity ?? '').toLowerCase();
+    if (!['critical', 'high', 'moderate', 'low', 'info'].includes(severity)) {
+      unresolved.push(`${packageName}|INVALID-SEVERITY`);
+      continue;
+    }
+    const resolved = leavesFor(packageName, vulnerabilities);
+    if (resolved.unresolved || resolved.leaves.length === 0) unresolved.push(`${packageName}|UNRESOLVED-CHAIN`);
+    for (const leaf of resolved.leaves) {
+      findings.push({
+        key: `${packageName}|${leaf.advisory}`,
+        package: packageName,
+        advisory: leaf.advisory,
+        advisoryPackage: leaf.advisoryPackage,
+        severity,
+        installedVersions: installedVersions(lockfile, packageName),
+      });
+    }
+  }
+  return {
+    findings: [...new Map(findings.map((finding) => [finding.key, finding])).values()].sort((a, b) =>
+      a.key.localeCompare(b.key),
+    ),
+    unresolved: [...new Set(unresolved)].sort(),
+  };
+}
+
+function validateInventory(inventory, today) {
+  const errors = [];
+  if (inventory?.schema_version !== 1 || !Array.isArray(inventory?.assessments)) {
+    return { errors: ['PDA-INVENTORY-SHAPE'], assessments: new Map() };
+  }
+  const assessments = new Map();
+  for (const [index, item] of inventory.assessments.entries()) {
+    const key = safeText(item?.finding_key) ? item.finding_key : `assessment[${index}]`;
+    const fields = [
+      item?.package,
+      item?.advisory,
+      item?.severity,
+      item?.importing_feature,
+      item?.reachability,
+      item?.mitigation,
+      item?.owner,
+      item?.tracking_issue,
+      item?.reviewed_on,
+      item?.expires_on,
+      item?.decision,
+    ];
+    const versionsValid =
+      Array.isArray(item?.installed_versions) &&
+      item.installed_versions.length > 0 &&
+      item.installed_versions.every(safeText) &&
+      new Set(item.installed_versions).size === item.installed_versions.length;
+    const evidenceValid = Array.isArray(item?.evidence) && item.evidence.length > 0 && item.evidence.every(safeText);
+    const keyValid = item?.finding_key === `${item?.package}|${item?.advisory}`;
+    const identifierValid = isPackageName(item?.package) && isAdvisory(item?.advisory);
+    const enumValid =
+      BLOCKING_SEVERITIES.has(item?.severity) &&
+      ALLOWED_REACHABILITY.has(item?.reachability) &&
+      ALLOWED_DECISIONS.has(item?.decision);
+    const issueValid = /^#\d+$/.test(item?.tracking_issue ?? '');
+    const dateValid = isDate(item?.reviewed_on) && isDate(item?.expires_on) && item.reviewed_on <= item.expires_on;
+    if (
+      !fields.every(safeText) ||
+      !versionsValid ||
+      !evidenceValid ||
+      !keyValid ||
+      !identifierValid ||
+      !enumValid ||
+      !issueValid ||
+      !dateValid
+    ) {
+      errors.push(`PDA-MALFORMED assessment[${index}]`);
+      continue;
+    }
+    if (assessments.has(key)) {
+      errors.push(`PDA-DUPLICATE ${key}`);
+      continue;
+    }
+    if (item.reviewed_on > today) errors.push(`PDA-FUTURE-REVIEW ${key}`);
+    if (item.expires_on < today) errors.push(`PDA-EXPIRED ${key}`);
+    if (daysBetween(item.reviewed_on, item.expires_on) > MAX_EXCEPTION_DAYS) {
+      errors.push(`PDA-EXCEPTION-TOO-LONG ${key}`);
+    }
+    assessments.set(key, item);
+  }
+  return { errors, assessments };
+}
+
+function evaluate(audit, inventory, lockfile, today) {
+  if (!isDate(today)) return { errors: ['PDA-TODAY-MALFORMED'], warnings: [], findings: [] };
+  const inventoryResult = validateInventory(inventory, today);
+  const current = currentFindings(audit, lockfile);
+  const errors = [...inventoryResult.errors, ...current.unresolved.map((key) => `PDA-UNRESOLVED ${key}`)];
+  const warnings = [];
+  const currentKeys = new Set(current.findings.map((finding) => finding.key));
+  for (const finding of current.findings) {
+    const assessment = inventoryResult.assessments.get(finding.key);
+    if (!BLOCKING_SEVERITIES.has(finding.severity)) {
+      if (!assessment) warnings.push(`PDA-NONBLOCKING-UNASSESSED ${finding.key}`);
+      continue;
+    }
+    if (!assessment) {
+      errors.push(`PDA-UNASSESSED-HIGH ${finding.key}`);
+      continue;
+    }
+    if (assessment.severity !== finding.severity) errors.push(`PDA-SEVERITY-DRIFT ${finding.key}`);
+    if (JSON.stringify([...assessment.installed_versions].sort()) !== JSON.stringify(finding.installedVersions)) {
+      errors.push(`PDA-VERSION-DRIFT ${finding.key}`);
+    }
+  }
+  for (const key of inventoryResult.assessments.keys()) {
+    if (!currentKeys.has(key)) errors.push(`PDA-STALE-ASSESSMENT ${key}`);
+  }
+  return { errors: [...new Set(errors)].sort(), warnings: [...new Set(warnings)].sort(), findings: current.findings };
+}
+
+function render(result, fixture) {
+  const lines = [
+    `production dependency audit: ${result.errors.length === 0 ? 'PASS' : 'FAIL'}`,
+    `scope: production (${fixture ? 'deterministic fixture' : 'npm audit --omit=dev'})`,
+    `finding_paths: ${result.findings.length}`,
+    `errors: ${result.errors.length}`,
+    `warnings: ${result.warnings.length}`,
+  ];
+  if (result.errors.length) lines.push('', ...result.errors.map((error) => `- ${error}`));
+  if (result.warnings.length) lines.push('', ...result.warnings.map((warning) => `- ${warning}`));
+  return `${lines.join('\n')}\n`;
+}
+
+export { currentFindings, evaluate, render, runProductionAudit, validateInventory };
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const audit = options.auditFixture
+    ? readJson(options.auditFixture, 'PDA-AUDIT-FIXTURE-MALFORMED')
+    : runProductionAudit();
+  const inventory = readJson(options.inventory, 'PDA-INVENTORY-UNREADABLE');
+  const lockfile = readJson(options.lockfile, 'PDA-LOCKFILE-UNREADABLE');
+  const result = evaluate(audit, inventory, lockfile, options.today);
+  process.stdout.write(render(result, Boolean(options.auditFixture)));
+  process.exitCode = result.errors.length === 0 ? 0 : 1;
+} catch (error) {
+  const code = error instanceof Error && /^PDA-[A-Z-]+$/.test(error.message) ? error.message : 'PDA-INTERNAL';
+  process.stdout.write(`production dependency audit: FAIL\nscope: unavailable\nerrors: 1\n\n- ${code}\n`);
+  process.exitCode = 1;
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/ambientcg-download.ts
@@ -1,7 +1,14 @@
 import * as path from 'node:path';
 import { z } from 'zod';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
-import { cachePathFor, downloadToFile, ensureDir, extractZip, importIntoUe, verifyAndMarkDelta, type DownloadedAsset } from './shared.js';
+import {
+  createUniqueCacheDir,
+  downloadExtractThen,
+  fetchJsonBounded,
+  importIntoUe,
+  verifyAndMarkDelta,
+  type DownloadedAsset,
+} from './shared.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'high',
@@ -41,7 +48,7 @@ export function pickZipUrl(assetJson: any, resolution: string): string | null {
   for (const folder of folders as any[]) {
     const cats = folder?.downloadFiletypeCategories ?? {};
     const zip = cats?.zip ?? cats?.Zip;
-    for (const d of (zip?.downloads ?? [])) {
+    for (const d of zip?.downloads ?? []) {
       if (typeof d?.attribute === 'string' && d.attribute.toLowerCase() === resolution.toLowerCase() && pathOf(d)) {
         return pathOf(d);
       }
@@ -64,23 +71,25 @@ export async function handleAmbientCgDownload(params: AmbientCgDownloadParams) {
   }
   const { asset_id, resolution, target_dir } = parsed.data;
   try {
-    const res = await fetch(assetInfoUrl(asset_id));
-    if (!res.ok) {
-      return { content: [{ type: 'text' as const, text: `ambientCG lookup failed: ${res.status} ${res.statusText}` }], isError: true };
-    }
-    const json = (await res.json()) as any;
+    const json = await fetchJsonBounded<any>(assetInfoUrl(asset_id));
     const zipUrl = pickZipUrl(json, resolution);
     if (!zipUrl) {
-      return { content: [{ type: 'text' as const, text: `No zip download found for ${asset_id} @ ${resolution}` }], isError: true };
+      return {
+        content: [{ type: 'text' as const, text: `No zip download found for ${asset_id} @ ${resolution}` }],
+        isError: true,
+      };
     }
-    const cacheDir = cachePathFor('ambientcg', asset_id);
-    await ensureDir(cacheDir);
-    const zipPath = path.join(cacheDir, `${asset_id}_${resolution}.zip`);
-    await downloadToFile(zipUrl, zipPath);
+    const cacheDir = await createUniqueCacheDir('ambientcg', asset_id);
+    const zipPath = path.join(cacheDir, 'archive.zip');
     const extractDir = path.join(cacheDir, 'extracted');
-    const files = await extractZip(zipPath, extractDir);
     const gamePath = target_dir ?? `/Game/AssetConnectors/ambientcg/${asset_id}`;
-    const importResult = await importIntoUe(extractDir, gamePath);
+    const { files, result: importResult } = await downloadExtractThen({
+      url: zipUrl,
+      archivePath: zipPath,
+      extractDir,
+      failureCleanupRoot: cacheDir,
+      afterVerified: () => importIntoUe(extractDir, gamePath),
+    });
     const data: DownloadedAsset = {
       assetId: asset_id,
       source: 'ambientcg',

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/polyhaven-download.ts
@@ -1,7 +1,16 @@
 import * as path from 'node:path';
+import * as fsp from 'node:fs/promises';
 import { z } from 'zod';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
-import { cachePathFor, downloadToFile, ensureDir, importIntoUe, verifyAndMarkDelta, type DownloadedAsset } from './shared.js';
+import {
+  createUniqueCacheDir,
+  downloadToFile,
+  fetchJsonBounded,
+  importIntoUe,
+  safeDownloadLeafName,
+  verifyAndMarkDelta,
+  type DownloadedAsset,
+} from './shared.js';
 
 export const meta: HaybaToolMeta = {
   cost: 'high',
@@ -68,21 +77,26 @@ export async function handlePolyhavenDownload(params: PolyhavenDownloadParams) {
     return { content: [{ type: 'text' as const, text: 'Invalid params: ' + parsed.error.message }], isError: true };
   }
   const { asset_id, type, resolution, target_dir } = parsed.data;
+  let requestCacheDir: string | undefined;
   try {
-    const res = await fetch(filesUrl(asset_id));
-    if (!res.ok) {
-      return { content: [{ type: 'text' as const, text: `Poly Haven files lookup failed: ${res.status} ${res.statusText}` }], isError: true };
-    }
-    const files = (await res.json()) as Record<string, any>;
+    const files = await fetchJsonBounded<Record<string, any>>(filesUrl(asset_id));
     const picks = pickDownloads(files, type, resolution);
     if (picks.length === 0) {
-      return { content: [{ type: 'text' as const, text: `No downloadable files for ${asset_id} at ${resolution}` }], isError: true };
+      return {
+        content: [{ type: 'text' as const, text: `No downloadable files for ${asset_id} at ${resolution}` }],
+        isError: true,
+      };
     }
-    const cacheDir = cachePathFor('polyhaven', asset_id);
-    await ensureDir(cacheDir);
+    const cacheDir = await createUniqueCacheDir('polyhaven', asset_id);
+    requestCacheDir = cacheDir;
     const written: string[] = [];
+    const names = new Set<string>();
     for (const pick of picks) {
-      const dest = path.join(cacheDir, pick.filename);
+      const filename = safeDownloadLeafName(pick.filename);
+      const folded = filename.toLocaleLowerCase('en-US');
+      if (names.has(folded)) throw new Error('provider returned duplicate/case-colliding filenames');
+      names.add(folded);
+      const dest = path.join(cacheDir, filename);
       await downloadToFile(pick.url, dest);
       written.push(dest);
     }
@@ -102,6 +116,7 @@ export async function handlePolyhavenDownload(params: PolyhavenDownloadParams) {
     };
     return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
   } catch (e: unknown) {
+    if (requestCacheDir) await fsp.rm(requestCacheDir, { recursive: true, force: true });
     const msg = e instanceof Error ? e.message : String(e);
     return { content: [{ type: 'text' as const, text: `Poly Haven download error: ${msg}` }], isError: true };
   }

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/secure-archive.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/secure-archive.test.ts
@@ -1,0 +1,457 @@
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { deflateRawSync } from 'node:zlib';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  downloadExtractThen,
+  downloadToFile,
+  extractZip,
+  fetchJsonBounded,
+  safeDownloadLeafName,
+  type ArchiveLimits,
+} from './secure-archive.js';
+
+interface FixtureEntry {
+  name: string;
+  content?: Buffer | string;
+  method?: 0 | 8;
+  flags?: number;
+  versionMadeBy?: number;
+  externalAttributes?: number;
+  declaredCompressedSize?: number;
+  declaredUncompressedSize?: number;
+  declaredCrc?: number;
+  extra?: Buffer;
+}
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  await Promise.all(roots.splice(0).map((root) => fsp.rm(root, { recursive: true, force: true })));
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'hayba-archive-test-'));
+  roots.push(root);
+  return root;
+}
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of buffer) crc = CRC_TABLE[(crc ^ byte) & 0xff]! ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function zipFixture(entries: FixtureEntry[], comment = ''): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let localOffset = 0;
+
+  for (const fixture of entries) {
+    const name = Buffer.from(fixture.name, 'utf8');
+    const source = Buffer.isBuffer(fixture.content) ? fixture.content : Buffer.from(fixture.content ?? '', 'utf8');
+    const method = fixture.method ?? 0;
+    const compressed = method === 8 ? deflateRawSync(source) : source;
+    const flags = fixture.flags ?? 0x800;
+    const extra = fixture.extra ?? Buffer.alloc(0);
+    const compressedSize = fixture.declaredCompressedSize ?? compressed.length;
+    const uncompressedSize = fixture.declaredUncompressedSize ?? source.length;
+
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(flags, 6);
+    local.writeUInt16LE(method, 8);
+    local.writeUInt32LE(fixture.declaredCrc ?? crc32(source), 14);
+    local.writeUInt32LE(compressedSize >>> 0, 18);
+    local.writeUInt32LE(uncompressedSize >>> 0, 22);
+    local.writeUInt16LE(name.length, 26);
+    local.writeUInt16LE(extra.length, 28);
+    localParts.push(local, name, extra, compressed);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(fixture.versionMadeBy ?? (3 << 8) | 20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(flags, 8);
+    central.writeUInt16LE(method, 10);
+    central.writeUInt32LE(fixture.declaredCrc ?? crc32(source), 16);
+    central.writeUInt32LE(compressedSize >>> 0, 20);
+    central.writeUInt32LE(uncompressedSize >>> 0, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt16LE(extra.length, 30);
+    central.writeUInt32LE((fixture.externalAttributes ?? 0o100644 << 16) >>> 0, 38);
+    central.writeUInt32LE(localOffset, 42);
+    centralParts.push(central, name, extra);
+    localOffset += local.length + name.length + extra.length + compressed.length;
+  }
+
+  const locals = Buffer.concat(localParts);
+  const central = Buffer.concat(centralParts);
+  const commentBytes = Buffer.from(comment, 'utf8');
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(central.length, 12);
+  eocd.writeUInt32LE(locals.length, 16);
+  eocd.writeUInt16LE(commentBytes.length, 20);
+  return Buffer.concat([locals, central, eocd, commentBytes]);
+}
+
+async function writeZip(root: string, bytes: Buffer): Promise<string> {
+  const file = path.join(root, 'fixture.zip');
+  await fsp.writeFile(file, bytes);
+  return file;
+}
+
+async function rejectArchive(
+  entriesOrBytes: FixtureEntry[] | Buffer,
+  expectedCode: string,
+  limits?: Partial<ArchiveLimits>,
+): Promise<void> {
+  const root = await tempRoot();
+  const zip = await writeZip(root, Buffer.isBuffer(entriesOrBytes) ? entriesOrBytes : zipFixture(entriesOrBytes));
+  const destination = path.join(root, 'published');
+  await expect(extractZip(zip, destination, limits)).rejects.toMatchObject({
+    code: expectedCode,
+  });
+  await expect(fsp.lstat(destination)).rejects.toMatchObject({ code: 'ENOENT' });
+  expect((await fsp.readdir(root)).filter((name) => name.startsWith('.hayba-extract-'))).toEqual([]);
+}
+
+describe('secure ZIP metadata preflight', () => {
+  it('streams a valid small archive, verifies CRCs, and atomically publishes it', async () => {
+    const root = await tempRoot();
+    const zip = await writeZip(
+      root,
+      zipFixture([
+        { name: 'model/', externalAttributes: (0o040755 << 16) >>> 0 },
+        { name: 'model/mesh.gltf', content: '{"asset":true}', method: 8 },
+        { name: 'model/empty.bin' },
+      ]),
+    );
+    const destination = path.join(root, 'published');
+    const files = await extractZip(zip, destination);
+
+    expect(files.map((file) => path.relative(destination, file).replaceAll('\\', '/')).sort()).toEqual([
+      'model/empty.bin',
+      'model/mesh.gltf',
+    ]);
+    await expect(fsp.readFile(path.join(destination, 'model', 'mesh.gltf'), 'utf8')).resolves.toBe('{"asset":true}');
+    await expect(fsp.readFile(path.join(destination, 'model', 'empty.bin'))).resolves.toHaveLength(0);
+  });
+
+  it('rejects a declared 4 GB / ZIP64 allocation before inflation', async () => {
+    await rejectArchive(
+      [{ name: 'bomb.bin', content: 'x', declaredCompressedSize: 0xffffffff, declaredUncompressedSize: 0xffffffff }],
+      'HAYBA-ARCHIVE-ENTRY-SIZE',
+    );
+  });
+
+  it('rejects an extreme compression ratio before inflation', async () => {
+    await rejectArchive([{ name: 'ratio.bin', content: Buffer.alloc(20_000, 65), method: 8 }], 'HAYBA-ARCHIVE-RATIO', {
+      maxCompressionRatio: 10,
+    });
+  });
+
+  it('rejects an entry flood before creating the destination', async () => {
+    await rejectArchive(
+      [
+        { name: 'a', content: 'a' },
+        { name: 'b', content: 'b' },
+        { name: 'c', content: 'c' },
+      ],
+      'HAYBA-ARCHIVE-ENTRIES',
+      { maxEntries: 2 },
+    );
+  });
+
+  it('enforces filename, depth, per-entry, and total-uncompressed budgets before extraction', async () => {
+    await rejectArchive([{ name: 'long-name.bin', content: 'x' }], 'HAYBA-ARCHIVE-NAME', { maxNameBytes: 4 });
+    await rejectArchive([{ name: 'a/b/c.bin', content: 'x' }], 'HAYBA-ARCHIVE-DEPTH', { maxDepth: 2 });
+    await rejectArchive([{ name: 'large.bin', content: '12345' }], 'HAYBA-ARCHIVE-ENTRY-SIZE', {
+      maxEntryUncompressedBytes: 4,
+    });
+    await rejectArchive(
+      [
+        { name: 'a.bin', content: '123456' },
+        { name: 'b.bin', content: '123456' },
+      ],
+      'HAYBA-ARCHIVE-TOTAL-SIZE',
+      { maxTotalUncompressedBytes: 10 },
+    );
+  });
+
+  it.each([
+    ['../escape.txt', 'zip slip'],
+    ['safe/..\\escape.txt', 'backslash traversal'],
+    ['/absolute.txt', 'absolute path'],
+    ['C:/drive.txt', 'drive path'],
+    ['safe/file.txt:secret', 'alternate data stream'],
+    ['safe/CON.txt', 'Windows device name'],
+    ['safe/trailing. ', 'Win32 normalized collision'],
+  ])('rejects %s (%s) without writing outside the stage', async (name) => {
+    await rejectArchive([{ name, content: 'owned' }], 'HAYBA-ARCHIVE-PATH');
+  });
+
+  it('rejects symlink and reparse metadata', async () => {
+    await rejectArchive(
+      [{ name: 'link', content: 'target', externalAttributes: (0o120777 << 16) >>> 0 }],
+      'HAYBA-ARCHIVE-LINK',
+    );
+    await rejectArchive([{ name: 'reparse', content: 'target', externalAttributes: 0x400 }], 'HAYBA-ARCHIVE-LINK');
+    const asiUnixLinkExtra = Buffer.from([0x6e, 0x75, 0x00, 0x00]);
+    await rejectArchive([{ name: 'hardlink', content: 'target', extra: asiUnixLinkExtra }], 'HAYBA-ARCHIVE-LINK');
+  });
+
+  it('rejects duplicate-normalized and case-colliding entries', async () => {
+    await rejectArchive(
+      [
+        { name: 'same.txt', content: 'a' },
+        { name: 'same.txt', content: 'b' },
+      ],
+      'HAYBA-ARCHIVE-DUPLICATE',
+    );
+    await rejectArchive(
+      [
+        { name: 'Asset/Thing.uasset', content: 'a' },
+        { name: 'asset/thing.uasset', content: 'b' },
+      ],
+      'HAYBA-ARCHIVE-CASE-COLLISION',
+    );
+    await rejectArchive(
+      [
+        { name: 'parent', content: 'file' },
+        { name: 'parent/child.bin', content: 'child' },
+      ],
+      'HAYBA-ARCHIVE-COLLISION',
+    );
+  });
+
+  it('rejects a truncated archive and removes its private extraction stage', async () => {
+    const valid = zipFixture([{ name: 'mesh.obj', content: 'v 0 0 0' }]);
+    await rejectArchive(valid.subarray(0, valid.length - 7), 'HAYBA-ARCHIVE-TRUNCATED');
+  });
+
+  it('removes every staged file when inflation-time CRC verification fails', async () => {
+    await rejectArchive(
+      [
+        { name: 'first.bin', content: 'first' },
+        { name: 'bad.bin', content: 'bad', declaredCrc: 0x12345678 },
+      ],
+      'HAYBA-ARCHIVE-CRC',
+    );
+  });
+
+  it('enforces one wall-clock deadline across preflight and extraction', async () => {
+    const root = await tempRoot();
+    const zip = await writeZip(root, zipFixture([{ name: 'mesh.bin', content: Buffer.alloc(4_096, 7), method: 8 }]));
+    const destination = path.join(root, 'published');
+    vi.useFakeTimers();
+
+    let stageReady!: () => void;
+    const reachedStage = new Promise<void>((resolve) => {
+      stageReady = resolve;
+    });
+    let releaseStage!: () => void;
+    const stageGate = new Promise<void>((resolve) => {
+      releaseStage = resolve;
+    });
+    const extraction = extractZip(
+      zip,
+      destination,
+      { extractionTimeoutMs: 10 },
+      {
+        afterStageReady: async () => {
+          stageReady();
+          await stageGate;
+        },
+      },
+    );
+    const rejected = expect(extraction).rejects.toMatchObject({ code: 'HAYBA-ARCHIVE-TIMEOUT' });
+    await reachedStage;
+    expect((await fsp.readdir(root)).some((name) => name.startsWith('.hayba-extract-'))).toBe(true);
+    await vi.advanceTimersByTimeAsync(11);
+    releaseStage();
+    await rejected;
+    vi.useRealTimers();
+    await expect(fsp.lstat(destination)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect((await fsp.readdir(root)).filter((name) => name.startsWith('.hayba-extract-'))).toEqual([]);
+  });
+
+  it('never overwrites an existing extraction destination', async () => {
+    const root = await tempRoot();
+    const zip = await writeZip(root, zipFixture([{ name: 'new.txt', content: 'new' }]));
+    const destination = path.join(root, 'published');
+    await fsp.mkdir(destination);
+    await fsp.writeFile(path.join(destination, 'keep.txt'), 'keep');
+
+    await expect(extractZip(zip, destination)).rejects.toMatchObject({ code: 'HAYBA-ARCHIVE-COLLISION' });
+    await expect(fsp.readFile(path.join(destination, 'keep.txt'), 'utf8')).resolves.toBe('keep');
+    await expect(fsp.lstat(path.join(destination, 'new.txt'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});
+
+describe('bounded archive download', () => {
+  it('rejects provider filenames that could escape or alias the request cache', () => {
+    expect(() => safeDownloadLeafName('../../outside.fbx')).toThrow(/HAYBA-ARCHIVE-PATH/);
+    expect(() => safeDownloadLeafName('folder/asset.fbx')).toThrow(/HAYBA-DOWNLOAD-NAME/);
+    expect(() => safeDownloadLeafName('NUL.obj')).toThrow(/HAYBA-ARCHIVE-PATH/);
+    expect(safeDownloadLeafName('mesh.glb')).toBe('mesh.glb');
+  });
+
+  it('aborts a streaming overrun, removes the temp file, and never publishes a partial download', async () => {
+    const root = await tempRoot();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(6));
+        controller.enqueue(new Uint8Array(6));
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+    const destination = path.join(root, 'archive.zip');
+
+    await expect(
+      downloadToFile('https://assets.invalid/big.zip', destination, undefined, { maxDownloadBytes: 10 }),
+    ).rejects.toMatchObject({ code: 'HAYBA-DOWNLOAD-SIZE' });
+    await expect(fsp.lstat(destination)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect((await fsp.readdir(root)).filter((name) => name.startsWith('.hayba-download-'))).toEqual([]);
+  });
+
+  it('aborts a stalled stream at the wall-clock deadline and cleans up', async () => {
+    const root = await tempRoot();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+    const destination = path.join(root, 'archive.zip');
+
+    await expect(
+      downloadToFile('https://assets.invalid/stall.zip', destination, undefined, { downloadTimeoutMs: 20 }),
+    ).rejects.toMatchObject({ code: 'HAYBA-DOWNLOAD-TIMEOUT' });
+    await expect(fsp.lstat(destination)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('uses atomic no-clobber publication for downloads', async () => {
+    const root = await tempRoot();
+    const destination = path.join(root, 'archive.zip');
+    await fsp.writeFile(destination, 'trusted');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('untrusted', { status: 200 })),
+    );
+
+    await expect(downloadToFile('https://assets.invalid/a.zip', destination)).rejects.toMatchObject({
+      code: 'HAYBA-DOWNLOAD-COLLISION',
+    });
+    await expect(fsp.readFile(destination, 'utf8')).resolves.toBe('trusted');
+  });
+});
+
+describe('bounded provider metadata', () => {
+  it('parses a small UTF-8 JSON response within the same pre-import boundary', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{"url":"https://assets.invalid/a.zip"}')),
+    );
+    await expect(fetchJsonBounded<{ url: string }>('https://provider.invalid/info')).resolves.toEqual({
+      url: 'https://assets.invalid/a.zip',
+    });
+  });
+
+  it('rejects actual metadata bytes beyond the ceiling without echoing body or URL', async () => {
+    const sentinel = 'SECRET-SIGNED-URL';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ value: sentinel.repeat(8) }))),
+    );
+    let error: unknown;
+    try {
+      await fetchJsonBounded('https://provider.invalid/secret?token=DO_NOT_ECHO', undefined, { maxMetadataBytes: 16 });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toMatchObject({ code: 'HAYBA-METADATA-SIZE' });
+    expect(String(error)).not.toContain(sentinel);
+    expect(String(error)).not.toContain('DO_NOT_ECHO');
+  });
+});
+
+describe('download/extract/import boundary', () => {
+  it('cannot call the UE import continuation after archive rejection', async () => {
+    const root = await tempRoot();
+    const cacheRoot = path.join(root, 'request-cache');
+    const malicious = zipFixture([{ name: '../../outside.uasset', content: 'owned' }]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(new Uint8Array(malicious), { status: 200 })),
+    );
+    const afterVerified = vi.fn(async () => ({ ok: true }));
+
+    await expect(
+      downloadExtractThen({
+        url: 'https://assets.invalid/malicious.zip',
+        archivePath: path.join(cacheRoot, 'archive.zip'),
+        extractDir: path.join(cacheRoot, 'extracted'),
+        failureCleanupRoot: cacheRoot,
+        afterVerified,
+      }),
+    ).rejects.toMatchObject({ code: 'HAYBA-ARCHIVE-PATH' });
+
+    expect(afterVerified).not.toHaveBeenCalled();
+    await expect(fsp.lstat(cacheRoot)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.lstat(path.join(root, '..', 'outside.uasset'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('cannot call the UE import continuation after a download overrun', async () => {
+    const root = await tempRoot();
+    const cacheRoot = path.join(root, 'request-cache');
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(16));
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+    const afterVerified = vi.fn(async () => ({ ok: true }));
+
+    await expect(
+      downloadExtractThen({
+        url: 'https://assets.invalid/oversized.zip',
+        archivePath: path.join(cacheRoot, 'archive.zip'),
+        extractDir: path.join(cacheRoot, 'extracted'),
+        failureCleanupRoot: cacheRoot,
+        limits: { maxDownloadBytes: 8 },
+        afterVerified,
+      }),
+    ).rejects.toMatchObject({ code: 'HAYBA-DOWNLOAD-SIZE' });
+    expect(afterVerified).not.toHaveBeenCalled();
+    await expect(fsp.lstat(cacheRoot)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/secure-archive.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/secure-archive.ts
@@ -1,0 +1,816 @@
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import { Readable, Transform, Writable, type TransformCallback } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { createInflateRaw } from 'node:zlib';
+
+/**
+ * Security budgets for data fetched from asset marketplaces. These are hard
+ * ceilings, not tuning hints: callers may lower them, but cannot disable them.
+ */
+export interface ArchiveLimits {
+  maxDownloadBytes: number;
+  downloadTimeoutMs: number;
+  maxMetadataBytes: number;
+  metadataTimeoutMs: number;
+  extractionTimeoutMs: number;
+  maxEntries: number;
+  maxCentralDirectoryBytes: number;
+  maxNameBytes: number;
+  maxExtraFieldBytes: number;
+  maxDepth: number;
+  maxEntryCompressedBytes: number;
+  maxEntryUncompressedBytes: number;
+  maxTotalUncompressedBytes: number;
+  maxCompressionRatio: number;
+}
+
+export const DEFAULT_ARCHIVE_LIMITS: Readonly<ArchiveLimits> = Object.freeze({
+  maxDownloadBytes: 512 * 1024 * 1024,
+  downloadTimeoutMs: 120_000,
+  maxMetadataBytes: 8 * 1024 * 1024,
+  metadataTimeoutMs: 30_000,
+  extractionTimeoutMs: 120_000,
+  maxEntries: 4_096,
+  maxCentralDirectoryBytes: 16 * 1024 * 1024,
+  maxNameBytes: 1_024,
+  maxExtraFieldBytes: 4_096,
+  maxDepth: 32,
+  maxEntryCompressedBytes: 512 * 1024 * 1024,
+  maxEntryUncompressedBytes: 256 * 1024 * 1024,
+  maxTotalUncompressedBytes: 2 * 1024 * 1024 * 1024,
+  maxCompressionRatio: 200,
+});
+
+export class ArchiveSecurityError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(`${code}: ${message}`);
+    this.name = 'ArchiveSecurityError';
+  }
+}
+
+/** @internal Deterministic test seam; production connector calls never supply it. */
+export interface ArchiveExtractionTestHooks {
+  afterStageReady?: () => Promise<void>;
+}
+
+function checkedLimits(overrides?: Partial<ArchiveLimits>): ArchiveLimits {
+  const merged = { ...DEFAULT_ARCHIVE_LIMITS, ...overrides };
+  for (const [name, value] of Object.entries(merged)) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-LIMIT', `${name} must be a positive safe integer`);
+    }
+  }
+  return merged;
+}
+
+class ByteLimitTransform extends Transform {
+  bytes = 0;
+
+  constructor(
+    private readonly maximum: number,
+    private readonly errorCode: string,
+  ) {
+    super();
+  }
+
+  override _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
+    this.bytes += chunk.length;
+    if (this.bytes > this.maximum) {
+      callback(new ArchiveSecurityError(this.errorCode, `stream exceeded ${this.maximum} bytes`));
+      return;
+    }
+    callback(null, chunk);
+  }
+}
+
+/** Bounded JSON reader for the provider lookup immediately before download. */
+export async function fetchJsonBounded<T>(
+  url: string,
+  headers?: Record<string, string>,
+  overrides?: Partial<ArchiveLimits>,
+): Promise<T> {
+  const limits = checkedLimits(overrides);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(new Error('metadata deadline exceeded')), limits.metadataTimeoutMs);
+  timeout.unref?.();
+  try {
+    const response = await fetch(url, { headers, signal: controller.signal });
+    if (!response.ok || !response.body) {
+      throw new ArchiveSecurityError('HAYBA-METADATA-HTTP', `provider lookup failed: ${response.status}`);
+    }
+    const declaredLength = response.headers.get('content-length');
+    if (declaredLength !== null) {
+      const parsed = Number(declaredLength);
+      if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > limits.maxMetadataBytes) {
+        throw new ArchiveSecurityError('HAYBA-METADATA-SIZE', 'provider metadata exceeds its byte ceiling');
+      }
+    }
+
+    const chunks: Buffer[] = [];
+    const collector = new Writable({
+      write(chunk: Buffer, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    });
+    const limiter = new ByteLimitTransform(limits.maxMetadataBytes, 'HAYBA-METADATA-SIZE');
+    await pipeline(Readable.fromWeb(response.body as never), limiter, collector, { signal: controller.signal });
+    if (controller.signal.aborted) {
+      throw new ArchiveSecurityError('HAYBA-METADATA-TIMEOUT', 'provider metadata deadline exceeded');
+    }
+    try {
+      const text = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.concat(chunks));
+      return JSON.parse(text) as T;
+    } catch {
+      throw new ArchiveSecurityError('HAYBA-METADATA-JSON', 'provider returned malformed UTF-8 JSON metadata');
+    }
+  } catch (error: unknown) {
+    if (controller.signal.aborted && !(error instanceof ArchiveSecurityError)) {
+      throw new ArchiveSecurityError('HAYBA-METADATA-TIMEOUT', 'provider metadata deadline exceeded');
+    }
+    if (error instanceof ArchiveSecurityError) throw error;
+    const code = (error as NodeJS.ErrnoException)?.code;
+    throw new ArchiveSecurityError(
+      'HAYBA-METADATA-NETWORK',
+      code ? `provider lookup failed (${code})` : 'provider lookup failed',
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Downloads into a private sibling directory, aborts at the byte/deadline
+ * boundary, and only then publishes the file. The final path is never opened
+ * for writing and an existing file is never replaced.
+ */
+export async function downloadToFile(
+  url: string,
+  dest: string,
+  headers?: Record<string, string>,
+  overrides?: Partial<ArchiveLimits>,
+): Promise<void> {
+  const limits = checkedLimits(overrides);
+  const parent = path.dirname(dest);
+  await fsp.mkdir(parent, { recursive: true });
+  const tempRoot = await fsp.mkdtemp(path.join(parent, '.hayba-download-'));
+  const tempFile = path.join(tempRoot, 'payload');
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(new Error('download deadline exceeded')), limits.downloadTimeoutMs);
+  timeout.unref?.();
+
+  try {
+    const res = await fetch(url, { headers, signal: controller.signal });
+    if (!res.ok || !res.body) {
+      throw new ArchiveSecurityError('HAYBA-DOWNLOAD-HTTP', `download failed: ${res.status} ${res.statusText}`);
+    }
+
+    const declaredLength = res.headers.get('content-length');
+    if (declaredLength !== null) {
+      const parsed = Number(declaredLength);
+      if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > limits.maxDownloadBytes) {
+        throw new ArchiveSecurityError(
+          'HAYBA-DOWNLOAD-SIZE',
+          `declared content length is invalid or exceeds ${limits.maxDownloadBytes} bytes`,
+        );
+      }
+    }
+
+    const limiter = new ByteLimitTransform(limits.maxDownloadBytes, 'HAYBA-DOWNLOAD-SIZE');
+    const out = fs.createWriteStream(tempFile, { flags: 'wx', mode: 0o600 });
+    const body = Readable.fromWeb(res.body as never);
+    await pipeline(body, limiter, out, { signal: controller.signal });
+    if (controller.signal.aborted) {
+      throw new ArchiveSecurityError('HAYBA-DOWNLOAD-TIMEOUT', `download exceeded ${limits.downloadTimeoutMs} ms`);
+    }
+
+    // A hard link is an atomic, no-clobber publication on the same volume.
+    // The private source is unlinked afterwards; no partially downloaded final
+    // path is ever observable.
+    try {
+      await fsp.link(tempFile, dest);
+    } catch (error: unknown) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === 'EEXIST') {
+        throw new ArchiveSecurityError(
+          'HAYBA-DOWNLOAD-COLLISION',
+          'destination already exists; refusing to overwrite it',
+        );
+      }
+      throw error;
+    }
+  } catch (error: unknown) {
+    if (controller.signal.aborted && !(error instanceof ArchiveSecurityError)) {
+      throw new ArchiveSecurityError('HAYBA-DOWNLOAD-TIMEOUT', `download exceeded ${limits.downloadTimeoutMs} ms`);
+    }
+    if (error instanceof ArchiveSecurityError) throw error;
+    const code = (error as NodeJS.ErrnoException)?.code;
+    throw new ArchiveSecurityError(
+      'HAYBA-DOWNLOAD-NETWORK',
+      code ? `network/filesystem failure (${code})` : 'network/filesystem failure',
+    );
+  } finally {
+    clearTimeout(timeout);
+    await fsp.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+interface ZipEntry {
+  rawName: Buffer;
+  name: string;
+  segments: string[];
+  isDirectory: boolean;
+  flags: number;
+  method: number;
+  crc32: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+  dataOffset: number;
+}
+
+interface ZipPlan {
+  entries: ZipEntry[];
+  archiveBytes: number;
+  totalUncompressedBytes: number;
+}
+
+const EOCD_SIGNATURE = 0x06054b50;
+const CENTRAL_SIGNATURE = 0x02014b50;
+const LOCAL_SIGNATURE = 0x04034b50;
+const EOCD_FIXED_BYTES = 22;
+const CENTRAL_FIXED_BYTES = 46;
+const LOCAL_FIXED_BYTES = 30;
+const ZIP64_SENTINEL_16 = 0xffff;
+const ZIP64_SENTINEL_32 = 0xffffffff;
+const UNIX_FILE_TYPE_MASK = 0xf000;
+const UNIX_DIRECTORY = 0x4000;
+const UNIX_REGULAR = 0x8000;
+const UNIX_SYMLINK = 0xa000;
+
+function throwIfArchiveAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-TIMEOUT', 'archive validation/extraction deadline exceeded');
+  }
+}
+
+async function readExactly(
+  handle: fsp.FileHandle,
+  length: number,
+  position: number,
+  signal: AbortSignal,
+): Promise<Buffer> {
+  throwIfArchiveAborted(signal);
+  const buffer = Buffer.allocUnsafe(length);
+  const { bytesRead } = await handle.read(buffer, 0, length, position);
+  throwIfArchiveAborted(signal);
+  if (bytesRead !== length) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-TRUNCATED', 'archive ended before declared metadata or data');
+  }
+  return buffer;
+}
+
+function rejectUnsafeName(
+  rawName: Buffer,
+  limits: ArchiveLimits,
+): { name: string; segments: string[]; isDirectory: boolean } {
+  if (rawName.length === 0 || rawName.length > limits.maxNameBytes) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-NAME', `entry filename must be 1..${limits.maxNameBytes} bytes`);
+  }
+  if (rawName.includes(0)) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-NAME', 'entry filename contains NUL');
+  }
+
+  const name = rawName.toString('utf8');
+  if (!Buffer.from(name, 'utf8').equals(rawName)) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-NAME', 'entry filename is not valid UTF-8');
+  }
+  if (name.includes('\\')) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-PATH', 'backslashes are forbidden in archive paths');
+  }
+  if (
+    name.startsWith('/') ||
+    name.startsWith('//') ||
+    /^[a-zA-Z]:/.test(name) ||
+    /^(?:\\\\|\\\?|\\\.|\/\?\?\/)/.test(name)
+  ) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-PATH', 'absolute, drive, UNC, and device paths are forbidden');
+  }
+
+  const isDirectory = name.endsWith('/');
+  const body = isDirectory ? name.slice(0, -1) : name;
+  const segments = body.split('/');
+  if (segments.length === 0 || segments.length > limits.maxDepth) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-DEPTH', `entry path exceeds ${limits.maxDepth} segments`);
+  }
+
+  const reserved = /^(?:con|prn|aux|nul|clock\$|conin\$|conout\$|com[1-9]|lpt[1-9])(?:\..*)?$/i;
+  for (const segment of segments) {
+    const normalized = segment.normalize('NFC');
+    if (
+      !segment ||
+      segment === '.' ||
+      segment === '..' ||
+      normalized !== segment ||
+      segment.normalize('NFKC') !== segment ||
+      segment.includes(':') ||
+      /[\u0000-\u001f\u007f<>"|?*]/u.test(segment) ||
+      /[. ]$/.test(segment) ||
+      reserved.test(segment)
+    ) {
+      throw new ArchiveSecurityError(
+        'HAYBA-ARCHIVE-PATH',
+        'empty, dot, non-canonical Unicode, ADS, trailing-dot/space, and device-name components are forbidden',
+      );
+    }
+  }
+  return { name, segments, isDirectory };
+}
+
+/** Validates provider metadata before a filename is joined to a cache root. */
+export function safeDownloadLeafName(name: string): string {
+  const safe = rejectUnsafeName(Buffer.from(name, 'utf8'), checkedLimits());
+  if (safe.isDirectory || safe.segments.length !== 1) {
+    throw new ArchiveSecurityError('HAYBA-DOWNLOAD-NAME', 'download filename must be one safe path component');
+  }
+  return safe.segments[0]!;
+}
+
+function inspectExternalAttributes(versionMadeBy: number, externalAttributes: number, isDirectory: boolean): void {
+  const host = versionMadeBy >>> 8;
+  const unixMode = externalAttributes >>> 16;
+  const unixType = unixMode & UNIX_FILE_TYPE_MASK;
+  if (unixType === UNIX_SYMLINK || (unixType !== 0 && unixType !== UNIX_REGULAR && unixType !== UNIX_DIRECTORY)) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-LINK', 'links and special filesystem entries are forbidden');
+  }
+  if (host === 3 && (unixType === UNIX_DIRECTORY) !== isDirectory) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-TYPE', 'directory metadata disagrees with the entry name');
+  }
+  const dosDirectory = (externalAttributes & 0x10) !== 0;
+  if (host !== 3 && dosDirectory !== isDirectory) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-TYPE', 'DOS directory metadata disagrees with the entry name');
+  }
+  // Some producers place FILE_ATTRIBUTE_REPARSE_POINT in either half.
+  if ((externalAttributes & 0x400) !== 0 || ((externalAttributes >>> 16) & 0x400) !== 0) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-LINK', 'reparse-point entries are forbidden');
+  }
+}
+
+function inspectExtraFields(extra: Buffer): void {
+  let offset = 0;
+  while (offset < extra.length) {
+    if (offset + 4 > extra.length) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-TRUNCATED', 'malformed ZIP extra field');
+    }
+    const id = extra.readUInt16LE(offset);
+    const size = extra.readUInt16LE(offset + 2);
+    offset += 4;
+    if (offset + size > extra.length) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-TRUNCATED', 'malformed ZIP extra field payload');
+    }
+    // ZIP64 changes all size/offset assumptions; NTFS and ASi Unix extras can
+    // encode reparse/link metadata. Reject rather than partially understand.
+    if (id === 0x0001) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-ZIP64', 'ZIP64 archives are not accepted');
+    }
+    if (id === 0x000a || id === 0x000d || id === 0x5855 || id === 0x756e) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-LINK', 'filesystem-specific link metadata is forbidden');
+    }
+    offset += size;
+  }
+}
+
+async function findEocd(
+  handle: fsp.FileHandle,
+  archiveBytes: number,
+  signal: AbortSignal,
+): Promise<{ offset: number; record: Buffer }> {
+  if (archiveBytes < EOCD_FIXED_BYTES) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-TRUNCATED', 'file is too short to be a ZIP archive');
+  }
+  const tailBytes = Math.min(archiveBytes, EOCD_FIXED_BYTES + 0xffff);
+  const tailOffset = archiveBytes - tailBytes;
+  const tail = await readExactly(handle, tailBytes, tailOffset, signal);
+  for (let i = tail.length - EOCD_FIXED_BYTES; i >= 0; i -= 1) {
+    if (tail.readUInt32LE(i) !== EOCD_SIGNATURE) continue;
+    const commentBytes = tail.readUInt16LE(i + 20);
+    if (i + EOCD_FIXED_BYTES + commentBytes !== tail.length) continue;
+    return { offset: tailOffset + i, record: tail.subarray(i, i + EOCD_FIXED_BYTES) };
+  }
+  throw new ArchiveSecurityError('HAYBA-ARCHIVE-TRUNCATED', 'end-of-central-directory record is missing');
+}
+
+async function inspectZip(handle: fsp.FileHandle, limits: ArchiveLimits, signal: AbortSignal): Promise<ZipPlan> {
+  throwIfArchiveAborted(signal);
+  const stat = await handle.stat();
+  throwIfArchiveAborted(signal);
+  if (!stat.isFile() || stat.size > limits.maxDownloadBytes) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-SIZE', `archive exceeds ${limits.maxDownloadBytes} bytes`);
+  }
+  const archiveBytes = stat.size;
+  const { offset: eocdOffset, record: eocd } = await findEocd(handle, archiveBytes, signal);
+  const disk = eocd.readUInt16LE(4);
+  const centralDisk = eocd.readUInt16LE(6);
+  const diskEntries = eocd.readUInt16LE(8);
+  const totalEntries = eocd.readUInt16LE(10);
+  const centralBytes = eocd.readUInt32LE(12);
+  const centralOffset = eocd.readUInt32LE(16);
+  if (disk !== 0 || centralDisk !== 0 || diskEntries !== totalEntries) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-MULTIDISK', 'multi-disk archives are not accepted');
+  }
+  if (totalEntries === ZIP64_SENTINEL_16 || centralBytes === ZIP64_SENTINEL_32 || centralOffset === ZIP64_SENTINEL_32) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-ZIP64', 'ZIP64 archives are not accepted');
+  }
+  if (totalEntries > limits.maxEntries) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-ENTRIES', `archive has more than ${limits.maxEntries} entries`);
+  }
+  if (centralBytes > limits.maxCentralDirectoryBytes || centralOffset + centralBytes !== eocdOffset) {
+    throw new ArchiveSecurityError(
+      'HAYBA-ARCHIVE-CENTRAL',
+      'central directory is oversized, overlapping, or non-canonical',
+    );
+  }
+
+  const entries: ZipEntry[] = [];
+  const normalizedNames = new Set<string>();
+  const caseFoldedNames = new Set<string>();
+  const localOffsets = new Set<number>();
+  let cursor = centralOffset;
+  let totalUncompressedBytes = 0;
+
+  for (let index = 0; index < totalEntries; index += 1) {
+    throwIfArchiveAborted(signal);
+    const fixed = await readExactly(handle, CENTRAL_FIXED_BYTES, cursor, signal);
+    if (fixed.readUInt32LE(0) !== CENTRAL_SIGNATURE) {
+      throw new ArchiveSecurityError(
+        'HAYBA-ARCHIVE-CENTRAL',
+        `entry ${index} has an invalid central-directory signature`,
+      );
+    }
+    const versionMadeBy = fixed.readUInt16LE(4);
+    const flags = fixed.readUInt16LE(8);
+    const method = fixed.readUInt16LE(10);
+    const crc32 = fixed.readUInt32LE(16);
+    const compressedSize = fixed.readUInt32LE(20);
+    const uncompressedSize = fixed.readUInt32LE(24);
+    const nameBytes = fixed.readUInt16LE(28);
+    const extraBytes = fixed.readUInt16LE(30);
+    const commentBytes = fixed.readUInt16LE(32);
+    const diskStart = fixed.readUInt16LE(34);
+    const externalAttributes = fixed.readUInt32LE(38);
+    const localHeaderOffset = fixed.readUInt32LE(42);
+    cursor += CENTRAL_FIXED_BYTES;
+
+    if (flags & 0x1) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-ENCRYPTED', 'encrypted entries are not accepted');
+    }
+    if (flags & 0x40) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-ENCRYPTED', 'strongly encrypted entries are not accepted');
+    }
+    if (method !== 0 && method !== 8) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-METHOD', `compression method ${method} is not supported`);
+    }
+    if (method === 0 && compressedSize !== uncompressedSize) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-ENTRY-SIZE', 'stored entry sizes disagree');
+    }
+    if (diskStart !== 0 || localHeaderOffset === ZIP64_SENTINEL_32) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-MULTIDISK', 'split or ZIP64 entries are not accepted');
+    }
+    if (cursor + nameBytes + extraBytes + commentBytes > centralOffset + centralBytes) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-TRUNCATED', 'entry metadata extends beyond the central directory');
+    }
+    if (nameBytes === 0 || nameBytes > limits.maxNameBytes) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-NAME', 'entry filename exceeds its metadata ceiling');
+    }
+    if (extraBytes > limits.maxExtraFieldBytes) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-METADATA', 'entry extra field exceeds its metadata ceiling');
+    }
+    const rawName = await readExactly(handle, nameBytes, cursor, signal);
+    const extra = await readExactly(handle, extraBytes, cursor + nameBytes, signal);
+    cursor += nameBytes + extraBytes + commentBytes;
+    inspectExtraFields(extra);
+
+    const safeName = rejectUnsafeName(rawName, limits);
+    inspectExternalAttributes(versionMadeBy, externalAttributes, safeName.isDirectory);
+    if (safeName.isDirectory && (compressedSize !== 0 || uncompressedSize !== 0)) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-TYPE', 'directory entries must have zero sizes');
+    }
+    if (compressedSize > limits.maxEntryCompressedBytes || uncompressedSize > limits.maxEntryUncompressedBytes) {
+      throw new ArchiveSecurityError(
+        'HAYBA-ARCHIVE-ENTRY-SIZE',
+        'entry exceeds its compressed or uncompressed byte ceiling',
+      );
+    }
+    totalUncompressedBytes += uncompressedSize;
+    if (!Number.isSafeInteger(totalUncompressedBytes) || totalUncompressedBytes > limits.maxTotalUncompressedBytes) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-TOTAL-SIZE', 'archive exceeds its total uncompressed byte ceiling');
+    }
+    if (
+      uncompressedSize > 0 &&
+      (compressedSize === 0 || uncompressedSize / compressedSize > limits.maxCompressionRatio)
+    ) {
+      throw new ArchiveSecurityError(
+        'HAYBA-ARCHIVE-RATIO',
+        `entry exceeds compression ratio ${limits.maxCompressionRatio}:1`,
+      );
+    }
+
+    const normalized = safeName.segments.join('/');
+    const caseFolded = normalized.toLocaleLowerCase('en-US');
+    if (normalizedNames.has(normalized)) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-DUPLICATE', 'duplicate normalized entry path');
+    }
+    if (caseFoldedNames.has(caseFolded)) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-CASE-COLLISION', 'case-colliding entry paths are forbidden');
+    }
+    if (localOffsets.has(localHeaderOffset)) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-DUPLICATE', 'entries alias the same local file record');
+    }
+    normalizedNames.add(normalized);
+    caseFoldedNames.add(caseFolded);
+    localOffsets.add(localHeaderOffset);
+
+    const localFixed = await readExactly(handle, LOCAL_FIXED_BYTES, localHeaderOffset, signal);
+    if (localFixed.readUInt32LE(0) !== LOCAL_SIGNATURE) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-LOCAL', 'invalid local file header');
+    }
+    const localFlags = localFixed.readUInt16LE(6);
+    const localMethod = localFixed.readUInt16LE(8);
+    const localNameBytes = localFixed.readUInt16LE(26);
+    const localExtraBytes = localFixed.readUInt16LE(28);
+    if (localExtraBytes > limits.maxExtraFieldBytes) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-METADATA', 'local extra field exceeds its metadata ceiling');
+    }
+    if (localFlags !== flags || localMethod !== method || localNameBytes !== rawName.length) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-LOCAL', 'local and central entry metadata disagree');
+    }
+    const localName = await readExactly(handle, localNameBytes, localHeaderOffset + LOCAL_FIXED_BYTES, signal);
+    if (!localName.equals(rawName)) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-LOCAL', 'local and central filenames disagree');
+    }
+    const localExtra = await readExactly(
+      handle,
+      localExtraBytes,
+      localHeaderOffset + LOCAL_FIXED_BYTES + localNameBytes,
+      signal,
+    );
+    inspectExtraFields(localExtra);
+    if ((flags & 0x8) === 0) {
+      const localCrc = localFixed.readUInt32LE(14);
+      const localCompressedSize = localFixed.readUInt32LE(18);
+      const localUncompressedSize = localFixed.readUInt32LE(22);
+      if (localCrc !== crc32 || localCompressedSize !== compressedSize || localUncompressedSize !== uncompressedSize) {
+        throw new ArchiveSecurityError('HAYBA-ARCHIVE-LOCAL', 'local and central size/CRC metadata disagree');
+      }
+    }
+    const dataOffset = localHeaderOffset + LOCAL_FIXED_BYTES + localNameBytes + localExtraBytes;
+    if (dataOffset < 0 || dataOffset + compressedSize > centralOffset) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-OVERLAP', 'entry data extends into archive metadata');
+    }
+
+    entries.push({
+      rawName,
+      ...safeName,
+      flags,
+      method,
+      crc32,
+      compressedSize,
+      uncompressedSize,
+      localHeaderOffset,
+      dataOffset,
+    });
+  }
+  if (cursor !== centralOffset + centralBytes) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-CENTRAL', 'central directory contains unparsed bytes');
+  }
+  if (!entries.some((entry) => !entry.isDirectory)) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-EMPTY', 'archive contains no regular files to import');
+  }
+  const filePaths = new Set(entries.filter((entry) => !entry.isDirectory).map((entry) => entry.segments.join('/')));
+  const filePathsFolded = new Set([...filePaths].map((file) => file.toLocaleLowerCase('en-US')));
+  for (const entry of entries) {
+    for (let depth = 1; depth < entry.segments.length; depth += 1) {
+      const prefix = entry.segments.slice(0, depth).join('/');
+      if (filePaths.has(prefix) || filePathsFolded.has(prefix.toLocaleLowerCase('en-US'))) {
+        throw new ArchiveSecurityError('HAYBA-ARCHIVE-COLLISION', 'a file entry is also used as a parent directory');
+      }
+    }
+  }
+  const ranges = entries
+    .map((entry) => ({ start: entry.localHeaderOffset, end: entry.dataOffset + entry.compressedSize }))
+    .sort((a, b) => a.start - b.start);
+  for (let index = 1; index < ranges.length; index += 1) {
+    if (ranges[index]!.start < ranges[index - 1]!.end) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-OVERLAP', 'local entry records overlap or alias archive bytes');
+    }
+  }
+  return { entries, archiveBytes, totalUncompressedBytes };
+}
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+class VerifyEntryTransform extends ByteLimitTransform {
+  private crc = 0xffffffff;
+
+  constructor(
+    maximum: number,
+    private readonly expectedBytes: number,
+    private readonly expectedCrc: number,
+  ) {
+    super(maximum, 'HAYBA-ARCHIVE-INFLATE-SIZE');
+  }
+
+  override _transform(chunk: Buffer, encoding: BufferEncoding, callback: TransformCallback): void {
+    for (const byte of chunk) this.crc = CRC_TABLE[(this.crc ^ byte) & 0xff]! ^ (this.crc >>> 8);
+    super._transform(chunk, encoding, callback);
+  }
+
+  assertComplete(): void {
+    if (this.bytes !== this.expectedBytes) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-INFLATE-SIZE', 'inflated byte count disagrees with metadata');
+    }
+    if ((this.crc ^ 0xffffffff) >>> 0 !== this.expectedCrc) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-CRC', 'entry CRC does not match archive metadata');
+    }
+  }
+}
+
+function containedPath(root: string, segments: string[]): string {
+  const resolvedRoot = path.resolve(root);
+  const candidate = path.resolve(resolvedRoot, ...segments);
+  if (candidate !== resolvedRoot && !candidate.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-PATH', 'resolved entry escapes the extraction root');
+  }
+  return candidate;
+}
+
+async function assertNoLinks(root: string, directory: string, signal: AbortSignal): Promise<void> {
+  throwIfArchiveAborted(signal);
+  const rootStat = await fsp.lstat(root);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new ArchiveSecurityError('HAYBA-ARCHIVE-LINK', 'private extraction root is not a real directory');
+  }
+  const relative = path.relative(root, directory);
+  let cursor = root;
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    throwIfArchiveAborted(signal);
+    cursor = path.join(cursor, segment);
+    const stat = await fsp.lstat(cursor);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-LINK', 'extraction parent is not a real directory');
+    }
+  }
+}
+
+async function extractPlan(
+  archiveHandle: fsp.FileHandle,
+  stageRoot: string,
+  plan: ZipPlan,
+  limits: ArchiveLimits,
+  signal: AbortSignal,
+): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of plan.entries) {
+    throwIfArchiveAborted(signal);
+    const destination = containedPath(stageRoot, entry.segments);
+    if (entry.isDirectory) {
+      await fsp.mkdir(destination, { recursive: true, mode: 0o700 });
+      await assertNoLinks(stageRoot, destination, signal);
+      continue;
+    }
+
+    const parent = path.dirname(destination);
+    await fsp.mkdir(parent, { recursive: true, mode: 0o700 });
+    await assertNoLinks(stageRoot, parent, signal);
+    if (entry.compressedSize === 0) {
+      if (entry.uncompressedSize !== 0 || entry.crc32 !== 0) {
+        throw new ArchiveSecurityError('HAYBA-ARCHIVE-INFLATE-SIZE', 'empty entry metadata is inconsistent');
+      }
+      const handle = await fsp.open(destination, 'wx', 0o600);
+      await handle.close();
+      throwIfArchiveAborted(signal);
+      files.push(destination);
+      continue;
+    }
+    const source = fs.createReadStream('bound-archive-handle', {
+      fd: archiveHandle.fd,
+      autoClose: false,
+      start: entry.dataOffset,
+      end: entry.dataOffset + entry.compressedSize - 1,
+    });
+    const verifier = new VerifyEntryTransform(
+      Math.min(entry.uncompressedSize, limits.maxEntryUncompressedBytes),
+      entry.uncompressedSize,
+      entry.crc32,
+    );
+    const output = fs.createWriteStream(destination, { flags: 'wx', mode: 0o600 });
+    if (entry.method === 8) await pipeline(source, createInflateRaw(), verifier, output, { signal });
+    else await pipeline(source, verifier, output, { signal });
+    throwIfArchiveAborted(signal);
+    verifier.assertComplete();
+    files.push(destination);
+  }
+  return files;
+}
+
+/**
+ * Validates every entry before inflating the first byte. Extraction happens in
+ * a private sibling directory and is promoted only after every CRC and size
+ * check succeeds. Any rejection removes the entire stage and leaves `destDir`
+ * absent and unchanged.
+ */
+export async function extractZip(
+  zipPath: string,
+  destDir: string,
+  overrides?: Partial<ArchiveLimits>,
+  testHooks?: ArchiveExtractionTestHooks,
+): Promise<string[]> {
+  const limits = checkedLimits(overrides);
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(new Error('archive validation/extraction deadline exceeded')),
+    limits.extractionTimeoutMs,
+  );
+  timeout.unref?.();
+  let archiveHandle: fsp.FileHandle | undefined;
+  let stageRoot: string | undefined;
+  try {
+    archiveHandle = await fsp.open(zipPath, 'r');
+    const plan = await inspectZip(archiveHandle, limits, controller.signal);
+    const parent = path.dirname(destDir);
+    await fsp.mkdir(parent, { recursive: true });
+    throwIfArchiveAborted(controller.signal);
+    const activeStageRoot = await fsp.mkdtemp(path.join(parent, '.hayba-extract-'));
+    stageRoot = activeStageRoot;
+    await testHooks?.afterStageReady?.();
+    throwIfArchiveAborted(controller.signal);
+    const stageFiles = await extractPlan(archiveHandle, activeStageRoot, plan, limits, controller.signal);
+    try {
+      await fsp.lstat(destDir);
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-COLLISION', 'destination already exists; refusing to overwrite it');
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error;
+    }
+    throwIfArchiveAborted(controller.signal);
+    await fsp.rename(activeStageRoot, destDir);
+    return stageFiles.map((file) => path.join(destDir, path.relative(activeStageRoot, file)));
+  } catch (error: unknown) {
+    if (stageRoot) await fsp.rm(stageRoot, { recursive: true, force: true });
+    if (controller.signal.aborted) {
+      throw new ArchiveSecurityError('HAYBA-ARCHIVE-TIMEOUT', 'archive validation/extraction deadline exceeded');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    await archiveHandle?.close();
+  }
+}
+
+/**
+ * One fail-closed production seam: the callback (UE import in connectors) is
+ * unreachable until both download and full extraction verification succeed.
+ */
+export async function downloadExtractThen<T>(options: {
+  url: string;
+  archivePath: string;
+  extractDir: string;
+  headers?: Record<string, string>;
+  limits?: Partial<ArchiveLimits>;
+  /** Request-owned directory removed in full if download or validation fails. */
+  failureCleanupRoot?: string;
+  afterVerified: (files: string[]) => Promise<T>;
+}): Promise<{ files: string[]; result: T }> {
+  const cleanupRoot = options.failureCleanupRoot ? path.resolve(options.failureCleanupRoot) : undefined;
+  if (cleanupRoot) {
+    const archive = path.resolve(options.archivePath);
+    const extraction = path.resolve(options.extractDir);
+    if (!archive.startsWith(`${cleanupRoot}${path.sep}`) || !extraction.startsWith(`${cleanupRoot}${path.sep}`)) {
+      throw new ArchiveSecurityError(
+        'HAYBA-ARCHIVE-CLEANUP-SCOPE',
+        'download and extraction paths must be children of their failure cleanup root',
+      );
+    }
+  }
+  try {
+    await downloadToFile(options.url, options.archivePath, options.headers, options.limits);
+    const files = await extractZip(options.archivePath, options.extractDir, options.limits);
+    const result = await options.afterVerified(files);
+    return { files, result };
+  } catch (error) {
+    if (cleanupRoot) await fsp.rm(cleanupRoot, { recursive: true, force: true });
+    throw error;
+  }
+}

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/shared.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/shared.ts
@@ -2,11 +2,17 @@ import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
+import { createHash } from 'node:crypto';
 import { executeCommand } from '../tool-executor.js';
 import { AssetVerifier } from '../asset-retriever/asset-verifier.js';
 import { getDefaultRetriever } from '../asset-retriever/asset-retriever.js';
+export {
+  downloadExtractThen,
+  downloadToFile,
+  extractZip,
+  fetchJsonBounded,
+  safeDownloadLeafName,
+} from './secure-archive.js';
 
 export interface DownloadedAsset {
   assetId: string;
@@ -23,33 +29,21 @@ export interface DownloadedAsset {
 }
 
 export function cachePathFor(source: string, assetId: string): string {
-  const safe = assetId.replace(/[^a-zA-Z0-9._-]/g, '_');
-  return path.join(os.tmpdir(), 'hayba-asset-connectors', source, safe);
+  const safeSource = source.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 32) || 'source';
+  const readable = assetId.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 64) || 'asset';
+  const digest = createHash('sha256').update(assetId).digest('hex').slice(0, 16);
+  return path.join(os.tmpdir(), 'hayba-asset-connectors', safeSource, `${readable}-${digest}`);
+}
+
+/** A request-owned cache root; concurrent/retried downloads never share files. */
+export async function createUniqueCacheDir(source: string, assetId: string): Promise<string> {
+  const prefix = cachePathFor(source, assetId);
+  await ensureDir(path.dirname(prefix));
+  return fsp.mkdtemp(`${prefix}-`);
 }
 
 export async function ensureDir(dir: string): Promise<void> {
   await fsp.mkdir(dir, { recursive: true });
-}
-
-export async function downloadToFile(url: string, dest: string, headers?: Record<string, string>): Promise<void> {
-  await ensureDir(path.dirname(dest));
-  const res = await fetch(url, { headers });
-  if (!res.ok || !res.body) {
-    throw new Error(`download failed: ${res.status} ${res.statusText} for ${url}`);
-  }
-  const nodeStream = Readable.fromWeb(res.body as any);
-  const out = fs.createWriteStream(dest);
-  await pipeline(nodeStream, out);
-}
-
-export async function extractZip(zipPath: string, destDir: string): Promise<string[]> {
-  await ensureDir(destDir);
-  // Lazy import — adm-zip is a CommonJS module.
-  const AdmZipMod = await import('adm-zip');
-  const AdmZip = (AdmZipMod as any).default ?? AdmZipMod;
-  const zip = new AdmZip(zipPath);
-  zip.extractAllTo(destDir, true);
-  return listFilesRecursive(destDir);
 }
 
 export async function listFilesRecursive(dir: string): Promise<string[]> {

--- a/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-download.ts
+++ b/mcp-tools/hayba-mcp/src/tools/asset-sources/sketchfab-download.ts
@@ -1,7 +1,14 @@
 import * as path from 'node:path';
 import { z } from 'zod';
 import type { HaybaToolMeta } from '../hayba-tool-meta.js';
-import { cachePathFor, downloadToFile, ensureDir, extractZip, importIntoUe, verifyAndMarkDelta, type DownloadedAsset } from './shared.js';
+import {
+  createUniqueCacheDir,
+  downloadExtractThen,
+  fetchJsonBounded,
+  importIntoUe,
+  verifyAndMarkDelta,
+  type DownloadedAsset,
+} from './shared.js';
 import { tokenMissingMessage } from './sketchfab-search.js';
 import { getTokenWithEnvFallback } from './get-setting.js';
 
@@ -41,23 +48,25 @@ export async function handleSketchfabDownload(params: SketchfabDownloadParams) {
   }
   const { uid, flavour, target_dir } = parsed.data;
   try {
-    const res = await fetch(downloadInfoUrl(uid), { headers: { Authorization: `Token ${token}` } });
-    if (!res.ok) {
-      return { content: [{ type: 'text' as const, text: `Sketchfab download lookup failed: ${res.status} ${res.statusText}` }], isError: true };
-    }
-    const info = (await res.json()) as any;
+    const info = await fetchJsonBounded<any>(downloadInfoUrl(uid), { Authorization: `Token ${token}` });
     const signedUrl = pickFlavourUrl(info, flavour);
     if (!signedUrl) {
-      return { content: [{ type: 'text' as const, text: `No ${flavour} download available for ${uid}` }], isError: true };
+      return {
+        content: [{ type: 'text' as const, text: `No ${flavour} download available for ${uid}` }],
+        isError: true,
+      };
     }
-    const cacheDir = cachePathFor('sketchfab', uid);
-    await ensureDir(cacheDir);
-    const zipPath = path.join(cacheDir, `${uid}_${flavour}.zip`);
-    await downloadToFile(signedUrl, zipPath);
+    const cacheDir = await createUniqueCacheDir('sketchfab', uid);
+    const zipPath = path.join(cacheDir, 'archive.zip');
     const extractDir = path.join(cacheDir, 'extracted');
-    const files = await extractZip(zipPath, extractDir);
     const gamePath = target_dir ?? `/Game/AssetConnectors/sketchfab/${uid}`;
-    const importResult = await importIntoUe(extractDir, gamePath);
+    const { files, result: importResult } = await downloadExtractThen({
+      url: signedUrl,
+      archivePath: zipPath,
+      extractDir,
+      failureCleanupRoot: cacheDir,
+      afterVerified: () => importIntoUe(extractDir, gamePath),
+    });
     const verify = importResult.ok ? await verifyAndMarkDelta(gamePath) : { verified: false, reason: 'import_failed' };
     const data: DownloadedAsset = {
       assetId: uid,

--- a/mcp-tools/hayba-mcp/src/tools/production-dependency-audit-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/production-dependency-audit-contract.test.ts
@@ -1,0 +1,255 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+interface Assessment {
+  finding_key: string;
+  package: string;
+  advisory: string;
+  severity: string;
+  installed_versions: string[];
+  importing_feature: string;
+  reachability: string;
+  decision: string;
+  mitigation: string;
+  owner: string;
+  tracking_issue: string;
+  reviewed_on: string;
+  expires_on: string;
+  evidence: string[];
+}
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = resolve(here, '..', '..', '..', '..');
+const script = join(repoRoot, 'mcp-tools', 'hayba-mcp', 'scripts', 'audit-production-dependencies.mjs');
+const ciWorkflow = join(repoRoot, '.github', 'workflows', 'ci.yml');
+const scheduledWorkflow = join(repoRoot, '.github', 'workflows', 'production-dependency-audit.yml');
+const productionInventory = join(repoRoot, 'docs', 'audit', 'production-dependency-assessments.json');
+const mcpPackage = join(repoRoot, 'mcp-tools', 'hayba-mcp', 'package.json');
+const tempDirs: string[] = [];
+
+const advisory = {
+  source: 1234567,
+  name: 'leaf-package',
+  severity: 'high',
+  title: 'SENSITIVE RAW ADVISORY PROSE',
+  url: 'https://github.com/advisories/GHSA-aaaa-bbbb-cccc',
+};
+
+function assessment(overrides: Partial<Assessment> = {}): Assessment {
+  return {
+    finding_key: 'root-package|GHSA-aaaa-bbbb-cccc',
+    package: 'root-package',
+    advisory: 'GHSA-aaaa-bbbb-cccc',
+    severity: 'high',
+    installed_versions: ['1.2.3'],
+    importing_feature: 'Fixture production feature',
+    reachability: 'unreachable_code_path',
+    decision: 'time_bounded_exception',
+    mitigation: 'The fixture path does not call the affected parser.',
+    owner: 'Security maintainers',
+    tracking_issue: '#380',
+    reviewed_on: '2026-08-10',
+    expires_on: '2026-08-17',
+    evidence: ['fixture/source.ts:1'],
+    ...overrides,
+  };
+}
+
+function run(options: {
+  audit?: Record<string, unknown>;
+  assessments?: Assessment[];
+  today?: string;
+  lock?: Record<string, unknown>;
+}) {
+  const dir = mkdtempSync(join(tmpdir(), 'hayba-production-audit-'));
+  tempDirs.push(dir);
+  const auditPath = join(dir, 'audit.json');
+  const inventoryPath = join(dir, 'inventory.json');
+  const lockPath = join(dir, 'package-lock.json');
+  writeFileSync(
+    auditPath,
+    JSON.stringify(
+      options.audit ?? {
+        metadata: { vulnerabilities: { high: 1 }, dependencies: { prod: 1, dev: 99 } },
+        vulnerabilities: { 'root-package': { severity: 'high', via: [advisory] } },
+      },
+    ),
+  );
+  writeFileSync(
+    inventoryPath,
+    JSON.stringify({ schema_version: 1, assessments: options.assessments ?? [assessment()] }),
+  );
+  writeFileSync(
+    lockPath,
+    JSON.stringify(
+      options.lock ?? {
+        lockfileVersion: 3,
+        packages: { 'node_modules/root-package': { version: '1.2.3' } },
+      },
+    ),
+  );
+  return spawnSync(
+    process.execPath,
+    [
+      script,
+      '--audit-fixture',
+      auditPath,
+      '--inventory',
+      inventoryPath,
+      '--lockfile',
+      lockPath,
+      '--today',
+      options.today ?? '2026-08-10',
+    ],
+    { encoding: 'utf8', windowsHide: true },
+  );
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('production dependency reachability gate', () => {
+  it('accepts a reviewed exception through its inclusive expiry date', () => {
+    const result = run({ today: '2026-08-17' });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('production dependency audit: PASS');
+  });
+
+  it('blocks a new or unassessed high advisory', () => {
+    const result = run({ assessments: [] });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('PDA-UNASSESSED-HIGH root-package|GHSA-aaaa-bbbb-cccc');
+  });
+
+  it('blocks an expired exception', () => {
+    const result = run({ today: '2026-08-18' });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('PDA-EXPIRED root-package|GHSA-aaaa-bbbb-cccc');
+  });
+
+  it.each([
+    ['missing owner', { owner: '' }],
+    ['invalid review date', { reviewed_on: '10/08/2026' }],
+    ['missing evidence', { evidence: [] }],
+    ['bad tracking issue', { tracking_issue: 'security someday' }],
+    ['mismatched key', { finding_key: 'some-other-package|GHSA-aaaa-bbbb-cccc' }],
+  ])('blocks malformed policy: %s', (_name, overrides) => {
+    const result = run({ assessments: [assessment(overrides)] });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('PDA-MALFORMED');
+  });
+
+  it('caps an exception at 30 days', () => {
+    const result = run({ assessments: [assessment({ expires_on: '2026-09-10' })] });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('PDA-EXCEPTION-TOO-LONG root-package|GHSA-aaaa-bbbb-cccc');
+  });
+
+  it('blocks version drift instead of reusing evidence for a different release', () => {
+    const result = run({
+      lock: { lockfileVersion: 3, packages: { 'node_modules/root-package': { version: '2.0.0' } } },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('PDA-VERSION-DRIFT root-package|GHSA-aaaa-bbbb-cccc');
+  });
+
+  it('resolves transitive via chains per importing package', () => {
+    const result = run({
+      audit: {
+        vulnerabilities: {
+          'root-package': { severity: 'high', via: ['leaf-package'] },
+          'leaf-package': { severity: 'high', via: [advisory] },
+        },
+      },
+      assessments: [
+        assessment(),
+        assessment({
+          finding_key: 'leaf-package|GHSA-aaaa-bbbb-cccc',
+          package: 'leaf-package',
+          installed_versions: ['4.5.6'],
+        }),
+      ],
+      lock: {
+        lockfileVersion: 3,
+        packages: {
+          'node_modules/root-package': { version: '1.2.3' },
+          'node_modules/leaf-package': { version: '4.5.6' },
+        },
+      },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('finding_paths: 2');
+  });
+
+  it('does not let dev dependency counts enter the production lane', () => {
+    const result = run({
+      audit: {
+        metadata: { vulnerabilities: { high: 0 }, dependencies: { prod: 1, dev: 500 } },
+        vulnerabilities: {},
+      },
+      assessments: [],
+      lock: { lockfileVersion: 3, packages: {} },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('finding_paths: 0');
+
+    const source = readFileSync(script, 'utf8');
+    expect(source).toContain("['audit', '--omit=dev', '--json']");
+    expect(source).not.toContain('--audit-level');
+  });
+
+  it('never echoes raw npm advisory prose', () => {
+    const result = run({ assessments: [] });
+    expect(result.status).toBe(1);
+    expect(result.stdout).not.toContain(advisory.title);
+    expect(result.stdout).not.toContain(advisory.url);
+    expect(result.stdout).not.toContain('node_modules');
+  });
+
+  it('rejects an unsafe audit identifier without reflecting it', () => {
+    const unsafePackage = 'evil\n```\nraw-secret';
+    const result = run({
+      audit: { vulnerabilities: { [unsafePackage]: { severity: 'high', via: [advisory] } } },
+      assessments: [],
+      lock: { lockfileVersion: 3, packages: {} },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('PDA-UNRESOLVED UNSAFE-PACKAGE-NAME');
+    expect(result.stdout).not.toContain('raw-secret');
+    expect(result.stdout).not.toContain('```');
+  });
+
+  it('wires the same gate into CI and one scheduled tracking issue', () => {
+    const ci = readFileSync(ciWorkflow, 'utf8');
+    const scheduled = readFileSync(scheduledWorkflow, 'utf8');
+    expect(ci).toContain('npm ci --ignore-scripts');
+    expect(ci).toContain('npm run audit:production');
+    expect(scheduled).toContain('schedule:');
+    expect(scheduled).toContain("title='[security] Production dependency audit drift'");
+    expect(scheduled).toContain('gh issue edit');
+    expect(scheduled).toContain('gh issue create');
+    expect(scheduled).toContain('gh issue close');
+  });
+
+  it('keeps the residual AdmZip finding transitive and installation-only', () => {
+    const packageJson = JSON.parse(readFileSync(mcpPackage, 'utf8')) as {
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    const inventory = JSON.parse(readFileSync(productionInventory, 'utf8')) as {
+      assessments: Assessment[];
+    };
+    expect(packageJson.dependencies).not.toHaveProperty('adm-zip');
+    expect(packageJson.devDependencies).not.toHaveProperty('@types/adm-zip');
+
+    const residual = inventory.assessments.find((item) => item.finding_key === 'adm-zip|GHSA-xcpc-8h2w-3j85');
+    expect(residual?.reachability).toBe('install_time_only');
+    expect(residual?.decision).toBe('time_bounded_exception');
+    expect(residual?.evidence).not.toContain('mcp-tools/hayba-mcp/src/tools/asset-sources/shared.ts:47-49');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,11 +31,10 @@
         "@anthropic-ai/sdk": "^0.110.0",
         "@distube/ytdl-core": "^4.16.12",
         "@huggingface/transformers": "^4.0.1",
-        "@modelcontextprotocol/sdk": "^1.0.0",
-        "adm-zip": "^0.5.17",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "cheerio": "^1.2.0",
         "express": "^4.21.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.1",
         "lru-cache": "^11.3.6",
         "minisearch": "^7.2.0",
         "openai": "^6.45.0",
@@ -47,7 +46,6 @@
         "hayba-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/adm-zip": "^0.5.5",
         "@types/express": "^5.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^26.1.1",
@@ -408,12 +406,12 @@
       "link": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1094,12 +1092,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1147,21 +1145,34 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1526,9 +1537,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
@@ -1544,12 +1555,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1863,16 +1868,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
-      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -2999,13 +2994,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -3069,9 +3064,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -4101,9 +4096,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -4247,16 +4242,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4475,9 +4470,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4498,9 +4493,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4663,9 +4658,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4781,9 +4776,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5881,19 +5886,18 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -6719,9 +6723,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --check \"**/*.{ts,js,json,md}\"",
     "format:fix": "prettier --write \"**/*.{ts,js,json,md}\"",
-    "typecheck": "tsc -b --noEmit"
+    "typecheck": "tsc -b --noEmit",
+    "audit:production": "node mcp-tools/hayba-mcp/scripts/audit-production-dependencies.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -30,9 +31,9 @@
   },
   "overrides": {
     "esbuild": "^0.25.0",
-    "hono": "^4.12.25",
-    "undici": "^7.28.0",
-    "protobufjs": "^7.6.3",
+    "hono": "^4.12.34",
+    "undici": "^7.29.0",
+    "protobufjs": "^7.6.5",
     "postcss": "^8.5.10"
   },
   "license": "MIT"


### PR DESCRIPTION
## Outcome
- replaces untrusted archive extraction with a bounded, deadline-aware streamed ZIP implementation
- removes Hayba's direct runtime adm-zip dependency and reduces the production audit from 15 findings (12 high) to four high nodes / five reviewed advisory paths
- adds fail-closed, sanitized reachability and expiry policy to push CI plus weekly drift checks
- upgrades compatible direct/transitive dependencies, including MCP SDK 1.30 and js-yaml 4.3.1

## Archive safety contract
- provider JSON, downloads, metadata, entry count, names, depth, sizes, compression ratios, and extraction time are bounded
- traversal, ADS/device/control/NUL/backslash/NFKC collisions, symlinks/reparse points, overlaps, CRC mismatches, and overwrite races are rejected
- one read-only file handle binds inspection to inflation; extraction uses private staging and no-clobber promotion
- UE continuation happens only after the archive is fully verified

## Dependency safety contract
- new/unassessed high findings fail
- malformed, stale, version-drifted, unresolved, or expired assessments fail
- remaining exceptions expire 2026-09-09 and may not exceed 30 days
- audit output never prints raw npm advisory prose

## Verification
- archive/provider focused suite: 34/34
- production audit: PASS; 5 assessed paths; 0 errors/warnings
- expiry mutation at 2026-09-10: five PDA-EXPIRED failures
- dependency contract: 16/16
- full Node suite before later unrelated concurrent work: 1,818/1,818
- typecheck, ESLint, Prettier, wrapper lint, JSON parse, and diff checks: green

The two commits are intentionally ordered: the secure parser lands before the direct adm-zip dependency is removed.

Closes #377.
Closes #380.