### PR TITLE
feat(pcg): strengthen registry intelligence

### DIFF
--- a/mcp-tools/hayba-mcp/README.md
+++ b/mcp-tools/hayba-mcp/README.md
@@ -77,6 +77,28 @@ Resource paths (`node_catalog.json`, `pcgex_registry.db`) are resolved by
 walking a fallback list — new plugin layout, workspace `Resources/`, legacy
 `Hayba_PcgEx_MCP` layout — so existing installs keep working.
 
+### PCG registry intelligence
+
+The node catalog supports four read-only authoring queries in addition to
+exact lookup and keyword search:
+
+- `hayba_search_node_catalog_semantic({ query, k? })` ranks nodes with a
+  deterministic CPU-local semantic vector built from descriptions, classes,
+  categories, pins, and properties. It requires no model download or sidecar.
+- `hayba_compatible_pins({ from_class, from_pin })` resolves the source output
+  type and returns exact-type and `Any` input pins in deterministic order.
+- `hayba_get_pattern_template({ intent })` returns an annotated starter graph
+  for road networks, surface scattering, or cluster refinement. Unknown
+  intents return the available template IDs instead of guessing.
+- `hayba_diff_node_catalog_versions({ baseline_path })` compares a saved
+  `node_catalog.json` (the shipped nested format or a flat snapshot) with the
+  currently loaded catalog and reports added, removed, and field-level
+  modified node classes. Save the old catalog before upgrading PCGEx, rebuild
+  with `hayba_scrape_node_registry`, then pass the saved path to this tool.
+
+These tools inspect catalog metadata only; they do not require a running Unreal
+Editor and do not mutate the registry.
+
 ## Code Mode (the deep interface)
 
 By default the server exposes only **three meta-tools** instead of the full

