### PR TITLE
fix(deps): migrate bounded YAML parsing to js-yaml 5

### DIFF
--- a/docs/yaml-input-policy.md
+++ b/docs/yaml-input-policy.md
@@ -1,0 +1,31 @@
+# YAML input policy
+
+Hayba parses YAML only for CLI specs and the built-in workflow-pack manifest.
+Both consumers use `src/security/bounded-yaml.ts`; adding a third direct
+`js-yaml` call would create a second policy and is intentionally unsupported.
+
+The shared policy deliberately selects js-yaml 5's YAML 1.2 `CORE_SCHEMA`.
+That means legacy YAML 1.1 booleans such as `yes` and `on` and timestamps remain
+strings. A leading-zero integer such as `012` is decimal 12 (rather than YAML
+1.1's octal 10), and YAML 1.2's explicit `0o12` is octal 10. JSON-style `true`,
+`false`, `null`, decimal numbers, arrays, and objects retain their usual types.
+
+Aliases and merge keys are not part of Hayba's configuration language. Alias
+count and total merge-key work are both limited to zero; `<<` is rejected even
+though `CORE_SCHEMA` otherwise treats it as an ordinary string key. Duplicate
+and complex mapping keys are rejected. Collection depth is capped at 32.
+
+Input is also bounded before construction:
+
+- CLI specs: 1 MiB before either the JSON or YAML parser runs
+- workflow-pack manifest: 256 KiB, checked from file metadata before reading
+
+Parser exceptions can include source excerpts. Hayba never forwards those
+excerpts: callers receive a fixed input label and, when available, line/column
+coordinates. This keeps malformed configuration diagnostics useful without
+echoing credentials or other document content.
+
+These choices intentionally differ from js-yaml 4's behavior: empty YAML now
+fails as empty input, merge inheritance is unavailable, and complex keys no
+longer stringify silently. The checked-in `packs.yaml` and existing valid CLI
+spec shapes are otherwise preserved.

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -27,7 +27,7 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "cheerio": "^1.2.0",
     "express": "^4.21.0",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "5.2.3",
     "minisearch": "^7.2.0",
     "openai": "^6.45.0",
     "youtube-transcript-api": "^3.0.6",
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^26.1.2",
     "msw": "^2.15.0",
     "typescript": "^7.0.2",

--- a/mcp-tools/hayba-mcp/src/cli/spec.test.ts
+++ b/mcp-tools/hayba-mcp/src/cli/spec.test.ts
@@ -1,5 +1,6 @@
+import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
-import { parseSpec, SpecParseError } from './spec.js';
+import { CLI_SPEC_MAX_INPUT_BYTES, parseSpec, SpecParseError } from './spec.js';
 
 describe('parseSpec', () => {
   it('parses a valid JSON spec', () => {
@@ -26,6 +27,68 @@ describe('parseSpec', () => {
     const yaml = 'steps:\n  - cmd: ping\n';
     const spec = parseSpec(yaml);
     expect(spec.steps).toEqual([{ cmd: 'ping', params: {}, name: undefined }]);
+  });
+
+  it('parses the checked-in CLI example without changing its command shape', () => {
+    const raw = readFileSync(new URL('../../examples/sample-spec.yaml', import.meta.url), 'utf8');
+    expect(parseSpec(raw, 'sample-spec.yaml')).toEqual({
+      version: 1,
+      steps: [
+        {
+          cmd: 'ping',
+          name: 'sanity check the connection before doing real work',
+          params: {},
+        },
+      ],
+    });
+  });
+
+  it('uses YAML 1.2 CORE scalar semantics in params', () => {
+    const yaml = [
+      'steps:',
+      '  - cmd: ping',
+      '    params:',
+      '      legacy_yes: yes',
+      '      legacy_on: on',
+      '      leading_zero: 012',
+      '      date: 2026-08-10',
+      '      real_bool: true',
+    ].join('\n');
+    expect(parseSpec(yaml, 'spec.yaml').steps[0].params).toEqual({
+      legacy_yes: 'yes',
+      legacy_on: 'on',
+      leading_zero: 12,
+      date: '2026-08-10',
+      real_bool: true,
+    });
+  });
+
+  it('rejects empty YAML with a stable diagnostic', () => {
+    expect(() => parseSpec('', 'spec.yaml')).toThrow('could not parse spec as JSON or YAML: CLI spec is empty');
+  });
+
+  it('bounds JSON and YAML specs before either parser runs', () => {
+    const oversized = `{"steps":[{"cmd":"${'a'.repeat(CLI_SPEC_MAX_INPUT_BYTES)}"}]}`;
+    expect(() => parseSpec(oversized, 'spec.json')).toThrow(
+      `spec exceeds the ${CLI_SPEC_MAX_INPUT_BYTES}-byte input limit`,
+    );
+    expect(() => parseSpec(oversized, 'spec.yaml')).toThrow(
+      `spec exceeds the ${CLI_SPEC_MAX_INPUT_BYTES}-byte input limit`,
+    );
+  });
+
+  it('never includes malformed YAML source or credentials in its diagnostic', () => {
+    const secret = 'sk-live-NEVER-ECHO';
+    let error: unknown;
+    try {
+      parseSpec(`steps:\n  - cmd: ping\nsecret: ${secret}\nbroken: [`, 'spec.yaml');
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(SpecParseError);
+    expect((error as Error).message).toMatch(/^could not parse spec as JSON or YAML: CLI spec is invalid YAML/);
+    expect((error as Error).message).not.toContain(secret);
+    expect((error as Error).message).not.toContain('broken');
   });
 
   it('rejects syntactically broken input as neither JSON nor YAML', () => {

--- a/mcp-tools/hayba-mcp/src/cli/spec.ts
+++ b/mcp-tools/hayba-mcp/src/cli/spec.ts
@@ -1,5 +1,8 @@
 // mcp_server/src/cli/spec.ts
-import { load as loadYaml } from 'js-yaml';
+import { Buffer } from 'node:buffer';
+import { BoundedYamlError, parseBoundedYaml } from '../security/bounded-yaml.js';
+
+export const CLI_SPEC_MAX_INPUT_BYTES = 1024 * 1024;
 
 /** One command sent over the same TCP seam every MCP tool uses
  *  (`executeCommand` in tool-executor.ts). `cmd` is a wire command name the
@@ -43,20 +46,29 @@ function looksLikeYaml(filename: string | undefined): boolean {
  *  — malformed syntax, wrong top-level shape, or a step missing `cmd` — never
  *  a bare parser exception. */
 export function parseSpec(raw: string, filename?: string): CliSpec {
+  if (Buffer.byteLength(raw, 'utf8') > CLI_SPEC_MAX_INPUT_BYTES) {
+    throw new SpecParseError(`spec exceeds the ${CLI_SPEC_MAX_INPUT_BYTES}-byte input limit`);
+  }
+
   let parsed: unknown;
   const yamlFirst = looksLikeYaml(filename);
 
   const tryJson = (): unknown => JSON.parse(raw);
-  const tryYaml = (): unknown => loadYaml(raw);
+  const tryYaml = (): unknown =>
+    parseBoundedYaml(raw, {
+      label: 'CLI spec',
+      maxBytes: CLI_SPEC_MAX_INPUT_BYTES,
+    });
 
   try {
     parsed = yamlFirst ? tryYaml() : tryJson();
   } catch (firstErr) {
     try {
       parsed = yamlFirst ? tryJson() : tryYaml();
-    } catch {
-      const msg = firstErr instanceof Error ? firstErr.message : String(firstErr);
-      throw new SpecParseError(`could not parse spec as JSON or YAML: ${msg}`);
+    } catch (secondErr) {
+      const yamlError = firstErr instanceof BoundedYamlError ? firstErr : secondErr;
+      const detail = yamlError instanceof BoundedYamlError ? `: ${yamlError.message}` : '';
+      throw new SpecParseError(`could not parse spec as JSON or YAML${detail}`);
     }
   }
 

--- a/mcp-tools/hayba-mcp/src/security/bounded-yaml.test.ts
+++ b/mcp-tools/hayba-mcp/src/security/bounded-yaml.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  BoundedYamlError,
+  HAYBA_YAML_MAX_ALIASES,
+  HAYBA_YAML_MAX_DEPTH,
+  HAYBA_YAML_MAX_TOTAL_MERGE_KEYS,
+  parseBoundedYaml,
+} from './bounded-yaml.js';
+
+const OPTIONS = { label: 'test manifest', maxBytes: 1024 } as const;
+
+describe('bounded YAML 1.2 policy', () => {
+  it('uses a named ESM import because js-yaml 5 deliberately has no default export', () => {
+    const source = readFileSync(new URL('./bounded-yaml.ts', import.meta.url), 'utf8');
+    expect(source).toMatch(/import\s*{[^}]*load as loadYaml[^}]*}\s*from 'js-yaml'/s);
+    expect(source).not.toMatch(/import\s+[A-Za-z_$][\w$]*\s+from ['"]js-yaml['"]/);
+  });
+
+  it('pins the deliberate resource limits', () => {
+    expect(HAYBA_YAML_MAX_DEPTH).toBe(32);
+    expect(HAYBA_YAML_MAX_ALIASES).toBe(0);
+    expect(HAYBA_YAML_MAX_TOTAL_MERGE_KEYS).toBe(0);
+  });
+
+  it('uses CORE_SCHEMA scalar semantics instead of YAML 1.1 coercions', () => {
+    expect(
+      parseBoundedYaml(
+        [
+          'legacy_yes: yes',
+          'legacy_on: ON',
+          'leading_zero: 012',
+          'explicit_octal: 0o12',
+          'date: 2026-08-10',
+          'real_bool: true',
+        ].join('\n'),
+        OPTIONS,
+      ),
+    ).toEqual({
+      legacy_yes: 'yes',
+      legacy_on: 'ON',
+      leading_zero: 12,
+      explicit_octal: 10,
+      date: '2026-08-10',
+      real_bool: true,
+    });
+  });
+
+  it('rejects empty input explicitly', () => {
+    expect(() => parseBoundedYaml('', OPTIONS)).toThrowError(
+      expect.objectContaining<Partial<BoundedYamlError>>({ code: 'empty_input', message: 'test manifest is empty' }),
+    );
+  });
+
+  it('bounds UTF-8 bytes rather than JavaScript character count', () => {
+    expect(() => parseBoundedYaml('value: éé', { label: 'test manifest', maxBytes: 10 })).toThrowError(
+      expect.objectContaining<Partial<BoundedYamlError>>({ code: 'input_too_large' }),
+    );
+  });
+
+  it('returns coordinates but never echoes malformed source or secrets', () => {
+    const secret = 'github_pat_NEVER_ECHO_THIS';
+    let error: unknown;
+    try {
+      parseBoundedYaml(`token: ${secret}\nbroken: [`, OPTIONS);
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(BoundedYamlError);
+    expect((error as Error).message).toMatch(/^test manifest is invalid YAML at line \d+, column \d+$/);
+    expect((error as Error).message).not.toContain(secret);
+    expect((error as Error).message).not.toContain('broken');
+  });
+
+  it('rejects duplicate mapping keys', () => {
+    expect(() => parseBoundedYaml('same: 1\nsame: 2\n', OPTIONS)).toThrowError(
+      expect.objectContaining<Partial<BoundedYamlError>>({ code: 'invalid_yaml' }),
+    );
+  });
+
+  it('keeps prototype-shaped keys as inert own data properties', () => {
+    const parsed = parseBoundedYaml('__proto__:\n  polluted: value\nconstructor: inert\n', OPTIONS) as Record<
+      string,
+      unknown
+    >;
+    expect(Object.prototype).not.toHaveProperty('polluted');
+    expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(true);
+    expect(parsed.__proto__).toEqual({ polluted: 'value' });
+    expect(parsed.constructor).toBe('inert');
+  });
+
+  it('rejects complex mapping keys instead of lossy stringification', () => {
+    expect(() => parseBoundedYaml('? [one, two]\n: value\n', OPTIONS)).toThrowError(
+      expect.objectContaining<Partial<BoundedYamlError>>({ code: 'invalid_yaml' }),
+    );
+  });
+
+  it('rejects aliases instead of expanding attacker-controlled graphs', () => {
+    const aliased = ['base: &base', '  value: 1', 'copy: *base'].join('\n');
+    expect(() => parseBoundedYaml(aliased, OPTIONS)).toThrowError(
+      expect.objectContaining<Partial<BoundedYamlError>>({ code: 'invalid_yaml' }),
+    );
+  });
+
+  it('rejects merge keys even though CORE_SCHEMA treats them as ordinary strings', () => {
+    const merged = ['defaults:', '  value: 1', 'actual:', '  <<:', '    value: 2'].join('\n');
+    expect(() => parseBoundedYaml(merged, OPTIONS)).toThrowError(
+      expect.objectContaining<Partial<BoundedYamlError>>({ code: 'merge_key_not_supported' }),
+    );
+  });
+
+  it('rejects nested flow collections beyond the configured depth', () => {
+    const depth = HAYBA_YAML_MAX_DEPTH + 2;
+    const nested = `value: ${'['.repeat(depth)}0${']'.repeat(depth)}`;
+    expect(() => parseBoundedYaml(nested, OPTIONS)).toThrowError(
+      expect.objectContaining<Partial<BoundedYamlError>>({ code: 'invalid_yaml' }),
+    );
+  });
+});

--- a/mcp-tools/hayba-mcp/src/security/bounded-yaml.ts
+++ b/mcp-tools/hayba-mcp/src/security/bounded-yaml.ts
@@ -1,0 +1,102 @@
+import { Buffer } from 'node:buffer';
+import { CORE_SCHEMA, YAMLException, load as loadYaml } from 'js-yaml';
+
+/**
+ * Deliberately conservative YAML 1.2 policy for Hayba-owned configuration.
+ *
+ * These inputs are small, hand-authored data files. They do not need aliases,
+ * merge keys, legacy YAML 1.1 tags, or deeply nested flow collections. Keeping
+ * those features out makes parsing cost proportional to the already-bounded
+ * input size and prevents two callers from quietly choosing different YAML
+ * semantics.
+ */
+export const HAYBA_YAML_MAX_DEPTH = 32;
+export const HAYBA_YAML_MAX_ALIASES = 0;
+export const HAYBA_YAML_MAX_TOTAL_MERGE_KEYS = 0;
+
+export type BoundedYamlErrorCode = 'empty_input' | 'input_too_large' | 'invalid_yaml' | 'merge_key_not_supported';
+
+export class BoundedYamlError extends Error {
+  constructor(
+    public readonly code: BoundedYamlErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'BoundedYamlError';
+  }
+}
+
+export interface BoundedYamlOptions {
+  /** A fixed, non-user-controlled label used in safe diagnostics. */
+  label: string;
+  maxBytes: number;
+}
+
+/** Parse one YAML 1.2 CORE document without returning parser snippets.
+ *
+ * js-yaml's detailed exception contains a source excerpt. That is excellent
+ * for a local YAML editor and unsafe at an MCP/CLI boundary where the document
+ * can contain credentials. We retain only its line/column coordinates.
+ */
+export function parseBoundedYaml(raw: string, options: BoundedYamlOptions): unknown {
+  const inputBytes = Buffer.byteLength(raw, 'utf8');
+  if (inputBytes === 0 || raw.trim().length === 0) {
+    throw new BoundedYamlError('empty_input', `${options.label} is empty`);
+  }
+  if (inputBytes > options.maxBytes) {
+    throw new BoundedYamlError('input_too_large', `${options.label} exceeds the ${options.maxBytes}-byte input limit`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = loadYaml(raw, {
+      schema: CORE_SCHEMA,
+      json: false,
+      maxDepth: HAYBA_YAML_MAX_DEPTH,
+      maxAliases: HAYBA_YAML_MAX_ALIASES,
+      maxTotalMergeKeys: HAYBA_YAML_MAX_TOTAL_MERGE_KEYS,
+    });
+  } catch (error) {
+    const location = safeLocation(error);
+    throw new BoundedYamlError('invalid_yaml', `${options.label} is invalid YAML${location}`);
+  }
+
+  // CORE_SCHEMA treats `<<` as an ordinary string key. Reject it explicitly
+  // rather than letting a future schema change silently enable merge behavior.
+  if (containsMergeKey(parsed)) {
+    throw new BoundedYamlError('merge_key_not_supported', `${options.label} uses the unsupported YAML merge key "<<"`);
+  }
+
+  return parsed;
+}
+
+function safeLocation(error: unknown): string {
+  if (!(error instanceof YAMLException) || !error.mark) return '';
+  return ` at line ${error.mark.line + 1}, column ${error.mark.column + 1}`;
+}
+
+function containsMergeKey(root: unknown): boolean {
+  if (root === null || typeof root !== 'object') return false;
+
+  const pending: object[] = [root];
+  const seen = new WeakSet<object>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    if (Array.isArray(current)) {
+      for (const value of current) {
+        if (value !== null && typeof value === 'object') pending.push(value);
+      }
+      continue;
+    }
+
+    for (const key of Object.keys(current)) {
+      if (key === '<<') return true;
+      const value = (current as Record<string, unknown>)[key];
+      if (value !== null && typeof value === 'object') pending.push(value);
+    }
+  }
+  return false;
+}

--- a/mcp-tools/hayba-mcp/src/tools/routing/pack-discovery.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/pack-discovery.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { deriveDomainPacks, loadWorkflowPacks } from './pack-discovery.js';
+import { WorkflowPackParseError, deriveDomainPacks, loadWorkflowPacks, parseWorkflowPacks } from './pack-discovery.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -9,24 +9,62 @@ describe('pack-discovery', () => {
   it('derives domain packs from tool->dir mapping', () => {
     const toolDirs = new Map<string, string | null>([
       ['actor_spawn', 'actor'],
-      ['actor_list',  'actor'],
+      ['actor_list', 'actor'],
       ['scene_export', 'scene'],
-      ['create_pcg_graph', null],            // root-level, no explicit pack
-      ['hayba_planet_dynamo_field', null],   // root-level
+      ['create_pcg_graph', null], // root-level, no explicit pack
+      ['hayba_planet_dynamo_field', null], // root-level
     ]);
-    const explicitPacks = new Map<string, string>([
-      ['hayba_planet_dynamo_field', 'planet'],
-    ]);
+    const explicitPacks = new Map<string, string>([['hayba_planet_dynamo_field', 'planet']]);
     const packs = deriveDomainPacks(toolDirs, explicitPacks);
-    expect(packs.find(p => p.name === 'actor')?.tools.sort()).toEqual(['actor_list', 'actor_spawn']);
-    expect(packs.find(p => p.name === 'scene')?.tools).toEqual(['scene_export']);
-    expect(packs.find(p => p.name === 'planet')?.tools).toEqual(['hayba_planet_dynamo_field']);
-    expect(packs.find(p => p.name === 'core')?.tools).toEqual(['create_pcg_graph']);
+    expect(packs.find((p) => p.name === 'actor')?.tools.sort()).toEqual(['actor_list', 'actor_spawn']);
+    expect(packs.find((p) => p.name === 'scene')?.tools).toEqual(['scene_export']);
+    expect(packs.find((p) => p.name === 'planet')?.tools).toEqual(['hayba_planet_dynamo_field']);
+    expect(packs.find((p) => p.name === 'core')?.tools).toEqual(['create_pcg_graph']);
   });
 
   it('loads workflow packs from yaml', () => {
     const packs = loadWorkflowPacks(resolve(__dirname, 'packs.yaml'));
-    expect(packs.find(p => p.name === 'biome')?.kind).toBe('workflow');
-    expect(packs.find(p => p.name === 'editor')?.autoLoadOn).toBe('ue_connected');
+    expect(packs.map((pack) => pack.name)).toEqual(['biome', 'connectors', 'editor', 'python']);
+    expect(packs.find((p) => p.name === 'biome')?.kind).toBe('workflow');
+    expect(packs.find((p) => p.name === 'editor')?.autoLoadOn).toBe('ue_connected');
+    expect(packs.find((p) => p.name === 'python')?.tools).toEqual(['python_run']);
+  });
+
+  it('parses workflow-pack fields with YAML 1.2 scalar semantics', () => {
+    const packs = parseWorkflowPacks(
+      ['packs:', '  - name: on', '    kind: workflow', '    description: yes', '    tools: [ping]'].join('\n'),
+    );
+    expect(packs[0]).toMatchObject({ name: 'on', description: 'yes', tools: ['ping'] });
+  });
+
+  it('rejects empty and malformed manifests with bounded secret-safe diagnostics', () => {
+    expect(() => parseWorkflowPacks('')).toThrowError(
+      expect.objectContaining<Partial<WorkflowPackParseError>>({
+        message: 'workflow pack manifest is empty',
+      }),
+    );
+
+    const secret = 'sk-secret-workflow-pack';
+    expect(() => parseWorkflowPacks(`token: ${secret}\npacks: [`)).toThrowError(WorkflowPackParseError);
+    try {
+      parseWorkflowPacks(`token: ${secret}\npacks: [`);
+    } catch (error) {
+      expect((error as Error).message).not.toContain(secret);
+      expect((error as Error).message).not.toContain('token');
+    }
+  });
+
+  it('rejects structurally invalid manifests instead of dereferencing undefined', () => {
+    expect(() => parseWorkflowPacks('not_packs: []')).toThrow(/must contain a "packs" array/);
+    expect(() => parseWorkflowPacks('packs:\n  - kind: workflow')).toThrow(/pack\[0\]\.name/);
+  });
+
+  it('does not disclose a caller-supplied path when discovery cannot read it', () => {
+    const secretPath = resolve(__dirname, 'sk-secret-do-not-echo.yaml');
+    expect(() => loadWorkflowPacks(secretPath)).toThrowError(
+      expect.objectContaining<Partial<WorkflowPackParseError>>({
+        message: 'could not read workflow pack manifest',
+      }),
+    );
   });
 });

--- a/mcp-tools/hayba-mcp/src/tools/routing/pack-discovery.ts
+++ b/mcp-tools/hayba-mcp/src/tools/routing/pack-discovery.ts
@@ -1,11 +1,17 @@
-import { readFileSync } from 'node:fs';
-import yaml from 'js-yaml';
+import { readFileSync, statSync } from 'node:fs';
+import { BoundedYamlError, parseBoundedYaml } from '../../security/bounded-yaml.js';
 import type { PackDef } from './pack-registry.js';
 
-export function deriveDomainPacks(
-  toolDirs: Map<string, string | null>,
-  explicitPacks: Map<string, string>,
-): PackDef[] {
+export const WORKFLOW_PACKS_MAX_YAML_BYTES = 256 * 1024;
+
+export class WorkflowPackParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkflowPackParseError';
+  }
+}
+
+export function deriveDomainPacks(toolDirs: Map<string, string | null>, explicitPacks: Map<string, string>): PackDef[] {
   const grouped = new Map<string, string[]>();
   for (const [tool, dir] of toolDirs) {
     const explicit = explicitPacks.get(tool);
@@ -33,13 +39,69 @@ interface WorkflowPacksFile {
 }
 
 export function loadWorkflowPacks(yamlPath: string): PackDef[] {
-  const raw = readFileSync(yamlPath, 'utf-8');
-  const parsed = yaml.load(raw) as WorkflowPacksFile;
-  return parsed.packs.map(p => ({
+  let raw: string;
+  try {
+    if (statSync(yamlPath).size > WORKFLOW_PACKS_MAX_YAML_BYTES) {
+      throw new WorkflowPackParseError(
+        `workflow pack manifest exceeds the ${WORKFLOW_PACKS_MAX_YAML_BYTES}-byte input limit`,
+      );
+    }
+    raw = readFileSync(yamlPath, 'utf-8');
+  } catch (error) {
+    if (error instanceof WorkflowPackParseError) throw error;
+    throw new WorkflowPackParseError('could not read workflow pack manifest');
+  }
+  return parseWorkflowPacks(raw);
+}
+
+export function parseWorkflowPacks(raw: string): PackDef[] {
+  let parsed: unknown;
+  try {
+    parsed = parseBoundedYaml(raw, {
+      label: 'workflow pack manifest',
+      maxBytes: WORKFLOW_PACKS_MAX_YAML_BYTES,
+    });
+  } catch (error) {
+    if (error instanceof BoundedYamlError) throw new WorkflowPackParseError(error.message);
+    throw error;
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.packs)) {
+    throw new WorkflowPackParseError('workflow pack manifest must contain a "packs" array');
+  }
+
+  const packs = parsed.packs.map((pack, index) => validateWorkflowPack(pack, index));
+  return packs.map((p) => ({
     name: p.name,
     kind: 'workflow' as const,
     description: p.description,
     tools: p.tools,
     autoLoadOn: p.autoLoadOn,
   }));
+}
+
+function validateWorkflowPack(pack: unknown, index: number): WorkflowPacksFile['packs'][number] {
+  if (!isRecord(pack)) {
+    throw new WorkflowPackParseError(`workflow pack[${index}] must be an object`);
+  }
+  if (typeof pack.name !== 'string' || pack.name.trim().length === 0) {
+    throw new WorkflowPackParseError(`workflow pack[${index}].name must be a non-empty string`);
+  }
+  if (pack.kind !== 'workflow') {
+    throw new WorkflowPackParseError(`workflow pack[${index}].kind must be "workflow"`);
+  }
+  if (typeof pack.description !== 'string' || pack.description.trim().length === 0) {
+    throw new WorkflowPackParseError(`workflow pack[${index}].description must be a non-empty string`);
+  }
+  if (!Array.isArray(pack.tools) || pack.tools.some((tool) => typeof tool !== 'string' || tool.length === 0)) {
+    throw new WorkflowPackParseError(`workflow pack[${index}].tools must be an array of non-empty strings`);
+  }
+  if (pack.autoLoadOn !== undefined && pack.autoLoadOn !== 'ue_connected') {
+    throw new WorkflowPackParseError(`workflow pack[${index}].autoLoadOn must be "ue_connected" when present`);
+  }
+  return pack as unknown as WorkflowPacksFile['packs'][number];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@modelcontextprotocol/sdk": "^1.30.0",
         "cheerio": "^1.2.0",
         "express": "^4.21.0",
-        "js-yaml": "^4.3.1",
+        "js-yaml": "5.2.3",
         "minisearch": "^7.2.0",
         "openai": "^6.45.0",
         "youtube-transcript-api": "^3.0.6",
@@ -46,7 +46,6 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^26.1.2",
         "msw": "^2.15.0",
         "typescript": "^7.0.2",
@@ -1951,13 +1950,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4775,9 +4767,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "funding": [
         {
           "type": "github",
@@ -4793,7 +4785,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {


### PR DESCRIPTION
## Outcome
- upgrades only js-yaml to 5.2.3 and removes the obsolete v4 @types package
- centralizes CLI/spec and workflow-pack parsing behind explicit named ESM imports and YAML 1.2 CORE_SCHEMA
- caps input bytes and collection depth; disables aliases and merge work; rejects merge/duplicate/complex keys
- validates workflow-pack structure and sanitizes parser/read failures so YAML content, credentials, and caller paths are never echoed
- documents the intentional YAML 1.2 semantic changes

## Evidence
- focused: 35/35 Vitest tests green
- full MCP on current main base: 1,836/1,836 tests green (178 files)
- typecheck: npx tsc --noEmit green
- build: npm run build:server green; built runtime loaded the checked-in CLI sample and all four workflow packs
- lint: legacy-wrapper guard green (22 C++ commands, 153 sidecar entries)
- format: Prettier check green
- mutation: restoring the v4-style ESM default import fails all three focused suites at module load because js-yaml 5 has no default export; reverted and re-ran green
- production audit: js-yaml 5.2.3 has no finding. npm audit still reports the pre-existing Transformers -> ONNX/Sharp chain already isolated in #397; no fix is available in this PR's dependency scope. No critical findings.

Closes #396