### PR TITLE
chore(deps): migrate direct HTTP surfaces to Express 5

### DIFF
--- a/mcp-tools/hayba-mcp/dashboard/src/pages/LinguisticsPage.tsx
+++ b/mcp-tools/hayba-mcp/dashboard/src/pages/LinguisticsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { CARDINAL_VOWELS, PULMONIC_CONSONANTS } from '../../../../linguistics/src/ipa-chart';
+import { CARDINAL_VOWELS, PULMONIC_CONSONANTS } from '../../../../../packages/linguistics/src/ipa-chart';
 
 /**
  * L1 — clickable IPA palette for assembling phoneme inventories before MCP persistence.

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -26,7 +26,7 @@
     "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "cheerio": "^1.2.0",
-    "express": "^4.21.0",
+    "express": "^5.2.1",
     "js-yaml": "5.2.3",
     "minisearch": "^7.2.0",
     "openai": "^6.45.0",

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -27,6 +27,7 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "cheerio": "^1.2.0",
     "express": "^5.2.1",
+    "express-rate-limit": "8.6.2",
     "js-yaml": "5.2.3",
     "minisearch": "^7.2.0",
     "openai": "^6.45.0",

--- a/mcp-tools/hayba-mcp/src/chat/chat-server.ts
+++ b/mcp-tools/hayba-mcp/src/chat/chat-server.ts
@@ -44,17 +44,12 @@ import type { Express, Request, Response } from 'express';
 import type { AddressInfo } from 'node:net';
 import { createLLMClient, type LLMMessage } from '../agents/llm-client.js';
 import { getProvider } from '../agents/providers.js';
-import {
-  runAgentLoop,
-  argsHash,
-  type AgentEvent,
-  type ApprovedCall,
-  type DispatchTool,
-} from './agent-loop.js';
+import { runAgentLoop, argsHash, type AgentEvent, type ApprovedCall, type DispatchTool } from './agent-loop.js';
 import type { LLMTool, LLMUsage } from '../agents/llm-client.js';
 import { createChatDispatcher } from './tool-dispatch.js';
 import { getArchetype } from '../agents/agent-registry.js';
 import { installExpressJsonRedaction, redactBoundaryValue } from '../security/secret-redaction.js';
+import { jsonObjectBody, stringQuery } from '../http/express-boundary.js';
 
 // ---------------------------------------------------------------------------
 // Localhost enforcement
@@ -63,12 +58,7 @@ import { installExpressJsonRedaction, redactBoundaryValue } from '../security/se
 /** True for IPv4/IPv6 loopback (incl. IPv4-mapped IPv6). Never network-exposed. */
 export function isLoopback(addr: string | undefined): boolean {
   if (!addr) return false;
-  return (
-    addr === '127.0.0.1' ||
-    addr === '::1' ||
-    addr === '::ffff:127.0.0.1' ||
-    addr.startsWith('127.')
-  );
+  return addr === '127.0.0.1' || addr === '::1' || addr === '::ffff:127.0.0.1' || addr.startsWith('127.');
 }
 
 function requireLoopback(req: Request, res: Response): boolean {
@@ -242,9 +232,7 @@ function sweepSessions(now: number = Date.now()): void {
 /** Enforce MAX_SESSIONS by LRU-evicting the oldest inactive (not running). */
 function enforceSessionCap(): void {
   if (sessions.size <= MAX_SESSIONS) return;
-  const candidates = [...sessions.values()]
-    .filter((s) => !s.running)
-    .sort((a, b) => a.lastActivity - b.lastActivity);
+  const candidates = [...sessions.values()].filter((s) => !s.running).sort((a, b) => a.lastActivity - b.lastActivity);
   for (const s of candidates) {
     if (sessions.size <= MAX_SESSIONS) break;
     evictSession(s);
@@ -328,17 +316,13 @@ function hasResumeGap(session: ChatSession, lastSeq: number): boolean {
 // Message normalization
 // ---------------------------------------------------------------------------
 
-function normalizeMessages(body: {
-  messages?: unknown;
-  prompt?: unknown;
-}): LLMMessage[] | null {
+function normalizeMessages(body: { messages?: unknown; prompt?: unknown }): LLMMessage[] | null {
   if (Array.isArray(body.messages)) {
     const ok = body.messages.every(
       (m) =>
         m &&
         typeof m === 'object' &&
-        (((m as { role?: unknown }).role === 'user') ||
-          ((m as { role?: unknown }).role === 'assistant')),
+        ((m as { role?: unknown }).role === 'user' || (m as { role?: unknown }).role === 'assistant'),
     );
     return ok ? (body.messages as LLMMessage[]) : null;
   }
@@ -389,7 +373,7 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
   // ── POST /chat/config ────────────────────────────────────────────────────
   app.post('/chat/config', (req: Request, res: Response) => {
     if (!requireLoopback(req, res)) return;
-    const body = req.body as {
+    const body = jsonObjectBody(req) as {
       session_id?: string;
       provider?: string;
       model?: string;
@@ -421,7 +405,9 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
   // ── GET /chat/config ─────────────────────────────────────────────────────
   app.get('/chat/config', (req: Request, res: Response) => {
     if (!requireLoopback(req, res)) return;
-    const sessionId = typeof req.query.session_id === 'string' ? req.query.session_id : undefined;
+    const parsed = stringQuery(req.query.session_id, 'session_id');
+    if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+    const sessionId = parsed.value;
     const cfg = resolveSessionConfig(sessionId);
     if (!cfg) return res.json({ configured: false });
     return res.json({
@@ -435,7 +421,7 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
   // ── POST /chat/cancel ────────────────────────────────────────────────────
   app.post('/chat/cancel', (req: Request, res: Response) => {
     if (!requireLoopback(req, res)) return;
-    const { session_id } = req.body as { session_id?: string };
+    const { session_id } = jsonObjectBody(req) as { session_id?: string };
     if (!session_id) return res.status(400).json({ error: 'session_id is required' });
     const session = sessions.get(session_id);
     if (!session) return res.status(404).json({ error: 'unknown session' });
@@ -447,7 +433,7 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
   // ── POST /chat/approve ───────────────────────────────────────────────────
   app.post('/chat/approve', (req: Request, res: Response) => {
     if (!requireLoopback(req, res)) return;
-    const { session_id } = req.body as { session_id?: string };
+    const { session_id } = jsonObjectBody(req) as { session_id?: string };
     if (!session_id) return res.status(400).json({ error: 'session_id is required' });
     const session = sessions.get(session_id);
     if (!session) return res.status(404).json({ error: 'unknown session' });
@@ -472,7 +458,7 @@ export function registerChatRoutes(app: Express, options: ChatRoutesOptions = {}
   // ── POST /chat/stream ────────────────────────────────────────────────────
   app.post('/chat/stream', async (req: Request, res: Response) => {
     if (!requireLoopback(req, res)) return;
-    const body = req.body as {
+    const body = jsonObjectBody(req) as {
       session_id?: string;
       messages?: LLMMessage[];
       prompt?: string;
@@ -681,11 +667,7 @@ interface RunTurnParams {
 }
 
 /** Emit the single consolidated final done frame + mark the turn finished. */
-function finalize(
-  session: ChatSession,
-  reason: string,
-  extra: Record<string, unknown> = {},
-): void {
+function finalize(session: ChatSession, reason: string, extra: Record<string, unknown> = {}): void {
   const frame = emit(session, 'done', {
     reason,
     assistant_text: session.assistantText,

--- a/mcp-tools/hayba-mcp/src/dashboard/api.ts
+++ b/mcp-tools/hayba-mcp/src/dashboard/api.ts
@@ -1,13 +1,25 @@
 import { Express, Request, Response } from 'express';
 import { config } from '../config.js';
-import { log } from '../logger.js';
 import { getUEClient } from '../tcp-client.js';
 import { loadCatalog, searchCatalog, getCategories } from '../catalog.js';
 import { createProject, deleteProject, getProject, listProjects } from '../projects.js';
-import { submitZones, getCurrentZones, setHeightmap, getHeightmap, getPainterSession, lockPainter, unlockPainter, createScratchSession, submitScratchZones, getScratchZones } from '../zones.js';
+import {
+  submitZones,
+  getCurrentZones,
+  setHeightmap,
+  getHeightmap,
+  getPainterSession,
+  lockPainter,
+  unlockPainter,
+  createScratchSession,
+  submitScratchZones,
+  getScratchZones,
+} from '../zones.js';
 import { getEntries, addEntry, deleteEntry, getBaseTemplates } from '../encyclopedia.js';
+import type { EncyclopediaEntry } from '../encyclopedia.js';
 import { getCachedSidecarHealth, pingSidecar } from '../tools/visual/sidecar-client.js';
 import { registerChatRoutes } from '../chat/chat-server.js';
+import { jsonObjectBody, stringQuery } from '../http/express-boundary.js';
 
 /**
  * Register REST API endpoints for the dashboard.
@@ -26,13 +38,15 @@ export function registerApiRoutes(app: Express): void {
       nodeVersion: process.version,
       port: config.dashboardPort,
       ueConnected: client.isConnected(),
-      ueTcpTarget: `${config.ueTcpHost}:${config.ueTcpPort}`
+      ueTcpTarget: `${config.ueTcpHost}:${config.ueTcpPort}`,
     });
   });
 
   // Node catalog search
   app.get('/api/catalog/search', (req: Request, res: Response) => {
-    const query = (req.query.q as string) || '';
+    const parsed = stringQuery(req.query.q, 'q');
+    if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+    const query = parsed.value ?? '';
     if (!query) {
       return res.status(400).json({ error: 'Missing query parameter: q' });
     }
@@ -57,7 +71,7 @@ export function registerApiRoutes(app: Express): void {
 
   // UE status (ping) + visual sidecar handshake
   app.get('/api/ue/status', async (_req: Request, res: Response) => {
-    const sidecar = getCachedSidecarHealth() ?? await pingSidecar();
+    const sidecar = getCachedSidecarHealth() ?? (await pingSidecar());
     const sidecarFields = {
       visual_embeddings_available: sidecar.available,
       active_models: sidecar.active_models,
@@ -94,7 +108,9 @@ export function registerApiRoutes(app: Express): void {
   app.get('/api/ue/assets', async (req: Request, res: Response) => {
     try {
       const client = getUEClient();
-      const path = (req.query.path as string) || '/Game/';
+      const parsed = stringQuery(req.query.path, 'path');
+      if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+      const path = parsed.value || '/Game/';
       const response = await client.send('list_pcg_assets', { path });
       if (response.ok) {
         res.json(response.data);
@@ -109,8 +125,9 @@ export function registerApiRoutes(app: Express): void {
   // ── Projects ──────────────────────────────────────────────────────────────
 
   app.post('/api/projects', async (req: Request, res: Response) => {
-    const { name } = req.body as { name?: string };
+    const { name } = jsonObjectBody(req) as { name?: unknown };
     if (!name) return res.status(400).json({ error: 'name is required' });
+    if (typeof name !== 'string') return res.status(400).json({ error: 'name must be a string' });
     const project = await createProject(name);
     res.json(project);
   });
@@ -135,17 +152,25 @@ export function registerApiRoutes(app: Express): void {
   // ── Zones ─────────────────────────────────────────────────────────────────
 
   app.post('/api/zones/submit', async (req: Request, res: Response) => {
-    const { projectId, zones, masks, canvasSize, phase } = req.body as {
+    const { projectId, zones, masks, canvasSize, phase } = jsonObjectBody(req) as {
       projectId?: string;
       zones?: unknown[];
       masks?: { zoneId: string; pngBase64: string }[];
       canvasSize?: 1024 | 2048 | 4096;
       phase?: 'a' | 'b';
     };
-    if (!projectId || !zones || !masks) return res.status(400).json({ error: 'projectId, zones, and masks are required' });
+    if (!projectId || !zones || !masks)
+      return res.status(400).json({ error: 'projectId, zones, and masks are required' });
     const project = await getProject(projectId);
     if (!project) return res.status(404).json({ error: 'Project not found' });
-    const session = await submitZones(projectId, zones as any, masks, undefined, canvasSize, phase);
+    const session = await submitZones(
+      projectId,
+      zones as Parameters<typeof submitZones>[1],
+      masks,
+      undefined,
+      canvasSize,
+      phase,
+    );
     res.json(session);
   });
 
@@ -156,8 +181,9 @@ export function registerApiRoutes(app: Express): void {
   });
 
   app.post('/api/zones/heightmap', async (req: Request, res: Response) => {
-    const { projectId, heightmapPath } = req.body as { projectId?: string; heightmapPath?: string };
-    if (!projectId || !heightmapPath) return res.status(400).json({ error: 'projectId and heightmapPath are required' });
+    const { projectId, heightmapPath } = jsonObjectBody(req) as { projectId?: string; heightmapPath?: string };
+    if (!projectId || !heightmapPath)
+      return res.status(400).json({ error: 'projectId and heightmapPath are required' });
     await setHeightmap(projectId, heightmapPath);
     res.json({ ok: true });
   });
@@ -174,7 +200,7 @@ export function registerApiRoutes(app: Express): void {
   });
 
   app.post('/api/zones/painter-session', (req: Request, res: Response) => {
-    const { projectId, phase } = req.body as { projectId?: string; phase?: 'a' | 'b' };
+    const { projectId, phase } = jsonObjectBody(req) as { projectId?: string; phase?: 'a' | 'b' };
     if (!projectId) return res.status(400).json({ error: 'projectId is required' });
     unlockPainter(projectId, phase ?? 'a');
     res.json({ ok: true });
@@ -194,7 +220,7 @@ export function registerApiRoutes(app: Express): void {
   });
 
   app.post('/api/zones/scratch-submit', async (req: Request, res: Response) => {
-    const { scratchSessionId, zones, masks, canvasSize } = req.body as {
+    const { scratchSessionId, zones, masks, canvasSize } = jsonObjectBody(req) as {
       scratchSessionId?: string;
       zones?: Omit<Parameters<typeof submitScratchZones>[1][0], never>[];
       masks?: { zoneId: string; pngBase64: string }[];
@@ -226,9 +252,9 @@ export function registerApiRoutes(app: Express): void {
   });
 
   app.post('/api/encyclopedia/:projectId', async (req: Request, res: Response) => {
-    const entry = req.body;
+    const entry = jsonObjectBody(req) as Partial<EncyclopediaEntry>;
     if (!entry?.id || !entry?.name) return res.status(400).json({ error: 'id and name are required' });
-    await addEntry(req.params.projectId as string, entry);
+    await addEntry(req.params.projectId as string, entry as EncyclopediaEntry);
     res.json({ ok: true });
   });
 

--- a/mcp-tools/hayba-mcp/src/dashboard/server.test.ts
+++ b/mcp-tools/hayba-mcp/src/dashboard/server.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { Express } from 'express';
+import { createDashboardApp, startDashboard } from './server.js';
+import { jsonObjectBody, stringQuery } from '../http/express-boundary.js';
+
+const servers = new Set<Server>();
+const tempDirs = new Set<string>();
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function listen(app: Express): Promise<{ server: Server; url: string }> {
+  const server = app.listen(0, '127.0.0.1');
+  servers.add(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', reject);
+  });
+  const port = (server.address() as AddressInfo).port;
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+function staticFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hayba-express5-'));
+  tempDirs.add(dir);
+  writeFileSync(join(dir, 'index.html'), '<!doctype html><title>Hayba SPA</title>', 'utf8');
+  writeFileSync(join(dir, 'app.js'), 'globalThis.haybaLoaded = true;', 'utf8');
+  writeFileSync(join(dir, '.env'), 'HAYBA_TEST_SECRET=must-not-serve', 'utf8');
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all([...servers].map(closeServer));
+  servers.clear();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+  vi.restoreAllMocks();
+});
+
+describe('Express 5 dashboard boundary', () => {
+  it('registers the named SPA wildcard and serves root plus nested navigation', async () => {
+    const staticDir = staticFixture();
+    const app = createDashboardApp({ staticDir, registerRoutes: () => undefined });
+    const { url } = await listen(app);
+
+    for (const path of ['/', '/projects/alpha/editor']) {
+      const response = await fetch(`${url}${path}`, { headers: { accept: 'text/html' } });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain('Hayba SPA');
+    }
+  });
+
+  it('pins static MIME behavior and refuses dotfiles or missing asset fallbacks', async () => {
+    const staticDir = staticFixture();
+    const app = createDashboardApp({ staticDir, registerRoutes: () => undefined });
+    const { url } = await listen(app);
+
+    const script = await fetch(`${url}/app.js`);
+    expect(script.status).toBe(200);
+    expect(script.headers.get('content-type')).toMatch(/^text\/javascript(?:;|$)/);
+    expect(await script.text()).toContain('haybaLoaded');
+
+    for (const path of ['/.env', '/missing.js']) {
+      const response = await fetch(`${url}${path}`, { headers: { accept: 'text/html' } });
+      expect(response.status).toBe(404);
+      expect(await response.text()).not.toContain('Hayba SPA');
+      expect(await fetch(`${url}${path}`).then((r) => r.text())).not.toContain('must-not-serve');
+    }
+  });
+
+  it('never lets the SPA shadow API, chat, or sliver 404s', async () => {
+    const app = createDashboardApp({ staticDir: staticFixture(), registerRoutes: () => undefined });
+    const { url } = await listen(app);
+
+    for (const path of ['/api/no-such-route', '/chat/no-such-route', '/sliver/no-such-route']) {
+      const response = await fetch(`${url}${path}`, { headers: { accept: 'text/html' } });
+      expect(response.status).toBe(404);
+      expect(response.headers.get('content-type')).toContain('application/json');
+      expect(await response.json()).toEqual({ error: 'Not found' });
+    }
+  });
+
+  it('handles absent and malformed JSON bodies without HTML errors or throws', async () => {
+    const app = createDashboardApp({
+      staticDir: null,
+      registerRoutes: (target) => {
+        target.post('/api/body', (req, res) => {
+          const body = jsonObjectBody(req);
+          if (typeof body.name !== 'string') return res.status(400).json({ error: 'name is required' });
+          return res.json({ name: body.name });
+        });
+      },
+    });
+    const { url } = await listen(app);
+
+    const absent = await fetch(`${url}/api/body`, { method: 'POST' });
+    expect(absent.status).toBe(400);
+    expect(await absent.json()).toEqual({ error: 'name is required' });
+
+    const malformed = await fetch(`${url}/api/body`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"name":',
+    });
+    expect(malformed.status).toBe(400);
+    expect(malformed.headers.get('content-type')).toContain('application/json');
+    expect(await malformed.json()).toEqual({ error: 'Request body must be one valid JSON object' });
+  });
+
+  it('accepts a scalar, rejects an array, and keeps the simple parser non-nesting', async () => {
+    const app = createDashboardApp({
+      staticDir: null,
+      registerRoutes: (target) => {
+        target.get('/api/query', (req, res) => {
+          const parsed = stringQuery(req.query.q, 'q');
+          if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+          return res.json({ q: parsed.value ?? null });
+        });
+      },
+    });
+    const { url } = await listen(app);
+
+    expect(await fetch(`${url}/api/query?q=one`).then((r) => r.json())).toEqual({ q: 'one' });
+
+    const duplicate = await fetch(`${url}/api/query?q=one&q=two`);
+    expect(duplicate.status).toBe(400);
+    expect((await duplicate.json()).error).toContain('exactly once');
+
+    // `simple` intentionally leaves bracket syntax as a different literal key;
+    // it never constructs an attacker-controlled nested object for `q`.
+    expect(await fetch(`${url}/api/query?q%5Bnested%5D=value`).then((r) => r.json())).toEqual({ q: null });
+    expect(await fetch(`${url}/api/query?__proto__%5Bpolluted%5D=yes`).then((r) => r.json())).toEqual({ q: null });
+    expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+  });
+
+  it('forwards rejected handlers to a generic redacted JSON error boundary', async () => {
+    const logged: unknown[][] = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logged.push(args);
+    });
+    const app = createDashboardApp({
+      staticDir: null,
+      registerRoutes: (target) => {
+        target.get('/api/reject', async () => {
+          throw new Error('api_key=sk-this-must-not-reach-the-response');
+        });
+      },
+    });
+    const { url } = await listen(app);
+
+    const response = await fetch(`${url}/api/reject`);
+    expect(response.status).toBe(500);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(await response.json()).toEqual({ error: 'Internal server error' });
+    expect(logged).toHaveLength(1);
+    expect(String((logged[0]![1] as Error).message)).not.toContain('sk-this-must-not-reach');
+  });
+
+  it('redacts a JSON response exactly once at the dashboard boundary', async () => {
+    const app = createDashboardApp({
+      staticDir: null,
+      registerRoutes: (target) => {
+        target.get('/api/secret', (_req, res) => res.json({ api_key: 'sk-example-secret-value' }));
+      },
+    });
+    const { url } = await listen(app);
+
+    const body = await fetch(`${url}/api/secret`).then((response) => response.json());
+    expect(body.api_key).toBe('[REDACTED:api_key]');
+    expect(body._security_redaction.redacted_values).toBe(1);
+  });
+
+  it('binds, responds, returns a closeable handle, and shuts down cleanly', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const server = await startDashboard(0, '127.0.0.1', {
+      staticDir: null,
+      registerRoutes: (app) => {
+        app.get('/api/smoke', (_req, res) => res.json({ ok: true }));
+      },
+    });
+    expect(server).not.toBeNull();
+    servers.add(server!);
+    const port = (server!.address() as AddressInfo).port;
+    expect(await fetch(`http://127.0.0.1:${port}/api/smoke`).then((r) => r.json())).toEqual({ ok: true });
+    await closeServer(server!);
+    expect(server!.listening).toBe(false);
+  });
+
+  it('reports EADDRINUSE through the Express 5 listen callback without crashing', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const blocker = createServer();
+    servers.add(blocker);
+    await new Promise<void>((resolve, reject) => {
+      blocker.listen(0, '127.0.0.1', resolve);
+      blocker.once('error', reject);
+    });
+    const port = (blocker.address() as AddressInfo).port;
+
+    await expect(
+      startDashboard(port, '127.0.0.1', {
+        staticDir: null,
+        registerRoutes: () => undefined,
+      }),
+    ).resolves.toBeNull();
+    expect(blocker.listening).toBe(true);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/dashboard/server.test.ts
+++ b/mcp-tools/hayba-mcp/src/dashboard/server.test.ts
@@ -89,6 +89,47 @@ describe('Express 5 dashboard boundary', () => {
     }
   });
 
+  it('rate-limits every HTTP surface and omits Express fingerprinting', async () => {
+    const app = createDashboardApp({
+      staticDir: null,
+      rateLimit: { windowMs: 60_000, limit: 2 },
+      registerRoutes: (target) => {
+        target.get('/api/limited', (_req, res) => res.json({ ok: true }));
+      },
+    });
+    const { url } = await listen(app);
+
+    for (let count = 0; count < 2; count += 1) {
+      const response = await fetch(`${url}/api/limited`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get('x-powered-by')).toBeNull();
+      expect(response.headers.get('ratelimit')).not.toBeNull();
+    }
+
+    const blocked = await fetch(`${url}/api/limited`);
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('content-type')).toContain('application/json');
+    expect(await blocked.json()).toEqual({
+      error: 'Too many requests; retry after the rate-limit window',
+    });
+  });
+
+  it('maps traversal-shaped storage identifiers to a stable non-reflective 400', async () => {
+    const app = createDashboardApp({ staticDir: null, rateLimit: false });
+    const { url } = await listen(app);
+    const attack = '..%2F..%2Foutside-secret';
+
+    const response = await fetch(`${url}/api/projects/${attack}`);
+    expect(response.status).toBe(400);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    const body = (await response.json()) as { code: string; error: string };
+    expect(body).toEqual({
+      code: 'invalid_storage_identifier',
+      error: 'projectId is not a valid storage identifier',
+    });
+    expect(JSON.stringify(body)).not.toContain('outside-secret');
+  });
+
   it('handles absent and malformed JSON bodies without HTML errors or throws', async () => {
     const app = createDashboardApp({
       staticDir: null,

--- a/mcp-tools/hayba-mcp/src/dashboard/server.ts
+++ b/mcp-tools/hayba-mcp/src/dashboard/server.ts
@@ -1,61 +1,93 @@
 import express from 'express';
-import { join, dirname } from 'node:path';
+import type { Server } from 'node:http';
+import { extname, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
-import { config } from '../config.js';
 import { registerApiRoutes } from './api.js';
 import { installExpressJsonRedaction } from '../security/secret-redaction.js';
+import { installHttpErrorBoundary } from '../http/express-boundary.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-/**
- * Start the Express dashboard server.
- */
-export async function startDashboard(port: number, host: string): Promise<void> {
+export interface DashboardAppOptions {
+  /** Test/embedding seam. `null` deliberately disables static + SPA serving. */
+  staticDir?: string | null;
+  /** Test/embedding seam for registering routes before the reserved-prefix 404. */
+  registerRoutes?: (app: express.Express) => void;
+}
+
+function detectStaticDir(): string | null {
+  // Auto-detect: standalone (../../dashboard) or bundled (../../../dashboard).
+  const candidates = [
+    join(__dirname, '..', '..', 'dashboard', 'dist'),
+    join(__dirname, '..', '..', 'dashboard'),
+    join(__dirname, '..', '..', '..', 'dashboard', 'dist'),
+    join(__dirname, '..', '..', '..', 'dashboard'),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function isSpaNavigation(path: string): boolean {
+  if (extname(path) !== '') return false;
+  return !path.split('/').some((segment) => segment.startsWith('.') && segment.length > 1);
+}
+
+/** Build the direct dashboard app without binding a socket. */
+export function createDashboardApp(options: DashboardAppOptions = {}): express.Express {
   const app = express();
-  app.use(express.json({ limit: '50mb' }));
+  // Pin Express 5 semantics instead of inheriting a future default change.
+  app.set('query parser', 'simple');
+  app.use(express.json({ limit: '50mb', strict: true }));
   installExpressJsonRedaction(app);
 
-  // Register API routes for dashboard data
-  registerApiRoutes(app);
+  (options.registerRoutes ?? registerApiRoutes)(app);
 
-  // Serve static files from the dashboard directory
-  // Auto-detect: standalone (../../dashboard) or bundled (../../../dashboard)
-  let staticDir = join(__dirname, '..', '..', 'dashboard', 'dist');
-  if (!existsSync(staticDir)) {
-    staticDir = join(__dirname, '..', '..', 'dashboard');
-  }
-  if (!existsSync(staticDir)) {
-    staticDir = join(__dirname, '..', '..', '..', 'dashboard', 'dist');
-  }
-  if (!existsSync(staticDir)) {
-    staticDir = join(__dirname, '..', '..', 'dashboard');
-  }
-  if (!existsSync(staticDir)) {
-    staticDir = join(__dirname, '..', '..', '..', 'dashboard', 'dist');
-  }
-  if (existsSync(staticDir)) {
-    app.use(express.static(staticDir));
+  // Once real routes have had their chance, reserved surfaces always stay JSON
+  // 404s. They must never be mistaken for client-side dashboard navigation.
+  app.use(['/api', '/chat', '/sliver'], (_req, res) => {
+    res.status(404).json({ error: 'Not found' });
+  });
 
-    // Catch-all: serve index.html for any non-API route (SPA behavior)
-    app.get('*', (_req: express.Request, res: express.Response) => {
-      res.sendFile(join(staticDir, 'index.html'));
+  const staticDir = options.staticDir === undefined ? detectStaticDir() : options.staticDir;
+  if (staticDir && existsSync(staticDir)) {
+    // Dotfiles remain deliberately unavailable. JS MIME is supplied by
+    // Express 5's mime-db and pinned by the migration tests.
+    app.use(express.static(staticDir, { dotfiles: 'ignore', fallthrough: true }));
+
+    // Express 5 requires a named wildcard. Only extensionless HTML navigation
+    // gets the SPA shell; missing assets and dot-paths remain genuine 404s.
+    app.get('/{*splat}', (req, res, next) => {
+      if (!isSpaNavigation(req.path) || !req.accepts('html')) return next();
+      return res.sendFile(join(staticDir, 'index.html'));
     });
   }
+
+  installHttpErrorBoundary(app);
+  return app;
+}
+
+/** Start the dashboard, returning a closeable server or null after bind failure. */
+export async function startDashboard(
+  port: number,
+  host: string,
+  options: DashboardAppOptions = {},
+): Promise<Server | null> {
+  const app = createDashboardApp(options);
 
   return new Promise((resolve) => {
-    const server = app.listen(port, host, () => {
-      console.error(`Dashboard listening at http://${host}:${port}`);
-      resolve();
-    });
-    server.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'EADDRINUSE') {
-        console.error(`Dashboard port ${port} already in use — dashboard HTTP skipped, MCP stdio still active`);
-        resolve(); // don't crash the MCP process
-      } else {
-        console.error(`Dashboard server error: ${err.message}`);
-        resolve();
+    const server = app.listen(port, host, (error?: Error) => {
+      if (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code === 'EADDRINUSE') {
+          console.error(`Dashboard port ${port} already in use — dashboard HTTP skipped, MCP stdio still active`);
+        } else {
+          console.error(`Dashboard server error: ${err.message}`);
+        }
+        resolve(null);
+        return;
       }
+      console.error(`Dashboard listening at http://${host}:${port}`);
+      resolve(server);
     });
   });
 }

--- a/mcp-tools/hayba-mcp/src/dashboard/server.ts
+++ b/mcp-tools/hayba-mcp/src/dashboard/server.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { rateLimit } from 'express-rate-limit';
 import type { Server } from 'node:http';
 import { extname, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,6 +15,8 @@ export interface DashboardAppOptions {
   staticDir?: string | null;
   /** Test/embedding seam for registering routes before the reserved-prefix 404. */
   registerRoutes?: (app: express.Express) => void;
+  /** Set false only in isolated tests/embeddings that provide their own limiter. */
+  rateLimit?: false | { windowMs?: number; limit?: number };
 }
 
 function detectStaticDir(): string | null {
@@ -35,10 +38,25 @@ function isSpaNavigation(path: string): boolean {
 /** Build the direct dashboard app without binding a socket. */
 export function createDashboardApp(options: DashboardAppOptions = {}): express.Express {
   const app = express();
+  app.disable('x-powered-by');
   // Pin Express 5 semantics instead of inheriting a future default change.
   app.set('query parser', 'simple');
-  app.use(express.json({ limit: '50mb', strict: true }));
+  // The dashboard binds directly to loopback; never trust a caller-supplied
+  // forwarding chain for localhost policy or per-client rate-limit identity.
+  app.set('trust proxy', false);
   installExpressJsonRedaction(app);
+  if (options.rateLimit !== false) {
+    app.use(
+      rateLimit({
+        windowMs: options.rateLimit?.windowMs ?? 60_000,
+        limit: options.rateLimit?.limit ?? 600,
+        standardHeaders: 'draft-8',
+        legacyHeaders: false,
+        message: { error: 'Too many requests; retry after the rate-limit window' },
+      }),
+    );
+  }
+  app.use(express.json({ limit: '50mb', strict: true }));
 
   (options.registerRoutes ?? registerApiRoutes)(app);
 

--- a/mcp-tools/hayba-mcp/src/encyclopedia.ts
+++ b/mcp-tools/hayba-mcp/src/encyclopedia.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { DEFAULT_PROJECTS_BASE } from './projects.js';
+import { isStorageUuid, requireStorageFileStem, requireStorageUuid, resolveStorageChild } from './storage-path.js';
 
 export interface EncyclopediaEntry {
   id: string;
@@ -26,10 +26,14 @@ export interface EncyclopediaEntry {
 }
 
 function encFile(projectId: string, base: string): string {
-  return join(base, projectId, 'encyclopedia.json');
+  return resolveStorageChild(base, requireStorageUuid(projectId, 'projectId'), 'encyclopedia.json');
 }
 
 export async function getEntries(projectId: string, base = DEFAULT_PROJECTS_BASE): Promise<EncyclopediaEntry[]> {
+  if (!isStorageUuid(projectId)) {
+    requireStorageFileStem(projectId, 'projectId');
+    return [];
+  }
   const file = encFile(projectId, base);
   if (!existsSync(file)) return [];
   return JSON.parse(readFileSync(file, 'utf-8')) as EncyclopediaEntry[];

--- a/mcp-tools/hayba-mcp/src/http/express-boundary.ts
+++ b/mcp-tools/hayba-mcp/src/http/express-boundary.ts
@@ -1,5 +1,6 @@
 import type { ErrorRequestHandler, Express, Request } from 'express';
 import { redactThrown } from '../security/secret-redaction.js';
+import { StorageIdentifierError } from '../storage-path.js';
 
 /**
  * Express 5 deliberately leaves `req.body` undefined when no parser produced a
@@ -48,6 +49,10 @@ export function installHttpErrorBoundary(app: Express): void {
     }
     if (candidate?.type === 'entity.too.large') {
       res.status(413).json({ error: "JSON body exceeds this endpoint's configured limit" });
+      return;
+    }
+    if (error instanceof StorageIdentifierError) {
+      res.status(400).json({ code: error.code, error: error.message });
       return;
     }
 

--- a/mcp-tools/hayba-mcp/src/http/express-boundary.ts
+++ b/mcp-tools/hayba-mcp/src/http/express-boundary.ts
@@ -1,0 +1,58 @@
+import type { ErrorRequestHandler, Express, Request } from 'express';
+import { redactThrown } from '../security/secret-redaction.js';
+
+/**
+ * Express 5 deliberately leaves `req.body` undefined when no parser produced a
+ * value. HTTP handlers should still be able to validate an absent body as an
+ * empty input object instead of throwing while destructuring it.
+ */
+export function jsonObjectBody(req: Request): Record<string, unknown> {
+  const body: unknown = req.body;
+  return body !== null && typeof body === 'object' && !Array.isArray(body) ? (body as Record<string, unknown>) : {};
+}
+
+export type StringQueryResult = { ok: true; value: string | undefined } | { ok: false; error: string };
+
+/**
+ * Read one string query value without silently accepting duplicate parameters.
+ * Express 5's simple parser represents `?x=a&x=b` as an array. Treating that as
+ * a scalar is endpoint-dependent and has caused parameter-pollution bypasses in
+ * other HTTP applications, so Hayba rejects the ambiguous form consistently.
+ */
+export function stringQuery(value: unknown, name: string): StringQueryResult {
+  if (value === undefined) return { ok: true, value: undefined };
+  if (typeof value === 'string') return { ok: true, value };
+  return { ok: false, error: `query parameter '${name}' must appear exactly once` };
+}
+
+/**
+ * Keep parser and async-handler failures on the JSON boundary. In particular,
+ * malformed request text must never fall through to the SPA or Express's HTML
+ * error page, and exception messages are not reflected to the caller.
+ */
+export function installHttpErrorBoundary(app: Express): void {
+  const boundary: ErrorRequestHandler = (error, _req, res, next) => {
+    const safeError = redactThrown(error);
+    if (res.headersSent) {
+      // Express's final handler owns the only safe action after bytes are on the
+      // wire: close the connection. Forward a redacted Error so even its
+      // diagnostic path cannot receive the original secret-bearing message.
+      next(safeError);
+      return;
+    }
+
+    const candidate = error as { status?: unknown; type?: unknown };
+    if (candidate?.type === 'entity.parse.failed') {
+      res.status(400).json({ error: 'Request body must be one valid JSON object' });
+      return;
+    }
+    if (candidate?.type === 'entity.too.large') {
+      res.status(413).json({ error: "JSON body exceeds this endpoint's configured limit" });
+      return;
+    }
+
+    console.error('Hayba HTTP request failed', safeError);
+    res.status(500).json({ error: 'Internal server error' });
+  };
+  app.use(boundary);
+}

--- a/mcp-tools/hayba-mcp/src/http/server.ts
+++ b/mcp-tools/hayba-mcp/src/http/server.ts
@@ -11,23 +11,30 @@ import type { Server } from 'node:http';
 import type { SliverSystem } from '../slivers/index.js';
 import { mountSliverRoutes } from './sliver-routes.js';
 import { installExpressJsonRedaction } from '../security/secret-redaction.js';
+import { installHttpErrorBoundary } from './express-boundary.js';
 
 export function startHttpServer(slivers: SliverSystem): Server {
   const app = express();
-  app.use(express.json({ limit: '1mb' }));
+  app.set('query parser', 'simple');
+  app.use(express.json({ limit: '1mb', strict: true }));
   installExpressJsonRedaction(app);
 
   mountSliverRoutes(app, slivers);
+  app.use('/sliver', (_req, res) => {
+    res.status(404).json({ error: 'Not found' });
+  });
+  installHttpErrorBoundary(app);
 
   const port = Number(process.env.HAYBA_MCP_HTTP_PORT ?? 3091);
   const host = '127.0.0.1';
 
-  const server = app.listen(port, host, () => {
+  const server = app.listen(port, host, (error?: Error) => {
+    if (error) {
+      const err = error as NodeJS.ErrnoException;
+      console.error(`Hayba HTTP server error: ${err.code ?? ''} ${err.message}`);
+      return;
+    }
     console.error(`Hayba HTTP server listening on http://${host}:${port}`);
-  });
-
-  server.on('error', (err: NodeJS.ErrnoException) => {
-    console.error(`Hayba HTTP server error: ${err.code ?? ''} ${err.message}`);
   });
 
   return server;

--- a/mcp-tools/hayba-mcp/src/http/sliver-routes.test.ts
+++ b/mcp-tools/hayba-mcp/src/http/sliver-routes.test.ts
@@ -7,6 +7,7 @@ import type { AddressInfo } from 'node:net';
 import type { Server } from 'node:http';
 import { setupSliverSystem } from '../slivers/index.js';
 import { mountSliverRoutes } from './sliver-routes.js';
+import { installHttpErrorBoundary } from './express-boundary.js';
 
 describe('sliver HTTP routes', () => {
   let userDir: string;
@@ -18,8 +19,11 @@ describe('sliver HTTP routes', () => {
     userDir = mkdtempSync(join(tmpdir(), 'hayba-sl-http-'));
     sys = await setupSliverSystem({ userDir, bundledDir: 'src/slivers/specs', maxDepth: 4 });
     const app = express();
-    app.use(express.json());
+    app.set('query parser', 'simple');
+    app.use(express.json({ limit: '1mb', strict: true }));
     mountSliverRoutes(app, sys);
+    app.use('/sliver', (_req, res) => res.status(404).json({ error: 'Not found' }));
+    installHttpErrorBoundary(app);
     server = app.listen(0);
     const port = (server.address() as AddressInfo).port;
     url = `http://127.0.0.1:${port}`;
@@ -66,7 +70,10 @@ describe('sliver HTTP routes', () => {
     const r = await fetch(`${url}/sliver/run`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ id: 'com.hayba.composition.frame_target', params: { target: '/Game/X.X', distance: 9999 } }),
+      body: JSON.stringify({
+        id: 'com.hayba.composition.frame_target',
+        params: { target: '/Game/X.X', distance: 9999 },
+      }),
     });
     const body = await r.json();
     expect(body.ok).toBe(false);
@@ -93,5 +100,41 @@ describe('sliver HTTP routes', () => {
     const body = await r.json();
     expect(body.ok).toBe(true);
     expect(sys.loader.get('com.test.http.demo')).toBeDefined();
+  });
+
+  it('rejects absent and malformed JSON bodies as JSON 400s', async () => {
+    const absent = await fetch(`${url}/sliver/run`, { method: 'POST' });
+    expect(absent.status).toBe(400);
+    expect(await absent.json()).toEqual({ error: 'missing id' });
+
+    const malformed = await fetch(`${url}/sliver/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"id":',
+    });
+    expect(malformed.status).toBe(400);
+    expect(await malformed.json()).toEqual({ error: 'Request body must be one valid JSON object' });
+  });
+
+  it('returns a bounded JSON 413 when the direct HTTP body limit is exceeded', async () => {
+    const response = await fetch(`${url}/sliver/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: 'x', padding: 'a'.repeat(1_100_000) }),
+    });
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: "JSON body exceeds this endpoint's configured limit" });
+  });
+
+  it('rejects duplicate query keys rather than selecting one implicitly', async () => {
+    const response = await fetch(`${url}/sliver/get?id=first&id=second`);
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain('exactly once');
+  });
+
+  it('keeps unknown sliver routes on the JSON boundary', async () => {
+    const response = await fetch(`${url}/sliver/not-a-route`);
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Not found' });
   });
 });

--- a/mcp-tools/hayba-mcp/src/http/sliver-routes.ts
+++ b/mcp-tools/hayba-mcp/src/http/sliver-routes.ts
@@ -7,42 +7,58 @@
 import type { Express, Request, Response } from 'express';
 import type { SliverSystem } from '../slivers/index.js';
 import { sliverListHandler } from '../tools/sliver/list.js';
-import { sliverGetHandler }  from '../tools/sliver/get.js';
-import { sliverRunHandler }  from '../tools/sliver/run.js';
+import { sliverGetHandler } from '../tools/sliver/get.js';
+import { sliverRunHandler } from '../tools/sliver/run.js';
+import { jsonObjectBody, stringQuery } from './express-boundary.js';
 
 export function mountSliverRoutes(app: Express, sys: SliverSystem): void {
   app.get('/sliver/list', async (req: Request, res: Response) => {
-    const r = await sliverListHandler({
-      category: typeof req.query.category === 'string' ? req.query.category : undefined,
-      namespace: typeof req.query.namespace === 'string' ? req.query.namespace : undefined,
-    }, { loader: sys.loader });
+    const category = stringQuery(req.query.category, 'category');
+    const namespace = stringQuery(req.query.namespace, 'namespace');
+    if (!category.ok) return void res.status(400).json({ error: category.error });
+    if (!namespace.ok) return void res.status(400).json({ error: namespace.error });
+    const r = await sliverListHandler(
+      {
+        category: category.value,
+        namespace: namespace.value,
+      },
+      { loader: sys.loader },
+    );
     res.json(r);
   });
 
   app.get('/sliver/get', async (req: Request, res: Response) => {
-    if (typeof req.query.id !== 'string' || !req.query.id) {
+    const id = stringQuery(req.query.id, 'id');
+    if (!id.ok) {
+      res.status(400).json({ error: id.error });
+      return;
+    }
+    if (!id.value) {
       res.status(400).json({ error: 'missing id' });
       return;
     }
-    const r = await sliverGetHandler({ id: req.query.id }, { loader: sys.loader });
+    const r = await sliverGetHandler({ id: id.value }, { loader: sys.loader });
     res.json(r);
   });
 
   app.post('/sliver/run', async (req: Request, res: Response) => {
-    const body = req.body as { id?: unknown; params?: unknown };
+    const body = jsonObjectBody(req) as { id?: unknown; params?: unknown };
     if (typeof body.id !== 'string' || !body.id) {
       res.status(400).json({ error: 'missing id' });
       return;
     }
-    const r = await sliverRunHandler({
-      id: body.id,
-      params: (body.params && typeof body.params === 'object' ? body.params : {}) as Record<string, unknown>,
-    }, { runtime: sys.runtime });
+    const r = await sliverRunHandler(
+      {
+        id: body.id,
+        params: (body.params && typeof body.params === 'object' ? body.params : {}) as Record<string, unknown>,
+      },
+      { runtime: sys.runtime },
+    );
     res.json(r);
   });
 
   app.post('/sliver/import', async (req: Request, res: Response) => {
-    const body = req.body as { spec?: unknown };
+    const body = jsonObjectBody(req) as { spec?: unknown };
     if (!body.spec || typeof body.spec !== 'object') {
       res.status(400).json({ error: 'missing spec' });
       return;

--- a/mcp-tools/hayba-mcp/src/projects.ts
+++ b/mcp-tools/hayba-mcp/src/projects.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
+import { isStorageUuid, requireStorageFileStem, requireStorageUuid, resolveStorageChild } from './storage-path.js';
 
 export interface Project {
   id: string;
@@ -15,7 +16,7 @@ export interface Project {
 export const DEFAULT_PROJECTS_BASE = join(homedir(), '.hayba', 'projects');
 
 function projectDir(id: string, base = DEFAULT_PROJECTS_BASE): string {
-  return join(base, id);
+  return resolveStorageChild(base, requireStorageUuid(id, 'projectId'));
 }
 
 export async function createProject(name: string, base = DEFAULT_PROJECTS_BASE): Promise<Project> {
@@ -39,12 +40,22 @@ export async function createProject(name: string, base = DEFAULT_PROJECTS_BASE):
 }
 
 export async function getProject(id: string, base = DEFAULT_PROJECTS_BASE): Promise<Project | null> {
+  if (!isStorageUuid(id)) {
+    // Preserve the read-only "unknown id" contract without ever turning the
+    // unknown value into a path. Traversal syntax remains a caller error.
+    requireStorageFileStem(id, 'projectId');
+    return null;
+  }
   const file = join(projectDir(id, base), 'project.json');
   if (!existsSync(file)) return null;
   return JSON.parse(readFileSync(file, 'utf-8')) as Project;
 }
 
-export async function updateProject(id: string, patch: Partial<Project>, base = DEFAULT_PROJECTS_BASE): Promise<Project | null> {
+export async function updateProject(
+  id: string,
+  patch: Partial<Project>,
+  base = DEFAULT_PROJECTS_BASE,
+): Promise<Project | null> {
   const existing = await getProject(id, base);
   if (!existing) return null;
   const updated = { ...existing, ...patch, lastModified: new Date().toISOString() };
@@ -53,6 +64,10 @@ export async function updateProject(id: string, patch: Partial<Project>, base = 
 }
 
 export async function deleteProject(id: string, base = DEFAULT_PROJECTS_BASE): Promise<boolean> {
+  if (!isStorageUuid(id)) {
+    requireStorageFileStem(id, 'projectId');
+    return false;
+  }
   const dir = projectDir(id, base);
   if (!existsSync(dir)) return false;
   rmSync(dir, { recursive: true, force: true });
@@ -63,7 +78,7 @@ export async function listProjects(base = DEFAULT_PROJECTS_BASE): Promise<Projec
   if (!existsSync(base)) return [];
   const projects: Project[] = [];
   for (const entry of readdirSync(base, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
+    if (!entry.isDirectory() || !isStorageUuid(entry.name)) continue;
     const p = await getProject(entry.name, base);
     if (p) projects.push(p);
   }

--- a/mcp-tools/hayba-mcp/src/storage-path.test.ts
+++ b/mcp-tools/hayba-mcp/src/storage-path.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  StorageIdentifierError,
+  requireStorageFileStem,
+  requireStorageUuid,
+  resolveStorageChild,
+} from './storage-path.js';
+import { submitScratchZones, submitZones } from './zones.js';
+
+const tempDirs = new Set<string>();
+
+function tempBase(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hayba-storage-boundary-'));
+  tempDirs.add(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+describe('storage path boundary', () => {
+  it('accepts generated UUIDs and resolves a strict child', () => {
+    const base = tempBase();
+    const id = randomUUID();
+    expect(requireStorageUuid(id, 'projectId')).toBe(id);
+    expect(resolveStorageChild(base, id, 'project.json')).toBe(resolve(base, id, 'project.json'));
+  });
+
+  it.each([
+    '../../outside',
+    '..\\..\\outside',
+    '00000000-0000-0000-0000-000000000000',
+    '6ba7b810-9dad-01d1-80b4-00c04fd430c8/extra',
+    '',
+    ['6ba7b810-9dad-41d1-80b4-00c04fd430c8'],
+    { toString: () => '6ba7b810-9dad-41d1-80b4-00c04fd430c8' },
+  ])('rejects a non-UUID storage directory: %s', (value) => {
+    expect(() => requireStorageUuid(value, 'projectId')).toThrow(StorageIdentifierError);
+  });
+
+  it.each(['../escape', '..\\escape', '.', '..', 'a/b', 'a:b', 'CON', 'lpt9', '', 'a'.repeat(129)])(
+    'rejects a non-portable filename stem: %s',
+    (value) => {
+      expect(() => requireStorageFileStem(value, 'zoneId')).toThrow(StorageIdentifierError);
+    },
+  );
+
+  it('rejects roots, parents, absolute escapes, and traversal segments', () => {
+    const base = tempBase();
+    for (const segments of [[], ['..'], ['..', 'outside'], [resolve(base, '..', 'outside')]]) {
+      expect(() => resolveStorageChild(base, ...segments)).toThrow(StorageIdentifierError);
+    }
+  });
+
+  it('rejects every invalid project/mask name before creating anything', async () => {
+    const base = tempBase();
+    const validProjectId = randomUUID();
+
+    await expect(submitZones('../../outside', [], [], base)).rejects.toBeInstanceOf(StorageIdentifierError);
+    await expect(
+      submitZones(validProjectId, [], [{ zoneId: '../outside', pngBase64: '' }], base),
+    ).rejects.toBeInstanceOf(StorageIdentifierError);
+
+    expect(readdirSync(base)).toEqual([]);
+    expect(existsSync(join(base, validProjectId))).toBe(false);
+  });
+
+  it('rejects invalid scratch identifiers and masks before creating anything', async () => {
+    const base = tempBase();
+    const validScratchId = randomUUID();
+
+    await expect(submitScratchZones('../outside', [], [], base)).rejects.toBeInstanceOf(StorageIdentifierError);
+    await expect(
+      submitScratchZones(validScratchId, [], [{ zoneId: 'NUL', pngBase64: '' }], base),
+    ).rejects.toBeInstanceOf(StorageIdentifierError);
+
+    expect(readdirSync(base)).toEqual([]);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/storage-path.ts
+++ b/mcp-tools/hayba-mcp/src/storage-path.ts
@@ -1,0 +1,46 @@
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const FILE_STEM = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+const WINDOWS_DEVICE = /^(?:CON|PRN|AUX|NUL|CLOCK\$|COM[1-9]|LPT[1-9])$/i;
+
+export class StorageIdentifierError extends Error {
+  readonly code = 'invalid_storage_identifier';
+
+  constructor(label: string) {
+    super(`${label} is not a valid storage identifier`);
+    this.name = 'StorageIdentifierError';
+  }
+}
+
+export function isStorageUuid(value: unknown): value is string {
+  return typeof value === 'string' && UUID.test(value);
+}
+
+export function requireStorageUuid(value: unknown, label: string): string {
+  if (!isStorageUuid(value)) throw new StorageIdentifierError(label);
+  return value;
+}
+
+/** A portable filename stem: no separators, dot segments, devices, or ADS. */
+export function requireStorageFileStem(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !FILE_STEM.test(value) || WINDOWS_DEVICE.test(value)) {
+    throw new StorageIdentifierError(label);
+  }
+  return value;
+}
+
+/**
+ * Resolve only strict child paths. This is a second boundary behind the
+ * identifier allowlists: a future caller cannot make a traversal safe merely
+ * by forgetting which segment validator it needed.
+ */
+export function resolveStorageChild(root: string, ...segments: string[]): string {
+  const absoluteRoot = resolve(root);
+  const candidate = resolve(absoluteRoot, ...segments);
+  const fromRoot = relative(absoluteRoot, candidate);
+  if (!fromRoot || isAbsolute(fromRoot) || fromRoot === '..' || fromRoot.startsWith(`..${sep}`)) {
+    throw new StorageIdentifierError('storage path');
+  }
+  return candidate;
+}

--- a/mcp-tools/hayba-mcp/src/zones.ts
+++ b/mcp-tools/hayba-mcp/src/zones.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { DEFAULT_PROJECTS_BASE } from './projects.js';
+import { isStorageUuid, requireStorageFileStem, requireStorageUuid, resolveStorageChild } from './storage-path.js';
 
 export interface Zone {
   id: string;
@@ -46,7 +47,7 @@ export function getPainterSession(): PainterSession | null {
 }
 
 function projectDir(projectId: string, base: string): string {
-  return join(base, projectId);
+  return resolveStorageChild(base, requireStorageUuid(projectId, 'projectId'));
 }
 
 export async function submitZones(
@@ -57,20 +58,26 @@ export async function submitZones(
   canvasSize: 1024 | 2048 | 4096 = 1024,
   phase: 'a' | 'b' = 'a',
 ): Promise<ZoneSession> {
+  // Validate the complete request before the first filesystem mutation. A bad
+  // name must not leave an empty project or masks directory behind.
+  const safeMasks = masks.map((mask) => ({
+    ...mask,
+    zoneId: requireStorageFileStem(mask.zoneId, 'zoneId'),
+  }));
   const masksDir = join(projectDir(projectId, base), 'masks');
   mkdirSync(masksDir, { recursive: true });
   const writtenMasks: { zoneId: string; pngPath: string }[] = [];
 
-  for (const m of masks) {
+  for (const m of safeMasks) {
     const filename = `${m.zoneId}.png`;
     const pngPath = join(masksDir, filename);
     writeFileSync(pngPath, Buffer.from(m.pngBase64, 'base64'));
     writtenMasks.push({ zoneId: m.zoneId, pngPath });
   }
 
-  const zonesWithPaths: Zone[] = zones.map(z => ({
+  const zonesWithPaths: Zone[] = zones.map((z) => ({
     ...z,
-    maskPath: writtenMasks.find(m => m.zoneId === z.id)?.pngPath ?? '',
+    maskPath: writtenMasks.find((m) => m.zoneId === z.id)?.pngPath ?? '',
   }));
 
   const session: ZoneSession = {
@@ -82,19 +89,16 @@ export async function submitZones(
     phase,
   };
 
-  writeFileSync(
-    join(projectDir(projectId, base), 'zones.json'),
-    JSON.stringify(session, null, 2),
-    'utf-8',
-  );
+  writeFileSync(join(projectDir(projectId, base), 'zones.json'), JSON.stringify(session, null, 2), 'utf-8');
 
   return session;
 }
 
-export async function getCurrentZones(
-  projectId: string,
-  base = DEFAULT_PROJECTS_BASE,
-): Promise<ZoneSession | null> {
+export async function getCurrentZones(projectId: string, base = DEFAULT_PROJECTS_BASE): Promise<ZoneSession | null> {
+  if (!isStorageUuid(projectId)) {
+    requireStorageFileStem(projectId, 'projectId');
+    return null;
+  }
   const file = join(projectDir(projectId, base), 'zones.json');
   if (!existsSync(file)) return null;
   const raw = readFileSync(file, 'utf-8');
@@ -108,7 +112,7 @@ const SCRATCH_SUBDIR = '.scratch';
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 function scratchSessionDir(scratchId: string, base: string): string {
-  return join(base, SCRATCH_SUBDIR, scratchId);
+  return resolveStorageChild(base, SCRATCH_SUBDIR, requireStorageUuid(scratchId, 'scratchSessionId'));
 }
 
 export function createScratchSession(
@@ -130,20 +134,26 @@ export async function submitScratchZones(
   base = DEFAULT_PROJECTS_BASE,
   canvasSize: 1024 | 2048 | 4096 = 1024,
 ): Promise<ZoneSession> {
+  // Keep rejection atomic: validate every attacker-controlled filename before
+  // creating the scratch session directory.
+  const safeMasks = masks.map((mask) => ({
+    ...mask,
+    zoneId: requireStorageFileStem(mask.zoneId, 'zoneId'),
+  }));
   const dir = scratchSessionDir(scratchSessionId, base);
   const masksDir = join(dir, 'masks');
   mkdirSync(masksDir, { recursive: true });
   const writtenMasks: { zoneId: string; pngPath: string }[] = [];
 
-  for (const m of masks) {
+  for (const m of safeMasks) {
     const pngPath = join(masksDir, `${m.zoneId}.png`);
     writeFileSync(pngPath, Buffer.from(m.pngBase64, 'base64'));
     writtenMasks.push({ zoneId: m.zoneId, pngPath });
   }
 
-  const zonesWithPaths: Zone[] = zones.map(z => ({
+  const zonesWithPaths: Zone[] = zones.map((z) => ({
     ...z,
-    maskPath: writtenMasks.find(m => m.zoneId === z.id)?.pngPath ?? '',
+    maskPath: writtenMasks.find((m) => m.zoneId === z.id)?.pngPath ?? '',
   }));
 
   const session: ZoneSession = {
@@ -163,6 +173,10 @@ export async function getScratchZones(
   scratchSessionId: string,
   base = DEFAULT_PROJECTS_BASE,
 ): Promise<ZoneSession | null> {
+  if (!isStorageUuid(scratchSessionId)) {
+    requireStorageFileStem(scratchSessionId, 'scratchSessionId');
+    return null;
+  }
   const file = join(scratchSessionDir(scratchSessionId, base), 'zones.json');
   if (!existsSync(file)) return null;
   return JSON.parse(readFileSync(file, 'utf-8')) as ZoneSession;
@@ -173,6 +187,7 @@ export function cleanupExpiredScratch(base = DEFAULT_PROJECTS_BASE): void {
   if (!existsSync(scratchBase)) return;
   const now = Date.now();
   for (const entry of readdirSync(scratchBase)) {
+    if (!isStorageUuid(entry)) continue;
     const metaPath = join(scratchBase, entry, 'meta.json');
     if (!existsSync(metaPath)) continue;
     try {
@@ -180,7 +195,9 @@ export function cleanupExpiredScratch(base = DEFAULT_PROJECTS_BASE): void {
       if (meta.expiresAt < now) {
         rmSync(join(scratchBase, entry), { recursive: true, force: true });
       }
-    } catch { /* skip corrupt entries */ }
+    } catch {
+      /* skip corrupt entries */
+    }
   }
 }
 
@@ -192,9 +209,6 @@ export async function setHeightmap(
   heightmapStore.set(projectId, heightmapPath);
 }
 
-export async function getHeightmap(
-  projectId: string,
-  _base = DEFAULT_PROJECTS_BASE,
-): Promise<string | null> {
+export async function getHeightmap(projectId: string, _base = DEFAULT_PROJECTS_BASE): Promise<string | null> {
   return heightmapStore.get(projectId) ?? null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@modelcontextprotocol/sdk": "^1.30.0",
         "cheerio": "^1.2.0",
         "express": "^5.2.1",
+        "express-rate-limit": "8.6.2",
         "js-yaml": "5.2.3",
         "minisearch": "^7.2.0",
         "openai": "^6.45.0",
@@ -3515,11 +3516,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "cheerio": "^1.2.0",
-        "express": "^4.21.0",
+        "express": "^5.2.1",
         "js-yaml": "5.2.3",
         "minisearch": "^7.2.0",
         "openai": "^6.45.0",
@@ -290,31 +290,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
-    },
-    "node_modules/@eslint/config-array/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.7.0",
@@ -1129,321 +1104,6 @@
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
-      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^2.0.0",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.1",
-        "iconv-lite": "^0.7.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.15.2",
-        "raw-body": "^3.0.2",
-        "type-is": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
-      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^2.0.0",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
@@ -2078,31 +1738,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
@@ -2124,31 +1759,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
       }
-    },
-    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/project-service/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.66.0",
@@ -2210,31 +1820,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@typescript-eslint/types": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
@@ -2276,31 +1861,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
       }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.66.0",
@@ -2798,16 +2358,41 @@
       }
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/acorn": {
@@ -2900,12 +2485,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2965,23 +2544,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/axios/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/axios/node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -2995,12 +2557,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/axios/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3012,54 +2568,56 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
-      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.15.1",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
       },
-      "engines": {
-        "node": ">= 0.8"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/boolbase": {
@@ -3270,15 +2828,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -3307,10 +2866,13 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -3372,12 +2934,20 @@
       }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-is": {
@@ -3437,16 +3007,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -3790,35 +3350,10 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/eslint/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3937,45 +3472,42 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.5",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.15.1",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
@@ -3998,6 +3530,31 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4101,21 +3658,24 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -4208,12 +3768,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -4536,29 +4096,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -5163,42 +4700,28 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -5254,9 +4777,9 @@
       "license": "MIT"
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/msw": {
@@ -5402,9 +4925,9 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5707,12 +5230,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -6013,29 +5530,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/router/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/router/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/router/node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -6045,26 +5539,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6100,34 +5574,55 @@
       "license": "MIT"
     },
     "node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
@@ -6157,18 +5652,22 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -6590,16 +6089,59 @@
       }
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -6683,15 +6225,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/vary": {


### PR DESCRIPTION
Closes #395

## Outcome

Migrates Hayba's direct dashboard/chat/sliver HTTP boundaries to Express 5.2.1 and makes the changed runtime semantics explicit.

- replaces the invalid Express 4 `*` SPA route with the Express 5 named `/{*splat}` form
- keeps `/api`, `/chat`, and `/sliver` failures on JSON 404s before SPA fallback
- serves the SPA only for extensionless HTML navigation; missing assets and dotfiles remain 404
- pins the simple query parser and rejects duplicate scalar query parameters instead of choosing one
- normalizes absent bodies for route validation and returns bounded JSON 400/413/500 envelopes
- forwards async handler rejections through a secret-redacting error boundary
- handles Express 5 listen callback errors, including `EADDRINUSE`, without a false listening log or process failure
- preserves SSE streaming/cancellation/approval/usage and exactly-once JSON redaction

The production build exposed a pre-existing one-segment-short import to `packages/linguistics`; `d1651e78` corrects it so the acceptance build genuinely runs.

## Security response

The first CodeQL run found 12 new HIGH alerts rather than a harmless aggregate-check artifact. This PR now fixes them instead of bypassing them:

- global loopback HTTP rate limiting before JSON/routes/static/SPA, with forwarding headers untrusted and Express fingerprinting disabled
- UUID-only project/scratch directories, portable allowlisted mask stems, Windows device-name rejection, and a second resolved-path containment boundary
- all attacker-controlled filenames validated before `mkdir`/write, so rejected requests leave no filesystem side effects
- stable non-reflective 400 responses for invalid storage identifiers
- read-only benign unknown IDs retain their historical null/404 behavior without ever becoming paths

Fresh-head CodeQL must pass before merge.

## Exact-head evidence (`189a9885`)

- clean `npm ci --ignore-scripts`
- production dependency audit: PASS, 5 assessed finding paths, 0 errors/warnings
- typecheck: clean
- focused Express/storage/sliver/chat gate: 6 files, 63 tests green
- full MCP tests: 180 files, 1,872 tests green (`--maxWorkers=4`, default assertions/timeouts unchanged)
- full dashboard + server build: green (47 dashboard modules transformed)
- legacy wrapper lint: green (22 C++ commands, 153 sidecar entries)
- changed-file ESLint: zero warnings/errors; new/formatted-file Prettier check: green
- Node 22.23.2 real-route smoke: API/root/nested SPA success, API miss JSON 404, clean shutdown
- migration mutations: restoring `app.get('*')` fails route-registration tests; accepting the first duplicate query value fails dashboard + sliver tests
- security mutations: disabling the limiter fails the header/429 test; disabling UUID validation fails six traversal/side-effect tests

The repo-wide lint/format commands remain red on the unchanged default-branch baseline (561 lint findings and 723 Prettier files); CI's corresponding advisory job remains non-blocking. No changed file adds a lint finding.