### PR TITLE
Dependencies: upgrade OpenAI SDK 7 with real-client smoke

### DIFF
--- a/mcp-tools/hayba-mcp/package.json
+++ b/mcp-tools/hayba-mcp/package.json
@@ -29,7 +29,7 @@
     "express": "^4.21.0",
     "js-yaml": "5.2.3",
     "minisearch": "^7.2.0",
-    "openai": "^6.45.0",
+    "openai": "^7.4.0",
     "youtube-transcript-api": "^3.0.6",
     "zod": "^4.4.3"
   },

--- a/mcp-tools/hayba-mcp/src/agents/llm-client.openai-real.test.ts
+++ b/mcp-tools/hayba-mcp/src/agents/llm-client.openai-real.test.ts
@@ -1,0 +1,329 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { log } from '../logger.js';
+import {
+  createLLMClient,
+  LLMError,
+  normalizeOpenAIBaseURL,
+  type LLMCompleteParams,
+  type LLMStreamEvent,
+} from './llm-client.js';
+
+interface SeenRequest {
+  url: string;
+  authorization: string;
+  body: Record<string, unknown>;
+}
+
+const seen: SeenRequest[] = [];
+let origin = '';
+let server: ReturnType<typeof createServer>;
+let originalFetch: typeof globalThis.fetch;
+const escapedURLs: string[] = [];
+
+function params(text = 'hello'): LLMCompleteParams {
+  return {
+    system: 'You are a compatibility probe.',
+    messages: [{ role: 'user', content: text }],
+    tools: [
+      {
+        name: 'actor_list',
+        description: 'List actors',
+        input_schema: { type: 'object', properties: { limit: { type: 'number' } } },
+      },
+    ],
+  };
+}
+
+function completion(model: string, finishReason: string, content: string | null = 'complete-ok') {
+  return {
+    id: `chatcmpl-${model}`,
+    object: 'chat.completion',
+    created: 1,
+    model,
+    choices: [{ index: 0, message: { role: 'assistant', content }, finish_reason: finishReason }],
+    usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+  };
+}
+
+function json(res: ServerResponse, status: number, value: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json', 'x-request-id': 'local-request' });
+  res.end(JSON.stringify(value));
+}
+
+function sse(res: ServerResponse, value: unknown): void {
+  res.write(`data: ${JSON.stringify(value)}\n\n`);
+}
+
+async function readJSON(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.from(chunk as Uint8Array);
+    bytes += buffer.length;
+    if (bytes > 128 * 1_024) throw new Error('test request exceeded 128 KiB');
+    chunks.push(buffer);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+  server = createServer(async (req, res) => {
+    try {
+      const body = await readJSON(req);
+      seen.push({
+        url: req.url ?? '',
+        authorization: String(req.headers.authorization ?? ''),
+        body,
+      });
+      const model = String(body.model ?? '');
+      if (model === 'network-close') {
+        req.socket.destroy();
+        return;
+      }
+      if (model === 'abort' || model === 'timeout') {
+        // The client must close this request through AbortSignal / SDK timeout.
+        return;
+      }
+      if (model === 'api-error') {
+        json(res, 400, {
+          error: {
+            message: JSON.stringify({
+              authorization: req.headers.authorization,
+              request_body: body,
+              api_key: 'sk-response-secret-1234567890',
+              nested: { client_secret: 'response-client-secret-123456' },
+            }),
+            type: 'invalid_request_error',
+            code: 'bad_request',
+          },
+        });
+        return;
+      }
+      if (body.stream === true) {
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        sse(res, {
+          id: 'chatcmpl-stream',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model,
+          choices: [{ index: 0, delta: { role: 'assistant', content: 'hel' }, finish_reason: null }],
+        });
+        sse(res, {
+          id: 'chatcmpl-stream',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: 'lo',
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_local',
+                    type: 'function',
+                    function: { name: 'actor_list', arguments: '{"limit":' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        });
+        sse(res, {
+          id: 'chatcmpl-stream',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model,
+          choices: [
+            {
+              index: 0,
+              delta: { tool_calls: [{ index: 0, function: { arguments: '3}' } }] },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        });
+        sse(res, {
+          id: 'chatcmpl-stream',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model,
+          choices: [],
+          usage: { prompt_tokens: 13, completion_tokens: 5, total_tokens: 18 },
+        });
+        res.end('data: [DONE]\n\n');
+        return;
+      }
+      if (model === 'length') return json(res, 200, completion(model, 'length'));
+      if (model === 'content-filter') return json(res, 200, completion(model, 'content_filter', null));
+      if (model === 'new-finish-reason') return json(res, 200, completion(model, 'future_reason'));
+      json(res, 200, completion(model, 'stop'));
+    } catch {
+      if (!res.headersSent) json(res, 400, { error: { message: 'invalid local request' } });
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as AddressInfo;
+  origin = `http://127.0.0.1:${address.port}`;
+
+  // A test regression must fail locally instead of making a billable/external
+  // request. The real SDK still drives the guarded native fetch implementation.
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.origin !== origin) {
+      escapedURLs.push(url.toString());
+      throw new Error('real-client smoke attempted to escape its local endpoint');
+    }
+    return originalFetch(input, init);
+  }) as typeof globalThis.fetch;
+});
+
+afterAll(async () => {
+  globalThis.fetch = originalFetch;
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('OpenAI 7 published client compatibility', () => {
+  it('uses the lazy real constructor for complete(), canonicalizes baseURL, and reports usage', async () => {
+    const apiKey = 'sk-local-real-client-1234567890';
+    const client = createLLMClient({
+      provider: 'custom',
+      model: 'complete',
+      baseURL: `${origin}/v1///`,
+      apiKey,
+    });
+
+    const response = await client.complete(params());
+    expect(response).toMatchObject({
+      content: 'complete-ok',
+      toolCalls: [],
+      stopReason: 'end_turn',
+      usage: { inputTokens: 11, outputTokens: 7 },
+    });
+    const request = seen.find((entry) => entry.body.model === 'complete');
+    expect(request).toMatchObject({ url: '/v1/chat/completions', authorization: `Bearer ${apiKey}` });
+    expect(request?.body).toMatchObject({ model: 'complete' });
+    expect(request?.body.stream).toBeUndefined();
+    expect(escapedURLs).toEqual([]);
+  });
+
+  it('sends the no-key placeholder only to the configured compatible endpoint', async () => {
+    const client = createLLMClient({ provider: 'custom', model: 'placeholder', baseURL: `${origin}/v1/` });
+    await client.complete(params());
+    const request = seen.find((entry) => entry.body.model === 'placeholder');
+    expect(request).toMatchObject({ url: '/v1/chat/completions', authorization: 'Bearer not-needed' });
+    expect(escapedURLs).toEqual([]);
+  });
+
+  it('streams text, tool-call fragments, finish reason, and usage through the real SDK parser', async () => {
+    const client = createLLMClient({ provider: 'custom', model: 'stream', baseURL: `${origin}/v1` });
+    const events: LLMStreamEvent[] = [];
+    for await (const event of client.stream(params())) events.push(event);
+
+    expect(events.slice(0, 2)).toEqual([
+      { type: 'text_delta', text: 'hel' },
+      { type: 'text_delta', text: 'lo' },
+    ]);
+    expect(events.at(-2)).toEqual({
+      type: 'tool_call',
+      call: { id: 'call_local', name: 'actor_list', input: { limit: 3 } },
+    });
+    expect(events.at(-1)).toEqual({
+      type: 'done',
+      response: {
+        content: 'hello',
+        toolCalls: [{ id: 'call_local', name: 'actor_list', input: { limit: 3 } }],
+        stopReason: 'tool_use',
+        usage: { inputTokens: 13, outputTokens: 5 },
+      },
+    });
+    const request = seen.find((entry) => entry.body.model === 'stream');
+    expect(request?.body).toMatchObject({ stream: true, stream_options: { include_usage: true } });
+  });
+
+  it('preserves length, content-filter, and unknown finish reasons instead of claiming end_turn', async () => {
+    const complete = async (model: string) =>
+      createLLMClient({
+        provider: 'custom',
+        model,
+        baseURL: `${origin}/v1`,
+      }).complete(params());
+    await expect(complete('length')).resolves.toMatchObject({ stopReason: 'max_tokens' });
+    await expect(complete('content-filter')).resolves.toMatchObject({ stopReason: 'content_filter' });
+    await expect(complete('new-finish-reason')).resolves.toMatchObject({ stopReason: 'unknown' });
+  });
+
+  it('propagates AbortSignal cancellation through the published client', async () => {
+    const controller = new AbortController();
+    const client = createLLMClient({ provider: 'custom', model: 'abort', baseURL: `${origin}/v1` });
+    const request = params('cancel me');
+    request.signal = controller.signal;
+    const pending = client.complete(request).catch((error: unknown) => error as LLMError);
+    setTimeout(() => controller.abort(), 20);
+    const error = await pending;
+    expect(error).toBeInstanceOf(LLMError);
+    expect(error).toMatchObject({ kind: 'network', message: expect.stringContaining('aborted') });
+    expect(seen.some((entry) => entry.body.model === 'abort')).toBe(true);
+  });
+
+  it('classifies SDK timeout and connection reset as network errors', async () => {
+    const timed = createLLMClient({
+      provider: 'custom',
+      model: 'timeout',
+      baseURL: `${origin}/v1`,
+      timeoutMs: 20,
+    });
+    await expect(timed.complete(params())).rejects.toMatchObject({
+      kind: 'network',
+      message: expect.stringContaining('timed out'),
+    });
+    expect(seen.some((entry) => entry.body.model === 'timeout')).toBe(true);
+
+    const reset = createLLMClient({ provider: 'custom', model: 'network-close', baseURL: `${origin}/v1` });
+    await expect(reset.complete(params())).rejects.toMatchObject({ kind: 'network' });
+  }, 10_000);
+
+  it('maps non-2xx errors without leaking auth, request bodies, or secret response fields to diagnostics/logs', async () => {
+    const apiKey = 'sk-local-diagnostic-1234567890';
+    const requestSecret = 'Authorization: Bearer sk-request-body-secret-1234567890';
+    const client = createLLMClient({ provider: 'custom', model: 'api-error', baseURL: `${origin}/v1`, apiKey });
+    let error: LLMError | undefined;
+    try {
+      await client.complete(params(requestSecret));
+    } catch (caught) {
+      error = caught as LLMError;
+    }
+
+    expect(error).toMatchObject({ kind: 'api', status: 400 });
+    expect(error?.message).toContain('HTTP 400');
+    const stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    log('error', error!.message);
+    const diagnostic = JSON.stringify([error!.message, stderr.mock.calls]);
+    stderr.mockRestore();
+    for (const secret of [
+      apiKey,
+      requestSecret,
+      'sk-request-body-secret-1234567890',
+      'sk-response-secret-1234567890',
+      'response-client-secret-123456',
+    ]) {
+      expect(diagnostic).not.toContain(secret);
+    }
+  });
+});
+
+describe('OpenAI-compatible endpoint confinement', () => {
+  it('requires custom endpoints and rejects URL authority/query tricks before importing or fetching', () => {
+    expect(() => createLLMClient({ provider: 'custom', model: 'x' })).toThrow(/explicit base URL/);
+    expect(() => normalizeOpenAIBaseURL('ftp://127.0.0.1/v1')).toThrow(/HTTP\(S\)/);
+    expect(() => normalizeOpenAIBaseURL('http://user:pass@127.0.0.1/v1')).toThrow(/without credentials/);
+    expect(() => normalizeOpenAIBaseURL(`${origin}/v1?api_key=secret`)).toThrow(/query string/);
+    expect(() => normalizeOpenAIBaseURL(`${origin}\\@example.com/v1`)).toThrow(/invalid/);
+    expect(escapedURLs).toEqual([]);
+  });
+});

--- a/mcp-tools/hayba-mcp/src/agents/llm-client.ts
+++ b/mcp-tools/hayba-mcp/src/agents/llm-client.ts
@@ -18,6 +18,7 @@
  *   - mock:           deterministic in-process echo (offline dev + tests)
  */
 
+import { redactSecrets } from '../security/secret-redaction.js';
 import { getProvider, type ProviderProtocol } from './providers.js';
 
 // ---------------------------------------------------------------------------
@@ -51,7 +52,7 @@ export interface LLMToolCall {
   input: Record<string, unknown>;
 }
 
-export type LLMStopReason = 'end_turn' | 'tool_use' | 'max_tokens';
+export type LLMStopReason = 'end_turn' | 'tool_use' | 'max_tokens' | 'content_filter' | 'unknown';
 
 /**
  * Token accounting for one LLM call. `cacheCreationInputTokens` /
@@ -146,6 +147,8 @@ export interface LLMClientConfig {
   model?: string;
   baseURL?: string;
   apiKey?: string;
+  /** Optional SDK request deadline. Primarily useful for local OpenAI-compatible providers. */
+  timeoutMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +168,47 @@ interface ResolvedConfig {
   model: string;
   baseURL: string;
   apiKey: string;
+  timeoutMs?: number;
+}
+
+function hasUnsafeBaseURLCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (value[index] === '\\' || code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/**
+ * Canonicalize an OpenAI-compatible endpoint before giving it to the SDK.
+ * A custom provider with no endpoint must fail closed: otherwise the OpenAI
+ * SDK silently falls back to api.openai.com, which is an unsafe surprise for
+ * a caller that selected a local provider.
+ */
+export function normalizeOpenAIBaseURL(raw: string, provider = 'OpenAI-compatible'): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new LLMError('api', `${provider} requires an explicit base URL`);
+  }
+  if (trimmed.length > 2_048 || hasUnsafeBaseURLCharacter(trimmed)) {
+    throw new LLMError('api', `${provider} base URL is invalid`);
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new LLMError('api', `${provider} base URL is invalid`);
+  }
+  if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.username || url.password) {
+    throw new LLMError('api', `${provider} base URL must be an HTTP(S) URL without credentials`);
+  }
+  if (url.search || url.hash) {
+    throw new LLMError('api', `${provider} base URL must not contain a query string or fragment`);
+  }
+
+  url.pathname = url.pathname.replace(/\/+$/, '') || '/';
+  return url.toString().replace(/\/$/, '');
 }
 
 export function resolveConfig(config: LLMClientConfig): ResolvedConfig {
@@ -173,13 +217,22 @@ export function resolveConfig(config: LLMClientConfig): ResolvedConfig {
     throw new LLMError('api', `Unknown provider: ${config.provider}`);
   }
   const envKey = ENV_KEY_BY_PROVIDER[config.provider];
-  const apiKey = config.apiKey ?? (envKey ? process.env[envKey] ?? '' : '');
+  const apiKey = config.apiKey ?? (envKey ? (process.env[envKey] ?? '') : '');
+  const rawBaseURL = config.baseURL ?? entry.baseURLDefault;
+  const baseURL = entry.protocol === 'openai' ? normalizeOpenAIBaseURL(rawBaseURL, entry.label) : rawBaseURL;
+  if (
+    config.timeoutMs !== undefined &&
+    (!Number.isInteger(config.timeoutMs) || config.timeoutMs < 1 || config.timeoutMs > 10 * 60_000)
+  ) {
+    throw new LLMError('api', 'LLM timeoutMs must be an integer between 1 and 600000');
+  }
   return {
     provider: entry.id,
     protocol: entry.protocol,
     model: config.model ?? entry.defaultModel,
-    baseURL: config.baseURL ?? entry.baseURLDefault,
+    baseURL,
     apiKey,
+    ...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
   };
 }
 
@@ -187,20 +240,33 @@ export function resolveConfig(config: LLMClientConfig): ResolvedConfig {
 // Error mapping + key redaction
 // ---------------------------------------------------------------------------
 
-function redact(text: string, apiKey: string): string {
-  if (!apiKey) return text;
-  return text.split(apiKey).join('***');
+function redactDiagnostic(text: string, apiKey: string): string {
+  // Exact replacement catches short/custom keys that do not look like a
+  // provider key; the central bounded redactor catches Authorization headers,
+  // URL credentials, and secret-looking fields in otherwise useful prose.
+  const withoutConfiguredKey = apiKey ? text.split(apiKey).join('[REDACTED:api_key]') : text;
+  return redactSecrets(withoutConfiguredKey, { maxStringChars: 2_048, maxTotalStringChars: 2_048 }).value;
 }
 
 function mapError(err: unknown, provider: string, apiKey: string): LLMError {
-  const e = err as { status?: number; statusCode?: number; message?: string; code?: string };
+  const e = err as { name?: string; status?: number; statusCode?: number; message?: string; code?: string };
   const status = e?.status ?? e?.statusCode;
   let kind: LLMErrorKind;
   if (status === 401 || status === 403) kind = 'auth';
   else if (status === 429) kind = 'rate_limit';
   else if (status === undefined) kind = 'network';
   else kind = 'api';
-  const detail = redact(e?.message ?? String(err ?? 'unknown error'), apiKey);
+  const rawMessage = e?.message ?? String(err ?? 'unknown error');
+  const redactedMessage = redactDiagnostic(rawMessage, apiKey);
+  const sensitiveDetailWasDropped = redactedMessage !== rawMessage;
+  // The SDK's non-2xx message is built from the entire response body. Do not
+  // repeat it: a compatible backend may reflect the prompt/request or return
+  // secret-bearing diagnostic fields. Status + a bounded code are enough to
+  // act, while network/abort messages have no response body and remain useful.
+  const detail =
+    status === undefined
+      ? redactedMessage
+      : `HTTP ${status}${e?.code ? ` (${redactDiagnostic(String(e.code).slice(0, 128), apiKey)})` : ''}${sensitiveDetailWasDropped ? ' ***' : ''}`;
   return new LLMError(kind, `LLM ${kind} error (${provider}): ${detail}`, status);
 }
 
@@ -244,8 +310,11 @@ function normalizeAnthropicStop(reason: unknown): LLMStopReason {
 
 function normalizeOpenAIStop(reason: unknown): LLMStopReason {
   if (reason === 'tool_calls') return 'tool_use';
+  if (reason === 'function_call') return 'tool_use';
   if (reason === 'length') return 'max_tokens';
-  return 'end_turn';
+  if (reason === 'stop') return 'end_turn';
+  if (reason === 'content_filter') return 'content_filter';
+  return 'unknown';
 }
 
 // ---------------------------------------------------------------------------
@@ -273,10 +342,7 @@ function normalizeOpenAIStop(reason: unknown): LLMStopReason {
  * and the volatile block last (messages) keeps the cached prefix at the head
  * of the prompt, which is what the API requires for a hit.
  */
-export function buildAnthropicRequest(
-  cfg: ResolvedConfig,
-  params: LLMCompleteParams,
-): Record<string, unknown> {
+export function buildAnthropicRequest(cfg: ResolvedConfig, params: LLMCompleteParams): Record<string, unknown> {
   const req: Record<string, unknown> = {
     model: cfg.model,
     max_tokens: params.maxTokens ?? 4096,
@@ -321,8 +387,7 @@ function parseAnthropicUsage(raw: RawAnthropicUsage | undefined): LLMUsage | und
   if (typeof raw.output_tokens === 'number') usage.outputTokens = raw.output_tokens;
   if (typeof raw.cache_creation_input_tokens === 'number')
     usage.cacheCreationInputTokens = raw.cache_creation_input_tokens;
-  if (typeof raw.cache_read_input_tokens === 'number')
-    usage.cacheReadInputTokens = raw.cache_read_input_tokens;
+  if (typeof raw.cache_read_input_tokens === 'number') usage.cacheReadInputTokens = raw.cache_read_input_tokens;
   return Object.keys(usage).length > 0 ? usage : undefined;
 }
 
@@ -506,11 +571,7 @@ function toOpenAIMessages(messages: LLMMessage[]): Array<Record<string, unknown>
   return out;
 }
 
-function buildOpenAIRequest(
-  cfg: ResolvedConfig,
-  params: LLMCompleteParams,
-  stream: boolean,
-): Record<string, unknown> {
+function buildOpenAIRequest(cfg: ResolvedConfig, params: LLMCompleteParams, stream: boolean): Record<string, unknown> {
   const messages: Array<Record<string, unknown>> = [
     { role: 'system', content: params.system },
     ...toOpenAIMessages(params.messages),
@@ -523,8 +584,20 @@ function buildOpenAIRequest(
   if (params.tools && params.tools.length > 0) {
     req.tools = toOpenAITools(params.tools);
   }
-  if (stream) req.stream = true;
+  if (stream) {
+    req.stream = true;
+    req.stream_options = { include_usage: true };
+  }
   return req;
+}
+
+function parseOpenAIUsage(raw: unknown): LLMUsage | undefined {
+  const usage = raw as { prompt_tokens?: unknown; completion_tokens?: unknown } | undefined;
+  if (!usage) return undefined;
+  const parsed: LLMUsage = {};
+  if (typeof usage.prompt_tokens === 'number') parsed.inputTokens = usage.prompt_tokens;
+  if (typeof usage.completion_tokens === 'number') parsed.outputTokens = usage.completion_tokens;
+  return Object.keys(parsed).length > 0 ? parsed : undefined;
 }
 
 function parseOpenAIResponse(resp: unknown): LLMResponse {
@@ -533,6 +606,7 @@ function parseOpenAIResponse(resp: unknown): LLMResponse {
       message?: { content?: string | null; tool_calls?: Array<Record<string, unknown>> };
       finish_reason?: unknown;
     }>;
+    usage?: unknown;
   };
   const choice = r.choices?.[0];
   const msg = choice?.message ?? {};
@@ -548,6 +622,7 @@ function parseOpenAIResponse(resp: unknown): LLMResponse {
     content: msg.content ?? null,
     toolCalls,
     stopReason: normalizeOpenAIStop(choice?.finish_reason),
+    usage: parseOpenAIUsage(r.usage),
   };
 }
 
@@ -557,7 +632,10 @@ async function* streamOpenAI(
   params: LLMCompleteParams,
 ): AsyncGenerator<LLMStreamEvent, void, unknown> {
   const textParts: string[] = [];
-  let stopReason: LLMStopReason = 'end_turn';
+  // A stream that closes without a terminal finish_reason is not a successful
+  // turn; keep it unknown unless the wire explicitly proves otherwise.
+  let stopReason: LLMStopReason = 'unknown';
+  let usage: LLMUsage | undefined;
   // Tool-call fragments accumulate by index; arguments arrive as JSON-string chunks.
   const pending = new Map<number, { id: string; name: string; args: string }>();
   const order: number[] = [];
@@ -578,7 +656,9 @@ async function* streamOpenAI(
           delta?: { content?: string | null; tool_calls?: Array<Record<string, unknown>> };
           finish_reason?: unknown;
         }>;
+        usage?: unknown;
       };
+      usage = parseOpenAIUsage(chunk.usage) ?? usage;
       const choice = chunk.choices?.[0];
       if (!choice) continue;
       const delta = choice.delta ?? {};
@@ -625,6 +705,7 @@ async function* streamOpenAI(
       content: textParts.length > 0 ? textParts.join('') : null,
       toolCalls,
       stopReason,
+      usage,
     },
   };
 }
@@ -656,8 +737,7 @@ async function* streamMock(params: LLMCompleteParams): AsyncGenerator<LLMStreamE
 
 async function buildAnthropic(cfg: ResolvedConfig): Promise<AnthropicClientLike> {
   const mod = await import('@anthropic-ai/sdk');
-  const Anthropic = (mod as unknown as { default: new (opts: Record<string, unknown>) => AnthropicClientLike })
-    .default;
+  const Anthropic = (mod as unknown as { default: new (opts: Record<string, unknown>) => AnthropicClientLike }).default;
   return new Anthropic({ apiKey: cfg.apiKey, ...(cfg.baseURL ? { baseURL: cfg.baseURL } : {}) });
 }
 
@@ -666,9 +746,16 @@ async function buildOpenAI(cfg: ResolvedConfig): Promise<OpenAIClientLike> {
     default?: new (opts: Record<string, unknown>) => OpenAIClientLike;
     OpenAI?: new (opts: Record<string, unknown>) => OpenAIClientLike;
   };
-  const OpenAI = mod.default ?? mod.OpenAI!;
+  const OpenAI = mod.default ?? mod.OpenAI;
+  if (typeof OpenAI !== 'function') {
+    throw new LLMError('api', 'Installed OpenAI SDK has no compatible constructor export');
+  }
   // OpenAI-compat servers (Ollama/LM Studio) may not require a key; send a placeholder.
-  return new OpenAI({ apiKey: cfg.apiKey || 'not-needed', ...(cfg.baseURL ? { baseURL: cfg.baseURL } : {}) });
+  return new OpenAI({
+    apiKey: cfg.apiKey || 'not-needed',
+    baseURL: cfg.baseURL,
+    ...(cfg.timeoutMs !== undefined ? { timeout: cfg.timeoutMs } : {}),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.test.ts
@@ -104,9 +104,7 @@ describe('runAgentLoop', () => {
     ]);
     const dispatch = vi.fn(async (name: string) => ({ ok: true, name }));
 
-    const events = await collect(
-      runAgentLoop(baseParams({ client, dispatchTool: dispatch })),
-    );
+    const events = await collect(runAgentLoop(baseParams({ client, dispatchTool: dispatch })));
 
     expect(dispatch).toHaveBeenCalledTimes(2);
     expect(dispatch.mock.calls.map((c) => c[0])).toEqual(['actor_list', 'actor_spawn']);
@@ -120,13 +118,10 @@ describe('runAgentLoop', () => {
     // Round-2 transcript must carry the round-1 assistant tool_use block AND the
     // tool_result block, keyed by matching ids.
     const round2 = client.seenMessages[1];
-    const blocks = round2.flatMap((m) =>
-      Array.isArray(m.content) ? (m.content as LLMContentBlock[]) : [],
-    );
+    const blocks = round2.flatMap((m) => (Array.isArray(m.content) ? (m.content as LLMContentBlock[]) : []));
     expect(blocks).toContainEqual({ type: 'tool_use', id: 'c1', name: 'actor_list', input: {} });
     const result = blocks.find(
-      (b): b is Extract<LLMContentBlock, { type: 'tool_result' }> =>
-        b.type === 'tool_result' && b.tool_use_id === 'c1',
+      (b): b is Extract<LLMContentBlock, { type: 'tool_result' }> => b.type === 'tool_result' && b.tool_use_id === 'c1',
     );
     expect(result).toBeDefined();
     expect(result!.content).toContain('actor_list');
@@ -169,20 +164,32 @@ describe('runAgentLoop', () => {
     expect(done.usage).toBeUndefined();
   });
 
-  it('refuses a filtered/disabled tool: not offered AND refused if called', async () => {
+  it('reports an unknown provider finish reason as a non-success state', async () => {
     const client = new FakeLLMClient([
-      toolResponse('actor_spawn', {}, 'c1'),
-      textResponse('ok'),
+      {
+        content: 'partial answer',
+        toolCalls: [],
+        stopReason: 'unknown',
+      },
     ]);
+    const events = await collect(runAgentLoop(baseParams({ client })));
+    expect(events.at(-2)).toMatchObject({ type: 'error', kind: 'api' });
+    expect(events.at(-1)).toEqual({
+      type: 'done',
+      reason: 'provider_stop',
+      stopReason: 'unknown',
+    });
+  });
+
+  it('refuses a filtered/disabled tool: not offered AND refused if called', async () => {
+    const client = new FakeLLMClient([toolResponse('actor_spawn', {}, 'c1'), textResponse('ok')]);
     const dispatch = vi.fn(async () => ({ ok: true }));
 
     // Only actor_list is offered; actor_spawn is filtered out of the catalog.
     const tools = [
       { name: 'actor_list', description: 'list', input_schema: { type: 'object' as const, properties: {} } },
     ];
-    const events = await collect(
-      runAgentLoop(baseParams({ client, tools, dispatchTool: dispatch })),
-    );
+    const events = await collect(runAgentLoop(baseParams({ client, tools, dispatchTool: dispatch })));
 
     // Not offered
     expect(client.offeredToolNames[0]).toEqual(['actor_list']);
@@ -230,10 +237,7 @@ describe('runAgentLoop', () => {
   });
 
   it('C1: approve A then model requests A (same args) → dispatches once', async () => {
-    const client = new FakeLLMClient([
-      toolResponse('actor_spawn', { id: 'A' }, 'c1'),
-      textResponse('done'),
-    ]);
+    const client = new FakeLLMClient([toolResponse('actor_spawn', { id: 'A' }, 'c1'), textResponse('done')]);
     const dispatch = vi.fn(async () => ({ ok: true }));
     const approvedCall = { name: 'actor_spawn', argsHash: argsHash({ id: 'A' }) };
     const events = await collect(
@@ -280,9 +284,7 @@ describe('runAgentLoop', () => {
     // Dispatch returns the C++ gate payload (plan mode NOT set on the loop side).
     const dispatch = vi.fn(async () => ({ status: 'plan_mode_required', hint: 'approve first' }));
 
-    const events = await collect(
-      runAgentLoop(baseParams({ client, dispatchTool: dispatch })),
-    );
+    const events = await collect(runAgentLoop(baseParams({ client, dispatchTool: dispatch })));
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     const plan = events.find((e) => e.type === 'plan_request');
@@ -295,14 +297,10 @@ describe('runAgentLoop', () => {
 
   it('halts at maxSteps', async () => {
     // Endlessly requests a (non-destructive) tool; loop must stop at maxSteps.
-    const client = new FakeLLMClient(
-      Array.from({ length: 10 }, (_, i) => toolResponse('actor_list', {}, `c${i}`)),
-    );
+    const client = new FakeLLMClient(Array.from({ length: 10 }, (_, i) => toolResponse('actor_list', {}, `c${i}`)));
     const dispatch = vi.fn(async () => ({ ok: true }));
 
-    const events = await collect(
-      runAgentLoop(baseParams({ client, dispatchTool: dispatch, maxSteps: 3 })),
-    );
+    const events = await collect(runAgentLoop(baseParams({ client, dispatchTool: dispatch, maxSteps: 3 })));
 
     const done = events.at(-1);
     expect(done).toEqual({ type: 'done', reason: 'max_steps' });
@@ -321,9 +319,7 @@ describe('runAgentLoop', () => {
       return { ok: true };
     });
 
-    const events = await collect(
-      runAgentLoop(baseParams({ client, dispatchTool: dispatch, signal: ac.signal })),
-    );
+    const events = await collect(runAgentLoop(baseParams({ client, dispatchTool: dispatch, signal: ac.signal })));
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(events.some((e) => e.type === 'error' && (e as { kind?: string }).kind === 'aborted')).toBe(true);
@@ -332,15 +328,10 @@ describe('runAgentLoop', () => {
 
   it('never leaks the API key in any event', async () => {
     const SECRET = 'sk-super-secret-key-123';
-    const client = new FakeLLMClient([
-      toolResponse('actor_list', {}, 'c1'),
-      textResponse(`done ${SECRET ? '' : ''}`),
-    ]);
+    const client = new FakeLLMClient([toolResponse('actor_list', {}, 'c1'), textResponse(`done ${SECRET ? '' : ''}`)]);
     const dispatch = vi.fn(async () => ({ ok: true }));
 
-    const events = await collect(
-      runAgentLoop(baseParams({ client, dispatchTool: dispatch })),
-    );
+    const events = await collect(runAgentLoop(baseParams({ client, dispatchTool: dispatch })));
 
     const serialized = JSON.stringify(events);
     expect(serialized).not.toContain(SECRET);
@@ -380,14 +371,14 @@ describe('buildToolCatalog', () => {
       returns: '{ok}',
     });
 
-    const tool = buildToolCatalog({ listCommands: () => ['zzz_default_probe'] })
-      .find((t) => t.name === 'zzz_default_probe');
+    const tool = buildToolCatalog({ listCommands: () => ['zzz_default_probe'] }).find(
+      (t) => t.name === 'zzz_default_probe',
+    );
 
     expect(tool, 'the probe tool should be in the catalog').toBeDefined();
     const schema = tool!.input_schema as { required?: string[]; properties: Record<string, { default?: unknown }> };
     expect(schema.required, 'only the genuinely required param is required').toEqual(['needed']);
     expect(schema.properties.capped.default, 'the value it gets by omitting it').toBe(5);
-    expect(schema.properties.maybe, 'a plain optional has no default to report')
-      .not.toHaveProperty('default');
+    expect(schema.properties.maybe, 'a plain optional has no default to report').not.toHaveProperty('default');
   });
 });

--- a/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
+++ b/mcp-tools/hayba-mcp/src/chat/agent-loop.ts
@@ -96,9 +96,7 @@ export function isDestructiveToolName(name: string): boolean {
   if (NON_IDEMPOTENT.has(name)) return true;
   if (EXTRA_DESTRUCTIVE.has(name)) return true;
   // Mutation verbs, matched as a segment (prefix, suffix, or *_verb_*).
-  return /(^|_)(create|delete|add|remove|set|spawn|duplicate|import|rename|clear|destroy)(_|$)/.test(
-    name,
-  );
+  return /(^|_)(create|delete|add|remove|set|spawn|duplicate|import|rename|clear|destroy)(_|$)/.test(name);
 }
 
 // ---------------------------------------------------------------------------
@@ -136,8 +134,7 @@ function zodToJsonSchema(t: ZodTypeAny): { schema: JsonSchema; optional: boolean
     // deeper nesting is left flat). shapeToInputSchema is hoisted below.
     const nestedShape = (inner as unknown as { _def: { shape: () => ZodRawShape } })._def.shape();
     schema = shapeToInputSchema(nestedShape);
-  }
-  else if (inner instanceof z.ZodRecord) schema = { type: 'object' };
+  } else if (inner instanceof z.ZodRecord) schema = { type: 'object' };
   else schema = {};
 
   // zod 4: .describe() lives on the public `.description` getter now, not on
@@ -249,7 +246,7 @@ export function argsHash(args: unknown): string {
  *  captured handlers. */
 export const defaultDispatchTool: DispatchTool = (name, args) => executeCommand(name, args);
 
-export type AgentDoneReason = 'end_turn' | 'max_steps' | 'token_budget' | 'aborted';
+export type AgentDoneReason = 'end_turn' | 'max_steps' | 'token_budget' | 'aborted' | 'provider_stop';
 
 export type AgentEvent =
   | { type: 'text_delta'; text: string }
@@ -302,9 +299,7 @@ function estimateTokens(text: string): number {
 /** Is a dispatch result the C++ Plan-Mode pause payload? */
 function isPlanModeRequired(result: unknown): result is { status: string; hint?: string } {
   return (
-    typeof result === 'object' &&
-    result !== null &&
-    (result as { status?: unknown }).status === 'plan_mode_required'
+    typeof result === 'object' && result !== null && (result as { status?: unknown }).status === 'plan_mode_required'
   );
 }
 
@@ -312,9 +307,7 @@ function isPlanModeRequired(result: unknown): result is { status: string; hint?:
  * Run the agentic tool-calling loop. Yields normalized events; halts on
  * end_turn, maxSteps, token budget, abort, or a plan_request pause.
  */
-export async function* runAgentLoop(
-  params: AgentLoopParams,
-): AsyncGenerator<AgentEvent, void, unknown> {
+export async function* runAgentLoop(params: AgentLoopParams): AsyncGenerator<AgentEvent, void, unknown> {
   const {
     client,
     system,
@@ -421,6 +414,21 @@ export async function* runAgentLoop(
     }
 
     // ── Halt when the model is done ──────────────────────────────────────
+    // A content filter or a finish reason added by a compatible provider is
+    // not a successful end turn. Preserve an explicit machine state so the UI
+    // can warn/retry instead of silently presenting a partial answer as done.
+    if (stopReason === 'content_filter' || stopReason === 'unknown') {
+      yield {
+        type: 'error',
+        kind: 'api',
+        error:
+          stopReason === 'content_filter'
+            ? 'The provider stopped the response because of its content filter.'
+            : 'The provider returned an unsupported or missing finish reason.',
+      };
+      yield { type: 'done', reason: 'provider_stop', stopReason, usage };
+      return;
+    }
     if (stopReason !== 'tool_use' || toolCalls.length === 0) {
       yield { type: 'done', reason: 'end_turn', stopReason, usage };
       return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "express": "^4.21.0",
         "js-yaml": "5.2.3",
         "minisearch": "^7.2.0",
-        "openai": "^6.45.0",
+        "openai": "^7.4.0",
         "youtube-transcript-api": "^3.0.6",
         "zod": "^4.4.3"
       },
@@ -5531,10 +5531,13 @@
       "license": "MIT"
     },
     "node_modules/openai": {
-      "version": "6.45.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
-      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.4.0.tgz",
+      "integrity": "sha512-+C9Muit5x8j9R8ej8ZzVgKcrVDtqFqTy9gxFdov0EItLgU68zrJtF9ZeT0cyqJQW9S3PCJkdFgADtRGquRBtew==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      },
       "peerDependencies": {
         "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
         "@smithy/hash-node": ">=4.3.0 <5",


### PR DESCRIPTION
Closes #399.

## What changed
- upgrades the production `openai` dependency from 6.45.0 to 7.4.0
- adds a loopback-only smoke that uses Hayba's lazy dynamic import and the published SDK constructor (no injected SDK fake, no key, no billable request)
- covers non-stream completion, SSE text/tool fragments, finish reasons, usage, cancellation, SDK timeout, connection reset, non-2xx errors, normalized compatible-provider base URLs, and `not-needed` auth
- fails closed when a custom provider has no endpoint and rejects credential/query/backslash base-URL tricks before fetch
- drops non-2xx backend bodies from diagnostics, uses the central bounded redactor, and proves auth/prompt/secret response fields cannot reach diagnostics or stderr
- preserves content-filter/unknown finish reasons and emits `provider_stop` instead of silently claiming `end_turn`

## Evidence
- `npx tsc --noEmit` — pass
- `npm run build:server` — pass
- `npm test` — 179 files / 1845 tests pass
- `npm run lint:legacy-wrappers` — pass (22 C++ commands, 153 sidecar entries)
- focused real-client + legacy compatibility — 59/59 pass
- scoped ESLint — pass
- scoped Prettier — pass
- `npm run audit:production` — pass (0 errors, 0 warnings)
- mutation: mapping an unknown OpenAI finish reason back to `end_turn` makes the real-client test fail; reverted before final gates

The generic npm audit still reports the existing Transformers/Sharp/ONNX chain tracked separately by #397; OpenAI 7 introduces no finding.