### PR TITLE
safety: add principal-scoped idempotency ledger

### DIFF
--- a/docs/audit/2026-08-10-principal-idempotency-ledger.md
+++ b/docs/audit/2026-08-10-principal-idempotency-ledger.md
@@ -1,0 +1,52 @@
+# Principal-scoped idempotency ledger (#378)
+
+## Boundary
+
+`hayba_invoke.idempotency_key` is gateway metadata. It is not part of the
+target tool's `args` object and is never forwarded to a TypeScript or Unreal
+handler. A keyed call is admitted only when the MCP SDK supplies validated
+`authInfo.clientId`; stdio and other unauthenticated transports fail closed and
+point to #379. Session IDs, request IDs, access-token text, and caller arguments
+are never treated as identity.
+
+The slot is a length-prefixed SHA-256 digest of authenticated principal, logical
+tool name, and key. Its request fingerprint is a separate digest of tool name
+and canonical validated arguments, including the selected dispatch route. The
+ledger retains neither the raw key nor raw parameters and exposes only aggregate
+diagnostics. A conflict can expose a 64-bit prefix of the one-way slot digest for
+correlation; it never exposes either fingerprint or the prior request.
+
+## State and replay rules
+
+- `in_flight`: identical retries join one Promise. Changed arguments fail with a
+  stable conflict. In-flight entries are never evicted.
+- `completed`: replay is allowed only for advisory state `success`, or for a
+  quiet response with explicit `readback_verified:true`, `verified:true`,
+  `compiled_clean:true`, or `saved:true` evidence and no contradictory failure.
+- `success_needs_verification`, partial/refused/retryable/unknown/suspect/fatal
+  states, bare `ok:true`, `saved:false`, thrown failures, and uncloneable
+  receipts are removed instead of cached.
+- Conventional machine contradictions also veto quiet replay: finite
+  `failed>0`, non-empty `error`/`errors`, `save_verified:false`, `valid:false`,
+  or `dirty:true` alongside otherwise-positive save/readback evidence. Warnings
+  remain advisory and do not veto a verified receipt.
+- Cancelling one MCP waiter does not cancel or remove the shared mutation. A
+  retry with the same identity continues to join it.
+
+The ledger is deliberately bounded: 128 distinct in-flight slots, 1,024
+completed receipts, and a 24-hour completed TTL. Capacity pressure may evict
+only completed receipts. At the in-flight limit, a different slot fails closed;
+an identical slot can still join.
+
+## Durability and acceptance boundary
+
+Receipts have `scope:"process_lifetime"`. They survive an authenticated client
+disconnect/reconnect while the same MCP server process remains alive, but not an
+MCP server restart. This implementation does not claim a durable journal or a
+stable authenticated identity for stdio; #379 owns that transport boundary.
+
+Source-only verification covers simultaneous dedupe, replay, principal
+isolation, canonicalization, conflicts, expiry/capacity, cancellation, failure
+retry, secret-safe diagnostics, MCP envelopes, and every #370 advisory state.
+The disposable-editor mutation proof remains a coordinated acceptance step; no
+editor was touched while the user-owned process held the MCP port.

