### PR TITLE
security: remove unreachable lru-cache dependency

### DIFF
--- a/docs/audit/2026-08-10-lru-cache-reachability.md
+++ b/docs/audit/2026-08-10-lru-cache-reachability.md
@@ -1,0 +1,33 @@
+# `lru-cache` production reachability (2026-08-10)
+
+Issue: #401
+
+## Decision
+
+Remove the direct `lru-cache` dependency from `@hayba/mcp`. The package had no
+production source consumer, so updating it would maintain install and audit
+surface without providing capability.
+
+## Evidence before removal
+
+- `git grep` found no `lru-cache` literal under
+  `mcp-tools/hayba-mcp/src/`.
+- `npm explain lru-cache --workspace @hayba/mcp` reported one edge only:
+  `@hayba/mcp@1.0.0 -> lru-cache@11.5.0` from the direct manifest range.
+- `npm ls lru-cache --omit=dev --all` reported the same single direct edge and
+  no transitive production parent.
+- The root lock contained one `node_modules/lru-cache` entry, version 11.5.0.
+
+The nested dashboard lock still contains transitive `lru-cache@5.1.1`. It is a
+different dependency graph owned by the dashboard build and is not the removed
+MCP runtime declaration.
+
+## Regression contract
+
+`production-dependency-reachability.test.ts` performs a comment-aware scan of
+non-test production source. It recognizes value imports, re-exports,
+import-equals, dynamic `import()`, `require()` and `require.resolve()`. It
+requires the direct manifest declaration and reachable runtime consumers to
+agree, so either an unused declaration or an undeclared new consumer fails the
+test. The guard is self-contained because TypeScript 7 exposes its compiler API
+only through explicitly unstable entry points.

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -28,7 +28,6 @@
     "cheerio": "^1.2.0",
     "express": "^4.21.0",
     "js-yaml": "^4.3.1",
-    "lru-cache": "^11.3.6",
     "minisearch": "^7.2.0",
     "openai": "^6.45.0",
     "youtube-transcript-api": "^3.0.6",

