### PR TITLE
security: redact secrets at Node response boundaries

### DIFF
--- a/docs/audit/2026-08-10-central-secret-redaction.md
+++ b/docs/audit/2026-08-10-central-secret-redaction.md
@@ -1,0 +1,62 @@
+# Central bounded secret redaction (#383)
+
+## Outbound boundary inventory
+
+One non-mutating policy now covers the Node server's actual egress paths:
+
+1. `wrapToolHandlerForStream` filters every native and deferred MCP tool return
+   and thrown error, then mirrors that same already-safe value and safe params.
+2. Chat `emit` filters before SSE frames enter the reconnect buffer or fan out;
+   tool inputs/results stored in the final trace are safe copies.
+3. Shared Express middleware wraps `res.json` for dashboard/chat and Sliver HTTP
+   routes. Overlapping app/route middleware recognizes an already-wrapped
+   response and does not filter twice.
+4. `OperationJournal` filters before memory and disk. Replay also sanitizes and
+   rewrites legacy JSONL records that contain secret material.
+5. Process console methods are wrapped once before server startup. The ordinary
+   logger also filters independently for library/test callers.
+
+MCP catalog resources and static files contain repository artifacts rather than
+handler-owned dynamic results; binary/static response bodies are deliberately
+not decoded or rewritten.
+
+## Policy and bounds
+
+`src/security/secret-redaction.ts` recognizes mixed-case, snake, camel, and
+closed-vocabulary concatenated credential keys; bearer/JWT/provider-key text;
+authorization/API-key/cookie assignments; URL userinfo; and secret query
+parameters. Serialized property names are scanned by the same bounded text
+policy; a sensitive name is replaced wholesale by a deterministic,
+collision-safe placeholder that contains no raw substring. Categories and
+counts are stable diagnostics. Values, matched text, and raw keys never appear
+in metadata.
+
+Default traversal bounds are 16 levels, 10,000 nodes, 256 array items, 256
+object keys, 256 key characters, 64 KiB per ordinary string, and 1 MiB total
+ordinary string text. Cycles and every exceeded budget fail closed with a
+machine-readable truncation reason. Errors and mandatory recovery keys are
+prioritized when an object-key budget is exhausted. Warnings are not treated as
+errors or removed. Accessors are never invoked; accessor and hostile-proxy
+subtrees fail closed with an `accessor` truncation fact.
+
+Buffers, typed arrays, explicitly named base64 fields, and image/audio/blob
+`data` remain byte-identical unless their owning key explicitly names a secret.
+The existing transport response-size cap remains the allocation boundary for
+those opaque artifacts.
+
+## Invariants
+
+- Handler-owned results are never mutated; safe payloads retain identity and
+  serialized bytes.
+- Filtering an already-filtered value is idempotent and does not create nested
+  metadata.
+- Only exact, closed-vocabulary redaction/truncation marker strings are trusted.
+  Attacker prose that merely starts with or contains a marker is scanned again.
+- MCP redaction facts live under `_meta["hayba/security_redaction"]`; ordinary
+  JSON/SSE objects use `_security_redaction`; bounded arrays carry a final fact.
+- Error and `mandatory_recovery` prose survives with only credential spans
+  replaced.
+
+The remaining acceptance step is a disposable-process smoke proving sentinels
+are absent from real MCP, Tool Stream, SSE/HTTP, journal, stderr, and crash-test
+artifacts. No user-owned editor process is used for that proof.

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -4,7 +4,7 @@
   "description": "Hayba MCP Toolkit — AI-powered terrain and PCG authoring for Unreal Engine",
   "type": "module",
   "bin": {
-    "hayba-mcp": "./dist/index.js",
+    "hayba-mcp": "./dist/bootstrap.js",
     "hayba-cli": "./dist/cli/index.js"
   },
   "main": "./dist/index.js",
@@ -14,7 +14,7 @@
     "build:server": "tsc && npm run build:assets",
     "build:assets": "node -e \"import('node:fs').then(fs=>{fs.mkdirSync('dist/tools/routing',{recursive:true});fs.copyFileSync('src/tools/routing/packs.yaml','dist/tools/routing/packs.yaml');fs.mkdirSync('dist/slivers/specs',{recursive:true});for(const f of fs.readdirSync('src/slivers/specs')){if(f.endsWith('.sliver.json'))fs.copyFileSync('src/slivers/specs/'+f,'dist/slivers/specs/'+f)}fs.mkdirSync('dist/legacy-commands',{recursive:true});fs.copyFileSync('src/legacy-commands/sidecar.json','dist/legacy-commands/sidecar.json');fs.copyFileSync('src/legacy-commands/sidecar.schema.json','dist/legacy-commands/sidecar.schema.json');console.error('[build:assets] copied packs.yaml + sliver specs + legacy sidecar')})\"",
     "dev": "tsc --watch",
-    "start": "node dist/index.js",
+    "start": "node dist/bootstrap.js",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint:legacy-wrappers": "node scripts/check-legacy-wrappers.mjs",

--- a/mcp-tools/hayba-mcp/src/bootstrap.ts
+++ b/mcp-tools/hayba-mcp/src/bootstrap.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+// Keep this executable boundary intentionally tiny. ESM evaluates every
+// static dependency before a module body, so installing the console wrapper in
+// index.ts alone cannot protect import-time diagnostics from the rest of the
+// server graph. This module imports only the redactor, installs it, and then
+// starts the application through a dynamic import.
+import { installConsoleSecretRedaction } from './security/secret-redaction.js';
+
+installConsoleSecretRedaction();
+await import('./index.js');

