### PR TITLE
chore(architecture): remove inert Three.js install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,28 @@ jobs:
         working-directory: mcp-tools/hayba-mcp
         run: npm run lint:legacy-wrappers
 
+  architecture:
+    name: Architecture — clean install + build + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Clean install
+        run: npm ci --ignore-scripts
+
+      # The package test builds first, exercises the real demo server tests,
+      # then runs the TypeScript suite. It also owns the CDN-only Three.js
+      # boundary guard, so an inert npm dependency cannot drift back unnoticed.
+      - name: Build and test
+        run: npm test --workspace=@hayba/architecture
+
+      - name: Typecheck
+        run: npm run typecheck --workspace=@hayba/architecture
+
   sidecar:
     name: Visual sidecar — import + test + lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ All notable changes to Hayba MCP Toolkit are documented here. Format based on [K
   `mcp-tools/hayba-mcp/examples/github-actions-hayba-cli.yml`.
 
 ### Changed
+- The architecture workspace now declares its actual Three.js boundary: the
+  browser-only Culture Studio keeps one pinned CDN import map, while the unused
+  `three` and `@types/three` npm dependencies are removed. A source/manifest/
+  lockfile guard prevents the inert duplicate from returning or the two CDN
+  addon URLs from drifting to different runtime versions.
 - **Satellite plugins settled** ([ADR-0008](docs/adr/0008-satellite-plugins-earn-their-place.md)).
   `HaybaMCPGAS` and `HaybaMCPMetaSound` are installed and surfaced.
   `HaybaMCPNiagara` and `HaybaMCPSequencer` are deleted — every command they

--- a/package-lock.json
+++ b/package-lock.json
@@ -1850,13 +1850,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tweenjs/tween.js": {
-      "version": "23.1.3",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
-      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2014,39 +2007,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/stats.js": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
-      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/three": {
-      "version": "0.169.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
-      "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tweenjs/tween.js": "~23.1.3",
-        "@types/stats.js": "*",
-        "@types/webxr": "*",
-        "@webgpu/types": "*",
-        "fflate": "~0.8.2",
-        "meshoptimizer": "~0.18.1"
-      }
-    },
-    "node_modules/@types/webxr": {
-      "version": "0.5.24",
-      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
-      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2832,13 +2796,6 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.70",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
-      "integrity": "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -4130,13 +4087,6 @@
         }
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5229,13 +5179,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/meshoptimizer": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
-      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -6508,12 +6451,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/three": {
-      "version": "0.169.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
-      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
-      "license": "MIT"
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7093,12 +7030,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.96.0",
-        "three": "^0.169.0"
+        "@anthropic-ai/sdk": "^0.96.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "@types/three": "^0.169.0",
         "@vitest/coverage-v8": "^4.1.10",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"

--- a/packages/architecture/README.md
+++ b/packages/architecture/README.md
@@ -17,6 +17,11 @@ node demo/serve.mjs
 
 Set `PORT=<n>` to override. The server auto-increments if the port is busy.
 
+The demo intentionally loads Three.js and its addons from the pinned import map
+in `demo/index.html`. The TypeScript package does not import Three.js, so the npm
+workspace must not install `three` or `@types/three`; `demo/three-boundary.test.mjs`
+guards that boundary and keeps both import-map URLs on one exact runtime version.
+
 ### Data layout
 
 Per-culture, three JSON files under `src/data/cultures/<culture-id>/`:

--- a/packages/architecture/demo/three-boundary.test.mjs
+++ b/packages/architecture/demo/three-boundary.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, extname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const demoRoot = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(demoRoot, '..');
+const repoRoot = resolve(packageRoot, '..', '..');
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+async function sourceFiles(root) {
+  const out = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) out.push(...(await sourceFiles(path)));
+    else if (['.ts', '.mts', '.cts'].includes(extname(entry.name))) out.push(path);
+  }
+  return out.sort();
+}
+
+function importedSpecifiers(source) {
+  const patterns = [
+    /\bfrom\s*['"]([^'"]+)['"]/g,
+    /\bimport\s*['"]([^'"]+)['"]/g,
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ];
+  return patterns.flatMap((pattern) => [...source.matchAll(pattern)].map((match) => match[1]));
+}
+
+test('the Node workspace cannot reinstall the CDN-only Three.js runtime', async () => {
+  const manifest = await readJson(join(packageRoot, 'package.json'));
+  const lock = await readJson(join(repoRoot, 'package-lock.json'));
+  const lockedWorkspace = lock.packages?.['packages/architecture'];
+
+  assert.ok(lockedWorkspace, 'package-lock must record the architecture workspace');
+  for (const name of ['three', '@types/three']) {
+    assert.equal(manifest.dependencies?.[name], undefined, `${name} is browser-only, not a Node dependency`);
+    assert.equal(manifest.devDependencies?.[name], undefined, `${name} types cannot describe CDN runtime code`);
+    assert.equal(
+      lockedWorkspace.dependencies?.[name],
+      undefined,
+      `${name} must not return in the workspace lock entry`,
+    );
+    assert.equal(lockedWorkspace.devDependencies?.[name], undefined, `${name} types must not return in the lock entry`);
+  }
+});
+
+test('architecture TypeScript has no hidden Three.js reachability', async () => {
+  const offenders = [];
+  for (const path of await sourceFiles(join(packageRoot, 'src'))) {
+    const source = await readFile(path, 'utf8');
+    for (const specifier of importedSpecifiers(source)) {
+      if (specifier === 'three' || specifier.startsWith('three/')) {
+        offenders.push(`${path.slice(packageRoot.length + 1)} -> ${specifier}`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], 'Three.js belongs only to the browser import map');
+});
+
+test('the served browser entrypoint pins one coherent Three.js runtime', async () => {
+  const html = await readFile(join(demoRoot, 'index.html'), 'utf8');
+  const importMapText = html.match(/<script\s+type="importmap">\s*([\s\S]*?)\s*<\/script>/)?.[1];
+  assert.ok(importMapText, 'demo/index.html must contain an import map');
+
+  const imports = JSON.parse(importMapText).imports;
+  assert.deepEqual(Object.keys(imports).sort(), ['three', 'three/addons/']);
+
+  const runtime = imports.three.match(/^https:\/\/unpkg\.com\/three@(\d+\.\d+\.\d+)\/build\/three\.module\.js$/);
+  const addons = imports['three/addons/'].match(/^https:\/\/unpkg\.com\/three@(\d+\.\d+\.\d+)\/examples\/jsm\/$/);
+  assert.ok(runtime, 'the runtime URL must use an exact unpkg Three.js version');
+  assert.ok(addons, 'the addon URL must use an exact unpkg Three.js version');
+  assert.equal(addons[1], runtime[1], 'runtime and addon versions must migrate together');
+
+  for (const browserContract of [
+    "import * as THREE from 'three'",
+    "from 'three/addons/loaders/GLTFLoader.js'",
+    "from 'three/addons/controls/OrbitControls.js'",
+    'new THREE.WebGLRenderer',
+    'new THREE.SphereGeometry',
+    'new GLTFLoader',
+    'new OrbitControls',
+    'renderer.setSize',
+    'renderer.render',
+  ]) {
+    assert.match(html, new RegExp(browserContract.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});

--- a/packages/architecture/package.json
+++ b/packages/architecture/package.json
@@ -21,17 +21,16 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "vitest run",
+    "test": "npm run build && npm run test:demo && vitest run",
+    "test:demo": "node --test demo/*.test.mjs",
     "typecheck": "tsc --noEmit",
     "serve": "tsc && node demo/serve.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.96.0",
-    "three": "^0.169.0"
+    "@anthropic-ai/sdk": "^0.96.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "@types/three": "^0.169.0",
     "@vitest/coverage-v8": "^4.1.10",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/packages/architecture/tsconfig.json
+++ b/packages/architecture/tsconfig.json
@@ -9,6 +9,7 @@
     "rootDir": "src",
     "strict": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "verbatimModuleSyntax": true,
     "resolveJsonModule": true
   },


### PR DESCRIPTION
## Outcome

Choose the CDN-only boundary for the Architecture Culture Studio and remove the inert `three` / `@types/three` npm install.

- removes both direct dependencies and only their unreachable lockfile subgraph;
- adds a deterministic guard for manifest/lock reachability, TypeScript imports, exact CDN pins, version parity, and the browser renderer/addon contract;
- makes the package test build first and run the existing demo server tests as well as Vitest;
- adds a clean-install architecture CI job;
- explicitly includes Node types so the package builds from a clean TypeScript 7 install.

## Verification

- `npm ci --ignore-scripts` from an empty install: pass (repeated after rebase)
- `npm test --workspace=@hayba/architecture`: 14/14 demo/server tests and 140/140 Vitest tests pass
- `npm run typecheck --workspace=@hayba/architecture`: pass
- changed-file ESLint/Prettier: pass
- production dependency audit: pass
- `npm ls three @types/three --workspace=@hayba/architecture --depth=0`: empty
- served `/demo/`, CSS, and representative culture data: HTTP 200
- pinned Three.js runtime, GLTFLoader, and OrbitControls URLs: HTTP 200
- mutation checks: reintroducing `three` fails the guard; splitting runtime/addon CDN versions fails the guard

Closes #400