--- a/mcp-tools/hayba-mcp/src/tools/production-dependency-reachability.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/production-dependency-reachability.test.ts
@@ -1,0 +1,138 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const sourceRoot = resolve(here, '..');
+const packagePath = resolve(sourceRoot, '..', 'package.json');
+const target = 'lru-cache';
+
+function productionSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (entry.name !== '__tests__') files.push(...productionSourceFiles(resolve(dir, entry.name)));
+      continue;
+    }
+    if (!entry.isFile() || !/\.(?:[cm]?[jt]s)$/.test(entry.name) || /\.(?:test|spec)\./.test(entry.name)) continue;
+    files.push(resolve(dir, entry.name));
+  }
+  return files.sort();
+}
+
+/** Remove comments without deleting quote delimiters or string contents. This
+ *  keeps import specifiers available to the patterns below while preventing a
+ *  commented-out import from preserving an otherwise dead dependency. */
+function withoutComments(source: string): string {
+  let out = '';
+  let state: 'code' | 'line' | 'block' | 'single' | 'double' | 'template' = 'code';
+  for (let i = 0; i < source.length; i += 1) {
+    const char = source[i];
+    const next = source[i + 1];
+    if (state === 'line') {
+      if (char === '\n') {
+        state = 'code';
+        out += char;
+      } else {
+        out += ' ';
+      }
+      continue;
+    }
+    if (state === 'block') {
+      if (char === '*' && next === '/') {
+        out += '  ';
+        state = 'code';
+        i += 1;
+      } else {
+        out += char === '\n' ? '\n' : ' ';
+      }
+      continue;
+    }
+    if (state !== 'code') {
+      out += char;
+      if (char === '\\' && next !== undefined) {
+        out += next;
+        i += 1;
+        continue;
+      }
+      if (
+        (state === 'single' && char === "'") ||
+        (state === 'double' && char === '"') ||
+        (state === 'template' && char === '`')
+      ) {
+        state = 'code';
+      }
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      out += '  ';
+      state = 'line';
+      i += 1;
+    } else if (char === '/' && next === '*') {
+      out += '  ';
+      state = 'block';
+      i += 1;
+    } else {
+      out += char;
+      if (char === "'") state = 'single';
+      else if (char === '"') state = 'double';
+      else if (char === '`') state = 'template';
+    }
+  }
+  return out;
+}
+
+function hasRuntimeSpecifier(rawSource: string): boolean {
+  const source = withoutComments(rawSource);
+  const specifier = String.raw`["']${target}(?:\/[^"']*)?["']`;
+  return [
+    new RegExp(String.raw`\bimport\s*\(\s*${specifier}`),
+    new RegExp(String.raw`\brequire(?:\.resolve)?\s*\(\s*${specifier}`),
+    new RegExp(String.raw`\bimport\s*${specifier}`),
+    new RegExp(String.raw`\b(?:import|export)\s+(?!type\b)[^;]*?\bfrom\s*${specifier}`),
+    new RegExp(String.raw`\bimport\s+(?!type\b)[$\w]+\s*=\s*require\s*\(\s*${specifier}`),
+  ].some((pattern) => pattern.test(source));
+}
+
+function hasRuntimeImport(file: string): boolean {
+  return hasRuntimeSpecifier(readFileSync(file, 'utf8'));
+}
+
+describe('production dependency reachability', () => {
+  it.each([
+    `import { LRUCache } from 'lru-cache';`,
+    `export { LRUCache } from 'lru-cache';`,
+    `import 'lru-cache/register';`,
+    `await import('lru-cache');`,
+    `require('lru-cache');`,
+    `require.resolve('lru-cache');`,
+    `import cache = require('lru-cache');`,
+  ])('recognizes a runtime call form: %s', (source) => {
+    expect(hasRuntimeSpecifier(source)).toBe(true);
+  });
+
+  it.each([
+    `// import { LRUCache } from 'lru-cache';`,
+    `/* require('lru-cache') */`,
+    `import type { LRUCache } from 'lru-cache';`,
+    `export type { LRUCache } from 'lru-cache';`,
+    `const packageName = 'lru-cache';`,
+  ])('does not count a non-runtime reference: %s', (source) => {
+    expect(hasRuntimeSpecifier(source)).toBe(false);
+  });
+
+  it('keeps the lru-cache declaration aligned with reachable production imports', () => {
+    const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as {
+      dependencies?: Record<string, string>;
+    };
+    const runtimeConsumers = productionSourceFiles(sourceRoot)
+      .filter(hasRuntimeImport)
+      .map((file) => relative(sourceRoot, file).replaceAll('\\', '/'));
+    const declared = Object.hasOwn(packageJson.dependencies ?? {}, target);
+
+    expect(declared, `${target} manifest/runtime mismatch; consumers: ${runtimeConsumers.join(', ') || '(none)'}`).toBe(
+      runtimeConsumers.length > 0,
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "cheerio": "^1.2.0",
         "express": "^4.21.0",
         "js-yaml": "^4.3.1",
-        "lru-cache": "^11.3.6",
         "minisearch": "^7.2.0",
         "openai": "^6.45.0",
         "youtube-transcript-api": "^3.0.6",
@@ -5148,15 +5147,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
-    },
-    "node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "node_modules/m3u8stream": {
       "version": "0.8.6",


### PR DESCRIPTION
## Outcome

`lru-cache` was not runtime-reachable. Remove the unused direct production dependency instead of bumping dead code.

## Evidence

Before removal:

- tracked MCP production source contained zero `lru-cache` literals/imports;
- `npm explain lru-cache --workspace @hayba/mcp` showed exactly one edge: the direct `@hayba/mcp` declaration;
- `npm ls lru-cache --omit=dev --all` showed `@hayba/mcp -> lru-cache@11.5.0` and no transitive production parent.

After removal and a clean `npm ci --ignore-scripts`:

- root install count decreased 458 -> 457;
- `node_modules/lru-cache` is absent;
- `npm explain` reports no matching dependency;
- `npm ls --omit=dev` is empty for `lru-cache`;
- the MCP manifest and root lock contain no `lru-cache` entry.

The nested dashboard lock's unrelated transitive `lru-cache@5.1.1` is deliberately untouched.

## Changes

- remove the direct dependency and its sole root lock node;
- add a comment-aware reachability contract covering ESM imports/re-exports, dynamic import, `require`, `require.resolve`, and import-equals;
- require the manifest declaration and actual non-test production consumers to agree;
- record the graph evidence and decision in `docs/audit/`.

## Verification

- focused reachability + production-audit contracts: 29/29;
- mutation: re-adding the manifest dependency with zero consumers makes the contract fail with `manifest/runtime mismatch`;
- full MCP suite: 1,799/1,799;
- `tsc --noEmit` and compiler emit: clean;
- `npm run audit:production`: PASS, five existing reviewed paths, zero errors/warnings;
- legacy wrapper lint, focused ESLint, Prettier, and `git diff --check`: clean.

Closes #401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an unused production dependency, reducing package overhead and simplifying maintenance.
  - Added automated safeguards to keep declared production dependencies aligned with actual runtime usage.

- **Documentation**
  - Added an audit documenting dependency reachability and confirming that the removed dependency was not required by production functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->