--- a/mcp-tools/hayba-mcp/src/chat/chat-server.redaction.test.ts
+++ b/mcp-tools/hayba-mcp/src/chat/chat-server.redaction.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { registerChatRoutes, __resetChatState } from './chat-server.js';
+import type { LLMClient, LLMCompleteParams, LLMResponse, LLMStreamEvent } from '../agents/llm-client.js';
+
+class SecretToolClient implements LLMClient {
+  provider = 'mock';
+  model = 'fake';
+  protocol = 'anthropic' as const;
+  private turn = 0;
+
+  async complete(): Promise<LLMResponse> { throw new Error('not used'); }
+
+  async *stream(_params: LLMCompleteParams): AsyncGenerator<LLMStreamEvent, void, unknown> {
+    this.turn += 1;
+    const response: LLMResponse = this.turn === 1
+      ? {
+          content: null,
+          toolCalls: [{ id: 'secret-call', name: 'actor_list', input: { apiKey: 'SENTINEL_SSE_INPUT' } }],
+          stopReason: 'tool_use',
+        }
+      : { content: 'Authorization: Bearer SENTINEL_ASSISTANT_123456 then done', toolCalls: [], stopReason: 'end_turn' };
+    if (response.content) yield { type: 'text_delta', text: response.content };
+    for (const call of response.toolCalls) yield { type: 'tool_call', call };
+    yield { type: 'done', response };
+  }
+}
+
+async function collectSse(res: Response): Promise<Array<{ event: string; data: unknown }>> {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const frames: Array<{ event: string; data: unknown }> = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return frames;
+    buffer += decoder.decode(value, { stream: true });
+    let boundary = buffer.indexOf('\n\n');
+    while (boundary >= 0) {
+      const chunk = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      const event = chunk.split('\n').find((line) => line.startsWith('event: '))?.slice(7);
+      const data = chunk.split('\n').find((line) => line.startsWith('data: '))?.slice(6);
+      if (event && data) {
+        frames.push({ event, data: JSON.parse(data) });
+        if (event === 'done') return frames;
+      }
+      boundary = buffer.indexOf('\n\n');
+    }
+  }
+}
+
+describe('chat HTTP/SSE redaction boundary', () => {
+  let server: Server | undefined;
+
+  afterEach(() => {
+    server?.close();
+    __resetChatState();
+  });
+
+  it('sanitizes tool frames and the buffered final trace before serialization', async () => {
+    const app = express();
+    app.use(express.json());
+    registerChatRoutes(app, {
+      createClient: () => new SecretToolClient(),
+      dispatchTool: async () => ({
+        authorization: 'Bearer SENTINEL_SSE_RESULT_123456',
+        mandatory_recovery: 'Reconnect after rotating credentials.',
+      }),
+      tools: [{ name: 'actor_list', description: 'list', input_schema: { type: 'object', properties: {} } }],
+    });
+    server = app.listen(0);
+    const port = (server.address() as AddressInfo).port;
+    const response = await fetch(`http://127.0.0.1:${port}/chat/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ prompt: 'go', provider: 'mock' }),
+    });
+    const frames = await collectSse(response);
+    const serialized = JSON.stringify(frames);
+    expect(serialized).not.toContain('SENTINEL');
+    expect(serialized).toContain('mandatory_recovery');
+    expect(frames.some((frame) => frame.event === 'tool_call')).toBe(true);
+    expect(frames.some((frame) => frame.event === 'tool_result')).toBe(true);
+    expect(frames.find((frame) => frame.event === 'done')).toBeDefined();
+  });
+
+  it('sanitizes ordinary JSON error responses through the same Express adapter', async () => {
+    const app = express();
+    app.use(express.json());
+    registerChatRoutes(app, { tools: [] });
+    server = app.listen(0);
+    const port = (server.address() as AddressInfo).port;
+    const response = await fetch(`http://127.0.0.1:${port}/chat/config`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ provider: 'apiKey=SENTINEL_HTTP' }),
+    });
+    const text = await response.text();
+    expect(response.status).toBe(400);
+    expect(text).not.toContain('SENTINEL_HTTP');
+    expect(text).toContain('unknown provider');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/chat/chat-server.ts
+++ b/mcp-tools/hayba-mcp/src/chat/chat-server.ts
@@ -54,6 +54,7 @@ import {
 import type { LLMTool, LLMUsage } from '../agents/llm-client.js';
 import { createChatDispatcher } from './tool-dispatch.js';
 import { getArchetype } from '../agents/agent-registry.js';
+import { installExpressJsonRedaction, redactBoundaryValue } from '../security/secret-redaction.js';
 
 // ---------------------------------------------------------------------------
 // Localhost enforcement
@@ -293,7 +294,9 @@ function writeFrame(res: Response, frame: BufferedFrame): void {
 /** Assign a seq, buffer (bounded), and fan out to every attached client. */
 function emit(session: ChatSession, event: string, data: unknown): BufferedFrame {
   session.seq += 1;
-  const frame: BufferedFrame = { seq: session.seq, event, data };
+  // Sanitize before buffering, not merely before socket write: reconnect replay,
+  // the final done frame and crash diagnostics must never retain a raw copy.
+  const frame: BufferedFrame = { seq: session.seq, event, data: redactBoundaryValue(data) };
   session.buffer.push(frame);
   if (session.buffer.length > BUFFER_LIMIT) session.buffer.shift();
   for (const client of session.clients) {
@@ -375,6 +378,10 @@ let chatRoutesRegistered = false;
 
 export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}): void {
   chatRoutesRegistered = true;
+  // `registerChatRoutes` is also used directly in tests/embedders, outside the
+  // dashboard app. Response wrapping is idempotent if the dashboard already
+  // installed the same shared middleware.
+  installExpressJsonRedaction(app, '/chat');
   const dispatchTool = options.dispatchTool ?? createChatDispatcher();
   const makeClient = options.createClient ?? createLLMClient;
   const system = options.system ?? DEFAULT_SYSTEM;
@@ -762,19 +769,23 @@ function forwardEvent(
       emit(session, 'text_delta', { text: ev.text });
       break;
     case 'tool_call':
-      session.toolTrace.push({ id: ev.call.id, name: ev.call.name, input: ev.call.input });
-      emit(session, 'tool_call', { id: ev.call.id, name: ev.call.name, input: ev.call.input });
+      {
+        const input = redactBoundaryValue(ev.call.input) as Record<string, unknown>;
+        session.toolTrace.push({ id: ev.call.id, name: ev.call.name, input });
+        emit(session, 'tool_call', { id: ev.call.id, name: ev.call.name, input });
+      }
       break;
     case 'tool_result': {
+      const result = redactBoundaryValue(ev.result);
       const entry = session.toolTrace.find((t) => t.id === ev.id);
       if (entry) {
-        entry.result = ev.result;
+        entry.result = result;
         entry.isError = ev.isError;
       }
       emit(session, 'tool_result', {
         id: ev.id,
         name: ev.name,
-        result: ev.result,
+        result,
         isError: ev.isError,
       });
       break;
@@ -784,10 +795,11 @@ function forwardEvent(
       // approval to THIS exact {name, argsHash} rather than the whole turn.
       const hash = ev.argsHash ?? argsHash(ev.call.input);
       session.pendingPlanCall = { name: ev.call.name, argsHash: hash };
+      const input = redactBoundaryValue(ev.call.input) as Record<string, unknown>;
       emit(session, 'plan_request', {
         id: ev.call.id,
         name: ev.call.name,
-        input: ev.call.input,
+        input,
         source: ev.source,
         hint: ev.hint,
         args_hash: hash,

--- a/mcp-tools/hayba-mcp/src/dag/journal.test.ts
+++ b/mcp-tools/hayba-mcp/src/dag/journal.test.ts
@@ -64,4 +64,36 @@ describe('OperationJournal', () => {
     const j = new OperationJournal(path);
     expect(j.append(sample).note).toBeNull();
   });
+
+  it('redacts secrets before disk, memory, tail, and replay while preserving useful notes', () => {
+    const j = new OperationJournal(path);
+    const input: JournalInput = {
+      ...sample,
+      actor: 'https://example.test/op?token=SENTINEL_QUERY',
+      reads: ['Bearer SENTINEL_READ_123456'],
+      note: 'Authorization: Bearer SENTINEL_NOTE_123456; recovery: rotate and retry',
+    };
+    const record = j.append(input);
+    const disk = readFileSync(path, 'utf8');
+    expect(JSON.stringify(record)).not.toContain('SENTINEL');
+    expect(disk).not.toContain('SENTINEL');
+    expect(record.note).toContain('recovery: rotate and retry');
+    expect(record.securityRedaction).toMatchObject({ applied: true });
+    expect(JSON.stringify(j.tail(1))).not.toContain('SENTINEL');
+    expect(JSON.stringify(new OperationJournal(path).all())).not.toContain('SENTINEL');
+    expect(input.note).toContain('SENTINEL_NOTE');
+  });
+
+  it('sanitizes a legacy on-disk journal before exposing or retaining it', () => {
+    const legacy = {
+      ...sample,
+      note: 'apiKey=SENTINEL_LEGACY',
+      ts: new Date(0).toISOString(),
+      seq: 1,
+    };
+    writeFileSync(path, `${JSON.stringify(legacy)}\n`, 'utf8');
+    const journal = new OperationJournal(path);
+    expect(JSON.stringify(journal.all())).not.toContain('SENTINEL_LEGACY');
+    expect(readFileSync(path, 'utf8')).not.toContain('SENTINEL_LEGACY');
+  });
 });

--- a/mcp-tools/hayba-mcp/src/dag/journal.ts
+++ b/mcp-tools/hayba-mcp/src/dag/journal.ts
@@ -5,8 +5,9 @@
 // the file is replayed to recover the last seq and the in-memory list;
 // a corrupt or truncated line is skipped, not fatal.
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { redactSecrets, type SecretRedactionSummary } from '../security/secret-redaction.js';
 
 export interface JournalInput {
   actor: string;
@@ -20,6 +21,7 @@ export interface JournalInput {
 export interface JournalRecord extends Required<JournalInput> {
   ts: string;
   seq: number;
+  securityRedaction?: SecretRedactionSummary;
 }
 
 export class OperationJournal {
@@ -33,7 +35,7 @@ export class OperationJournal {
   }
 
   append(input: JournalInput): JournalRecord {
-    const rec: JournalRecord = {
+    const raw: JournalRecord = {
       ts: new Date().toISOString(),
       seq: ++this.lastSeq,
       actor: input.actor,
@@ -43,6 +45,10 @@ export class OperationJournal {
       ok: input.ok,
       note: input.note ?? null,
     };
+    const redacted = redactSecrets(raw);
+    const rec: JournalRecord = redacted.summary.applied || redacted.summary.truncated
+      ? { ...(redacted.value as JournalRecord), securityRedaction: redacted.summary }
+      : redacted.value as JournalRecord;
     mkdirSync(dirname(this.path), { recursive: true });
     appendFileSync(this.path, JSON.stringify(rec) + '\n', 'utf8');
     this.records.push(rec);
@@ -58,17 +64,26 @@ export class OperationJournal {
   private replay(): void {
     if (!existsSync(this.path)) return;
     const lines = readFileSync(this.path, 'utf8').split('\n');
+    let sanitizedLegacyRecord = false;
     for (const line of lines) {
       const trimmed = line.trim();
       if (!trimmed) continue;
       try {
-        const rec = JSON.parse(trimmed) as JournalRecord;
-        if (typeof rec.seq !== 'number') continue;
+        const parsed = JSON.parse(trimmed) as JournalRecord;
+        if (typeof parsed.seq !== 'number') continue;
+        const redacted = redactSecrets(parsed);
+        const rec = redacted.summary.applied || redacted.summary.truncated
+          ? { ...(redacted.value as JournalRecord), securityRedaction: redacted.summary }
+          : redacted.value as JournalRecord;
+        sanitizedLegacyRecord ||= rec !== parsed;
         this.records.push(rec);
         this.lastSeq = Math.max(this.lastSeq, rec.seq);
       } catch {
         // Corrupt / truncated line — skip, keep replaying.
       }
+    }
+    if (sanitizedLegacyRecord) {
+      writeFileSync(this.path, this.records.map((record) => JSON.stringify(record)).join('\n') + '\n', 'utf8');
     }
   }
 }

--- a/mcp-tools/hayba-mcp/src/dashboard/server.ts
+++ b/mcp-tools/hayba-mcp/src/dashboard/server.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
 import { config } from '../config.js';
 import { registerApiRoutes } from './api.js';
+import { installExpressJsonRedaction } from '../security/secret-redaction.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -13,6 +14,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export async function startDashboard(port: number, host: string): Promise<void> {
   const app = express();
   app.use(express.json({ limit: '50mb' }));
+  installExpressJsonRedaction(app);
 
   // Register API routes for dashboard data
   registerApiRoutes(app);

--- a/mcp-tools/hayba-mcp/src/http/server.ts
+++ b/mcp-tools/hayba-mcp/src/http/server.ts
@@ -10,10 +10,12 @@ import express from 'express';
 import type { Server } from 'node:http';
 import type { SliverSystem } from '../slivers/index.js';
 import { mountSliverRoutes } from './sliver-routes.js';
+import { installExpressJsonRedaction } from '../security/secret-redaction.js';
 
 export function startHttpServer(slivers: SliverSystem): Server {
   const app = express();
   app.use(express.json({ limit: '1mb' }));
+  installExpressJsonRedaction(app);
 
   mountSliverRoutes(app, slivers);
 

--- a/mcp-tools/hayba-mcp/src/index.ts
+++ b/mcp-tools/hayba-mcp/src/index.ts
@@ -7,6 +7,12 @@ import { registerTools } from './tools/index.js';
 import { startDashboard } from './dashboard/server.js';
 import { startHttpServer } from './http/server.js';
 import { pingSidecar } from './tools/visual/sidecar-client.js';
+import { installConsoleSecretRedaction } from './security/secret-redaction.js';
+
+// Install before startup diagnostics, sidecar errors, dashboard logs, or an
+// unhandled rejection can reach stderr. The adapter is process-global and
+// idempotent; structured args and Error stacks use the same bounded policy.
+installConsoleSecretRedaction();
 
 // ── MCP server setup ─────────────────────────────────────────────────────────
 const server = new McpServer({

--- a/mcp-tools/hayba-mcp/src/logger.ts
+++ b/mcp-tools/hayba-mcp/src/logger.ts
@@ -1,8 +1,10 @@
 /**
  * Log a message to stderr (MCP stdio uses stdout, so logs go to stderr).
  */
+import { redactSecrets } from './security/secret-redaction.js';
+
 export function log(level: 'info' | 'warn' | 'error', message: string): void {
   const timestamp = new Date().toISOString();
-  const line = `[${timestamp}] [${level.toUpperCase()}] ${message}`;
+  const line = `[${timestamp}] [${level.toUpperCase()}] ${redactSecrets(message).value}`;
   console.error(line);
 }

--- a/mcp-tools/hayba-mcp/src/security/bootstrap-redaction.test.ts
+++ b/mcp-tools/hayba-mcp/src/security/bootstrap-redaction.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const bootstrap = readFileSync(join(packageRoot, 'src', 'bootstrap.ts'), 'utf8');
+const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as {
+  bin: Record<string, string>;
+  scripts: Record<string, string>;
+};
+
+describe('secret redaction installs before the server import graph', () => {
+  it('routes the executable and start script through the bootstrap', () => {
+    expect(manifest.bin['hayba-mcp']).toBe('./dist/bootstrap.js');
+    expect(manifest.scripts.start).toBe('node dist/bootstrap.js');
+  });
+
+  it('installs redaction before dynamically importing the application', () => {
+    const install = bootstrap.indexOf('installConsoleSecretRedaction();');
+    const start = bootstrap.indexOf("await import('./index.js')");
+    expect(install).toBeGreaterThan(0);
+    expect(start).toBeGreaterThan(install);
+    expect(bootstrap).not.toMatch(/import\s+.*from\s+['"]\.\/index\.js['"]/);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/security/secret-redaction.test.ts
+++ b/mcp-tools/hayba-mcp/src/security/secret-redaction.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  installConsoleSecretRedaction,
+  installExpressJsonRedaction,
+  redactBoundaryValue,
+  redactMcpResult,
+  redactSecrets,
+  redactThrown,
+} from './secret-redaction.js';
+
+const JWT = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZWNyZXQifQ.dGVzdHNpZ25hdHVyZQ';
+
+describe('bounded central secret redaction', () => {
+  it('masks mixed-case, snake, camel, and concatenated secret keys', () => {
+    const original = {
+      apiKey: 'SENTINEL_API',
+      ACCESS_TOKEN: 'SENTINEL_ACCESS',
+      clientSecret: 'SENTINEL_CLIENT',
+      SECRETKEY: 'SENTINEL_SECRET',
+      ApiAccessToken: 'SENTINEL_CONCAT',
+      authorization: { scheme: 'Bearer', value: 'SENTINEL_AUTH' },
+    };
+    const result = redactSecrets(original);
+    const serialized = JSON.stringify(result.value);
+    for (const sentinel of Object.values(original).filter((v): v is string => typeof v === 'string')) {
+      expect(serialized).not.toContain(sentinel);
+    }
+    expect(serialized).not.toContain('SENTINEL_AUTH');
+    expect(result.summary.categories).toEqual(expect.arrayContaining(['api_key', 'authorization', 'credential', 'token']));
+    expect(original.apiKey).toBe('SENTINEL_API');
+  });
+
+  it('preserves false-positive vocabulary and harmless token metrics', () => {
+    const safe = {
+      token_count: 42,
+      TOKENCOUNT: 43,
+      tokenizer: 'sentencepiece',
+      passwordless: true,
+      secretStatus: 'absent',
+      authorization_error: 'none',
+      credential_present: false,
+      apiKeyName: 'OPENAI_API_KEY',
+    };
+    const result = redactSecrets(safe);
+    expect(result.value).toBe(safe);
+    expect(result.summary.applied).toBe(false);
+  });
+
+  it('masks bearer, JWT, provider keys, assignments, headers, URL credentials and query secrets', () => {
+    const prose = [
+      'Authorization: Bearer SENTINEL_BEARER_123456',
+      `jwt=${JWT}`,
+      'OPENAI_API_KEY=sk-1234567890abcdefghijklmnop',
+      'X-API-Key: SENTINEL_HEADER_123456',
+      'https://user:SENTINEL_PASSWORD@example.test/path?token=SENTINEL_QUERY&safe=yes',
+    ].join('\n');
+    const result = redactSecrets(prose);
+    expect(result.value).not.toContain('SENTINEL');
+    expect(result.value).not.toContain(JWT);
+    expect(result.value).toContain('safe=yes');
+    expect(result.summary.categories).toEqual(expect.arrayContaining([
+      'bearer', 'credential', 'password', 'provider_key', 'token', 'url_query',
+    ]));
+
+    const veryLong = redactSecrets(`Bearer ${'S'.repeat(10_000)}`);
+    expect(veryLong.value).toBe('[REDACTED:bearer]');
+    expect(veryLong.value).not.toContain('SSSS');
+  });
+
+  it('accepts only exact machine markers and rescans attacker-controlled marker prefixes', () => {
+    const hostile = {
+      direct: '[REDACTED:token] Bearer SENTINEL_MARKER_BEARER_123456',
+      prefixed: 'prefix [TRUNCATED:depth] token=SENTINEL_MARKER_TOKEN',
+      apiKey: '[REDACTED:token] SENTINEL_SECRET_KEY_BYPASS',
+    };
+    const once = redactSecrets(hostile);
+    const twice = redactSecrets(once.value);
+    expect(JSON.stringify(once.value)).not.toContain('SENTINEL');
+    expect((once.value as typeof hostile).direct).toContain('[REDACTED:token]');
+    expect((once.value as typeof hostile).direct).toContain('[REDACTED:bearer]');
+    expect((once.value as typeof hostile).apiKey).toBe('[REDACTED:api_key]');
+    expect(twice.value).toBe(once.value);
+  });
+
+  it('replaces secret-bearing property names with collision-safe deterministic placeholders', () => {
+    const providerKey = 'sk-1234567890abcdefghijklmnop';
+    const queryKey = 'https://example.test/callback?token=SENTINEL_KEY_QUERY';
+    const bearerKey = 'Authorization: Bearer SENTINEL_KEY_BEARER_123456';
+    const hostile = JSON.parse(JSON.stringify({
+      [providerKey]: 1,
+      [queryKey]: 2,
+      [bearerKey]: 3,
+      _redacted_key_provider_key_0: 'collision remains safe',
+      __proto__: 'safe prototype spelling',
+      token_count: 4,
+    }));
+    Object.defineProperty(hostile, '__proto__', {
+      enumerable: true,
+      configurable: true,
+      writable: true,
+      value: 'safe prototype spelling',
+    });
+
+    const first = redactSecrets(hostile);
+    const second = redactSecrets(hostile);
+    const serialized = JSON.stringify(first.value);
+    expect(serialized).not.toContain(providerKey);
+    expect(serialized).not.toContain('SENTINEL_KEY');
+    expect(Object.keys(first.value)).toEqual(Object.keys(second.value));
+    expect(Object.keys(first.value)).toEqual(expect.arrayContaining([
+      '_redacted_key_provider_key_0_1',
+      '_redacted_key_url_query_1',
+      '_redacted_key_bearer_2',
+      '_redacted_key_provider_key_0',
+      '__proto__',
+      'token_count',
+    ]));
+    expect(first.summary.categories).toEqual(expect.arrayContaining(['bearer', 'provider_key', 'url_query']));
+    expect(Object.prototype.hasOwnProperty.call(first.value, '__proto__')).toBe(true);
+  });
+
+  it('masks private-key blocks without deleting surrounding recovery text', () => {
+    const text = 'Recovery: rotate this key\n-----BEGIN PRIVATE KEY-----\nSENTINEL_PRIVATE\n-----END PRIVATE KEY-----\nThen retry safely.';
+    const result = redactSecrets(text);
+    expect(result.value).not.toContain('SENTINEL_PRIVATE');
+    expect(result.value).toContain('Recovery: rotate this key');
+    expect(result.value).toContain('Then retry safely.');
+  });
+
+  it('handles prototype keys without prototype pollution', () => {
+    const hostile = JSON.parse('{"__proto__":{"apiKey":"SENTINEL_PROTO"},"constructor":{"token":"SENTINEL_CTOR"},"prototype":{"password":"SENTINEL_PASS"}}');
+    const result = redactSecrets(hostile);
+    expect(JSON.stringify(result.value)).not.toContain('SENTINEL');
+    expect(Object.prototype).not.toHaveProperty('apiKey');
+    expect(Object.prototype.hasOwnProperty.call(result.value, '__proto__')).toBe(true);
+  });
+
+  it('never invokes hostile getters and fails closed on proxy traversal traps', () => {
+    const getter = vi.fn(() => { throw new Error('SENTINEL_GETTER_EXCEPTION'); });
+    const hostile: Record<string, unknown> = { safe: 'preserved' };
+    Object.defineProperty(hostile, 'apiKey', { enumerable: true, get: getter });
+    const getterResult = redactSecrets(hostile);
+    expect(getter).not.toHaveBeenCalled();
+    expect(JSON.stringify(getterResult.value)).not.toContain('SENTINEL');
+    expect((getterResult.value as Record<string, unknown>).apiKey).toBe('[REDACTED:api_key]');
+
+    const proxy = new Proxy({}, {
+      ownKeys() { throw new Error('SENTINEL_PROXY_EXCEPTION'); },
+    });
+    const proxyResult = redactSecrets(proxy);
+    expect(proxyResult.value).toBe('[TRUNCATED:accessor]');
+    expect(proxyResult.summary.truncation_reasons).toContain('accessor');
+  });
+
+  it('fails closed on cycles, depth, node, array, object-key, and text budgets', () => {
+    const cycle: Record<string, unknown> = { safe: true };
+    cycle.self = cycle;
+    const result = redactSecrets({
+      cycle,
+      deep: { a: { b: { c: { apiKey: 'SENTINEL_DEEP' } } } },
+      array: Array.from({ length: 20 }, (_, i) => i),
+      object: Object.fromEntries(Array.from({ length: 20 }, (_, i) => [`k${i}`, i])),
+      prose: 'x'.repeat(200),
+    }, {
+      maxDepth: 3,
+      maxNodes: 50,
+      maxArrayItems: 4,
+      maxObjectKeys: 6,
+      maxKeyChars: 20,
+      maxStringChars: 32,
+      maxTotalStringChars: 64,
+    });
+    expect(() => JSON.stringify(result.value)).not.toThrow();
+    expect(result.summary.truncated).toBe(true);
+    expect(result.summary.truncation_reasons).toEqual(expect.arrayContaining(['array_items', 'cycle', 'depth', 'object_keys', 'string_chars']));
+    expect(JSON.stringify(result.value)).not.toContain('SENTINEL_DEEP');
+  });
+
+  it('exposes truncation as a machine fact at object and array boundaries', () => {
+    const object = redactBoundaryValue({ prose: 'x'.repeat(70_000) }) as Record<string, unknown>;
+    expect(object._security_redaction).toMatchObject({ truncated: true });
+    const array = redactBoundaryValue(Array.from({ length: 300 }, (_, i) => i)) as unknown[];
+    expect(array.at(-1)).toMatchObject({ _security_redaction: { truncated: true } });
+    expect(array.length).toBeLessThanOrEqual(256);
+  });
+
+  it('prioritizes errors and mandatory recovery when an object exceeds its key budget', () => {
+    const payload = {
+      ...Object.fromEntries(Array.from({ length: 300 }, (_, i) => [`filler_${i}`, i])),
+      error: 'A bounded but useful error',
+      mandatory_recovery: 'Reconnect and retry with the same key.',
+    };
+    const result = redactSecrets(payload, { maxObjectKeys: 8 });
+    expect(result.value).toMatchObject({
+      error: 'A bounded but useful error',
+      mandatory_recovery: 'Reconnect and retry with the same key.',
+    });
+    expect(result.summary.truncated).toBe(true);
+  });
+
+  it('preserves binary, base64, and image/audio content unless the key itself is secret', () => {
+    const binary = Buffer.from('Bearer SENTINEL_BINARY');
+    const payload = {
+      png_base64: 'Bearer SENTINEL_BASE64',
+      artifact_path: '/Saved/SENTINEL_ARTIFACT.png',
+      image: { type: 'image', data: 'Bearer SENTINEL_IMAGE_DATA', mimeType: 'image/png' },
+      binary,
+      secret_base64: 'SENTINEL_SECRET_BASE64',
+    };
+    const result = redactSecrets(payload);
+    expect((result.value as typeof payload).png_base64).toBe(payload.png_base64);
+    expect((result.value as typeof payload).artifact_path).toBe(payload.artifact_path);
+    expect((result.value as typeof payload).image.data).toBe(payload.image.data);
+    expect((result.value as typeof payload).binary).toBe(binary);
+    expect(JSON.stringify(result.value)).not.toContain('SENTINEL_SECRET_BASE64');
+  });
+
+  it('redacts nested JSON text in MCP content, annotates `_meta`, and is idempotent', () => {
+    const original = {
+      content: [{ type: 'text', text: JSON.stringify({ error: 'apiKey=SENTINEL_MCP', mandatory_recovery: 'rotate and retry' }) }],
+      isError: true,
+    };
+    const once = redactMcpResult(original) as typeof original & { _meta?: Record<string, unknown> };
+    const twice = redactMcpResult(once);
+    expect(JSON.stringify(once)).not.toContain('SENTINEL_MCP');
+    expect(JSON.stringify(once)).toContain('mandatory_recovery');
+    expect(once._meta?.['hayba/security_redaction']).toMatchObject({ applied: true });
+    expect(twice).toBe(once);
+    expect(original.content[0]!.text).toContain('SENTINEL_MCP');
+  });
+
+  it('keeps a safe payload byte-for-byte and reference-identical', () => {
+    const safe = { ok: true, token_count: 7, warnings: ['Nothing sensitive'], nested: { value: 4 } };
+    const result = redactSecrets(safe);
+    expect(result.value).toBe(safe);
+    expect(JSON.stringify(result.value)).toBe(JSON.stringify(safe));
+    expect(result.summary).toMatchObject({ applied: false, truncated: false });
+  });
+
+  it('bounds hostile prose before regex matching', () => {
+    const hostile = `${'a'.repeat(1_000_000)} Authorization: Bearer SENTINEL_TOO_LATE`;
+    const started = performance.now();
+    const result = redactSecrets(hostile, { maxStringChars: 2_048, maxTotalStringChars: 2_048 });
+    expect(result.value.length).toBeLessThan(2_100);
+    expect(result.summary.truncated).toBe(true);
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it('redacts thrown Error messages, stacks, and enumerable detail without mutating the source', () => {
+    const error = Object.assign(new Error('Authorization: Bearer SENTINEL_ERROR_12345'), {
+      detail: { apiKey: 'SENTINEL_DETAIL' },
+    });
+    const safe = redactThrown(error) as Error & { detail: unknown };
+    expect(JSON.stringify({ message: safe.message, stack: safe.stack, detail: safe.detail })).not.toContain('SENTINEL');
+    expect(error.message).toContain('SENTINEL_ERROR');
+
+    const detailOnly = Object.assign(new Error('safe outer message'), {
+      detail: { accessToken: 'SENTINEL_DETAIL_ONLY' },
+    });
+    const safeDetailOnly = redactThrown(detailOnly) as Error & { detail: unknown };
+    expect(JSON.stringify(safeDetailOnly.detail)).not.toContain('SENTINEL_DETAIL_ONLY');
+    expect(safeDetailOnly.message).toBe('safe outer message');
+
+    const caused = new Error('outer', { cause: new Error('token=SENTINEL_CAUSE') });
+    const safeCaused = redactThrown(caused) as Error;
+    expect(String((safeCaused.cause as Error).message)).not.toContain('SENTINEL_CAUSE');
+
+    const detailGetter = vi.fn(() => { throw new Error('SENTINEL_ERROR_GETTER'); });
+    const hostile = new Error('safe message');
+    Object.defineProperty(hostile, 'detail', { enumerable: true, get: detailGetter });
+    const safeHostile = redactThrown(hostile) as Error & { detail: unknown };
+    expect(detailGetter).not.toHaveBeenCalled();
+    expect(safeHostile.detail).toBe('[TRUNCATED:accessor]');
+  });
+
+  it('console installation is exactly once and sanitizes structured arguments', () => {
+    const original = console.error;
+    const sink = vi.fn();
+    console.error = sink;
+    try {
+      installConsoleSecretRedaction();
+      const wrapped = console.error;
+      installConsoleSecretRedaction();
+      expect(console.error).toBe(wrapped);
+      console.error('apiKey=SENTINEL_LOG', { authorization: 'SENTINEL_STRUCTURED' });
+      expect(JSON.stringify(sink.mock.calls)).not.toContain('SENTINEL');
+    } finally {
+      console.error = original;
+    }
+  });
+
+  it('wraps overlapping Express JSON middleware exactly once', () => {
+    const middleware: Array<(req: unknown, res: unknown, next: () => void) => void> = [];
+    const app = {
+      use: vi.fn((...args: unknown[]) => {
+        middleware.push(args.at(-1) as (req: unknown, res: unknown, next: () => void) => void);
+      }),
+    };
+    installExpressJsonRedaction(app as never);
+    installExpressJsonRedaction(app as never, '/chat');
+    const sink = vi.fn((body: unknown) => body);
+    const response = { json: sink };
+    middleware[0]!({}, response, () => {});
+    const once = response.json;
+    middleware[1]!({}, response, () => {});
+    expect(response.json).toBe(once);
+    response.json({ apiKey: 'SENTINEL_EXPRESS' });
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(sink.mock.calls)).not.toContain('SENTINEL_EXPRESS');
+  });
+});

--- a/mcp-tools/hayba-mcp/src/security/secret-redaction.ts
+++ b/mcp-tools/hayba-mcp/src/security/secret-redaction.ts
@@ -1,0 +1,582 @@
+import type { Express, NextFunction, Request, Response } from 'express';
+
+export type SecretCategory =
+  | 'api_key'
+  | 'authorization'
+  | 'bearer'
+  | 'credential'
+  | 'password'
+  | 'private_key'
+  | 'provider_key'
+  | 'token'
+  | 'url_query';
+
+export type TruncationReason =
+  | 'accessor'
+  | 'array_items'
+  | 'cycle'
+  | 'depth'
+  | 'nodes'
+  | 'object_keys'
+  | 'string_chars'
+  | 'total_string_chars';
+
+const SECRET_CATEGORIES: readonly SecretCategory[] = [
+  'api_key',
+  'authorization',
+  'bearer',
+  'credential',
+  'password',
+  'private_key',
+  'provider_key',
+  'token',
+  'url_query',
+];
+
+const TRUNCATION_REASONS: readonly TruncationReason[] = [
+  'accessor',
+  'array_items',
+  'cycle',
+  'depth',
+  'nodes',
+  'object_keys',
+  'string_chars',
+  'total_string_chars',
+];
+
+export interface SecretRedactionSummary {
+  applied: boolean;
+  redacted_values: number;
+  categories: SecretCategory[];
+  truncated: boolean;
+  truncation_reasons: TruncationReason[];
+}
+
+export interface SecretRedactionResult<T> {
+  value: T;
+  summary: SecretRedactionSummary;
+}
+
+export interface SecretRedactionOptions {
+  maxDepth?: number;
+  maxNodes?: number;
+  maxArrayItems?: number;
+  maxObjectKeys?: number;
+  maxKeyChars?: number;
+  maxStringChars?: number;
+  maxTotalStringChars?: number;
+}
+
+const DEFAULTS: Required<SecretRedactionOptions> = {
+  maxDepth: 16,
+  maxNodes: 10_000,
+  maxArrayItems: 256,
+  maxObjectKeys: 256,
+  maxKeyChars: 256,
+  maxStringChars: 64 * 1_024,
+  maxTotalStringChars: 1 * 1_024 * 1_024,
+};
+
+const REDACTED_PREFIX = '[REDACTED:';
+const TRUNCATED_PREFIX = '[TRUNCATED:';
+const SECURITY_META_KEY = 'hayba/security_redaction';
+const CONSOLE_INSTALLED = Symbol.for('hayba.consoleSecretRedactionInstalled');
+const JSON_WRAPPED_RESPONSES = new WeakSet<object>();
+
+const MEASUREMENT_HEADS = new Set([
+  'age', 'algorithm', 'allowed', 'at', 'budget', 'count', 'date', 'depth',
+  'disabled', 'duration', 'enabled', 'error', 'expired', 'format', 'found',
+  'id', 'index', 'kind', 'label', 'last4', 'length', 'limit', 'max', 'message',
+  'min', 'missing', 'mode', 'name', 'offset', 'order', 'policy', 'position',
+  'present', 'reason', 'remaining', 'required', 'rule', 'scheme', 'size',
+  'source', 'state', 'status', 'supported', 'time', 'timestamp', 'total',
+  'ttl', 'type', 'used', 'valid', 'version',
+]);
+
+const SECRET_COMPOUNDS: ReadonlyArray<[string, SecretCategory]> = [
+  ['authorization', 'authorization'],
+  ['proxyauthorization', 'authorization'],
+  ['privatekey', 'private_key'],
+  ['signingkey', 'private_key'],
+  ['clientsecret', 'credential'],
+  ['webhooksecret', 'credential'],
+  ['accesskey', 'credential'],
+  ['apikey', 'api_key'],
+  ['accesstoken', 'token'],
+  ['refreshtoken', 'token'],
+  ['authtoken', 'token'],
+  ['bearertoken', 'token'],
+  ['password', 'password'],
+  ['passwd', 'password'],
+  ['pwd', 'password'],
+  ['credential', 'credential'],
+  ['secretkey', 'credential'],
+  ['token', 'token'],
+  ['secret', 'credential'],
+];
+
+// Every pattern runs only after the input string is bounded. None contains a
+// nested quantifier or an unbounded alternation over attacker-controlled text.
+const BEARER = /\bBearer[ \t]+[A-Za-z0-9._~+\/=:-]+/gi;
+const JWT = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;
+const PROVIDER_KEY = /\b(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{20,}|AIza[A-Za-z0-9_-]{30,}|AKIA[A-Z0-9]{16})\b/g;
+const URL_SECRET = /([?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|token|client[_-]?secret|signature|sig|x-amz-signature|x-amz-credential)=)([^&#\s]+)/gi;
+const URL_USERINFO = /(\bhttps?:\/\/[^\s\/@:]+:)([^\s\/@]+)(@)/gi;
+const ASSIGNMENT = /((?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|auth[_ -]?token|client[_ -]?secret|private[_ -]?key|password|passwd|pwd|token|secret|authorization|credential|x-api-key|cookie|set-cookie)["']?\s*[:=]\s*["']?)([^"'&,;\s}\]]+)/gi;
+
+interface WalkState {
+  options: Required<SecretRedactionOptions>;
+  nodes: number;
+  stringChars: number;
+  active: WeakSet<object>;
+  categories: Set<SecretCategory>;
+  truncationReasons: Set<TruncationReason>;
+  redactedValues: number;
+}
+
+interface WalkResult<T> {
+  value: T;
+  changed: boolean;
+}
+
+/** Non-mutating, bounded, cycle-safe redaction of an arbitrary response value. */
+export function redactSecrets<T>(value: T, options: SecretRedactionOptions = {}): SecretRedactionResult<T> {
+  const bounded = validateOptions({ ...DEFAULTS, ...options });
+  const state: WalkState = {
+    options: bounded,
+    nodes: 0,
+    stringChars: 0,
+    active: new WeakSet(),
+    categories: new Set(),
+    truncationReasons: new Set(),
+    redactedValues: 0,
+  };
+  const walked = walk(value, state, 0, false);
+  return {
+    value: walked.value,
+    summary: summaryOf(state),
+  };
+}
+
+/** Add a serializable machine fact when redaction/truncation changed a boundary value. */
+export function redactBoundaryValue<T>(value: T): T {
+  const result = redactSecrets(value);
+  if (!result.summary.applied && !result.summary.truncated) return result.value;
+  return attachObjectFact(result.value, '_security_redaction', result.summary);
+}
+
+/** MCP-specific form uses `_meta`, leaving content/errors/recovery in place. */
+export function redactMcpResult<T>(value: T): T {
+  const result = redactSecrets(value);
+  if (!result.summary.applied && !result.summary.truncated) return result.value;
+  if (!isRecord(result.value) || Array.isArray(result.value)) return result.value;
+  const currentMeta = isRecord(result.value._meta) ? result.value._meta : {};
+  return cloneWithProperty(result.value, '_meta', cloneWithProperty(currentMeta, SECURITY_META_KEY, result.summary)) as T;
+}
+
+/** Preserve Error type while ensuring SDK error serialization and stacks are safe. */
+export function redactThrown(error: unknown): unknown {
+  try {
+    return redactThrownInner(error, new WeakSet());
+  } catch {
+    return new Error(`${TRUNCATED_PREFIX}accessor]`);
+  }
+}
+
+function redactThrownInner(error: unknown, active: WeakSet<object>): unknown {
+  if (!(error instanceof Error)) return redactBoundaryValue(error);
+  if (active.has(error)) return `${TRUNCATED_PREFIX}cycle]`;
+  active.add(error);
+  const message = redactSecrets(error.message).value;
+  const stack = typeof error.stack === 'string' ? redactSecrets(error.stack).value : undefined;
+  const causeDescriptor = Object.getOwnPropertyDescriptor(error, 'cause');
+  const causeWasAccessor = !!causeDescriptor && !('value' in causeDescriptor);
+  const rawCause = causeDescriptor && 'value' in causeDescriptor ? causeDescriptor.value : undefined;
+  const cause = causeWasAccessor
+    ? `${TRUNCATED_PREFIX}accessor]`
+    : rawCause === undefined ? undefined : redactThrownInner(rawCause, active);
+  const details = Object.keys(error).map((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(error, key);
+    const hasValue = !!descriptor && 'value' in descriptor;
+    const wasAccessor = !hasValue;
+    const raw = hasValue ? descriptor.value : `${TRUNCATED_PREFIX}accessor]`;
+    return [key, raw, redactBoundaryValue(raw), wasAccessor] as const;
+  });
+  const detailsChanged = details.some(([, raw, safe, wasAccessor]) => wasAccessor || safe !== raw);
+  if (message === error.message && stack === error.stack && !causeWasAccessor && cause === rawCause && !detailsChanged) {
+    active.delete(error);
+    return error;
+  }
+  const safe = new Error(message, cause === undefined ? undefined : { cause });
+  safe.name = error.name;
+  if (stack) safe.stack = stack;
+  for (const [key, , detail] of details) {
+    Object.defineProperty(safe, key, {
+      enumerable: true,
+      configurable: true,
+      writable: true,
+      value: detail,
+    });
+  }
+  active.delete(error);
+  return safe;
+}
+
+/** Install once at process startup so dynamic stderr arguments cannot bypass policy. */
+export function installConsoleSecretRedaction(): void {
+  const tagged = console as Console & { [CONSOLE_INSTALLED]?: boolean };
+  if (tagged[CONSOLE_INSTALLED]) return;
+  for (const level of ['debug', 'error', 'info', 'log', 'warn'] as const) {
+    const original = console[level].bind(console);
+    console[level] = ((...args: unknown[]) => original(...args.map(redactThrown))) as typeof console[typeof level];
+  }
+  Object.defineProperty(tagged, CONSOLE_INSTALLED, { value: true, enumerable: false });
+}
+
+/** Wrap Express `res.json` once; safe for overlapping app- and route middleware. */
+export function installExpressJsonRedaction(app: Express, path?: string): void {
+  // Some in-process capability probes pass a registration-only stand-in with
+  // `get`/`post` but no middleware stack. It cannot emit HTTP by itself, so
+  // there is no response boundary to wrap.
+  if (typeof (app as { use?: unknown }).use !== 'function') return;
+  const middleware = (_req: Request, res: Response, next: NextFunction): void => {
+    if (!JSON_WRAPPED_RESPONSES.has(res)) {
+      const original = res.json.bind(res);
+      res.json = ((body?: unknown) => original(redactBoundaryValue(body))) as Response['json'];
+      JSON_WRAPPED_RESPONSES.add(res);
+    }
+    next();
+  };
+  if (path) app.use(path, middleware);
+  else app.use(middleware);
+}
+
+function walk<T>(value: T, state: WalkState, depth: number, opaque: boolean): WalkResult<T> {
+  state.nodes += 1;
+  if (state.nodes > state.options.maxNodes) return truncated(state, 'nodes') as WalkResult<T>;
+  if (depth > state.options.maxDepth) return truncated(state, 'depth') as WalkResult<T>;
+
+  if (typeof value === 'string') {
+    return walkString(value, state, opaque) as WalkResult<T>;
+  }
+  if (value === null || typeof value !== 'object') return { value, changed: false };
+  if (Buffer.isBuffer(value) || ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    return { value, changed: false };
+  }
+  if (state.active.has(value)) return truncated(state, 'cycle') as WalkResult<T>;
+
+  state.active.add(value);
+  try {
+    if (Array.isArray(value)) return walkArray(value, state, depth) as WalkResult<T>;
+    try {
+      return walkObject(value as Record<string, unknown>, state, depth) as WalkResult<T>;
+    } catch {
+      // Proxies can throw from ownKeys/getOwnPropertyDescriptor. Returning the
+      // subtree unread would bypass redaction; fail closed without echoing the
+      // hostile exception text.
+      return truncated(state, 'accessor') as WalkResult<T>;
+    }
+  } finally {
+    state.active.delete(value);
+  }
+}
+
+function walkArray(value: unknown[], state: WalkState, depth: number): WalkResult<unknown[]> {
+  const limit = Math.min(value.length, state.options.maxArrayItems);
+  let changed = value.length > limit;
+  if (changed) state.truncationReasons.add('array_items');
+  const output: unknown[] = [];
+  for (let i = 0; i < limit; i += 1) {
+    const next = walk(value[i], state, depth + 1, false);
+    output.push(next.value);
+    changed ||= next.changed;
+  }
+  return changed ? { value: output, changed: true } : { value, changed: false };
+}
+
+function walkObject(value: Record<string, unknown>, state: WalkState, depth: number): WalkResult<Record<string, unknown>> {
+  const entries: Array<[string, unknown]> = [];
+  for (const key of Object.keys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor && 'value' in descriptor) entries.push([key, descriptor.value]);
+    else {
+      entries.push([key, `${TRUNCATED_PREFIX}accessor]`]);
+      state.truncationReasons.add('accessor');
+    }
+  }
+  const limit = Math.min(entries.length, state.options.maxObjectKeys);
+  let changed = entries.length > limit;
+  if (changed) state.truncationReasons.add('object_keys');
+  const output: Record<string, unknown> = {};
+  const selected = selectObjectEntries(entries, limit);
+  const reservedKeys = new Set(entries.map(([key]) => key));
+  const emittedKeys = new Set<string>();
+
+  for (let i = 0; i < selected.length; i += 1) {
+    const [rawKey, rawValue] = selected[i]!;
+    const category = secretCategoryForKey(rawKey);
+    let key = rawKey;
+    const keySecret = inspectPropertyKey(rawKey, state);
+    if (keySecret) {
+      key = uniquePropertyPlaceholder(`_redacted_key_${keySecret}_${i}`, reservedKeys, emittedKeys);
+      changed = true;
+    } else if (rawKey.length > state.options.maxKeyChars) {
+      key = uniquePropertyPlaceholder(`_truncated_key_${i}`, reservedKeys, emittedKeys);
+      state.truncationReasons.add('object_keys');
+      changed = true;
+    }
+
+    let next: WalkResult<unknown>;
+    if (category && !isRedactedMarker(rawValue)) {
+      state.categories.add(category);
+      state.redactedValues += 1;
+      next = { value: marker(category), changed: true };
+    } else {
+      next = walk(rawValue, state, depth + 1, isOpaquePayload(rawKey, value));
+    }
+    defineSafe(output, key, next.value);
+    emittedKeys.add(key);
+    changed ||= next.changed || key !== rawKey;
+  }
+  return changed ? { value: output, changed: true } : { value, changed: false };
+}
+
+function selectObjectEntries(entries: Array<[string, unknown]>, limit: number): Array<[string, unknown]> {
+  if (entries.length <= limit) return entries;
+  const chosen = new Set<number>();
+  for (let i = 0; i < entries.length && chosen.size < limit; i += 1) {
+    if (isMandatoryOutputKey(entries[i]![0])) chosen.add(i);
+  }
+  for (let i = 0; i < entries.length && chosen.size < limit; i += 1) chosen.add(i);
+  return [...chosen].sort((a, b) => a - b).map((index) => entries[index]!);
+}
+
+function isMandatoryOutputKey(key: string): boolean {
+  const normalized = key.replace(/[^A-Za-z0-9]/g, '').toLowerCase();
+  return normalized === 'error'
+    || normalized === 'errors'
+    || normalized === 'mandatoryrecovery'
+    || normalized === 'recovery'
+    || normalized === 'recoveryaction'
+    || normalized === 'recoveryactions';
+}
+
+function walkString(value: string, state: WalkState, opaque: boolean): WalkResult<string> {
+  if (isRedactedMarker(value) || isTruncationMarker(value)) return { value, changed: false };
+  // Binary/base64 payloads retain exact bytes; transport response limits remain
+  // their allocation boundary. Secret-named keys are masked before this point.
+  if (opaque) return { value, changed: false };
+
+  let text = value;
+  let changed = false;
+  const remaining = Math.max(0, state.options.maxTotalStringChars - state.stringChars);
+  const allowed = Math.min(state.options.maxStringChars, remaining);
+  if (text.length > allowed) {
+    text = `${text.slice(0, Math.max(0, allowed))}${TRUNCATED_PREFIX}string_chars]`;
+    state.truncationReasons.add(remaining < state.options.maxStringChars ? 'total_string_chars' : 'string_chars');
+    changed = true;
+  }
+  state.stringChars += Math.min(text.length, allowed);
+
+  const privateKey = redactPrivateKeyBlocks(text, state);
+  text = privateKey.value;
+  changed ||= privateKey.changed;
+  ({ text, changed } = replaceSecrets(text, BEARER, 'bearer', changed, state));
+  ({ text, changed } = replaceSecrets(text, JWT, 'token', changed, state));
+  ({ text, changed } = replaceSecrets(text, PROVIDER_KEY, 'provider_key', changed, state));
+  ({ text, changed } = replaceMiddleGroup(text, URL_USERINFO, 'password', changed, state));
+  ({ text, changed } = replaceValueGroup(text, URL_SECRET, 'url_query', changed, state));
+  ({ text, changed } = replaceValueGroup(text, ASSIGNMENT, 'credential', changed, state));
+  return changed ? { value: text, changed: true } : { value, changed: false };
+}
+
+function replaceMiddleGroup(
+  input: string,
+  pattern: RegExp,
+  category: SecretCategory,
+  changed: boolean,
+  state: WalkState,
+): { text: string; changed: boolean } {
+  const text = input.replace(pattern, (match, prefix: string, raw: string, suffix: string) => {
+    if (isRedactedMarker(raw)) return match;
+    state.categories.add(category);
+    state.redactedValues += 1;
+    return `${prefix}${marker(category)}${suffix}`;
+  });
+  return { text, changed: changed || text !== input };
+}
+
+function replaceSecrets(
+  input: string,
+  pattern: RegExp,
+  category: SecretCategory,
+  changed: boolean,
+  state: WalkState,
+): { text: string; changed: boolean } {
+  const text = input.replace(pattern, (match) => {
+    if (isRedactedMarker(match)) return match;
+    state.categories.add(category);
+    state.redactedValues += 1;
+    return marker(category);
+  });
+  return { text, changed: changed || text !== input };
+}
+
+function replaceValueGroup(
+  input: string,
+  pattern: RegExp,
+  category: SecretCategory,
+  changed: boolean,
+  state: WalkState,
+): { text: string; changed: boolean } {
+  const text = input.replace(pattern, (match, prefix: string, raw: string) => {
+    // Assignment values stop before a JSON/object closing bracket. A marker
+    // therefore arrives here without its own final `]`; recognizing precisely
+    // that complete adjacent marker keeps a second pass idempotent without
+    // blessing attacker-controlled marker prefixes.
+    if (isRedactedMarker(raw) || isRedactedMarker(`${raw}]`)) return match;
+    state.categories.add(category);
+    state.redactedValues += 1;
+    return `${prefix}${marker(category)}`;
+  });
+  return { text, changed: changed || text !== input };
+}
+
+function redactPrivateKeyBlocks(input: string, state: WalkState): { value: string; changed: boolean } {
+  const terminal = 'PRIVATE KEY-----';
+  let output = '';
+  let cursor = 0;
+  let changed = false;
+  while (cursor < input.length) {
+    const begin = input.indexOf('-----BEGIN ', cursor);
+    if (begin < 0) { output += input.slice(cursor); break; }
+    const headerEnd = input.indexOf(terminal, begin);
+    if (headerEnd < 0 || headerEnd - begin > 80) { output += input.slice(cursor, begin + 11); cursor = begin + 11; continue; }
+    const end = input.indexOf(terminal, headerEnd + terminal.length);
+    if (end < 0) { output += input.slice(cursor, begin); output += marker('private_key'); cursor = input.length; }
+    else { output += input.slice(cursor, begin); output += marker('private_key'); cursor = end + terminal.length; }
+    state.categories.add('private_key');
+    state.redactedValues += 1;
+    changed = true;
+  }
+  return { value: changed ? output : input, changed };
+}
+
+function secretCategoryForKey(key: string): SecretCategory | undefined {
+  const bounded = key.length > 1_024 ? `${key.slice(0, 512)}${key.slice(-512)}` : key;
+  const words = bounded
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((word) => word.toLowerCase());
+  const last = words.at(-1);
+  if (last && MEASUREMENT_HEADS.has(last)) return undefined;
+  const normalized = words.join('');
+  if ([...MEASUREMENT_HEADS].some((head) => normalized !== head && normalized.endsWith(head))) return undefined;
+  const candidates = new Set<string>([normalized, ...words]);
+  for (let i = 0; i < words.length; i += 1) {
+    candidates.add(`${words[i] ?? ''}${words[i + 1] ?? ''}`);
+    candidates.add(`${words[i] ?? ''}${words[i + 1] ?? ''}${words[i + 2] ?? ''}`);
+  }
+  for (const [compound, category] of SECRET_COMPOUNDS) {
+    if (candidates.has(compound) || normalized.endsWith(compound)) return category;
+  }
+  return undefined;
+}
+
+function isOpaquePayload(key: string, owner: Record<string, unknown>): boolean {
+  const normalized = key.replace(/[^A-Za-z0-9]/g, '').toLowerCase();
+  if (normalized.includes('base64') || normalized.endsWith('binary') || normalized.endsWith('bytes')) return true;
+  const type = String(owner.type ?? '').toLowerCase();
+  return normalized === 'data' && (type === 'image' || type === 'audio' || type === 'blob');
+}
+
+function marker(category: SecretCategory): string { return `${REDACTED_PREFIX}${category}]`; }
+function isRedactedMarker(value: unknown): boolean {
+  return typeof value === 'string'
+    && SECRET_CATEGORIES.some((category) => value === marker(category));
+}
+function isTruncationMarker(value: string): boolean {
+  return TRUNCATION_REASONS.some((reason) => value === `${TRUNCATED_PREFIX}${reason}]`);
+}
+
+/**
+ * Property names are serialized just like values. Scan only the bounded key
+ * itself, then replace a sensitive name wholesale so no substring of it can
+ * escape in a partially-redacted key. The parent summary absorbs the local
+ * categories/counts, but not the local string truncation: overlong keys have a
+ * dedicated object-key machine fact below.
+ */
+function inspectPropertyKey(rawKey: string, state: WalkState): SecretCategory | undefined {
+  const boundedKey = rawKey.slice(0, state.options.maxKeyChars);
+  const result = redactSecrets(boundedKey, {
+    maxDepth: 1,
+    maxNodes: 2,
+    maxArrayItems: 1,
+    maxObjectKeys: 1,
+    maxKeyChars: state.options.maxKeyChars,
+    maxStringChars: state.options.maxKeyChars,
+    maxTotalStringChars: state.options.maxKeyChars,
+  });
+  if (!result.summary.applied) return undefined;
+  for (const category of result.summary.categories) state.categories.add(category);
+  state.redactedValues += result.summary.redacted_values;
+  return result.summary.categories[0] ?? 'credential';
+}
+
+function uniquePropertyPlaceholder(base: string, reserved: Set<string>, emitted: Set<string>): string {
+  let candidate = base;
+  let suffix = 1;
+  while (reserved.has(candidate) || emitted.has(candidate)) {
+    candidate = `${base}_${suffix}`;
+    suffix += 1;
+  }
+  return candidate;
+}
+
+function truncated(state: WalkState, reason: TruncationReason): WalkResult<unknown> {
+  state.truncationReasons.add(reason);
+  return { value: `${TRUNCATED_PREFIX}${reason}]`, changed: true };
+}
+
+function summaryOf(state: WalkState): SecretRedactionSummary {
+  return {
+    applied: state.redactedValues > 0,
+    redacted_values: state.redactedValues,
+    categories: [...state.categories].sort(),
+    truncated: state.truncationReasons.size > 0,
+    truncation_reasons: [...state.truncationReasons].sort(),
+  };
+}
+
+function validateOptions(options: Required<SecretRedactionOptions>): Required<SecretRedactionOptions> {
+  for (const [name, value] of Object.entries(options)) {
+    if (!Number.isSafeInteger(value) || value <= 0) throw new TypeError(`${name} must be a positive integer`);
+  }
+  return options;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function defineSafe(target: Record<string, unknown>, key: string, value: unknown): void {
+  Object.defineProperty(target, key, { value, enumerable: true, configurable: true, writable: true });
+}
+
+function cloneWithProperty(source: Record<string, unknown>, key: string, value: unknown): Record<string, unknown> {
+  const output: Record<string, unknown> = {};
+  for (const [existingKey, existingValue] of Object.entries(source)) defineSafe(output, existingKey, existingValue);
+  defineSafe(output, key, value);
+  return output;
+}
+
+function attachObjectFact<T>(value: T, key: string, summary: SecretRedactionSummary): T {
+  if (Array.isArray(value)) {
+    const output = value.slice(0, Math.max(0, DEFAULTS.maxArrayItems - 1));
+    output.push({ [key]: summary } as never);
+    return output as T;
+  }
+  if (!isRecord(value) || Buffer.isBuffer(value) || ArrayBuffer.isView(value)) return value;
+  return cloneWithProperty(value, key, summary) as T;
+}

--- a/mcp-tools/hayba-mcp/src/tools/tool-stream-mirror.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-stream-mirror.ts
@@ -7,6 +7,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ensureConnected } from '../tcp-client.js';
 import { getAdvisoryVerbosity, isToolDisabled } from './disabled-tools-watcher.js';
 import { applyAdvisoryVerbosity } from './advisory-verbosity.js';
+import { redactBoundaryValue, redactMcpResult, redactThrown } from '../security/secret-redaction.js';
 
 function preview(value: unknown, max: number): string {
   if (value == null) return '';
@@ -83,6 +84,7 @@ export function wrapToolHandlerForStream<T extends Function>(name: string, handl
   if (MIRRORED_HANDLERS.has(handler)) return handler;
 
   const wrapped = async (params: unknown, ...rest: unknown[]) => {
+    try {
       // MCP panel gate: if the user disabled this tool, short-circuit with a
       // clear status. Meta-tools (list_tool_categories / get_tool_signature)
       // are never gated themselves — they handle disabled-state internally.
@@ -104,11 +106,18 @@ export function wrapToolHandlerForStream<T extends Function>(name: string, handl
         && Array.isArray((result as { content?: unknown }).content)
         ? applyAdvisoryVerbosity(result as never, getAdvisoryVerbosity())
         : result;
+      // This is the final shared MCP boundary for native registrations and the
+      // deferred catalogue. Redact BEFORE returning and feed that same safe
+      // value to Tool Stream so the mirror cannot retain a second raw copy.
+      const boundaryResult = filteredResult && typeof filteredResult === 'object'
+        && Array.isArray((filteredResult as { content?: unknown }).content)
+        ? redactMcpResult(filteredResult)
+        : redactBoundaryValue(filteredResult);
       // Extract the text content the tool returned, when available — that's
       // what users care about in the stream. Fall back to the full object.
-      let resultForMirror: unknown = filteredResult;
-      if (filteredResult && typeof filteredResult === 'object') {
-        const r = filteredResult as { content?: Array<{ type?: string; text?: string }> };
+      let resultForMirror: unknown = boundaryResult;
+      if (boundaryResult && typeof boundaryResult === 'object') {
+        const r = boundaryResult as { content?: Array<{ type?: string; text?: string }> };
         if (Array.isArray(r.content)) {
           const text = r.content
             .filter(c => c?.type === 'text' && typeof c.text === 'string')
@@ -117,8 +126,13 @@ export function wrapToolHandlerForStream<T extends Function>(name: string, handl
           if (text) resultForMirror = text;
         }
       }
-      mirror(name, params, resultForMirror).catch(() => {});
-      return filteredResult;
+      mirror(name, redactBoundaryValue(params), resultForMirror).catch(() => {});
+      return boundaryResult;
+    } catch (error) {
+      // MCP SDKs serialize thrown messages; never let that error path bypass
+      // the same policy applied to successful tool content.
+      throw redactThrown(error);
+    }
   };
 
   MIRRORED_HANDLERS.add(wrapped);

--- a/mcp-tools/hayba-mcp/src/tools/tool-stream-redaction.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/tool-stream-redaction.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { wrapToolHandlerForStream } from './tool-stream-mirror.js';
+
+describe('MCP + Tool Stream final redaction boundary', () => {
+  it('returns one redacted MCP result without mutating the handler-owned value', async () => {
+    const owned = {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({
+          error: 'Authorization: Bearer SENTINEL_RESULT_123456',
+          mandatory_recovery: 'Rotate the credential, reconnect, and retry.',
+        }),
+      }],
+      isError: true,
+    };
+    const handler: (params: unknown) => Promise<typeof owned> = async (_params: unknown) => owned;
+    const wrapped = wrapToolHandlerForStream('secret_probe', handler);
+    const result = await wrapped({ apiKey: 'SENTINEL_PARAM' }) as typeof owned & { _meta?: unknown };
+
+    expect(JSON.stringify(result)).not.toContain('SENTINEL');
+    expect(JSON.stringify(result)).toContain('mandatory_recovery');
+    expect(result._meta).toBeDefined();
+    expect(owned.content[0]!.text).toContain('SENTINEL_RESULT');
+    expect(wrapToolHandlerForStream('secret_probe', wrapped)).toBe(wrapped);
+  });
+
+  it('redacts thrown errors while preserving useful recovery prose', async () => {
+    const handler: (params: unknown) => Promise<never> = async (_params: unknown) => {
+      throw new Error('apiKey=SENTINEL_THROW; reconnect after rotating it');
+    };
+    const wrapped = wrapToolHandlerForStream('throw_probe', handler);
+    const error = await wrapped({}).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain('SENTINEL_THROW');
+    expect((error as Error).message).toContain('reconnect after rotating it');
+  });
+});


### PR DESCRIPTION
## Outcome
- introduces one bounded, cycle-safe, non-mutating secret redactor for MCP/tool-stream, SSE/chat, HTTP JSON, journal, logger, console, and thrown-error boundaries
- recognizes mixed/camel/snake secret keys plus bearer/JWT/provider/private-key/URL/assignment text
- rejects attacker-controlled fake marker prefixes and redacts secret-bearing property names with collision-safe placeholders
- never invokes getters; hostile proxies/accessors fail closed
- preserves machine errors/recovery and opaque binary/base64 artifacts while exposing redaction/truncation facts
- adds an executable bootstrap so console redaction is installed before the server import graph evaluates

## Verification
- focused boundary: 33/33 including bootstrap
- boundary plus routing/first-install: 69/69 before bootstrap addition
- full TS suite: 1,861/1,861 before bootstrap addition
- typecheck and build:server: green after bootstrap addition
- legacy-wrapper lint and diff check: green
- three security mutations (marker prefix, truncation prefix, property-key bypass) went red and were reverted

## Acceptance boundary
Issue 383 remains open. This PR is the Node half. Direct native TCP envelopes still need the equivalent bounded redactor, followed by a real-process sentinel scan across responses, Tool Stream, SSE/HTTP, journal, stderr, and crash artifacts.

Tracks issue 383.