### PR TITLE
fix(mcp): handle Anthropic 0.115 stop states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ All notable changes to Hayba MCP Toolkit are documented here. Format based on [K
   response send completion, suspends only the empty next-frame idle timeout
   while work is outstanding, and still disconnects idle clients and partial-
   frame slowloris senders on a bounded deadline.
+- Anthropic SDK 0.115 compatibility keeps context-window exhaustion,
+  refusals, token limits, pauses, and unknown future stop reasons distinct
+  instead of reporting them as a successful `end_turn`. Unsupported
+  mid-turn tool-catalog changes and malformed streamed tool JSON now fail
+  closed with bounded diagnostics; the unused second SDK dependency in the
+  architecture package was removed.
 - `test_run` now accepts the same case-insensitive filter/category selectors as
   `test_list`, rejects empty, ambiguous, and zero-match requests instead of
   returning false-green empty results, and reports explicit pass/fail/skip

--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -21,7 +21,7 @@
     "gen:plumb-enums": "npx tsx scripts/gen-plumb-enums.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.110.0",
+    "@anthropic-ai/sdk": "^0.115.0",
     "@distube/ytdl-core": "^4.16.12",
     "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp-tools/hayba-mcp/src/agents/llm-client.test.ts
+++ b/mcp-tools/hayba-mcp/src/agents/llm-client.test.ts
@@ -1,9 +1,13 @@
+import { createServer } from 'node:http';
+import { once } from 'node:events';
 import { describe, it, expect, vi } from 'vitest';
 import {
   createLLMClient,
   buildAnthropicRequest,
+  LLMError,
   type AnthropicClientLike,
   type LLMCompleteParams,
+  type LLMStreamEvent,
   type LLMTool,
 } from './llm-client.js';
 
@@ -23,7 +27,29 @@ function baseParams(over: Partial<LLMCompleteParams> = {}): LLMCompleteParams {
   };
 }
 
-const RESOLVED_CFG = { provider: 'anthropic', protocol: 'anthropic' as const, model: 'claude-x', baseURL: '', apiKey: 'k' };
+const RESOLVED_CFG = {
+  provider: 'anthropic',
+  protocol: 'anthropic' as const,
+  model: 'claude-x',
+  baseURL: '',
+  apiKey: 'k',
+};
+
+function anthropicFake(over: Partial<AnthropicClientLike['messages']> = {}): AnthropicClientLike {
+  return {
+    messages: {
+      create: vi.fn(),
+      stream: vi.fn(),
+      ...over,
+    },
+  };
+}
+
+async function collectStream(client: ReturnType<typeof createLLMClient>): Promise<LLMStreamEvent[]> {
+  const events: LLMStreamEvent[] = [];
+  for await (const event of client.stream(baseParams())) events.push(event);
+  return events;
+}
 
 // ---------------------------------------------------------------------------
 // cache_control placement (Issue #30)