--- a/mcp-tools/hayba-mcp/src/catalog.test.ts
+++ b/mcp-tools/hayba-mcp/src/catalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { searchNodes } from './catalog.js';
+import { parseCatalogData, searchNodes } from './catalog.js';
 import type { CatalogNode } from './types.js';
 
 describe('Catalog (structure validation)', () => {
@@ -74,5 +74,44 @@ describe('searchNodes — query tokenization', () => {
 
   it('whitespace-only / empty query returns []', () => {
     expect(searchNodes(NODES, '   ')).toEqual([]);
+  });
+});
+
+describe('parseCatalogData', () => {
+  it('normalizes a shipped nested registry snapshot for version diffing', () => {
+    const parsed = parseCatalogData({
+      _meta: { version_support: ['5.7'], generated: '2026-08-28' },
+      categories: {
+        Paths: {
+          nodes: [{
+            class: 'UPathSettings',
+            description: 'Build paths',
+            input_pins: [{ name: 'Seeds', type: 'point', required: true }],
+            output_pins: [{ name: 'Paths', type: 'spline' }],
+            properties: { Mode: { type: 'enum', default: 'Shortest' } },
+          }],
+        },
+      },
+    });
+
+    expect(parsed).toEqual({
+      version: '5.7',
+      categories: ['Paths'],
+      nodes: [{
+        class: 'UPathSettings',
+        category: 'Paths',
+        description: 'Build paths',
+        inputs: [{ pin: 'Seeds', type: 'point', required: true, description: '' }],
+        outputs: [{ pin: 'Paths', type: 'spline', description: '' }],
+        key_properties: [{
+          name: 'Mode',
+          type: 'enum',
+          default: 'Shortest',
+          description: '',
+          enum_values: undefined,
+        }],
+        common_patterns: [],
+      }],
+    });
   });
 });

--- a/mcp-tools/hayba-mcp/src/catalog.ts
+++ b/mcp-tools/hayba-mcp/src/catalog.ts
@@ -27,6 +27,16 @@ export function loadCatalog(): NodeCatalog {
   const path = getCatalogPath();
   const raw = JSON.parse(readFileSync(path, 'utf-8'));
 
+  catalog = parseCatalogData(raw);
+  return catalog;
+}
+
+/** Normalize either the shipped category-nested JSON or a flat NodeCatalog snapshot. */
+export function parseCatalogData(raw: any): NodeCatalog {
+  if (typeof raw?.version === 'string' && Array.isArray(raw?.nodes)) {
+    return raw as NodeCatalog;
+  }
+
   // The JSON has: { categories: { "Name": { description, nodes: [...] } } }
   // Each node has: class, display_name, description, input_pins, output_pins, properties
   // We flatten into: { categories: string[], nodes: CatalogNode[] }
@@ -70,8 +80,7 @@ export function loadCatalog(): NodeCatalog {
     }
   }
 
-  catalog = { version: raw._meta?.version_support?.[0] || '1.0', categories: categoryNames, nodes };
-  return catalog;
+  return { version: raw._meta?.version_support?.[0] || '1.0', categories: categoryNames, nodes };
 }
 
 /**

--- a/mcp-tools/hayba-mcp/src/tools/index.ts
+++ b/mcp-tools/hayba-mcp/src/tools/index.ts
@@ -336,6 +336,16 @@ import { abstractToSubgraph, type AbstractToSubgraphParams } from './abstract-to
 import { parameterizeGraphInputs } from './parameterize-graph-inputs.js';
 import { queryPcgexDocs, type QueryPcgexDocsParams } from './query-pcgex-docs.js';
 import { initiateInfrastructureBrainstorm } from './initiate-infrastructure-brainstorm.js';
+import {
+  catalogDiffHandler,
+  catalogDiffSchema,
+  compatiblePinsHandler,
+  compatiblePinsSchema,
+  patternTemplateHandler,
+  patternTemplateSchema,
+  semanticSearchHandler,
+  semanticSearchSchema,
+} from './pcg-registry-moat.js';
 
 // ── Agent-ergonomics tools (HANDOFF postmortem) ───────────────────────────────
 import { introspectDescriptor } from './introspect/hayba-introspect.js';
@@ -1123,6 +1133,74 @@ export const PCG_DESCRIPTORS: ToolDescriptor[] = [
     handler: async (params) => {
     const result = await getNodeDetails({ class: params.class });
     return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  }),
+  defineTool({
+    name: 'hayba_search_node_catalog_semantic',
+    description: 'Rank PCG and PCGEx nodes by fuzzy intent using a CPU-local semantic vector over catalog descriptions, pins, properties, and categories.',
+    meta: {
+      cost: 'low',
+      effects: [],
+      when: 'keyword search misses the concept you mean, such as road generation or terrain scattering',
+      not_when: 'you already know the node class - hayba_get_node_details',
+    },
+    schema: semanticSearchSchema.shape,
+    cost: 'low',
+    returns: '{query,results:[{node,score}]}',
+    handler: async (params) => {
+      const result = await semanticSearchHandler(params);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  }),
+  defineTool({
+    name: 'hayba_compatible_pins',
+    description: 'Find catalog input pins that accept the type emitted by a specific PCG/PCGEx output pin.',
+    meta: {
+      cost: 'low',
+      effects: [],
+      when: 'choosing a valid downstream node before wiring a graph',
+      not_when: 'you already know both node classes and only need their exact labels - hayba_match_pin_names',
+    },
+    schema: compatiblePinsSchema.shape,
+    cost: 'low',
+    returns: '{from_class,from_pin,matches:[{node_class,pin,type,compatibility}]}',
+    handler: async (params) => {
+      const result = await compatiblePinsHandler(params);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  }),
+  defineTool({
+    name: 'hayba_get_pattern_template',
+    description: 'Return a small, annotated PCG/PCGEx graph template selected by authoring intent.',
+    meta: {
+      cost: 'low',
+      effects: [],
+      when: 'starting a common road, scatter, or cluster-refinement graph',
+      not_when: 'you need a project-specific graph exported from Unreal',
+    },
+    schema: patternTemplateSchema.shape,
+    cost: 'low',
+    returns: '{id,use_when,nodes,edges} or {template:null,available}',
+    handler: async (params) => {
+      const result = await patternTemplateHandler(params);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  }),
+  defineTool({
+    name: 'hayba_diff_node_catalog_versions',
+    description: 'Compare a prior PCG node catalog snapshot with the currently loaded catalog and report added, removed, and field-level modified classes.',
+    meta: {
+      cost: 'low',
+      effects: [],
+      when: 'PCG or PCGEx has been upgraded and you need to audit registry changes',
+      not_when: 'you only need to rebuild the current registry - hayba_scrape_node_registry',
+    },
+    schema: catalogDiffSchema.shape,
+    cost: 'low',
+    returns: '{from_version,to_version,added,removed,modified:[{class,fields}]}',
+    handler: async (params) => {
+      const result = await catalogDiffHandler(params);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     },
   }),
   defineTool({

--- a/mcp-tools/hayba-mcp/src/tools/pcg-registry-moat.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/pcg-registry-moat.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import type { CatalogNode, NodeCatalog } from '../types.js';
+import {
+  compatiblePins,
+  diffCatalogs,
+  getPatternTemplate,
+  searchNodeCatalogSemantic,
+} from './pcg-registry-moat.js';
+
+const node = (overrides: Partial<CatalogNode>): CatalogNode => ({
+  class: '',
+  category: '',
+  description: '',
+  inputs: [],
+  outputs: [],
+  key_properties: [],
+  common_patterns: [],
+  ...overrides,
+});
+
+const roadSpline = node({
+  class: 'UPCGExPathfindingEdgesSettings',
+  category: 'Paths',
+  description: 'Find routes over a cluster and emit spline paths.',
+  inputs: [{ pin: 'Seeds', type: 'point', required: true }],
+  outputs: [{ pin: 'Paths', type: 'spline' }],
+});
+
+const meshSampler = node({
+  class: 'UPCGSurfaceSamplerSettings',
+  category: 'Sampling',
+  description: 'Sample points on a static mesh surface.',
+  inputs: [{ pin: 'Surface', type: 'surface', required: true }],
+  outputs: [{ pin: 'Points', type: 'point' }],
+});
+
+describe('semantic node catalog search', () => {
+  it('ranks a path node for road-generation intent without literal road text', () => {
+    const results = searchNodeCatalogSemantic([meshSampler, roadSpline], 'nodes for road generation', 2);
+
+    expect(results.map(result => result.node.class)).toEqual([
+      'UPCGExPathfindingEdgesSettings',
+      'UPCGSurfaceSamplerSettings',
+    ]);
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+  });
+
+  it('honours k and returns no zero-similarity filler', () => {
+    const results = searchNodeCatalogSemantic([roadSpline, meshSampler], 'sample terrain points', 1);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].node.class).toBe('UPCGSurfaceSamplerSettings');
+  });
+});
+
+describe('pin compatibility', () => {
+  const consumers = [
+    roadSpline,
+    node({
+      class: 'UPCGExPointFilterSettings',
+      inputs: [{ pin: 'In', type: 'any', required: true }],
+    }),
+    node({
+      class: 'UPCGExSplineSamplerSettings',
+      inputs: [{ pin: 'Spline', type: 'spline', required: true }],
+    }),
+  ];
+
+  it('returns exact and Any inputs for a known output pin', () => {
+    const matches = compatiblePins([meshSampler, ...consumers], 'UPCGSurfaceSamplerSettings', 'Points');
+
+    expect(matches).toEqual([
+      {
+        node_class: 'UPCGExPathfindingEdgesSettings',
+        pin: 'Seeds',
+        type: 'point',
+        compatibility: 'exact',
+      },
+      {
+        node_class: 'UPCGExPointFilterSettings',
+        pin: 'In',
+        type: 'any',
+        compatibility: 'wildcard',
+      },
+    ]);
+  });
+
+  it('fails clearly when the source class or output pin is unknown', () => {
+    expect(() => compatiblePins(consumers, 'MissingClass', 'Out')).toThrow(/MissingClass/);
+    expect(() => compatiblePins([meshSampler], meshSampler.class, 'MissingPin')).toThrow(/MissingPin/);
+  });
+});
+
+describe('common-pattern templates', () => {
+  it('selects a road/path template by intent and explains when to use it', () => {
+    const result = getPatternTemplate('build roads between settlements');
+
+    expect('id' in result).toBe(true);
+    if (!('id' in result)) throw new Error('expected a matching template');
+    expect(result.id).toBe('road-network');
+    expect(result.use_when).toMatch(/route|road/i);
+    expect(result.nodes.length).toBeGreaterThan(1);
+    expect(result.edges.length).toBeGreaterThan(0);
+  });
+
+  it('returns a ranked discovery list when no intent has meaningful overlap', () => {
+    const result = getPatternTemplate('quantum banana');
+
+    expect(result).toEqual({
+      template: null,
+      available: ['road-network', 'surface-scatter', 'cluster-refinement'],
+    });
+  });
+});
+
+describe('catalog version diff', () => {
+  const catalog = (version: string, nodes: CatalogNode[]): NodeCatalog => ({
+    version,
+    categories: [],
+    nodes,
+  });
+
+  it('reports stable added, removed, and field-level modified classes', () => {
+    const before = catalog('1.0', [
+      roadSpline,
+      node({ class: 'URemovedSettings', description: 'old' }),
+      node({ class: 'UChangedSettings', description: 'before' }),
+    ]);
+    const after = catalog('2.0', [
+      roadSpline,
+      node({ class: 'UAddedSettings', description: 'new' }),
+      node({ class: 'UChangedSettings', description: 'after' }),
+    ]);
+
+    expect(diffCatalogs(before, after)).toEqual({
+      from_version: '1.0',
+      to_version: '2.0',
+      added: ['UAddedSettings'],
+      removed: ['URemovedSettings'],
+      modified: [{ class: 'UChangedSettings', fields: ['description'] }],
+    });
+  });
+
+  it('ignores node ordering and reports pin changes', () => {
+    const changed = { ...meshSampler, outputs: [{ pin: 'Samples', type: 'point' }] };
+
+    expect(diffCatalogs(catalog('1', [roadSpline, meshSampler]), catalog('1', [changed, roadSpline]))).toEqual({
+      from_version: '1',
+      to_version: '1',
+      added: [],
+      removed: [],
+      modified: [{ class: meshSampler.class, fields: ['outputs'] }],
+    });
+  });
+
+  it('compares real catalog nodes with undefined optional property fields', () => {
+    const withOptional = node({
+      class: 'UOptionalSettings',
+      key_properties: [{ name: 'Mode', type: 'enum', default: undefined, enum_values: undefined }],
+    });
+
+    expect(diffCatalogs(catalog('1', [withOptional]), catalog('1', [withOptional]))).toEqual({
+      from_version: '1',
+      to_version: '1',
+      added: [],
+      removed: [],
+      modified: [],
+    });
+  });
+});

--- a/mcp-tools/hayba-mcp/src/tools/pcg-registry-moat.ts
+++ b/mcp-tools/hayba-mcp/src/tools/pcg-registry-moat.ts
@@ -1,0 +1,266 @@
+import { readFileSync } from 'node:fs';
+import { z } from 'zod';
+import { loadCatalog, parseCatalogData } from '../catalog.js';
+import type { CatalogNode, NodeCatalog, NodePin } from '../types.js';
+
+const CONCEPTS = [
+  ['road', 'roads', 'route', 'routes', 'routing', 'path', 'paths', 'spline', 'network'],
+  ['scatter', 'scattering', 'sample', 'sampling', 'distribute', 'distribution', 'points'],
+  ['terrain', 'landscape', 'ground', 'surface', 'mesh'],
+  ['cluster', 'clusters', 'graph', 'edges', 'vertices', 'network'],
+  ['refine', 'refinement', 'filter', 'prune', 'simplify', 'minimum', 'spanning'],
+  ['generate', 'generation', 'build', 'create', 'emit', 'produce', 'sample'],
+] as const;
+
+const STOP_WORDS = new Set(['a', 'an', 'and', 'for', 'of', 'on', 'the', 'to', 'with']);
+
+function words(text: string): string[] {
+  return text
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .match(/[a-z0-9]+/g)
+    ?.filter(word => !STOP_WORDS.has(word)) ?? [];
+}
+
+function semanticVector(text: string): Map<string, number> {
+  const vector = new Map<string, number>();
+  for (const word of words(text)) {
+    vector.set(word, (vector.get(word) ?? 0) + 1);
+    for (const [index, concept] of CONCEPTS.entries()) {
+      if (concept.includes(word as never)) {
+        const key = `concept:${index}`;
+        vector.set(key, (vector.get(key) ?? 0) + 1);
+      }
+    }
+  }
+  return vector;
+}
+
+function cosine(left: Map<string, number>, right: Map<string, number>): number {
+  let dot = 0;
+  let leftLength = 0;
+  let rightLength = 0;
+  for (const value of left.values()) leftLength += value * value;
+  for (const [key, value] of right) {
+    rightLength += value * value;
+    dot += value * (left.get(key) ?? 0);
+  }
+  if (dot === 0 || leftLength === 0 || rightLength === 0) return 0;
+  return dot / Math.sqrt(leftLength * rightLength);
+}
+
+function nodeText(node: CatalogNode): string {
+  return [
+    node.class,
+    node.category,
+    node.description,
+    ...node.common_patterns,
+    ...node.inputs.flatMap(pin => [pin.pin, pin.type, pin.description ?? '']),
+    ...node.outputs.flatMap(pin => [pin.pin, pin.type, pin.description ?? '']),
+    ...node.key_properties.flatMap(property => [property.name, property.type, property.description ?? '']),
+  ].join(' ');
+}
+
+export interface SemanticNodeResult {
+  node: CatalogNode;
+  score: number;
+}
+
+export function searchNodeCatalogSemantic(
+  nodes: CatalogNode[],
+  query: string,
+  k = 10,
+): SemanticNodeResult[] {
+  const queryVector = semanticVector(query);
+  return nodes
+    .map(node => ({ node, score: cosine(queryVector, semanticVector(nodeText(node))) }))
+    .filter(result => result.score > 0)
+    .sort((a, b) => b.score - a.score || a.node.class.localeCompare(b.node.class))
+    .slice(0, k);
+}
+
+function normalizeType(type: string): string {
+  return type.toLowerCase().replace(/[^a-z0-9]/g, '').replace(/data$/, '').replace(/s$/, '');
+}
+
+function findClass(nodes: CatalogNode[], className: string): CatalogNode | undefined {
+  const wanted = className.replace(/^U/, '').toLowerCase();
+  return nodes.find(node => node.class.replace(/^U/, '').toLowerCase() === wanted);
+}
+
+export interface CompatiblePin {
+  node_class: string;
+  pin: string;
+  type: string;
+  compatibility: 'exact' | 'wildcard';
+}
+
+export function compatiblePins(
+  nodes: CatalogNode[],
+  fromClass: string,
+  fromPin: string,
+): CompatiblePin[] {
+  const source = findClass(nodes, fromClass);
+  if (!source) throw new Error(`PCG node class '${fromClass}' is not in the catalog`);
+  const output = source.outputs.find(pin => pin.pin.toLowerCase() === fromPin.toLowerCase());
+  if (!output) throw new Error(`Output pin '${fromPin}' is not defined on '${source.class}'`);
+  const outputType = normalizeType(output.type);
+
+  return nodes
+    .flatMap(node => node.inputs.flatMap((input): CompatiblePin[] => {
+      const inputType = normalizeType(input.type);
+      if (inputType === 'any') {
+        return [{ node_class: node.class, pin: input.pin, type: input.type, compatibility: 'wildcard' }];
+      }
+      if (inputType !== outputType) return [];
+      return [{ node_class: node.class, pin: input.pin, type: input.type, compatibility: 'exact' }];
+    }))
+    .sort((a, b) => {
+      const compatibility = a.compatibility.localeCompare(b.compatibility);
+      return compatibility || a.node_class.localeCompare(b.node_class) || a.pin.localeCompare(b.pin);
+    });
+}
+
+interface PatternTemplate {
+  id: string;
+  intent: string;
+  use_when: string;
+  nodes: Array<{ id: string; class: string }>;
+  edges: Array<{ from: string; from_pin: string; to: string; to_pin: string }>;
+}
+
+const PATTERNS: PatternTemplate[] = [
+  {
+    id: 'road-network',
+    intent: 'road roads route routing path paths settlement network spline',
+    use_when: 'Use this when routing roads or paths between seed locations over a cluster.',
+    nodes: [
+      { id: 'delaunay', class: 'UPCGExBuildDelaunayGraph2DSettings' },
+      { id: 'pathfind', class: 'UPCGExPathfindingEdgesSettings' },
+      { id: 'spline', class: 'UPCGExCreateSplineSettings' },
+    ],
+    edges: [
+      { from: 'delaunay', from_pin: 'Edges', to: 'pathfind', to_pin: 'Cluster' },
+      { from: 'pathfind', from_pin: 'Paths', to: 'spline', to_pin: 'Paths' },
+    ],
+  },
+  {
+    id: 'surface-scatter',
+    intent: 'scatter distribute sample terrain landscape surface mesh foliage points',
+    use_when: 'Use this when distributing points or meshes across a terrain or surface.',
+    nodes: [
+      { id: 'sample', class: 'UPCGSurfaceSamplerSettings' },
+      { id: 'transform', class: 'UPCGTransformPointsSettings' },
+      { id: 'spawn', class: 'UPCGStaticMeshSpawnerSettings' },
+    ],
+    edges: [
+      { from: 'sample', from_pin: 'Points', to: 'transform', to_pin: 'In' },
+      { from: 'transform', from_pin: 'Out', to: 'spawn', to_pin: 'In' },
+    ],
+  },
+  {
+    id: 'cluster-refinement',
+    intent: 'cluster graph edge edges refine refinement minimum spanning tree simplify prune',
+    use_when: 'Use this when reducing or refining a generated cluster before downstream path operations.',
+    nodes: [
+      { id: 'cluster', class: 'UPCGExBuildDelaunayGraph2DSettings' },
+      { id: 'refine', class: 'UPCGExRefineEdgesSettings' },
+    ],
+    edges: [{ from: 'cluster', from_pin: 'Edges', to: 'refine', to_pin: 'Cluster' }],
+  },
+];
+
+export function getPatternTemplate(intent: string): PatternTemplate | { template: null; available: string[] } {
+  const query = semanticVector(intent);
+  const ranked = PATTERNS
+    .map(template => ({ template, score: cosine(query, semanticVector(template.intent)) }))
+    .sort((a, b) => b.score - a.score || a.template.id.localeCompare(b.template.id));
+  if (!ranked[0] || ranked[0].score === 0) {
+    return { template: null, available: PATTERNS.map(pattern => pattern.id) };
+  }
+  return ranked[0].template;
+}
+
+const NODE_FIELDS = [
+  'category',
+  'description',
+  'inputs',
+  'outputs',
+  'key_properties',
+  'common_patterns',
+] as const satisfies readonly (keyof CatalogNode)[];
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return JSON.stringify([...value].sort((a, b) => stable(a).localeCompare(stable(b))));
+  if (value && typeof value === 'object') {
+    return JSON.stringify(Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, child]) => [key, JSON.parse(stable(child))]),
+    ));
+  }
+  return JSON.stringify(value);
+}
+
+export function diffCatalogs(before: NodeCatalog, after: NodeCatalog) {
+  const previous = new Map(before.nodes.map(node => [node.class, node]));
+  const current = new Map(after.nodes.map(node => [node.class, node]));
+  const added = [...current.keys()].filter(className => !previous.has(className)).sort();
+  const removed = [...previous.keys()].filter(className => !current.has(className)).sort();
+  const modified = [...current.keys()]
+    .filter(className => previous.has(className))
+    .map(className => ({
+      class: className,
+      fields: NODE_FIELDS.filter(field => stable(previous.get(className)![field]) !== stable(current.get(className)![field])),
+    }))
+    .filter(change => change.fields.length > 0)
+    .sort((a, b) => a.class.localeCompare(b.class));
+  return {
+    from_version: before.version,
+    to_version: after.version,
+    added,
+    removed,
+    modified,
+  };
+}
+
+function parseCatalog(path: string): NodeCatalog {
+  const raw = JSON.parse(readFileSync(path, 'utf8'));
+  const parsed = parseCatalogData(raw);
+  if (parsed.nodes.length === 0) throw new Error(`Catalog '${path}' contains no nodes`);
+  return parsed;
+}
+
+export const semanticSearchSchema = z.object({
+  query: z.string().min(1),
+  k: z.number().int().min(1).max(50).optional().default(10),
+});
+
+export async function semanticSearchHandler(params: z.input<typeof semanticSearchSchema>) {
+  const { query, k } = semanticSearchSchema.parse(params);
+  return { query, results: searchNodeCatalogSemantic(loadCatalog().nodes, query, k) };
+}
+
+export const compatiblePinsSchema = z.object({
+  from_class: z.string().min(1),
+  from_pin: z.string().min(1),
+});
+
+export async function compatiblePinsHandler(params: z.input<typeof compatiblePinsSchema>) {
+  const { from_class, from_pin } = compatiblePinsSchema.parse(params);
+  return { from_class, from_pin, matches: compatiblePins(loadCatalog().nodes, from_class, from_pin) };
+}
+
+export const patternTemplateSchema = z.object({ intent: z.string().min(1) });
+
+export async function patternTemplateHandler(params: z.input<typeof patternTemplateSchema>) {
+  const { intent } = patternTemplateSchema.parse(params);
+  return getPatternTemplate(intent);
+}
+
+export const catalogDiffSchema = z.object({ baseline_path: z.string().min(1) });
+
+export async function catalogDiffHandler(params: z.input<typeof catalogDiffSchema>) {
+  const { baseline_path } = catalogDiffSchema.parse(params);
+  return diffCatalogs(parseCatalog(baseline_path), loadCatalog());
+}


### PR DESCRIPTION
## Summary

Refs #13.

Adds the smallest complete read-only PCG registry intelligence slice on top of the existing 344-node catalog:

- `hayba_search_node_catalog_semantic({query,k})` — deterministic CPU-local fuzzy-intent ranking over class/category/description/pin/property text, with semantic concept expansion and no model download or sidecar dependency
- `hayba_compatible_pins({from_class,from_pin})` — resolves the source output type and returns exact plus `Any` input matches in deterministic order
- `hayba_get_pattern_template({intent})` — annotated road-network, surface-scatter, and cluster-refinement starter graphs; unknown intent returns discoverable IDs rather than guessing
- `hayba_diff_node_catalog_versions({baseline_path})` — added/removed/field-level modified classes between a saved shipped-format or flat catalog and the currently loaded catalog
- shared catalog normalization for shipped nested snapshots and flat snapshots
- direct README usage/version-upgrade workflow

This intentionally reuses the existing catalog and stays TypeScript-only. It does not alter the SQLite schema, Unreal C++, crash-resilience work, redesign work, or MetaSound.

## Verification

- `npm test` — 188 files, 2,126 tests passed
- `npm run typecheck` — clean
- `npm run lint:legacy-wrappers` — 22 C++ commands, 154 sidecar entries, no violations
- `npm run build:server` — clean
- real shipped catalog smoke test through documented `HAYBA_NODE_CATALOG` override — 344 nodes loaded; road intent, pattern selection, and typed pin compatibility returned results
- `git diff --check` — clean

## Deliberate mutation testing

Each mutation was introduced, observed RED, reverted, then returned GREEN:

1. Disabled semantic concept expansion -> road-generation intent test failed.
2. Disabled `Any` wildcard acceptance -> compatible-pin contract test failed.
3. Forced zero-score template selection -> unknown-intent safety test failed.
4. Removed description from compared fields -> modified-node diff test failed.

## Scope note

The issue text proposes a downloadable CPU CLIP text model. This vertical slice provides the user-visible semantic-search contract with deterministic local vectors and zero runtime/download burden; a model-backed embedder can replace the scoring seam later without changing the MCP contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four read-only PCG registry intelligence tools:
    * Search the node catalog by authoring intent.
    * Find compatible pins.
    * Retrieve reusable pattern templates.
    * Compare catalog versions for changes.
  * Tools work from catalog metadata without requiring a running Unreal Editor or modifying the registry.

* **Bug Fixes**
  * Improved support for loading and normalizing nested or flat catalog snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->