--- a/mcp-tools/hayba-mcp/src/tools/routing/idempotency-ledger.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/idempotency-ledger.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  IdempotencyLedger,
+  IdempotencyLedgerError,
+  isVerifiedSuccessReceipt,
+} from './idempotency-ledger.js';
+
+const verified = { advisory: { state: 'success' }, receipt: 'r-1' };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function request(overrides: Partial<{ principal: string; tool: string; key: string; request: unknown }> = {}) {
+  return {
+    principal: 'authenticated-client-a',
+    tool: 'actor_spawn',
+    key: 'retry-key-1',
+    request: { args: { label: 'One', location: [1, 2, 3] }, via: 'ts' },
+    ...overrides,
+  };
+}
+
+describe('IdempotencyLedger', () => {
+  it('joins simultaneous canonical duplicates and executes the mutation once', async () => {
+    const ledger = new IdempotencyLedger();
+    const gate = deferred<typeof verified>();
+    const operation = vi.fn(() => gate.promise);
+
+    const first = ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    const second = ledger.run(request({
+      request: { via: 'ts', args: { location: [1, 2, 3], label: 'One' } },
+    }), operation, isVerifiedSuccessReceipt);
+    await vi.waitFor(() => expect(operation).toHaveBeenCalledTimes(1));
+    gate.resolve(verified);
+
+    await expect(first).resolves.toEqual(verified);
+    await expect(second).resolves.toEqual(verified);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('scopes identical tool+key pairs by authenticated principal', async () => {
+    const ledger = new IdempotencyLedger();
+    let calls = 0;
+    await ledger.run(request(), async () => ({ ...verified, calls: ++calls }), isVerifiedSuccessReceipt);
+    const other = await ledger.run(
+      request({ principal: 'authenticated-client-b' }),
+      async () => ({ ...verified, calls: ++calls }),
+      isVerifiedSuccessReceipt,
+    );
+    expect(other.calls).toBe(2);
+  });
+
+  it('fails closed when the same slot carries changed params without revealing either request', async () => {
+    const ledger = new IdempotencyLedger();
+    await ledger.run(request(), async () => verified, isVerifiedSuccessReceipt);
+
+    const conflict = await ledger.run(
+      request({ request: { args: { label: 'SECRET-CHANGED' }, via: 'ts' } }),
+      async () => verified,
+      isVerifiedSuccessReceipt,
+    ).catch((error: unknown) => error);
+
+    expect(conflict).toBeInstanceOf(IdempotencyLedgerError);
+    if (!(conflict instanceof IdempotencyLedgerError)) throw new Error('expected ledger conflict');
+    expect(conflict.code).toBe('idempotency_conflict');
+    const safe = JSON.stringify({ error: conflict, diagnostics: ledger.diagnostics() });
+    expect(safe).not.toContain('retry-key-1');
+    expect(safe).not.toContain('SECRET-CHANGED');
+    expect(safe).not.toContain('authenticated-client-a');
+    expect(conflict.reference).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it('rejects a changed request while the original slot is still in flight', async () => {
+    const ledger = new IdempotencyLedger();
+    const gate = deferred<typeof verified>();
+    const original = ledger.run(request(), () => gate.promise, isVerifiedSuccessReceipt);
+    const changed = ledger.run(
+      request({ request: { via: 'ue_legacy', args: { label: 'One', location: [1, 2, 3] } } }),
+      async () => verified,
+      isVerifiedSuccessReceipt,
+    );
+    await expect(changed).rejects.toMatchObject({ code: 'idempotency_conflict' });
+    gate.resolve(verified);
+    await expect(original).resolves.toEqual(verified);
+  });
+
+  it('replays only a verified success and protects the stored receipt from caller mutation', async () => {
+    const ledger = new IdempotencyLedger();
+    const operation = vi.fn(async () => ({ advisory: { state: 'success' }, nested: { count: 1 } }));
+    const first = await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    first.nested.count = 99;
+
+    const replay = await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(replay.nested.count).toBe(1);
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(ledger.diagnostics()).toMatchObject({ scope: 'process_lifetime', completed: 1, in_flight: 0 });
+  });
+
+  it.each([
+    { receipt: { readback_verified: true }, label: 'readback' },
+    { receipt: { data: { verified: true } }, label: 'nested verification' },
+    { receipt: { result: { compiled_clean: true } }, label: 'clean compile' },
+    { receipt: { content: [{ type: 'text', text: JSON.stringify({ saved: true }) }] }, label: 'saved MCP content' },
+  ])('replays a quiet verified success with explicit $label evidence', async ({ receipt }) => {
+    const ledger = new IdempotencyLedger();
+    const operation = vi.fn(async () => receipt);
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not treat a bare ok:true as verified completion', async () => {
+    const ledger = new IdempotencyLedger();
+    const operation = vi.fn(async () => ({ ok: true }));
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache saved:false even when another field claims verification', async () => {
+    const ledger = new IdempotencyLedger();
+    const operation = vi.fn(async () => ({ verified: true, saved: false }));
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { label: 'failed count', receipt: { saved: true, failed: 1 } },
+    { label: 'error string', receipt: { verified: true, error: 'write rejected' } },
+    { label: 'errors array in a nested result', receipt: { result: { readback_verified: true, errors: ['mismatch'] } } },
+    { label: 'failed save verification', receipt: { saved: true, save_verified: false } },
+    { label: 'invalid result', receipt: { compiled_clean: true, valid: false } },
+    { label: 'still-dirty save/readback', receipt: { saved: true, dirty: true } },
+  ])('does not cache quiet verification contradicted by $label', async ({ receipt }) => {
+    const ledger = new IdempotencyLedger();
+    const operation = vi.fn(async () => receipt);
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not treat warnings or empty error containers as failure evidence', async () => {
+    const ledger = new IdempotencyLedger();
+    const operation = vi.fn(async () => ({
+      readback_verified: true,
+      warnings: ['a useful warning'],
+      error: '',
+      errors: [],
+    }));
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a non-success advisory veto otherwise-positive readback evidence', () => {
+    expect(isVerifiedSuccessReceipt({
+      advisory: { state: 'success_needs_verification' },
+      readback_verified: true,
+      saved: true,
+    })).toBe(false);
+  });
+
+  it.each([
+    'success_needs_verification',
+    'partial_success',
+    'input_rejected',
+    'policy_blocked',
+    'retryable_failure',
+    'unknown_outcome',
+    'session_suspect',
+    'fatal_error',
+  ])('does not cache the advisory state %s', async (state) => {
+    const ledger = new IdempotencyLedger();
+    const operation = vi.fn(async () => ({ advisory: { state } }));
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(ledger.diagnostics().completed).toBe(0);
+  });
+
+  it('removes rejected operations so the same key is retryable', async () => {
+    const ledger = new IdempotencyLedger();
+    const operation = vi.fn()
+      .mockRejectedValueOnce(new Error('transport outcome unknown'))
+      .mockResolvedValueOnce(verified);
+    await expect(ledger.run(request(), operation, isVerifiedSuccessReceipt)).rejects.toThrow('outcome unknown');
+    await expect(ledger.run(request(), operation, isVerifiedSuccessReceipt)).resolves.toEqual(verified);
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('never evicts in-flight work at capacity, while same-slot retries still join it', async () => {
+    const ledger = new IdempotencyLedger({ maxInFlight: 1 });
+    const gate = deferred<typeof verified>();
+    const operation = vi.fn(() => gate.promise);
+    const first = ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    const joined = ledger.run(request(), operation, isVerifiedSuccessReceipt);
+
+    const rejected = ledger.run(
+      request({ key: 'different-key' }),
+      async () => verified,
+      isVerifiedSuccessReceipt,
+    );
+    await expect(rejected).rejects.toMatchObject({ code: 'idempotency_capacity' });
+    expect(ledger.diagnostics().in_flight).toBe(1);
+    expect(operation).toHaveBeenCalledTimes(1);
+
+    gate.resolve(verified);
+    await Promise.all([first, joined]);
+    await expect(ledger.run(
+      request({ key: 'different-key' }),
+      async () => verified,
+      isVerifiedSuccessReceipt,
+    )).resolves.toEqual(verified);
+  });
+
+  it('cancels one waiter without abandoning shared work or allowing a duplicate', async () => {
+    const ledger = new IdempotencyLedger();
+    const gate = deferred<typeof verified>();
+    const controller = new AbortController();
+    const operation = vi.fn(() => gate.promise);
+    const cancelled = ledger.run(
+      { ...request(), waitSignal: controller.signal },
+      operation,
+      isVerifiedSuccessReceipt,
+    );
+    controller.abort();
+    await expect(cancelled).rejects.toMatchObject({ code: 'idempotency_wait_cancelled' });
+
+    const retry = ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(1);
+    gate.resolve(verified);
+    await expect(retry).resolves.toEqual(verified);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires completed receipts and re-executes after the process-local TTL', async () => {
+    let now = 1_000;
+    const ledger = new IdempotencyLedger({ completedTtlMs: 100, now: () => now });
+    const operation = vi.fn(async () => verified);
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    now = 1_099;
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(1);
+    now = 1_100;
+    await ledger.run(request(), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds completed receipts by evicting the oldest completed slot only', async () => {
+    const ledger = new IdempotencyLedger({ maxCompleted: 1 });
+    const operation = vi.fn(async () => verified);
+    await ledger.run(request({ key: 'old' }), operation, isVerifiedSuccessReceipt);
+    await ledger.run(request({ key: 'new' }), operation, isVerifiedSuccessReceipt);
+    expect(ledger.diagnostics().completed).toBe(1);
+    await ledger.run(request({ key: 'old' }), operation, isVerifiedSuccessReceipt);
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it('recognises verified success in a standard MCP text envelope, but not malformed content', () => {
+    expect(isVerifiedSuccessReceipt({
+      content: [{ type: 'text', text: JSON.stringify({ data: { advisory: { state: 'success' } } }) }],
+    })).toBe(true);
+    expect(isVerifiedSuccessReceipt({ content: [{ type: 'text', text: '{not-json' }] })).toBe(false);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/routing/idempotency-ledger.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/idempotency-ledger.ts
@@ -1,0 +1,365 @@
+import { createHash } from 'node:crypto';
+
+export interface IdempotencyLedgerOptions {
+  /** Completed receipts live in memory only and expire after this interval. */
+  completedTtlMs?: number;
+  /** Maximum replayable receipts. In-flight work is never evicted to meet it. */
+  maxCompleted?: number;
+  /** Fail closed instead of admitting unbounded distinct in-flight mutations. */
+  maxInFlight?: number;
+  now?: () => number;
+}
+
+export interface IdempotentRequest {
+  /** Stable identity supplied by an authenticated transport, never request args. */
+  principal: string;
+  tool: string;
+  key: string;
+  /** Canonical, validated tool parameters (including dispatch-affecting fields). */
+  request: unknown;
+  /** Cancels only this waiter. Shared work continues for other retries. */
+  waitSignal?: AbortSignal;
+}
+
+export type IdempotencyErrorCode =
+  | 'idempotency_invalid'
+  | 'idempotency_conflict'
+  | 'idempotency_capacity'
+  | 'idempotency_wait_cancelled';
+
+/** Safe to return to a caller: it contains no principal, key, params, or fingerprint. */
+export class IdempotencyLedgerError extends Error {
+  constructor(
+    public readonly code: IdempotencyErrorCode,
+    message: string,
+    /** One-way slot identifier, useful for correlation without revealing the key. */
+    public readonly reference?: string,
+  ) {
+    super(message);
+    this.name = 'IdempotencyLedgerError';
+  }
+}
+
+interface InFlightEntry<T> {
+  state: 'in_flight';
+  fingerprint: string;
+  promise: Promise<T>;
+}
+
+interface CompletedEntry<T> {
+  state: 'completed';
+  fingerprint: string;
+  receipt: T;
+  completedAt: number;
+  sequence: number;
+}
+
+type Entry<T> = InFlightEntry<T> | CompletedEntry<T>;
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1_000;
+const DEFAULT_MAX_COMPLETED = 1_024;
+const DEFAULT_MAX_IN_FLIGHT = 128;
+const MAX_IDENTITY_BYTES = 4_096;
+const MAX_KEY_BYTES = 512;
+const MAX_CANONICAL_REQUEST_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Process-local idempotency for mutation dispatch.
+ *
+ * Slots are SHA-256(principal, tool, key); only the digest is retained. A slot
+ * either joins one in-flight promise or replays one verified completed receipt.
+ * Rejections and unverified/unknown outcomes remove the slot so they never pose
+ * as success. This is intentionally not a durable, cross-process journal.
+ */
+export class IdempotencyLedger {
+  private readonly entries = new Map<string, Entry<unknown>>();
+  private readonly completedTtlMs: number;
+  private readonly maxCompleted: number;
+  private readonly maxInFlight: number;
+  private readonly now: () => number;
+  private sequence = 0;
+
+  constructor(options: IdempotencyLedgerOptions = {}) {
+    this.completedTtlMs = positiveInteger(options.completedTtlMs ?? DEFAULT_TTL_MS, 'completedTtlMs');
+    this.maxCompleted = positiveInteger(options.maxCompleted ?? DEFAULT_MAX_COMPLETED, 'maxCompleted');
+    this.maxInFlight = positiveInteger(options.maxInFlight ?? DEFAULT_MAX_IN_FLIGHT, 'maxInFlight');
+    this.now = options.now ?? Date.now;
+  }
+
+  async run<T>(
+    request: IdempotentRequest,
+    operation: () => Promise<T>,
+    isVerifiedCompleted: (receipt: T) => boolean,
+  ): Promise<T> {
+    validateBoundedString(request.principal, 'authenticated principal', MAX_IDENTITY_BYTES);
+    validateBoundedString(request.tool, 'tool name', MAX_IDENTITY_BYTES);
+    validateBoundedString(request.key, 'idempotency key', MAX_KEY_BYTES);
+
+    const canonical = canonicalJson(request.request);
+    if (Buffer.byteLength(canonical, 'utf8') > MAX_CANONICAL_REQUEST_BYTES) {
+      throw new IdempotencyLedgerError('idempotency_invalid', 'The canonical request is too large for idempotency tracking.');
+    }
+
+    const slot = digestParts([request.principal, request.tool, request.key]);
+    const reference = slot.slice(0, 16);
+    const fingerprint = digestParts([request.tool, canonical]);
+    const now = this.now();
+    this.purgeExpiredCompleted(now);
+
+    const existing = this.entries.get(slot) as Entry<T> | undefined;
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) {
+        throw new IdempotencyLedgerError(
+          'idempotency_conflict',
+          'This idempotency key was already used for a different request.',
+          reference,
+        );
+      }
+      if (existing.state === 'in_flight') {
+        return await waitWithoutCancellingSharedWork(existing.promise, request.waitSignal);
+      }
+      return cloneReceipt(existing.receipt);
+    }
+
+    if (this.inFlightCount() >= this.maxInFlight) {
+      throw new IdempotencyLedgerError(
+        'idempotency_capacity',
+        'The idempotency ledger is at its in-flight limit; retry this request later with the same key.',
+      );
+    }
+
+    let entry!: InFlightEntry<T>;
+    const shared = Promise.resolve()
+      .then(operation)
+      .then((receipt) => {
+        // A classifier or clone failure must not turn successful tool work into
+        // a failed call. It merely makes the outcome non-replayable.
+        try {
+          if (isVerifiedCompleted(receipt)) {
+            const snapshot = cloneReceipt(receipt);
+            if (this.entries.get(slot) === entry) {
+              this.entries.set(slot, {
+                state: 'completed',
+                fingerprint,
+                receipt: snapshot,
+                completedAt: this.now(),
+                sequence: ++this.sequence,
+              });
+              this.evictCompletedOverCapacity();
+            }
+          } else if (this.entries.get(slot) === entry) {
+            this.entries.delete(slot);
+          }
+        } catch {
+          if (this.entries.get(slot) === entry) this.entries.delete(slot);
+        }
+        return receipt;
+      }, (error: unknown) => {
+        if (this.entries.get(slot) === entry) this.entries.delete(slot);
+        throw error;
+      });
+
+    entry = { state: 'in_flight', fingerprint, promise: shared };
+    this.entries.set(slot, entry as InFlightEntry<unknown>);
+    return await waitWithoutCancellingSharedWork(shared, request.waitSignal);
+  }
+
+  /** Aggregate diagnostics only: no slot IDs, principals, keys, or fingerprints. */
+  diagnostics(): { scope: 'process_lifetime'; in_flight: number; completed: number; completed_ttl_ms: number } {
+    this.purgeExpiredCompleted(this.now());
+    let inFlight = 0;
+    let completed = 0;
+    for (const entry of this.entries.values()) {
+      if (entry.state === 'in_flight') inFlight += 1;
+      else completed += 1;
+    }
+    return {
+      scope: 'process_lifetime',
+      in_flight: inFlight,
+      completed,
+      completed_ttl_ms: this.completedTtlMs,
+    };
+  }
+
+  private inFlightCount(): number {
+    let count = 0;
+    for (const entry of this.entries.values()) if (entry.state === 'in_flight') count += 1;
+    return count;
+  }
+
+  private purgeExpiredCompleted(now: number): void {
+    for (const [slot, entry] of this.entries) {
+      if (entry.state === 'completed' && now - entry.completedAt >= this.completedTtlMs) {
+        this.entries.delete(slot);
+      }
+    }
+  }
+
+  private evictCompletedOverCapacity(): void {
+    const completed = [...this.entries.entries()]
+      .filter((pair): pair is [string, CompletedEntry<unknown>] => pair[1].state === 'completed')
+      .sort((a, b) => a[1].sequence - b[1].sequence);
+    for (let i = 0; i < completed.length - this.maxCompleted; i += 1) {
+      this.entries.delete(completed[i]![0]);
+    }
+  }
+}
+
+/**
+ * Cache only #370's strongest terminal state. Quiet verified successes may
+ * omit advisory presentation, so explicit readback/save evidence is accepted
+ * only when no advisory or contradictory failure evidence exists.
+ */
+export function isVerifiedSuccessReceipt(receipt: unknown): boolean {
+  const evidence = collectEvidence(receipt);
+  const contradiction = evidence.contradiction
+    || (evidence.dirty && evidence.explicitVerification);
+  if (evidence.advisoryStates.length > 0) {
+    return evidence.advisoryStates.every((state) => state === 'success') && !contradiction;
+  }
+  return evidence.explicitVerification && !contradiction;
+}
+
+interface ReceiptEvidence {
+  advisoryStates: string[];
+  explicitVerification: boolean;
+  contradiction: boolean;
+  dirty: boolean;
+}
+
+function collectEvidence(value: unknown, depth = 0, evidence?: ReceiptEvidence): ReceiptEvidence {
+  const out = evidence ?? {
+    advisoryStates: [],
+    explicitVerification: false,
+    contradiction: false,
+    dirty: false,
+  };
+  if (depth > 4 || !value || typeof value !== 'object') return out;
+  const object = value as Record<string, unknown>;
+  const advisory = object.advisory;
+  if (advisory && typeof advisory === 'object') {
+    const state = (advisory as Record<string, unknown>).state;
+    if (typeof state === 'string') out.advisoryStates.push(state);
+  }
+
+  // A successful Promise is not enough: TS handlers can resolve an explicit
+  // `{ok:false}` or a failed save. Any such evidence vetoes replay even if a
+  // different field claims verification.
+  if (
+    object.ok === false
+    || object.success === false
+    || object.saved === false
+    || object.save_verified === false
+    || object.valid === false
+  ) {
+    out.contradiction = true;
+  }
+  const failed = object.failed;
+  if (typeof failed === 'number' && Number.isFinite(failed) && failed > 0) {
+    out.contradiction = true;
+  }
+  if (hasNonEmptyFailure(object.error) || hasNonEmptyFailure(object.errors)) {
+    out.contradiction = true;
+  }
+  if (object.dirty === true) out.dirty = true;
+
+  for (const key of ['readback_verified', 'verified', 'compiled_clean', 'saved', 'save_verified']) {
+    if (object[key] === false) out.contradiction = true;
+    if (object[key] === true) out.explicitVerification = true;
+  }
+
+  for (const key of ['data', 'result']) {
+    collectEvidence(object[key], depth + 1, out);
+  }
+  if (Array.isArray(object.content)) {
+    for (const block of object.content) {
+      if (!block || typeof block !== 'object') continue;
+      const text = (block as Record<string, unknown>).text;
+      if (typeof text !== 'string') continue;
+      try {
+        collectEvidence(JSON.parse(text), depth + 1, out);
+      } catch {
+        // Non-JSON content cannot establish a verified terminal receipt.
+      }
+    }
+  }
+  return out;
+}
+
+function hasNonEmptyFailure(value: unknown): boolean {
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (value && typeof value === 'object') return Object.keys(value as Record<string, unknown>).length > 0;
+  return value === true || (typeof value === 'number' && Number.isFinite(value) && value > 0);
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new TypeError(`${name} must be a positive integer`);
+  return value;
+}
+
+function validateBoundedString(value: string, name: string, maxBytes: number): void {
+  if (typeof value !== 'string' || value.length === 0 || Buffer.byteLength(value, 'utf8') > maxBytes) {
+    throw new IdempotencyLedgerError('idempotency_invalid', `The ${name} is missing or too large.`);
+  }
+}
+
+function digestParts(parts: string[]): string {
+  const hash = createHash('sha256');
+  for (const part of parts) {
+    const bytes = Buffer.from(part, 'utf8');
+    const length = Buffer.allocUnsafe(4);
+    length.writeUInt32BE(bytes.length);
+    hash.update(length);
+    hash.update(bytes);
+  }
+  return hash.digest('hex');
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value);
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new IdempotencyLedgerError('idempotency_invalid', 'The request contains a non-finite number.');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item ?? null)).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const fields = Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`);
+    return `{${fields.join(',')}}`;
+  }
+  throw new IdempotencyLedgerError('idempotency_invalid', 'The request contains a value that cannot be represented as JSON.');
+}
+
+function cloneReceipt<T>(receipt: T): T {
+  return structuredClone(receipt);
+}
+
+function waitWithoutCancellingSharedWork<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) {
+    return Promise.reject(new IdempotencyLedgerError(
+      'idempotency_wait_cancelled',
+      'This waiter was cancelled; the keyed operation may still be in flight. Retry with the same key.',
+    ));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const cancelled = () => {
+      cleanup();
+      reject(new IdempotencyLedgerError(
+        'idempotency_wait_cancelled',
+        'This waiter was cancelled; the keyed operation may still be in flight. Retry with the same key.',
+      ));
+    };
+    const cleanup = () => signal.removeEventListener('abort', cancelled);
+    signal.addEventListener('abort', cancelled, { once: true });
+    promise.then(
+      (value) => { cleanup(); resolve(value); },
+      (error: unknown) => { cleanup(); reject(error); },
+    );
+  });
+}

--- a/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
 import { recordSchema } from '../../schema-registry.js';
 import { invokeHandler, UE_LEGACY_ALLOWLIST } from './invoke.js';
+import { IdempotencyLedger } from '../idempotency-ledger.js';
 
 describe('hayba_invoke', () => {
   beforeEach(() => {
@@ -47,6 +48,84 @@ describe('hayba_invoke', () => {
     });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error.kind).toBe('tool_disabled');
+  });
+
+  describe('principal-scoped idempotency', () => {
+    it('fails closed without SDK-authenticated principal context and never dispatches', async () => {
+      const dispatch = vi.fn();
+      const res = await invokeHandler(
+        { name: 'echo_tool', args: { msg: 'hi' }, idempotency_key: 'outside-tool-params' },
+        { dispatch, isDisabled: () => false, idempotency: { ledger: new IdempotencyLedger() } },
+      );
+      expect(res).toMatchObject({
+        ok: false,
+        error: {
+          kind: 'idempotency_unavailable',
+          scope: 'process_lifetime',
+        },
+      });
+      expect(JSON.stringify(res)).toContain('authenticated MCP principal');
+      expect(JSON.stringify(res)).toContain('#379');
+      expect(JSON.stringify(res)).not.toContain('outside-tool-params');
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates verified calls after validation without forwarding the envelope key', async () => {
+      const ledger = new IdempotencyLedger();
+      const dispatch = vi.fn(async (_cmd: string, params: Record<string, unknown>) => ({
+        echoed: params.msg,
+        advisory: { state: 'success' },
+      }));
+      const ctx = {
+        dispatch,
+        isDisabled: () => false,
+        idempotency: { ledger, authenticatedPrincipal: 'resource\0authenticated-client' },
+      };
+      const envelope = { name: 'echo_tool', args: { msg: 'hi' }, idempotency_key: 'retry-7' };
+      const first = await invokeHandler(envelope, ctx);
+      const replay = await invokeHandler(envelope, ctx);
+
+      expect(replay).toEqual(first);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith('echo_tool', { msg: 'hi' });
+      expect(JSON.stringify(dispatch.mock.calls)).not.toContain('retry-7');
+    });
+
+    it('returns a stable secret-safe conflict for changed validated params', async () => {
+      const ledger = new IdempotencyLedger();
+      const ctx = {
+        dispatch: vi.fn(async () => ({ advisory: { state: 'success' } })),
+        isDisabled: () => false,
+        idempotency: { ledger, authenticatedPrincipal: 'authenticated-client' },
+      };
+      await invokeHandler(
+        { name: 'echo_tool', args: { msg: 'first-secret' }, idempotency_key: 'raw-secret-key' },
+        ctx,
+      );
+      const conflict = await invokeHandler(
+        { name: 'echo_tool', args: { msg: 'changed-secret' }, idempotency_key: 'raw-secret-key' },
+        ctx,
+      );
+      expect(conflict).toMatchObject({ ok: false, error: { kind: 'idempotency_conflict' } });
+      const json = JSON.stringify(conflict);
+      expect(json).not.toContain('raw-secret-key');
+      expect(json).not.toContain('first-secret');
+      expect(json).not.toContain('changed-secret');
+    });
+
+    it('does not replay a result that still needs verification', async () => {
+      const ledger = new IdempotencyLedger();
+      const dispatch = vi.fn(async () => ({ advisory: { state: 'success_needs_verification' } }));
+      const ctx = {
+        dispatch,
+        isDisabled: () => false,
+        idempotency: { ledger, authenticatedPrincipal: 'authenticated-client' },
+      };
+      const envelope = { name: 'echo_tool', args: { msg: 'hi' }, idempotency_key: 'retry-8' };
+      await invokeHandler(envelope, ctx);
+      await invokeHandler(envelope, ctx);
+      expect(dispatch).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('returns unknown_tool when no schema recorded', async () => {

--- a/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/meta-tools/invoke.ts
@@ -3,6 +3,11 @@ import { getRawShape } from '../../schema-registry.js';
 import { listAgentCallableLegacyCommands } from '../../../legacy-commands/index.js';
 import { resolveAliases } from '../../param-aliases.js';
 import { TOOL_ALIASES } from '../../tool-aliases.js';
+import {
+  IdempotencyLedger,
+  IdempotencyLedgerError,
+  isVerifiedSuccessReceipt,
+} from '../idempotency-ledger.js';
 
 /**
  * Built once at module load from sidecar.json. Every entry with
@@ -27,6 +32,8 @@ export const invokeSchema = {
   args: z.record(z.string(), z.unknown()).default({}),
   via: z.enum(['ts', 'ue_legacy']).optional().default('ts')
     .describe('Dispatch route. "ts" (default) looks the tool up in the TS captured map. "ue_legacy" calls executeCommand(name, args) directly against the UE plugin — only commands marked agent_callable:true in legacy-commands/sidecar.json are accepted.'),
+  idempotency_key: z.string().min(1).max(256).optional()
+    .describe('Retry identity for a mutation. This is envelope metadata, never forwarded as a tool parameter. Requires an authenticated MCP principal; receipts are process-local and expire.'),
 };
 
 export type InvokeResult =
@@ -34,16 +41,30 @@ export type InvokeResult =
   | { ok: false; error: { kind: 'validation'; issues: unknown; accepted_params?: string[] } }
   | { ok: false; error: { kind: 'tool_disabled'; name: string } }
   | { ok: false; error: { kind: 'unknown_tool'; name: string } }
-  | { ok: false; error: { kind: 'legacy_not_allowlisted'; name: string } };
+  | { ok: false; error: { kind: 'legacy_not_allowlisted'; name: string } }
+  | { ok: false; error: {
+      kind: 'idempotency_unavailable' | 'idempotency_invalid' | 'idempotency_conflict' | 'idempotency_capacity' | 'idempotency_wait_cancelled';
+      message: string;
+      reference?: string;
+      scope: 'process_lifetime';
+    } };
+
+export interface InvokeIdempotencyContext {
+  ledger: IdempotencyLedger;
+  /** Derived only from SDK-validated authInfo. Never use sessionId or args. */
+  authenticatedPrincipal?: string;
+  waitSignal?: AbortSignal;
+}
 
 export interface InvokeCtx {
   dispatch: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
   dispatchLegacy?: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
   isDisabled: (name: string) => boolean;
+  idempotency?: InvokeIdempotencyContext;
 }
 
 export async function invokeHandler(
-  args: { name: string; args: Record<string, unknown>; via?: 'ts' | 'ue_legacy' },
+  args: { name: string; args: Record<string, unknown>; via?: 'ts' | 'ue_legacy'; idempotency_key?: string },
   ctx: InvokeCtx,
 ): Promise<InvokeResult> {
   const via = args.via ?? 'ts';
@@ -81,8 +102,7 @@ export async function invokeHandler(
       return { ok: false, error: { kind: 'legacy_not_allowlisted', name: args.name } };
     }
     const legacy = ctx.dispatchLegacy ?? ctx.dispatch;
-    const result = await legacy(args.name, rawArgs);
-    return { ok: true, result };
+    return await dispatchWithOptionalIdempotency(args, rawArgs, ctx, legacy);
   }
   const shape: ZodRawShape | null = getRawShape(args.name);
   if (!shape) {
@@ -93,8 +113,7 @@ export async function invokeHandler(
     // allow-listed. Only when neither route knows the command do we error.
     if (LEGACY_ALLOWLIST.has(args.name)) {
       const legacy = ctx.dispatchLegacy ?? ctx.dispatch;
-      const result = await legacy(args.name, rawArgs);
-      return { ok: true, result };
+      return await dispatchWithOptionalIdempotency(args, rawArgs, ctx, legacy);
     }
     return { ok: false, error: { kind: 'unknown_tool', name: args.name } };
   }
@@ -112,8 +131,64 @@ export async function invokeHandler(
       error: { kind: 'validation', issues: parse.error.issues, accepted_params: Object.keys(shape) },
     };
   }
-  const result = await ctx.dispatch(args.name, parse.data as Record<string, unknown>);
-  return { ok: true, result };
+  return await dispatchWithOptionalIdempotency(
+    args,
+    parse.data as Record<string, unknown>,
+    ctx,
+    ctx.dispatch,
+  );
+}
+
+async function dispatchWithOptionalIdempotency(
+  envelope: { name: string; via?: 'ts' | 'ue_legacy'; idempotency_key?: string },
+  validatedArgs: Record<string, unknown>,
+  ctx: InvokeCtx,
+  dispatch: (cmd: string, args: Record<string, unknown>) => Promise<unknown>,
+): Promise<InvokeResult> {
+  const key = envelope.idempotency_key;
+  if (!key) {
+    return { ok: true, result: await dispatch(envelope.name, validatedArgs) };
+  }
+
+  const authenticatedPrincipal = ctx.idempotency?.authenticatedPrincipal;
+  if (!ctx.idempotency || !authenticatedPrincipal) {
+    return {
+      ok: false,
+      error: {
+        kind: 'idempotency_unavailable',
+        message: 'Idempotency requires an authenticated MCP principal; this transport supplied none. See #379 for authenticated transport support.',
+        scope: 'process_lifetime',
+      },
+    };
+  }
+
+  try {
+    const result = await ctx.idempotency.ledger.run(
+      {
+        principal: authenticatedPrincipal,
+        tool: envelope.name,
+        key,
+        // `via` changes which implementation runs, so it belongs in the
+        // fingerprint even though the logical tool owns the keyed slot.
+        request: { via: envelope.via ?? 'ts', args: validatedArgs },
+        waitSignal: ctx.idempotency.waitSignal,
+      },
+      () => dispatch(envelope.name, validatedArgs),
+      isVerifiedSuccessReceipt,
+    );
+    return { ok: true, result };
+  } catch (error) {
+    if (!(error instanceof IdempotencyLedgerError)) throw error;
+    return {
+      ok: false,
+      error: {
+        kind: error.code,
+        message: error.message,
+        ...(error.reference ? { reference: error.reference } : {}),
+        scope: 'process_lifetime',
+      },
+    };
+  }
 }
 
 export const meta = {

--- a/mcp-tools/hayba-mcp/src/tools/routing/register.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/register.ts
@@ -39,6 +39,7 @@ import { setAssetDagSink } from '../asset-sources/shared.js';
 import { registerChatCapturedTools } from '../../chat/tool-dispatch.js';
 import { buildOrientation, shouldOrient } from './orientation.js';
 import { wrapToolHandlerForStream } from '../tool-stream-mirror.js';
+import { IdempotencyLedger } from './idempotency-ledger.js';
 
 // ── First-install surface ────────────────────────────────────────────────────
 //
@@ -146,6 +147,11 @@ export async function registerDeferredRouting(
   cacheDir?: string,
   options: DeferredRoutingOptions = {},
 ): Promise<RoutingHandle> {
+  // One bounded process-local ledger spans both captured TS tools and the UE
+  // legacy fallthrough. Restarting this MCP process intentionally loses its
+  // receipts; durable/reconnect identity belongs to the authenticated transport
+  // work tracked in #379, not to a fabricated stdio principal.
+  const idempotencyLedger = new IdempotencyLedger();
   // Publish the captured-tool map to the chat dispatcher (Task 4) so the sidecar
   // SSE copilot reaches TS-side handlers, not just UE-bridged commands.
   registerChatCapturedTools(captured);
@@ -482,7 +488,13 @@ export async function registerDeferredRouting(
     'hayba_invoke',
     'CALL ANY TOOL BY NAME, whether or not its pack is loaded — the whole catalogue is reachable through here. Pair with hayba_search_tools when you do not know the name. USE_WHEN: any call into an unloaded domain, which is most of them. NOT_WHEN: you are making many calls into one domain — hayba_pack_load gives you native schemas.',
     invokeSchema,
-    async (args: { name: string; args: Record<string, unknown>; via?: 'ts' | 'ue_legacy' }) => {
+    async (args, extra) => {
+      const auth = extra?.authInfo;
+      // `authInfo` is produced by the SDK only after access-token validation.
+      // Never substitute the request/session ID, token, or caller args here.
+      const authenticatedPrincipal = auth?.clientId
+        ? `${auth.resource?.href ?? ''}\u0000${auth.clientId}`
+        : undefined;
       const r = await invokeHandler(args, {
         dispatch: async (cmd, params) => {
           // Prefer the captured handler if present — covers TS-side tools.
@@ -500,6 +512,11 @@ export async function registerDeferredRouting(
           return await executeCommand(cmd, params);
         },
         isDisabled: isToolDisabled,
+        idempotency: {
+          ledger: idempotencyLedger,
+          authenticatedPrincipal,
+          waitSignal: extra?.signal,
+        },
       });
       return withOrientation(toMcpResponse(r));
     },

--- a/mcp-tools/hayba-mcp/src/tools/validation-nudge.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/validation-nudge.test.ts
@@ -18,6 +18,7 @@ import {
 } from './hayba-tool-meta.js';
 import { withValidationNudge } from './tool-result.js';
 import type { SessionManager, ToolResult } from './types.js';
+import { PLUMB_DESCRIPTORS, VALIDATOR_DESCRIPTORS } from './index.js';
 
 function fakeServer() {
   const calls: Array<{
@@ -117,8 +118,7 @@ describe('validation tools carry strengthened when/USE_WHEN guidance', () => {
   // The validator tools are now ToolDescriptors, so the guidance lives in
   // meta.when and appendMeta renders it — same words reach the agent, and the
   // assertion no longer breaks when a tool changes how it is registered.
-  it('validator descriptions are loud and directive as rendered', async () => {
-    const { VALIDATOR_DESCRIPTORS } = await import('./index.js');
+  it('validator descriptions are loud and directive as rendered', () => {
     const rendered = new Map(VALIDATOR_DESCRIPTORS.map((d) => [d.name, appendMeta(d.description, d.meta)]));
 
     const run = rendered.get('validator_run')!;
@@ -133,8 +133,7 @@ describe('validation tools carry strengthened when/USE_WHEN guidance', () => {
     expect(rendered.get('validator_history')!).toMatch(/NOT_WHEN:[\s\S]{0,200}validator_run/);
   });
 
-  it('every validator tool that persists state declares an effect', async () => {
-    const { VALIDATOR_DESCRIPTORS } = await import('./index.js');
+  it('every validator tool that persists state declares an effect', () => {
     // The hand-written form had nowhere to put effects, so the tools that write
     // config and history declared none and sat outside the evidence contract.
     for (const name of ['validator_resolve', 'validator_clear', 'validator_set_rule_enabled', 'validator_strictness']) {
@@ -147,8 +146,7 @@ describe('validation tools carry strengthened when/USE_WHEN guidance', () => {
     }
   });
 
-  it('plumb_validate copy is still loud as rendered', async () => {
-    const { PLUMB_DESCRIPTORS } = await import('./index.js');
+  it('plumb_validate copy is still loud as rendered', () => {
     const d = PLUMB_DESCRIPTORS.find((x) => x.name === 'plumb_validate')!;
     const rendered = appendMeta(d.description, d.meta);
     expect(rendered).toContain('VERIFY PLACEMENT IS ACTUALLY CORRECT');
@@ -157,8 +155,7 @@ describe('validation tools carry strengthened when/USE_WHEN guidance', () => {
     expect(rendered).toContain('provably grounded and non-overlapping');
   });
 
-  it('plumb tools declare effects by what they DO, not by their verb', async () => {
-    const { PLUMB_DESCRIPTORS } = await import('./index.js');
+  it('plumb tools declare effects by what they DO, not by their verb', () => {
     const eff = (n: string) => PLUMB_DESCRIPTORS.find((x) => x.name === n)!.meta.effects;
     // Reads like a query, but persists a lesson via upsertLesson.
     expect(eff('plumb_study_take').length).toBeGreaterThan(0);


### PR DESCRIPTION
## Outcome
- adds a bounded process-local idempotency ledger to hayba_invoke
- scopes keys to SDK-validated authenticated principal plus logical tool
- fingerprints canonical validated args and dispatch route; conflicts expose only a one-way reference
- joins identical in-flight calls, never evicts in-flight work, and bounds completed receipts by TTL/capacity
- replays only #370 success or quiet explicit verified/save evidence with no contradictory failure
- fails keyed stdio/no-auth calls closed and points to #379 instead of fabricating identity
- removes a deterministic full-suite timeout caused by repeated dynamic catalogue imports

## Verification
- routing/registration/validation focused suite: 108/108
- dedicated ledger/envelope cases include concurrency, cancellation, capacity, expiry, conflicts, principal isolation, secret-safe diagnostics, all advisory states, and contradiction vetoes
- typecheck and legacy-wrapper lint: green
- two deliberate mutations were killed and reverted

## Acceptance boundary
This intentionally does not close #378 yet. Receipts are process-local and keyed mode requires authenticated SDK context. The remaining disposable-editor mutation/reconnect proof will be run after #379 provides the default-on authenticated transport; unauthenticated stdio cannot honestly stand in for that principal boundary.

Advances #378.