@@ -99,6 +125,261 @@ describe('buildAnthropicRequest — cache_control placement', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Anthropic 0.115 stop/content compatibility (Issue #398)
+// ---------------------------------------------------------------------------
+
+describe('Anthropic 0.115 non-stream responses', () => {
+  it.each([
+    ['end_turn', 'end_turn'],
+    ['max_tokens', 'max_tokens'],
+    ['model_context_window_exceeded', 'model_context_window_exceeded'],
+  ] as const)('keeps %s distinct instead of collapsing it to success', async (wireReason, expected) => {
+    const fake = anthropicFake({
+      create: vi.fn().mockResolvedValue({ content: [], stop_reason: wireReason }),
+    });
+    const response = await createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake }).complete(
+      baseParams(),
+    );
+    expect(response.stopReason).toBe(expected);
+  });
+
+  it('parses a complete tool_use block as a structured call', async () => {
+    const fake = anthropicFake({
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: 'tool_use', id: 'tool_1', name: 'actor_list', input: { class: 'Pawn' } }],
+        stop_reason: 'tool_use',
+      }),
+    });
+    const response = await createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake }).complete(
+      baseParams(),
+    );
+    expect(response).toMatchObject({
+      stopReason: 'tool_use',
+      toolCalls: [{ id: 'tool_1', name: 'actor_list', input: { class: 'Pawn' } }],
+    });
+  });
+
+  it('maps an unknown future stop reason to unknown with bounded guidance', async () => {
+    const futureReason = `future_${'x'.repeat(5000)}`;
+    const fake = anthropicFake({
+      create: vi.fn().mockResolvedValue({ content: [], stop_reason: futureReason }),
+    });
+    const response = await createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake }).complete(
+      baseParams(),
+    );
+    expect(response.stopReason).toBe('unknown');
+    expect(response.stopDiagnostic?.code).toBe('unknown_stop_reason');
+    expect(JSON.stringify(response.stopDiagnostic)).not.toContain(futureReason);
+    expect(JSON.stringify(response.stopDiagnostic).length).toBeLessThan(320);
+  });
+
+  it('gives context exhaustion a bounded recovery tip without provider or prompt text', async () => {
+    const secret = 'sk-ant-context-secret';
+    const fake = anthropicFake({
+      create: vi.fn().mockResolvedValue({
+        content: [],
+        stop_reason: 'model_context_window_exceeded',
+        stop_details: { explanation: `repeat prompt and ${secret}` },
+      }),
+    });
+    const response = await createLLMClient({ provider: 'anthropic', apiKey: secret }, { anthropic: fake }).complete(
+      baseParams({ messages: [{ role: 'user', content: `private prompt ${secret}` }] }),
+    );
+    expect(response.stopDiagnostic).toMatchObject({
+      code: 'context_window_exceeded',
+      recoveryTip: expect.stringContaining('remove older messages'),
+    });
+    const serialized = JSON.stringify(response.stopDiagnostic);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain('private prompt');
+    expect(serialized.length).toBeLessThan(320);
+  });
+
+  it('handles refusal stop details without echoing the provider explanation', async () => {
+    const secret = 'sk-ant-refusal-secret';
+    const fake = anthropicFake({
+      create: vi.fn().mockResolvedValue({
+        content: [],
+        stop_reason: 'refusal',
+        stop_details: { type: 'refusal', category: 'cyber', explanation: `provider repeated ${secret}` },
+      }),
+    });
+    const response = await createLLMClient({ provider: 'anthropic', apiKey: secret }, { anthropic: fake }).complete(
+      baseParams(),
+    );
+    expect(response).toMatchObject({
+      stopReason: 'refusal',
+      stopDiagnostic: { code: 'provider_refusal', message: expect.stringContaining('cyber') },
+    });
+    expect(JSON.stringify(response)).not.toContain(secret);
+    expect(JSON.stringify(response)).not.toContain('provider repeated');
+  });
+
+  it.each(['tool_addition', 'tool_removal'])(
+    'rejects unsupported %s blocks explicitly instead of discarding catalog state',
+    async (type) => {
+      const fake = anthropicFake({
+        create: vi.fn().mockResolvedValue({
+          content: [{ type, tool: { type: 'tool_reference', name: 'actor_spawn' } }],
+          stop_reason: 'end_turn',
+        }),
+      });
+      await expect(
+        createLLMClient({ provider: 'anthropic', apiKey: 'k' }, { anthropic: fake }).complete(baseParams()),
+      ).rejects.toMatchObject({ kind: 'protocol', message: expect.stringContaining(type) });
+    },
+  );
+
+  it('rejects error content without reflecting its untrusted payload', async () => {
+    const secret = 'sk-ant-block-secret';
+    const fake = anthropicFake({
+      create: vi.fn().mockResolvedValue({
+        content: [{ type: 'error', message: `wire payload ${secret}` }],
+        stop_reason: 'end_turn',
+      }),
+    });
+    const promise = createLLMClient({ provider: 'anthropic', apiKey: secret }, { anthropic: fake }).complete(
+      baseParams(),
+    );
+    await expect(promise).rejects.toMatchObject({ kind: 'protocol' });
+    await expect(promise).rejects.not.toThrow(secret);
+  });
+});
+
+describe('Anthropic 0.115 stream events', () => {
+  function streamThrough(...events: unknown[]): ReturnType<typeof createLLMClient> {
+    async function* fixture() {
+      for (const event of events) yield event;
+    }
+    return createLLMClient(
+      { provider: 'anthropic', apiKey: 'k' },
+      { anthropic: anthropicFake({ stream: vi.fn().mockReturnValue(fixture()) }) },
+    );
+  }
+
+  it.each([
+    ['end_turn', 'end_turn'],
+    ['max_tokens', 'max_tokens'],
+    ['model_context_window_exceeded', 'model_context_window_exceeded'],
+    ['future_stop', 'unknown'],
+  ] as const)('keeps streamed %s as %s', async (wireReason, expected) => {
+    const events = await collectStream(
+      streamThrough(
+        { type: 'message_start', message: { usage: { input_tokens: 3, output_tokens: 0 } } },
+        { type: 'message_delta', delta: { stop_reason: wireReason }, usage: { output_tokens: 2 } },
+        { type: 'message_stop' },
+      ),
+    );
+    const done = events.at(-1) as Extract<LLMStreamEvent, { type: 'done' }>;
+    expect(done.response.stopReason).toBe(expected);
+    expect(done.response.usage).toEqual({ inputTokens: 3, outputTokens: 2 });
+  });
+
+  it('assembles a streamed tool call from partial JSON', async () => {
+    const events = await collectStream(
+      streamThrough(
+        {
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'tool_use', id: 'tool_2', name: 'actor_list' },
+        },
+        { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{"class":' } },
+        { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '"Pawn"}' } },
+        { type: 'content_block_stop', index: 1 },
+        { type: 'message_delta', delta: { stop_reason: 'tool_use' } },
+        { type: 'message_stop' },
+      ),
+    );
+    expect(events).toContainEqual({
+      type: 'tool_call',
+      call: { id: 'tool_2', name: 'actor_list', input: { class: 'Pawn' } },
+    });
+    expect((events.at(-1) as Extract<LLMStreamEvent, { type: 'done' }>).response.stopReason).toBe('tool_use');
+  });
+
+  it('rejects malformed partial tool JSON as a protocol error without echoing it', async () => {
+    const client = streamThrough(
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'tool_bad', name: 'actor_spawn' },
+      },
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"secret":"DO_NOT_ECHO"' },
+      },
+      { type: 'content_block_stop', index: 0 },
+    );
+    const error = await collectStream(client).catch((caught: unknown) => caught as LLMError);
+    expect(error).toMatchObject({
+      kind: 'protocol',
+      message: expect.stringContaining('malformed tool input JSON'),
+    });
+    expect((error as LLMError).message).not.toContain('DO_NOT_ECHO');
+  });
+
+  it.each(['tool_addition', 'tool_removal'])(
+    'rejects streamed %s content blocks instead of discarding catalog state',
+    async (type) => {
+      await expect(
+        collectStream(
+          streamThrough({
+            type: 'content_block_start',
+            index: 0,
+            content_block: { type, tool: { type: 'tool_reference', name: 'actor_spawn' } },
+          }),
+        ),
+      ).rejects.toMatchObject({ kind: 'protocol', message: expect.stringContaining(type) });
+    },
+  );
+
+  it('rejects a streamed tool_change event explicitly', async () => {
+    await expect(
+      collectStream(streamThrough({ type: 'tool_change', tool: { type: 'tool_reference', name: 'actor_spawn' } })),
+    ).rejects.toMatchObject({ kind: 'protocol', message: expect.stringContaining('tool_change') });
+  });
+
+  it('normalizes a streamed refusal without reflecting its explanation', async () => {
+    const secret = 'streamed-refusal-secret';
+    const events = await collectStream(
+      streamThrough(
+        {
+          type: 'message_delta',
+          delta: {
+            stop_reason: 'refusal',
+            stop_details: { type: 'refusal', category: 'cyber', explanation: `provider repeated ${secret}` },
+          },
+        },
+        { type: 'message_stop' },
+      ),
+    );
+    const done = events.at(-1) as Extract<LLMStreamEvent, { type: 'done' }>;
+    expect(done.response).toMatchObject({
+      stopReason: 'refusal',
+      stopDiagnostic: { code: 'provider_refusal', message: expect.stringContaining('cyber') },
+    });
+    expect(JSON.stringify(done.response)).not.toContain(secret);
+    expect(JSON.stringify(done.response)).not.toContain('provider repeated');
+  });
+
+  it('redacts a provider stream error and preserves its API classification', async () => {
+    const secret = 'sk-ant-stream-secret';
+    async function* fixture() {
+      yield { type: 'error', error: { type: 'overloaded_error', message: `upstream exposed ${secret}` } };
+    }
+    const client = createLLMClient(
+      { provider: 'anthropic', apiKey: secret },
+      { anthropic: anthropicFake({ stream: vi.fn().mockReturnValue(fixture()) }) },
+    );
+    const error = await collectStream(client).catch((caught: unknown) => caught as LLMError);
+    expect(error).toMatchObject({ kind: 'api' });
+    expect((error as LLMError).message).toContain('[REDACTED:api_key]');
+    expect((error as LLMError).message).not.toContain(secret);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Usage / cache-hit metrics
 // ---------------------------------------------------------------------------
 
@@ -163,5 +444,103 @@ describe('cache-hit usage metrics', () => {
     const client = createLLMClient({ provider: 'mock' });
     const resp = await client.complete(baseParams());
     expect(resp.usage).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transport invariants retained across the SDK upgrade
+// ---------------------------------------------------------------------------
+
+describe('Anthropic request/error invariants', () => {
+  it('threads the same AbortSignal through complete() and stream()', async () => {
+    const controller = new AbortController();
+    const create = vi.fn().mockResolvedValue({ content: [], stop_reason: 'end_turn' });
+    async function* fixture() {
+      yield { type: 'message_delta', delta: { stop_reason: 'end_turn' } };
+      yield { type: 'message_stop' };
+    }
+    const stream = vi.fn().mockReturnValue(fixture());
+    const client = createLLMClient(
+      { provider: 'anthropic', apiKey: 'k' },
+      { anthropic: anthropicFake({ create, stream }) },
+    );
+
+    await client.complete(baseParams({ signal: controller.signal }));
+    const streamed: LLMStreamEvent[] = [];
+    for await (const event of client.stream(baseParams({ signal: controller.signal }))) streamed.push(event);
+    expect(streamed.at(-1)?.type).toBe('done');
+
+    expect(create.mock.calls[0]?.[1]).toEqual({ signal: controller.signal });
+    expect(stream.mock.calls[0]?.[1]).toEqual({ signal: controller.signal });
+  });
+
+  it('keeps AbortError distinct from an ordinary network failure', async () => {
+    async function* fixture() {
+      yield { type: 'message_stop' };
+      const error = new Error('request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+    const client = createLLMClient(
+      { provider: 'anthropic', apiKey: 'k' },
+      { anthropic: anthropicFake({ stream: vi.fn().mockReturnValue(fixture()) }) },
+    );
+    await expect(collectStream(client)).rejects.toMatchObject({ kind: 'aborted' });
+  });
+
+  it('redacts the configured key from a provider HTTP error', async () => {
+    const secret = 'sk-ant-provider-secret';
+    const create = vi.fn().mockRejectedValue({ status: 401, message: `bad bearer ${secret}` });
+    const promise = createLLMClient(
+      { provider: 'anthropic', apiKey: secret },
+      { anthropic: anthropicFake({ create }) },
+    ).complete(baseParams());
+    const error = await promise.catch((caught: unknown) => caught as LLMError);
+    expect(error).toMatchObject({ kind: 'auth', status: 401 });
+    expect((error as LLMError).message).toContain('***');
+    expect((error as LLMError).message).not.toContain(secret);
+  });
+
+  it('constructs the real 0.115 module lazily against localhost with no external API key', async () => {
+    let requests = 0;
+    const server = createServer((_request, response) => {
+      requests += 1;
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          id: 'msg_local_fixture',
+          type: 'message',
+          role: 'assistant',
+          model: 'claude-local-fixture',
+          content: [{ type: 'text', text: 'local module loaded' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 2, output_tokens: 3 },
+        }),
+      );
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected a TCP test listener');
+
+    try {
+      const client = createLLMClient({
+        provider: 'anthropic',
+        apiKey: 'local-fixture-key',
+        baseURL: `http://127.0.0.1:${address.port}`,
+      });
+      expect(requests, 'construction must not perform I/O').toBe(0);
+      const response = await client.complete(baseParams());
+      expect(requests).toBe(1);
+      expect(response).toMatchObject({
+        content: 'local module loaded',
+        stopReason: 'end_turn',
+        usage: { inputTokens: 2, outputTokens: 3 },
+      });
+    } finally {
+      server.close();
+      await once(server, 'close');
+    }
   });
 });

--- a/mcp-tools/hayba-mcp/src/agents/llm-client.ts
+++ b/mcp-tools/hayba-mcp/src/agents/llm-client.ts
@@ -2,7 +2,7 @@
  * BYOK LLM client with tool-calling + streaming.
  *
  * Restored from the removed commit ac46d40 (packages/hayba/src/agents/llm-client.ts):
- *   - LLMTool / LLMToolCall / LLMResponse (stopReason:'end_turn'|'tool_use'|'max_tokens')
+ *   - LLMTool / LLMToolCall / LLMResponse
  *   - complete()
  *
  * Extended for the chat copilot:
@@ -52,7 +52,31 @@ export interface LLMToolCall {
   input: Record<string, unknown>;
 }
 
-export type LLMStopReason = 'end_turn' | 'tool_use' | 'max_tokens' | 'content_filter' | 'unknown';
+/**
+ * Provider stop states kept distinct at the protocol boundary. In particular,
+ * an unfamiliar future value must never become `end_turn`: that would turn a
+ * provider/schema mismatch into an apparently successful response.
+ */
+export type LLMStopReason =
+  | 'end_turn'
+  | 'tool_use'
+  | 'max_tokens'
+  | 'stop_sequence'
+  | 'pause_turn'
+  | 'refusal'
+  | 'model_context_window_exceeded'
+  | 'content_filter'
+  | 'unknown';
+
+export type LLMStopDiagnosticCode =
+  'context_window_exceeded' | 'provider_refusal' | 'turn_paused' | 'unknown_stop_reason';
+
+/** Bounded, provider-safe guidance attached to exceptional stop states. */
+export interface LLMStopDiagnostic {
+  code: LLMStopDiagnosticCode;
+  message: string;
+  recoveryTip: string;
+}
 
 /**
  * Token accounting for one LLM call. `cacheCreationInputTokens` /
@@ -71,6 +95,7 @@ export interface LLMResponse {
   content: string | null;
   toolCalls: LLMToolCall[];
   stopReason: LLMStopReason;
+  stopDiagnostic?: LLMStopDiagnostic;
   usage?: LLMUsage;
 }
 
@@ -80,7 +105,7 @@ export type LLMStreamEvent =
   | { type: 'tool_call'; call: LLMToolCall }
   | { type: 'done'; response: LLMResponse };
 
-export type LLMErrorKind = 'auth' | 'rate_limit' | 'network' | 'api';
+export type LLMErrorKind = 'auth' | 'rate_limit' | 'network' | 'api' | 'protocol' | 'aborted';
 
 /** Typed error so the agent loop / UI can react. Never contains the API key. */
 export class LLMError extends Error {
@@ -249,10 +274,12 @@ function redactDiagnostic(text: string, apiKey: string): string {
 }
 
 function mapError(err: unknown, provider: string, apiKey: string): LLMError {
+  if (err instanceof LLMError) return err;
   const e = err as { name?: string; status?: number; statusCode?: number; message?: string; code?: string };
   const status = e?.status ?? e?.statusCode;
   let kind: LLMErrorKind;
-  if (status === 401 || status === 403) kind = 'auth';
+  if (e?.name === 'AbortError' || e?.code === 'ABORT_ERR') kind = 'aborted';
+  else if (status === 401 || status === 403) kind = 'auth';
   else if (status === 429) kind = 'rate_limit';
   else if (status === undefined) kind = 'network';
   else kind = 'api';
@@ -302,10 +329,65 @@ function toOpenAITools(tools: LLMTool[]): Array<Record<string, unknown>> {
 // Stop-reason normalization
 // ---------------------------------------------------------------------------
 
-function normalizeAnthropicStop(reason: unknown): LLMStopReason {
-  if (reason === 'tool_use') return 'tool_use';
-  if (reason === 'max_tokens') return 'max_tokens';
-  return 'end_turn';
+interface NormalizedAnthropicStop {
+  stopReason: LLMStopReason;
+  stopDiagnostic?: LLMStopDiagnostic;
+}
+
+const CONTEXT_RECOVERY_TIP =
+  'Start a new chat or remove older messages and large tool results, then retry the request.';
+
+function normalizeAnthropicStop(reason: unknown, stopDetails?: { category?: unknown } | null): NormalizedAnthropicStop {
+  switch (reason) {
+    case 'end_turn':
+    case 'tool_use':
+    case 'max_tokens':
+    case 'stop_sequence':
+      return { stopReason: reason };
+    case 'model_context_window_exceeded':
+      return {
+        stopReason: reason,
+        stopDiagnostic: {
+          code: 'context_window_exceeded',
+          message: 'Anthropic stopped because the model context window was exhausted.',
+          recoveryTip: CONTEXT_RECOVERY_TIP,
+        },
+      };
+    case 'refusal': {
+      const category =
+        typeof stopDetails?.category === 'string' && /^[a-z_]{1,32}$/.test(stopDetails.category)
+          ? ` (${stopDetails.category})`
+          : '';
+      return {
+        stopReason: reason,
+        stopDiagnostic: {
+          code: 'provider_refusal',
+          // Do not echo stop_details.explanation: providers may repeat prompt
+          // material there. The category is a bounded enum-like identifier.
+          message: `Anthropic refused the request${category}.`,
+          recoveryTip: 'Rephrase or narrow the request while preserving the intended safe operation.',
+        },
+      };
+    }
+    case 'pause_turn':
+      return {
+        stopReason: reason,
+        stopDiagnostic: {
+          code: 'turn_paused',
+          message: 'Anthropic paused a long-running turn that Hayba cannot resume automatically.',
+          recoveryTip: 'Retry the request as a smaller operation or continue it in a new turn.',
+        },
+      };
+    default:
+      return {
+        stopReason: 'unknown',
+        stopDiagnostic: {
+          code: 'unknown_stop_reason',
+          message: 'Anthropic returned an unsupported stop reason; the turn was not treated as complete.',
+          recoveryTip: 'Upgrade Hayba or choose another provider before retrying this turn.',
+        },
+      };
+  }
 }
 
 function normalizeOpenAIStop(reason: unknown): LLMStopReason {
@@ -391,30 +473,69 @@ function parseAnthropicUsage(raw: RawAnthropicUsage | undefined): LLMUsage | und
   return Object.keys(usage).length > 0 ? usage : undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function anthropicProtocolError(message: string): LLMError {
+  return new LLMError('protocol', `Anthropic protocol error: ${message}`);
+}
+
+function parseAnthropicToolUse(block: Record<string, unknown>, location: string): LLMToolCall {
+  if (typeof block.id !== 'string' || block.id.length === 0) {
+    throw anthropicProtocolError(`${location} has no valid tool-use id.`);
+  }
+  if (typeof block.name !== 'string' || block.name.length === 0) {
+    throw anthropicProtocolError(`${location} has no valid tool name.`);
+  }
+  if (!isRecord(block.input)) {
+    throw anthropicProtocolError(`${location} tool input is not a JSON object.`);
+  }
+  return { id: block.id, name: block.name, input: block.input };
+}
+
+function rejectStateChangingAnthropicBlock(type: unknown, location: string): void {
+  if (type === 'tool_addition' || type === 'tool_removal' || type === 'mid_conv_system') {
+    throw anthropicProtocolError(
+      `${location} contains unsupported ${type} state. Hayba will not mutate its tool catalog mid-turn.`,
+    );
+  }
+  if (type === 'error' || type === 'refusal') {
+    throw anthropicProtocolError(`${location} contains an unsupported ${type} content block.`);
+  }
+}
+
 function parseAnthropicResponse(resp: unknown): LLMResponse {
+  if (!isRecord(resp)) throw anthropicProtocolError('the response is not a JSON object.');
   const r = resp as {
-    content?: Array<Record<string, unknown>>;
+    content?: unknown;
     stop_reason?: unknown;
     usage?: RawAnthropicUsage;
+    stop_details?: { category?: unknown } | null;
   };
-  const blocks = r.content ?? [];
+  if (!Array.isArray(r.content)) {
+    throw anthropicProtocolError('the response content field is not an array.');
+  }
+  const blocks = r.content;
   const textParts: string[] = [];
   const toolCalls: LLMToolCall[] = [];
-  for (const b of blocks) {
+  for (const [index, rawBlock] of blocks.entries()) {
+    if (!isRecord(rawBlock)) {
+      throw anthropicProtocolError(`content block ${index} is not a JSON object.`);
+    }
+    const b = rawBlock;
+    rejectStateChangingAnthropicBlock(b.type, `content block ${index}`);
     if (b.type === 'text' && typeof b.text === 'string') {
       textParts.push(b.text);
     } else if (b.type === 'tool_use') {
-      toolCalls.push({
-        id: String(b.id),
-        name: String(b.name),
-        input: (b.input as Record<string, unknown>) ?? {},
-      });
+      toolCalls.push(parseAnthropicToolUse(b, `content block ${index}`));
     }
   }
+  const stop = normalizeAnthropicStop(r.stop_reason, r.stop_details);
   return {
     content: textParts.length > 0 ? textParts.join('') : null,
     toolCalls,
-    stopReason: normalizeAnthropicStop(r.stop_reason),
+    ...stop,
     usage: parseAnthropicUsage(r.usage),
   };
 }
@@ -426,7 +547,8 @@ async function* streamAnthropic(
 ): AsyncGenerator<LLMStreamEvent, void, unknown> {
   const textParts: string[] = [];
   const toolCalls: LLMToolCall[] = [];
-  let stopReason: LLMStopReason = 'end_turn';
+  // A missing message_delta is a protocol failure, never an implicit success.
+  let stop = normalizeAnthropicStop(undefined);
   // Accumulator for the tool_use block currently being streamed, keyed by index.
   const pending = new Map<number, { id: string; name: string; json: string }>();
   // Usage arrives in two pieces: `message_start` carries input/cache tokens,
@@ -454,6 +576,7 @@ async function* streamAnthropic(
         delta?: Record<string, unknown>;
         message?: { usage?: RawAnthropicUsage };
         usage?: RawAnthropicUsage;
+        error?: { message?: unknown; type?: unknown };
       };
       switch (ev.type) {
         case 'message_start': {
@@ -462,8 +585,19 @@ async function* streamAnthropic(
         }
         case 'content_block_start': {
           const cb = ev.content_block ?? {};
+          rejectStateChangingAnthropicBlock(cb.type, `stream block ${ev.index ?? 0}`);
           if (cb.type === 'tool_use') {
-            pending.set(ev.index ?? 0, { id: String(cb.id), name: String(cb.name), json: '' });
+            const index = ev.index ?? 0;
+            if (pending.has(index)) {
+              throw anthropicProtocolError(`stream block ${index} started twice.`);
+            }
+            if (typeof cb.id !== 'string' || cb.id.length === 0) {
+              throw anthropicProtocolError(`stream block ${index} has no valid tool-use id.`);
+            }
+            if (typeof cb.name !== 'string' || cb.name.length === 0) {
+              throw anthropicProtocolError(`stream block ${index} has no valid tool name.`);
+            }
+            pending.set(index, { id: cb.id, name: cb.name, json: '' });
           }
           break;
         }
@@ -474,18 +608,30 @@ async function* streamAnthropic(
             yield { type: 'text_delta', text: d.text };
           } else if (d.type === 'input_json_delta' && typeof d.partial_json === 'string') {
             const acc = pending.get(ev.index ?? 0);
-            if (acc) acc.json += d.partial_json;
+            if (!acc) {
+              throw anthropicProtocolError(`stream block ${ev.index ?? 0} sent tool input before a tool-use start.`);
+            }
+            acc.json += d.partial_json;
+          } else if (d.type !== 'thinking_delta' && d.type !== 'signature_delta' && d.type !== 'citations_delta') {
+            throw anthropicProtocolError('the stream contains an unsupported content delta.');
           }
           break;
         }
         case 'content_block_stop': {
           const acc = pending.get(ev.index ?? 0);
           if (acc) {
-            const call: LLMToolCall = {
-              id: acc.id,
-              name: acc.name,
-              input: acc.json ? (JSON.parse(acc.json) as Record<string, unknown>) : {},
-            };
+            let input: unknown = {};
+            if (acc.json) {
+              try {
+                input = JSON.parse(acc.json);
+              } catch {
+                throw anthropicProtocolError(`stream block ${ev.index ?? 0} ended with malformed tool input JSON.`);
+              }
+            }
+            if (!isRecord(input)) {
+              throw anthropicProtocolError(`stream block ${ev.index ?? 0} tool input is not a JSON object.`);
+            }
+            const call: LLMToolCall = { id: acc.id, name: acc.name, input };
             toolCalls.push(call);
             pending.delete(ev.index ?? 0);
             yield { type: 'tool_call', call };
@@ -494,16 +640,36 @@ async function* streamAnthropic(
         }
         case 'message_delta': {
           const d = ev.delta ?? {};
-          if (d.stop_reason !== undefined) stopReason = normalizeAnthropicStop(d.stop_reason);
+          if (d.stop_reason !== undefined) {
+            stop = normalizeAnthropicStop(d.stop_reason, isRecord(d.stop_details) ? d.stop_details : undefined);
+          }
           mergeUsage(ev.usage);
           break;
         }
-        default:
+        case 'message_stop':
+        case 'ping':
           break;
+        case 'tool_change':
+        case 'tool_addition':
+        case 'tool_removal':
+          throw anthropicProtocolError(
+            `the stream contains unsupported ${ev.type} state; Hayba will not mutate its tool catalog mid-turn.`,
+          );
+        case 'error': {
+          const providerMessage =
+            typeof ev.error?.message === 'string' ? redactDiagnostic(ev.error.message, cfg.apiKey) : 'stream failed';
+          throw new LLMError('api', `LLM api error (${cfg.provider}): ${providerMessage}`);
+        }
+        default:
+          throw anthropicProtocolError('the stream contains an unsupported event type.');
       }
     }
   } catch (err) {
     throw mapError(err, cfg.provider, cfg.apiKey);
+  }
+
+  if (pending.size > 0) {
+    throw anthropicProtocolError('the stream ended with an unfinished tool-use block.');
   }
 
   yield {
@@ -511,7 +677,7 @@ async function* streamAnthropic(
     response: {
       content: textParts.length > 0 ? textParts.join('') : null,
       toolCalls,
-      stopReason,
+      ...stop,
       usage,
     },
   };

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
@@ -181,6 +181,73 @@ describe('runAgentLoop', () => {
     });
   });
 
+  it('treats context-window exhaustion as an error with bounded recovery guidance', async () => {
+    const secret = 'sk-ant-must-not-leak';
+    const client = new FakeLLMClient([
+      {
+        content: null,
+        toolCalls: [],
+        stopReason: 'model_context_window_exceeded',
+        stopDiagnostic: {
+          code: 'context_window_exceeded',
+          message: 'Anthropic stopped because the model context window was exhausted.',
+          recoveryTip: 'Start a new chat or remove older messages and large tool results, then retry.',
+        },
+      },
+    ]);
+    const events = await collect(
+      runAgentLoop(
+        baseParams({
+          client,
+          messages: [{ role: 'user', content: `private prompt ${secret}` }],
+        }),
+      ),
+    );
+    const error = events.find((event) => event.type === 'error') as Extract<AgentEvent, { type: 'error' }>;
+    expect(error).toMatchObject({ kind: 'context_window_exceeded' });
+    expect(error.error).toContain('Tip:');
+    expect(error.error.length).toBeLessThanOrEqual(384);
+    expect(error.error).not.toContain(secret);
+    expect(events.at(-1)).toMatchObject({
+      type: 'done',
+      reason: 'context_window_exceeded',
+      stopReason: 'model_context_window_exceeded',
+    });
+    expect(events.at(-1)).not.toMatchObject({ reason: 'end_turn' });
+  });
+
+  it.each([
+    ['max_tokens', 'max_tokens'],
+    ['refusal', 'provider_refusal'],
+  ] as const)('reports %s as %s instead of a successful end_turn', async (stopReason, reason) => {
+    const client = new FakeLLMClient([{ content: null, toolCalls: [], stopReason }]);
+    const events = await collect(runAgentLoop(baseParams({ client })));
+    expect(events.at(-1)).toMatchObject({ type: 'done', reason, stopReason });
+    expect(events.at(-1)).not.toMatchObject({ reason: 'end_turn' });
+  });
+
+  it('reports a diagnosed Anthropic unknown stop as a provider protocol error', async () => {
+    const client = new FakeLLMClient([
+      {
+        content: null,
+        toolCalls: [],
+        stopReason: 'unknown',
+        stopDiagnostic: {
+          code: 'unknown_stop_reason',
+          message: 'Anthropic returned an unsupported stop reason; the turn was not treated as complete.',
+          recoveryTip: 'Upgrade Hayba or choose another provider before retrying this turn.',
+        },
+      },
+    ]);
+    const events = await collect(runAgentLoop(baseParams({ client })));
+    expect(events.at(-2)).toMatchObject({ type: 'error', kind: 'provider_protocol' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'done',
+      reason: 'provider_protocol_error',
+      stopReason: 'unknown',
+    });
+  });
+
   it('refuses a filtered/disabled tool: not offered AND refused if called', async () => {
     const client = new FakeLLMClient([toolResponse('actor_spawn', {}, 'c1'), textResponse('ok')]);
     const dispatch = vi.fn(async () => ({ ok: true }));

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
@@ -36,6 +36,7 @@ import type {
   LLMTool,
   LLMToolCall,
   LLMStopReason,
+  LLMStopDiagnostic,
   LLMUsage,
 } from '../agents/llm-client.js';
 import { deriveSignature, getRawShape, listRecordedCommands } from '../tools/schema-registry.js';
@@ -246,7 +247,16 @@ export function argsHash(args: unknown): string {
  *  captured handlers. */
 export const defaultDispatchTool: DispatchTool = (name, args) => executeCommand(name, args);
 
-export type AgentDoneReason = 'end_turn' | 'max_steps' | 'token_budget' | 'aborted' | 'provider_stop';
+export type AgentDoneReason =
+  | 'end_turn'
+  | 'max_tokens'
+  | 'context_window_exceeded'
+  | 'provider_refusal'
+  | 'provider_protocol_error'
+  | 'provider_stop'
+  | 'max_steps'
+  | 'token_budget'
+  | 'aborted';
 
 export type AgentEvent =
   | { type: 'text_delta'; text: string }
@@ -290,6 +300,17 @@ export interface AgentLoopParams {
 }
 
 const DEFAULT_MAX_STEPS = 16;
+const MAX_STOP_ERROR_CHARS = 384;
+
+function boundedStopError(
+  diagnostic: LLMStopDiagnostic | undefined,
+  fallbackMessage: string,
+  fallbackTip: string,
+): string {
+  const message = diagnostic?.message ?? fallbackMessage;
+  const tip = diagnostic?.recoveryTip ?? fallbackTip;
+  return `${message} Tip: ${tip}`.slice(0, MAX_STOP_ERROR_CHARS);
+}
 
 /** chars/4 rough token estimate — good enough for a budget guard. */
 function estimateTokens(text: string): number {
@@ -373,6 +394,7 @@ export async function* runAgentLoop(params: AgentLoopParams): AsyncGenerator<Age
     let content: string | null = null;
     let toolCalls: LLMToolCall[] = [];
     let stopReason: LLMStopReason = 'end_turn';
+    let stopDiagnostic: LLMStopDiagnostic | undefined;
 
     try {
       for await (const ev of client.stream({ system, messages, tools, maxTokens, signal })) {
@@ -388,12 +410,18 @@ export async function* runAgentLoop(params: AgentLoopParams): AsyncGenerator<Age
           content = ev.response.content;
           toolCalls = ev.response.toolCalls;
           stopReason = ev.response.stopReason;
+          stopDiagnostic = ev.response.stopDiagnostic;
           accumulateUsage(ev.response.usage);
         }
         // 'tool_call' stream events are consolidated in the 'done' response.
       }
     } catch (err) {
       const e = err as { kind?: string; message?: string };
+      if (signal?.aborted || e?.kind === 'aborted') {
+        yield { type: 'error', error: 'aborted', kind: 'aborted' };
+        yield { type: 'done', reason: 'aborted', usage };
+        return;
+      }
       yield { type: 'error', error: e?.message ?? String(err), kind: e?.kind };
       return;
     }
@@ -414,23 +442,73 @@ export async function* runAgentLoop(params: AgentLoopParams): AsyncGenerator<Age
     }
 
     // ── Halt when the model is done ──────────────────────────────────────
-    // A content filter or a finish reason added by a compatible provider is
-    // not a successful end turn. Preserve an explicit machine state so the UI
-    // can warn/retry instead of silently presenting a partial answer as done.
-    if (stopReason === 'content_filter' || stopReason === 'unknown') {
+    if (stopReason !== 'tool_use') {
+      if (stopReason === 'end_turn' || stopReason === 'stop_sequence') {
+        yield { type: 'done', reason: 'end_turn', stopReason, usage };
+        return;
+      }
+      if (stopReason === 'max_tokens') {
+        yield { type: 'done', reason: 'max_tokens', stopReason, usage };
+        return;
+      }
+      if (stopReason === 'model_context_window_exceeded') {
+        yield {
+          type: 'error',
+          kind: 'context_window_exceeded',
+          error: boundedStopError(
+            stopDiagnostic,
+            'Anthropic stopped because the model context window was exhausted.',
+            'Start a new chat or remove older messages and large tool results, then retry.',
+          ),
+        };
+        yield { type: 'done', reason: 'context_window_exceeded', stopReason, usage };
+        return;
+      }
+      if (stopReason === 'refusal') {
+        yield {
+          type: 'error',
+          kind: 'provider_refusal',
+          error: boundedStopError(
+            stopDiagnostic,
+            'Anthropic refused the request.',
+            'Rephrase or narrow the request while preserving the intended safe operation.',
+          ),
+        };
+        yield { type: 'done', reason: 'provider_refusal', stopReason, usage };
+        return;
+      }
+      if (stopReason === 'content_filter' || (stopReason === 'unknown' && !stopDiagnostic)) {
+        yield {
+          type: 'error',
+          kind: 'api',
+          error:
+            stopReason === 'content_filter'
+              ? 'The provider stopped the response because of its content filter.'
+              : 'The provider returned an unsupported or missing finish reason.',
+        };
+        yield { type: 'done', reason: 'provider_stop', stopReason, usage };
+        return;
+      }
       yield {
         type: 'error',
-        kind: 'api',
-        error:
-          stopReason === 'content_filter'
-            ? 'The provider stopped the response because of its content filter.'
-            : 'The provider returned an unsupported or missing finish reason.',
+        kind: 'provider_protocol',
+        error: boundedStopError(
+          stopDiagnostic,
+          'Anthropic returned a stop state Hayba cannot continue safely.',
+          'Upgrade Hayba or retry the operation in a new turn.',
+        ),
       };
-      yield { type: 'done', reason: 'provider_stop', stopReason, usage };
+      yield { type: 'done', reason: 'provider_protocol_error', stopReason, usage };
       return;
     }
-    if (stopReason !== 'tool_use' || toolCalls.length === 0) {
-      yield { type: 'done', reason: 'end_turn', stopReason, usage };
+
+    if (toolCalls.length === 0) {
+      yield {
+        type: 'error',
+        kind: 'provider_protocol',
+        error: 'Anthropic stopped for tool use but supplied no complete tool call.',
+      };
+      yield { type: 'done', reason: 'provider_protocol_error', stopReason, usage };
       return;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.110.0",
+        "@anthropic-ai/sdk": "^0.115.0",
         "@distube/ytdl-core": "^4.16.12",
         "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
-      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+      "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -6567,35 +6567,11 @@
       "name": "@hayba/architecture",
       "version": "0.1.0",
       "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.96.0"
-      },
       "devDependencies": {
         "@types/node": "^26.1.2",
         "@vitest/coverage-v8": "^4.1.10",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"
-      }
-    },
-    "packages/architecture/node_modules/@anthropic-ai/sdk": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.96.0.tgz",
-      "integrity": "sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "packages/architecture/node_modules/@vitest/coverage-v8": {

--- a/packages/architecture/package.json
+++ b/packages/architecture/package.json
@@ -26,9 +26,6 @@
     "typecheck": "tsc --noEmit",
     "serve": "tsc && node demo/serve.mjs"
   },
-  "dependencies": {
-    "@anthropic-ai/sdk": "^0.96.0"
-  },
   "devDependencies": {
     "@types/node": "^26.1.2",
     "@vitest/coverage-v8": "^4.1.10",


### PR DESCRIPTION
Closes #398

## Outcome
- upgrade the sole runtime `@anthropic-ai/sdk` install from 0.110.0 to 0.115.0 and remove the unused architecture declaration
- represent Anthropic's context exhaustion, refusal, pause, stop sequence, unknown future stops, and provider protocol failures explicitly
- reject unsupported tool addition/removal blocks and `tool_change` events instead of silently mutating or discarding tool-catalog state
- keep context exhaustion out of the successful `end_turn` path and return bounded, prompt/key-safe recovery guidance
- preserve usage/cache accounting, lazy SDK loading, AbortSignal identity, and redacted provider errors
- coexist with the merged OpenAI 7 boundary: OpenAI content filters/undiagnosed unknown finishes remain explicit `provider_stop`; Anthropic diagnosed unknown states are `provider_protocol_error`

## Compatibility fixtures
Both non-stream and stream coverage discriminate `end_turn`, `tool_use`, `max_tokens`, `model_context_window_exceeded`, unknown future values, refusal/error handling, real 0.115 tool-add/remove content-block shapes, `tool_change`, usage/cache counters, malformed partial tool JSON, aborts, and a real lazily imported SDK client talking only to an ephemeral localhost server.

Mutation checks were observed red before being reverted:
- mapping context exhaustion to `end_turn` fails the stream and non-stream context fixtures
- accepting `tool_addition` fails the state-change rejection fixture

## Verification on current main (includes OpenAI 7 + Express 5)
- focused Express/Anthropic/agent-loop integration: 3 files / 67 tests passing
- MCP full suite: 181 files / 1,910 tests passing
- MCP `build:server`: passing
- MCP typecheck + focused ESLint + changed-file Prettier: passing
- legacy wrapper lint: 22 C++ commands / 153 descriptors, no violations
- architecture build/typecheck/demo/Vitest: 14 demo tests + 14 files / 140 tests passing
- production dependency audit: PASS, 5 assessed paths, 0 errors, 0 warnings
- dependency graph: exactly `@anthropic-ai/sdk@0.115.0`; no architecture copy

No OpenAI/MCP v2 migration or Unreal/editor work is included.