### PR TITLE
fix: isolate unsafe automation tests from serving editor

### DIFF
--- a/mcp-tools/hayba-mcp/scripts/native-contracts/automation-isolation-policy-smoke.cpp
+++ b/mcp-tools/hayba-mcp/scripts/native-contracts/automation-isolation-policy-smoke.cpp
@@ -1,0 +1,20 @@
+#include "HaybaMCPAutomationIsolationPolicy.h"
+
+using namespace HaybaAutomationIsolation;
+
+static_assert(ClassifyLiteral(L"Hayba.MCP.Params.Reader") == EExecutionMode::InProcess);
+static_assert(ClassifyLiteral(L"Hayba.MCP.Future.Unreviewed") == EExecutionMode::OwnedChild);
+static_assert(ClassifyLiteral(L"Aphrosia.GameInstance.InvalidOuter") == EExecutionMode::OwnedChild);
+static_assert(ClassifyLiteral(L"Engine.Editor.ContextFixture") == EExecutionMode::OwnedChild);
+
+static_assert(ClassifyChildOutcome(false, false, false, false, -1) == EChildOutcome::NeverStarted);
+static_assert(ClassifyChildOutcome(true, false, true, false, -1) == EChildOutcome::TimedOut);
+static_assert(ClassifyChildOutcome(true, false, false, true, -1) == EChildOutcome::Cancelled);
+static_assert(ClassifyChildOutcome(true, true, false, false, 1) == EChildOutcome::Reported);
+static_assert(ClassifyChildOutcome(true, false, false, false, 0) == EChildOutcome::NeverStarted);
+static_assert(ClassifyChildOutcome(true, false, false, false, 3) == EChildOutcome::Crashed);
+
+int main()
+{
+    return 0;
+}

--- a/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/sidecar.json
@@ -375,11 +375,11 @@
           "required": false,
           "description": "Restrict to SmokeFilter-tagged tests"
         },
-        {
-          "name": "timeout_seconds",
-          "type": "number",
-          "required": false,
-          "description": "Per-test latent-command drain timeout (default 120)"
+          {
+            "name": "timeout_seconds",
+            "type": "number",
+            "required": false,
+            "description": "For allowlisted in-process tests: per-test latent drain timeout. For owned-child runs: total process deadline, default 300 and hard-capped at 900 seconds."
         }
       ],
       "returns": {
@@ -394,6 +394,21 @@
             "name": "status",
             "type": "string",
             "description": "'running' immediately; 'busy' if another run is already in flight"
+          },
+          {
+            "name": "execution_mode",
+            "type": "string",
+            "description": "'in_process_allowlisted' only for exact audited Hayba contracts; otherwise 'owned_child'"
+          },
+          {
+            "name": "ownership_token",
+            "type": "string",
+            "description": "Unique command-line tag proving ownership of a disposable child"
+          },
+          {
+            "name": "child_pid",
+            "type": "number",
+            "description": "PID of the owned UnrealEditor-Cmd child when execution_mode is owned_child"
           },
           {
             "name": "total",
@@ -422,7 +437,48 @@
       },
       "agent_callable": true,
       "has_ts_wrapper": false,
-      "notes": "JOB ENVELOPE (async, non-freezing): run explicit test_names, 'all', or the same filter/filter_pattern/category selectors accepted by test_list. Selectors are case-insensitive and cannot be combined with explicit names; an empty or zero-match selection is an error rather than a false green run. Returns { job_id, status:'running' } immediately and runs tests on the editor's game-thread core ticker. Poll build_status for { passed, failed, skipped, elapsed_seconds, total }, or test_get_log for detailed entries. Only one pollable run may be active; busy errors include its job_id, while orphaned/done ownership is recovered automatically."
+      "notes": "JOB ENVELOPE (async, non-freezing): unknown project, engine, plugin, and future Hayba tests default to a tagged owned UnrealEditor-Cmd child. Only exact lifecycle-audited pure Hayba contracts use the serving editor's core ticker. Empty or unmatched selections fail closed instead of producing a false green. Poll build_status for structured counts plus execution_mode, child PID/token, exit code, report validity, crash, timeout, cancellation, output-bound, and crash-artifact-count evidence. A crash or never-started child is failed, never skipped. Only one run may be active."
+    },
+    "test_cancel": {
+      "aliases": [],
+      "handler_cpp": "FHaybaMCPTestHandler::Handle",
+      "params": [
+        {
+          "name": "job_id",
+          "type": "string",
+          "required": true,
+          "description": "Active owned-child test_run job id"
+        }
+      ],
+      "returns": {
+        "shape": "object",
+        "fields": [
+          {
+            "name": "job_id",
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "description": "'cancelling'; poll build_status for terminal evidence"
+          },
+          {
+            "name": "child_pid",
+            "type": "number"
+          },
+          {
+            "name": "ownership_token",
+            "type": "string"
+          },
+          {
+            "name": "cancel_requested",
+            "type": "boolean"
+          }
+        ]
+      },
+      "agent_callable": true,
+      "has_ts_wrapper": false,
+      "notes": "Cancels only the tagged UnrealEditor-Cmd child owned by the matching active test_run job. It never enumerates or terminates arbitrary editor processes."
     },
     "test_get_log": {
       "aliases": [],

--- a/mcp-tools/hayba-mcp/src/legacy-commands/test-run-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/legacy-commands/test-run-contract.test.ts
@@ -27,6 +27,11 @@ const lifecycle = readFileSync(
     'HaybaMCPToolkit', 'Private', 'handlers', 'HaybaMCPTestRunLifecycle.h'),
   'utf8',
 );
+const isolationPolicy = readFileSync(
+  join(here, '..', '..', '..', '..', 'unreal', 'HaybaMCPToolkit', 'Source',
+    'HaybaMCPToolkit', 'Private', 'handlers', 'HaybaMCPAutomationIsolationPolicy.h'),
+  'utf8',
+);
 const moduleCpp = readFileSync(
   join(here, '..', '..', '..', '..', 'unreal', 'HaybaMCPToolkit', 'Source',
     'HaybaMCPToolkit', 'Private', 'HaybaMCPModule.cpp'),
@@ -69,13 +74,34 @@ describe('test_run selection contract', () => {
   });
 
   it('fails closed for empty, zero-match, and ambiguous selections', () => {
+    const runHandler = cpp.slice(
+      cpp.indexOf('static FHaybaHandlerResult Cmd_TestRun'),
+      cpp.indexOf('static FHaybaHandlerResult Cmd_TestCancel'),
+    );
     expect(selectionOps).toContain('test_run requires test_names');
     expect(selectionOps).toContain('test_run matched no tests');
     expect(selectionOps).toContain('cannot combine filter/category selectors with explicit test_names');
     expect(cpp).toContain('ValidateResolvedSelection');
     expect(cpp).toContain('ValidateCombination');
     expect(sidecar.commands.test_run!.notes).toContain('false green');
-    expect(cpp.indexOf('ValidateResolvedSelection')).toBeLessThan(cpp.indexOf('AllocateJob(TEXT("test_run"))'));
+    expect(runHandler.indexOf('ValidateResolvedSelection')).toBeLessThan(
+      runHandler.indexOf('StartOwnedChildRun('),
+    );
+  });
+
+  it('defaults every non-allowlisted test to an owned child', () => {
+    expect(isolationPolicy).toContain('return EExecutionMode::OwnedChild;');
+    expect(isolationPolicy).not.toMatch(/StartsWith|Contains|Hayba\.\*/i);
+    expect(cpp).toContain('HaybaAutomationIsolation::Classify(Name)');
+    expect(cpp).toContain('StartOwnedChildRun(');
+    expect(cpp).toContain('-HaybaAutomationChild=%s');
+    expect(cpp).toContain('GAutomationChildOutputLimitChars');
+    expect(cpp).toContain('GAutomationChildMaximumTimeoutSeconds');
+    expect(sidecar.commands).toHaveProperty('test_cancel');
+    expect(moduleCpp).toContain('HaybaAutomationChild=');
+    expect(moduleCpp).toContain('!bOwnedAutomationChild && !StartTcpServer()');
+    expect(cpp).not.toMatch(/taskkill|Stop-Process|CreateToolhelp32Snapshot/);
+    expect(cpp).toContain('FPlatformProcess::TerminateProc(State->Process, true)');
   });
 
   it('cannot strand the single-flight lease on completion or setup failure', () => {

--- a/mcp-tools/hayba-mcp/src/tools/code-mode/list-tool-categories.ts
+++ b/mcp-tools/hayba-mcp/src/tools/code-mode/list-tool-categories.ts
@@ -223,7 +223,7 @@ const DOMAINS: ReadonlyArray<{ domain: string; command_count: number; commands: 
     command_count: 4,
     commands: ['build_project', 'build_cook', 'build_generate_project_files', 'build_status'],
   },
-  { domain: 'test', command_count: 3, commands: ['test_list', 'test_run', 'test_get_log'] },
+  { domain: 'test', command_count: 4, commands: ['test_list', 'test_run', 'test_cancel', 'test_get_log'] },
 ];
 
 /** Domain for a command name. Mirrors inferDir() in ../index.ts, duplicated

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPModule.cpp
@@ -63,6 +63,8 @@
 #include "HAL/PlatformMisc.h"
 #include "HAL/IConsoleManager.h"
 #include "Misc/Paths.h"
+#include "Misc/CommandLine.h"
+#include "Misc/Parse.h"
 #include "Misc/FileHelper.h"
 #include "HAL/FileManager.h"
 #include "Logging/LogMacros.h"
@@ -245,10 +247,18 @@ void FHaybaMCPModule::StartupModule()
         }
     }
 
+    // A disposable automation child must never publish a heartbeat or claim a
+    // listener port. Doing so could redirect the MCP client away from the
+    // serving editor that owns the run.
+    FString AutomationChildToken;
+    const bool bOwnedAutomationChild = FParse::Value(
+        FCommandLine::Get(), TEXT("HaybaAutomationChild="), AutomationChildToken)
+        && !AutomationChildToken.IsEmpty();
+
     // Auto-start the TCP listener so external MCP clients (Claude Code, Cline,
     // OpenCode, …) can connect as soon as the editor is up. The MCP node
     // server itself can still be started/stopped independently via the panel.
-    if (!StartTcpServer())
+    if (!bOwnedAutomationChild && !StartTcpServer())
     {
         UE_LOG(LogHaybaMCP, Error, TEXT("Failed to start TCP listener on port %d at module startup"), TcpPort);
     }
@@ -256,7 +266,7 @@ void FHaybaMCPModule::StartupModule()
     // Auto-start the Node chat sidecar so the in-editor chat works with no manual
     // step. Skip if disabled, or if something is already listening on the sidecar
     // port (a manually-run sidecar or a prior instance) — in that case we reuse it.
-    if (FHaybaMCPSettings::Get().bAutoStartSidecar)
+    if (!bOwnedAutomationChild && FHaybaMCPSettings::Get().bAutoStartSidecar)
     {
         const int32 SidecarPort = HaybaParseSidecarPort(FHaybaMCPSettings::Get().SidecarURL, 7821);
         // Short, bounded probe so we never block editor startup.

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPAutomationIsolationPolicyTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPAutomationIsolationPolicyTest.cpp
@@ -1,0 +1,35 @@
+#include "Misc/AutomationTest.h"
+#include "handlers/HaybaMCPAutomationIsolationPolicy.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FHaybaMCPAutomationIsolationPolicyTest,
+    "Hayba.MCP.Tests.AutomationIsolationPolicy",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FHaybaMCPAutomationIsolationPolicyTest::RunTest(const FString& Parameters)
+{
+    using namespace HaybaAutomationIsolation;
+
+    TestEqual(
+        TEXT("an explicitly audited pure Hayba contract stays in process"),
+        Classify(FString(TEXT("Hayba.MCP.Params.Reader"))),
+        EExecutionMode::InProcess);
+    TestEqual(
+        TEXT("an unknown Hayba test is isolated instead of trusted by namespace"),
+        Classify(FString(TEXT("Hayba.MCP.Future.Unreviewed"))),
+        EExecutionMode::OwnedChild);
+    TestEqual(
+        TEXT("an arbitrary project test defaults to an owned child"),
+        Classify(FString(TEXT("Aphrosia.GameInstance.InvalidOuter"))),
+        EExecutionMode::OwnedChild);
+    TestEqual(
+        TEXT("an engine test defaults to an owned child despite EditorContext"),
+        Classify(FString(TEXT("Engine.Editor.ContextFixture"))),
+        EExecutionMode::OwnedChild);
+
+    return true;
+}
+
+#endif

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPAutomationIsolationPolicy.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPAutomationIsolationPolicy.h
@@ -1,0 +1,85 @@
+#pragma once
+
+namespace HaybaAutomationIsolation
+{
+    enum class EExecutionMode
+    {
+        InProcess,
+        OwnedChild,
+    };
+
+    enum class EChildOutcome
+    {
+        NeverStarted,
+        TimedOut,
+        Cancelled,
+        Reported,
+        Crashed,
+    };
+
+    constexpr EChildOutcome ClassifyChildOutcome(
+        bool bStarted,
+        bool bHasValidReport,
+        bool bTimedOut,
+        bool bCancelled,
+        int ExitCode)
+    {
+        if (!bStarted) return EChildOutcome::NeverStarted;
+        if (bTimedOut) return EChildOutcome::TimedOut;
+        if (bCancelled) return EChildOutcome::Cancelled;
+        if (bHasValidReport) return EChildOutcome::Reported;
+        return ExitCode == 0 ? EChildOutcome::NeverStarted : EChildOutcome::Crashed;
+    }
+
+    template <typename CharType>
+    constexpr bool Equals(const CharType* Value, int Length, const wchar_t* Expected)
+    {
+        int Index = 0;
+        while (Expected[Index] != L'\0')
+        {
+            if (Index >= Length || Value[Index] != static_cast<CharType>(Expected[Index]))
+            {
+                return false;
+            }
+            ++Index;
+        }
+        return Index == Length;
+    }
+
+    /**
+     * Exact, lifecycle-audited allowlist for pure Hayba contract tests.
+     *
+     * These tests operate on value types or isolated registries and do not
+     * create worlds, UObject graphs, render resources, subprocesses, or editor
+     * state. Adding an entry requires reviewing the test body against those
+     * constraints. Namespace/category membership is deliberately insufficient.
+     */
+    template <typename CharType>
+    constexpr EExecutionMode ClassifyName(const CharType* Name, int Length)
+    {
+        if (Equals(Name, Length, L"Hayba.MCP.Params.Reader")
+            || Equals(Name, Length, L"Hayba.MCP.ResponseBuilder.ImageIsNeverTrimmed")
+            || Equals(Name, Length, L"Hayba.MCP.TestSelection.SelectorsAndFailuresAreTruthful")
+            || Equals(Name, Length, L"Hayba.MCP.Tests.RunLifecycle")
+            || Equals(Name, Length, L"Hayba.MCP.Transport.FrameReadPolicy"))
+        {
+            return EExecutionMode::InProcess;
+        }
+
+        // The containment invariant: every unknown project, engine, plugin,
+        // and future Hayba test executes in a disposable owned child.
+        return EExecutionMode::OwnedChild;
+    }
+
+    template <typename StringType>
+    constexpr EExecutionMode Classify(const StringType& Name)
+    {
+        return ClassifyName(*Name, Name.Len());
+    }
+
+    template <int Length>
+    constexpr EExecutionMode ClassifyLiteral(const wchar_t (&Name)[Length])
+    {
+        return ClassifyName(Name, Length - 1);
+    }
+}

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPTestHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPTestHandler.cpp
@@ -1,4 +1,5 @@
 #include "HaybaMCPTestHandler.h"
+#include "HaybaMCPAutomationIsolationPolicy.h"
 #include "HaybaMCPTestSelectionOps.h"
 #include "HaybaMCPTestRunLifecycle.h"
 #include "CoreGlobals.h"
@@ -8,12 +9,17 @@
 #include "HaybaMCPSecurityManager.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/App.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Guid.h"
+#include "Misc/Paths.h"
 #include "HAL/PlatformProcess.h"
+#include "HAL/PlatformFileManager.h"
 #include "HAL/PlatformTime.h"
 #include "Containers/Ticker.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
 #include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonReader.h"
 #include "Serialization/JsonWriter.h"
 #include "Policies/CondensedJsonPrintPolicy.h"
 #endif
@@ -85,6 +91,22 @@ namespace
             }
         }
         return Requested;  // unknown — let StartTestByName report it
+    }
+
+    static FString ResolveCanonicalTestPath(
+        const FString& Requested,
+        const TArray<FAutomationTestInfo>& Discovered)
+    {
+        for (const FAutomationTestInfo& Info : Discovered)
+        {
+            if (Info.GetTestName() == Requested
+                || Info.GetFullTestPath() == Requested
+                || Info.GetDisplayName() == Requested)
+            {
+                return Info.GetFullTestPath();
+            }
+        }
+        return FString();
     }
 
     static void ReadTestSelectors(
@@ -209,6 +231,391 @@ namespace
             TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&ResultsJson);
         FJsonSerializer::Serialize(Results, Writer);
         return ResultsJson;
+    }
+
+    constexpr int32 GAutomationChildOutputLimitChars = 16 * 1024;
+    constexpr double GAutomationChildDefaultTimeoutSeconds = 300.0;
+    constexpr double GAutomationChildMaximumTimeoutSeconds = 900.0;
+
+    struct FOwnedAutomationChildState
+    {
+        FString JobId;
+        FString OwnershipToken;
+        FString ReportDirectory;
+        TArray<FString> Names;
+        double TimeoutSeconds = GAutomationChildDefaultTimeoutSeconds;
+        double StartedAtSeconds = 0.0;
+        FDateTime StartedAtUtc;
+        FProcHandle Process;
+        uint32 ProcessId = 0;
+        void* ReadPipe = nullptr;
+        void* WritePipe = nullptr;
+        FString OutputTail;
+        int64 OutputChars = 0;
+        bool bOutputTruncated = false;
+        bool bCancelRequested = false;
+        bool bTimedOut = false;
+        bool bFinalized = false;
+        FTSTicker::FDelegateHandle TickHandle;
+        TUniquePtr<FHaybaMCPTestRunLeaseGuard> LeaseGuard;
+
+        ~FOwnedAutomationChildState()
+        {
+            if (!bFinalized && Process.IsValid()
+                && FPlatformProcess::IsProcRunning(Process))
+            {
+                // The state owns this exact handle. Abnormal ticker teardown
+                // must not strand an untracked UnrealEditor-Cmd process.
+                FPlatformProcess::TerminateProc(Process, true);
+            }
+            if (Process.IsValid())
+            {
+                FPlatformProcess::CloseProc(Process);
+            }
+            if (ReadPipe || WritePipe)
+            {
+                FPlatformProcess::ClosePipe(ReadPipe, WritePipe);
+            }
+        }
+    };
+
+    static TWeakPtr<FOwnedAutomationChildState>& GetActiveOwnedChildState()
+    {
+        static TWeakPtr<FOwnedAutomationChildState>* State =
+            new TWeakPtr<FOwnedAutomationChildState>();
+        return *State;
+    }
+
+    static FString MakeOwnedChildNeverStartedResultsJson(
+        const TSharedRef<FOwnedAutomationChildState>& State,
+        const FString& Reason)
+    {
+        TArray<TSharedPtr<FJsonValue>> Failed;
+        for (const FString& Name : State->Names)
+        {
+            auto Failure = MakeShared<FJsonObject>();
+            Failure->SetStringField(TEXT("name"), Name);
+            Failure->SetStringField(TEXT("outcome"), TEXT("never_started"));
+            Failure->SetStringField(TEXT("reason"), Reason);
+            Failed.Add(MakeShared<FJsonValueObject>(Failure));
+        }
+
+        TSharedRef<FJsonObject> Results = MakeShared<FJsonObject>();
+        const TArray<TSharedPtr<FJsonValue>> Empty;
+        Results->SetArrayField(TEXT("passed"), Empty);
+        Results->SetArrayField(TEXT("failed"), Failed);
+        Results->SetArrayField(TEXT("skipped"), Empty);
+        Results->SetNumberField(TEXT("passed_count"), 0);
+        Results->SetNumberField(TEXT("failed_count"), FMath::Max(Failed.Num(), 1));
+        Results->SetNumberField(TEXT("skipped_count"), 0);
+        Results->SetNumberField(TEXT("total"), State->Names.Num());
+        Results->SetBoolField(TEXT("all_passed"), false);
+        Results->SetNumberField(TEXT("elapsed_seconds"), 0);
+        Results->SetStringField(TEXT("execution_mode"), TEXT("owned_child"));
+        Results->SetStringField(TEXT("ownership_token"), State->OwnershipToken);
+        Results->SetNumberField(TEXT("child_pid"), 0);
+        Results->SetBoolField(TEXT("child_started"), false);
+        Results->SetBoolField(TEXT("never_started"), true);
+        Results->SetNumberField(TEXT("process_exit_code"), -1);
+        Results->SetBoolField(TEXT("report_valid"), false);
+        Results->SetBoolField(TEXT("timed_out"), false);
+        Results->SetBoolField(TEXT("cancelled"), false);
+        Results->SetBoolField(TEXT("crashed"), false);
+        Results->SetNumberField(TEXT("crash_artifact_count"), 0);
+        Results->SetNumberField(TEXT("captured_output_chars"), 0);
+        Results->SetBoolField(TEXT("output_truncated"), false);
+
+        FString Json;
+        const TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+            TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Json);
+        FJsonSerializer::Serialize(Results, Writer);
+        return Json;
+    }
+
+    static void CaptureBoundedChildOutput(
+        const TSharedRef<FOwnedAutomationChildState>& State)
+    {
+        const FString Chunk = FPlatformProcess::ReadPipe(State->ReadPipe);
+        if (Chunk.IsEmpty()) return;
+
+        State->OutputChars += Chunk.Len();
+        State->OutputTail.Append(Chunk);
+        if (State->OutputTail.Len() > GAutomationChildOutputLimitChars)
+        {
+            State->OutputTail.RightChopInline(
+                State->OutputTail.Len() - GAutomationChildOutputLimitChars,
+                EAllowShrinking::No);
+            State->bOutputTruncated = true;
+        }
+    }
+
+    static bool TryGetNumberEither(
+        const TSharedPtr<FJsonObject>& Object,
+        const TCHAR* LowerName,
+        const TCHAR* UpperName,
+        double& OutValue)
+    {
+        return Object.IsValid()
+            && (Object->TryGetNumberField(LowerName, OutValue)
+                || Object->TryGetNumberField(UpperName, OutValue));
+    }
+
+    static bool TryGetArrayEither(
+        const TSharedPtr<FJsonObject>& Object,
+        const TCHAR* LowerName,
+        const TCHAR* UpperName,
+        const TArray<TSharedPtr<FJsonValue>>*& OutValue)
+    {
+        return Object.IsValid()
+            && (Object->TryGetArrayField(LowerName, OutValue)
+                || Object->TryGetArrayField(UpperName, OutValue));
+    }
+
+    static FString ReadStringEither(
+        const TSharedPtr<FJsonObject>& Object,
+        const TCHAR* LowerName,
+        const TCHAR* UpperName)
+    {
+        FString Value;
+        if (Object.IsValid())
+        {
+            if (!Object->TryGetStringField(LowerName, Value))
+            {
+                Object->TryGetStringField(UpperName, Value);
+            }
+        }
+        return Value;
+    }
+
+    static bool ReadOwnedChildReport(
+        const TSharedRef<FOwnedAutomationChildState>& State,
+        TArray<TSharedPtr<FJsonValue>>& OutPassed,
+        TArray<TSharedPtr<FJsonValue>>& OutFailed,
+        TArray<TSharedPtr<FJsonValue>>& OutSkipped,
+        double& OutDuration,
+        bool& bOutSelectionMatched)
+    {
+        const FString ReportFile = State->ReportDirectory / TEXT("index.json");
+        if (!FPaths::FileExists(ReportFile)) return false;
+
+        const FDateTime Timestamp = IFileManager::Get().GetTimeStamp(*ReportFile);
+        if (Timestamp < State->StartedAtUtc - FTimespan::FromSeconds(1.0)) return false;
+
+        FString Json;
+        if (!FFileHelper::LoadFileToString(Json, *ReportFile)) return false;
+
+        TSharedPtr<FJsonObject> Root;
+        const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+        if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid()) return false;
+
+        double Succeeded = 0.0;
+        double SucceededWithWarnings = 0.0;
+        double Failed = 0.0;
+        double NotRun = 0.0;
+        double InProcess = 0.0;
+        if (!TryGetNumberEither(Root, TEXT("succeeded"), TEXT("Succeeded"), Succeeded)
+            || !TryGetNumberEither(Root, TEXT("failed"), TEXT("Failed"), Failed)
+            || !TryGetNumberEither(Root, TEXT("notRun"), TEXT("NotRun"), NotRun))
+        {
+            return false;
+        }
+        TryGetNumberEither(
+            Root, TEXT("succeededWithWarnings"), TEXT("SucceededWithWarnings"),
+            SucceededWithWarnings);
+        TryGetNumberEither(Root, TEXT("inProcess"), TEXT("InProcess"), InProcess);
+        TryGetNumberEither(Root, TEXT("totalDuration"), TEXT("TotalDuration"), OutDuration);
+
+        const TArray<TSharedPtr<FJsonValue>>* Tests = nullptr;
+        if (!TryGetArrayEither(Root, TEXT("tests"), TEXT("Tests"), Tests) || !Tests)
+        {
+            return false;
+        }
+
+        for (const TSharedPtr<FJsonValue>& Value : *Tests)
+        {
+            const TSharedPtr<FJsonObject> Test = Value.IsValid() ? Value->AsObject() : nullptr;
+            if (!Test.IsValid()) continue;
+
+            FString Name = ReadStringEither(Test, TEXT("fullTestPath"), TEXT("FullTestPath"));
+            if (Name.IsEmpty())
+            {
+                Name = ReadStringEither(Test, TEXT("testDisplayName"), TEXT("TestDisplayName"));
+            }
+            const FString StateName = ReadStringEither(Test, TEXT("state"), TEXT("State"));
+            if (StateName.Equals(TEXT("Success"), ESearchCase::IgnoreCase)
+                || StateName.Equals(TEXT("SuccessWithWarnings"), ESearchCase::IgnoreCase))
+            {
+                OutPassed.Add(MakeStr(Name));
+            }
+            else if (StateName.Equals(TEXT("NotRun"), ESearchCase::IgnoreCase)
+                || StateName.Equals(TEXT("InProcess"), ESearchCase::IgnoreCase))
+            {
+                OutSkipped.Add(MakeStr(Name));
+            }
+            else
+            {
+                auto Failure = MakeShared<FJsonObject>();
+                Failure->SetStringField(TEXT("name"), Name);
+                Failure->SetStringField(TEXT("outcome"), TEXT("failed"));
+                OutFailed.Add(MakeShared<FJsonValueObject>(Failure));
+            }
+        }
+
+        const int32 ReportedTotal = FMath::RoundToInt(
+            Succeeded + SucceededWithWarnings + Failed + NotRun + InProcess);
+        bOutSelectionMatched = ReportedTotal == State->Names.Num()
+            && Tests->Num() == State->Names.Num();
+        return true;
+    }
+
+    static int32 CountAttributedCrashArtifacts(
+        const TSharedRef<FOwnedAutomationChildState>& State)
+    {
+        const FString CrashRoot = FPaths::ProjectSavedDir() / TEXT("Crashes");
+        TArray<FString> ContextFiles;
+        IFileManager::Get().FindFilesRecursive(
+            ContextFiles,
+            *CrashRoot,
+            TEXT("CrashContext.runtime-xml"),
+            true,
+            false,
+            false);
+
+        int32 Count = 0;
+        const FString TokenMarker = TEXT("-HaybaAutomationChild=") + State->OwnershipToken;
+        for (const FString& ContextFile : ContextFiles)
+        {
+            if (IFileManager::Get().GetTimeStamp(*ContextFile)
+                < State->StartedAtUtc - FTimespan::FromSeconds(1.0))
+            {
+                continue;
+            }
+            FString Context;
+            if (FFileHelper::LoadFileToString(Context, *ContextFile)
+                && Context.Contains(TokenMarker, ESearchCase::CaseSensitive))
+            {
+                ++Count;
+            }
+        }
+        return Count;
+    }
+
+    static FString MakeOwnedChildResultsJson(
+        const TSharedRef<FOwnedAutomationChildState>& State,
+        int32 ExitCode)
+    {
+        TArray<TSharedPtr<FJsonValue>> Passed;
+        TArray<TSharedPtr<FJsonValue>> Failed;
+        TArray<TSharedPtr<FJsonValue>> Skipped;
+        double ReportDuration = 0.0;
+        bool bSelectionMatched = false;
+        const bool bReportValid = ReadOwnedChildReport(
+            State, Passed, Failed, Skipped, ReportDuration, bSelectionMatched);
+        const HaybaAutomationIsolation::EChildOutcome Outcome =
+            HaybaAutomationIsolation::ClassifyChildOutcome(
+                true, bReportValid, State->bTimedOut, State->bCancelRequested, ExitCode);
+
+        if (Outcome != HaybaAutomationIsolation::EChildOutcome::Reported)
+        {
+            Passed.Reset();
+            Skipped.Reset();
+            Failed.Reset();
+            for (const FString& Name : State->Names)
+            {
+                auto Failure = MakeShared<FJsonObject>();
+                Failure->SetStringField(TEXT("name"), Name);
+                Failure->SetStringField(TEXT("outcome"),
+                    Outcome == HaybaAutomationIsolation::EChildOutcome::TimedOut ? TEXT("timed_out") :
+                    Outcome == HaybaAutomationIsolation::EChildOutcome::Cancelled ? TEXT("cancelled") :
+                    Outcome == HaybaAutomationIsolation::EChildOutcome::NeverStarted ? TEXT("never_started") :
+                    TEXT("child_crashed"));
+                Failed.Add(MakeShared<FJsonValueObject>(Failure));
+            }
+        }
+        else if (!bSelectionMatched)
+        {
+            auto Failure = MakeShared<FJsonObject>();
+            Failure->SetStringField(TEXT("name"), TEXT("test_run selection contract"));
+            Failure->SetStringField(TEXT("outcome"), TEXT("report_selection_mismatch"));
+            Failed.Add(MakeShared<FJsonValueObject>(Failure));
+        }
+
+        const double Elapsed = FPlatformTime::Seconds() - State->StartedAtSeconds;
+        TSharedRef<FJsonObject> Results = MakeShared<FJsonObject>();
+        Results->SetArrayField(TEXT("passed"), Passed);
+        Results->SetArrayField(TEXT("failed"), Failed);
+        Results->SetArrayField(TEXT("skipped"), Skipped);
+        Results->SetNumberField(TEXT("passed_count"), Passed.Num());
+        Results->SetNumberField(TEXT("failed_count"), Failed.Num());
+        Results->SetNumberField(TEXT("skipped_count"), Skipped.Num());
+        Results->SetNumberField(TEXT("total"), State->Names.Num());
+        Results->SetBoolField(TEXT("all_passed"),
+            bReportValid && bSelectionMatched && ExitCode == 0
+            && Failed.IsEmpty() && Skipped.IsEmpty() && Passed.Num() == State->Names.Num());
+        Results->SetNumberField(TEXT("elapsed_seconds"), Elapsed);
+        Results->SetNumberField(TEXT("report_duration_seconds"), ReportDuration);
+        Results->SetStringField(TEXT("execution_mode"), TEXT("owned_child"));
+        Results->SetStringField(TEXT("ownership_token"), State->OwnershipToken);
+        Results->SetNumberField(TEXT("child_pid"), State->ProcessId);
+        Results->SetBoolField(TEXT("child_started"), true);
+        Results->SetNumberField(TEXT("process_exit_code"), ExitCode);
+        Results->SetBoolField(TEXT("report_valid"), bReportValid);
+        Results->SetBoolField(TEXT("report_selection_matched"), bSelectionMatched);
+        Results->SetBoolField(TEXT("timed_out"), State->bTimedOut);
+        Results->SetBoolField(TEXT("cancelled"), State->bCancelRequested);
+        Results->SetBoolField(TEXT("crashed"),
+            Outcome == HaybaAutomationIsolation::EChildOutcome::Crashed);
+        Results->SetNumberField(TEXT("crash_artifact_count"), CountAttributedCrashArtifacts(State));
+        Results->SetNumberField(TEXT("captured_output_chars"), State->OutputChars);
+        Results->SetBoolField(TEXT("output_truncated"), State->bOutputTruncated);
+
+        FString Json;
+        const TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer =
+            TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&Json);
+        FJsonSerializer::Serialize(Results, Writer);
+        return Json;
+    }
+
+    static void FinalizeOwnedChild(
+        const TSharedRef<FOwnedAutomationChildState>& State,
+        int32 ExitCode)
+    {
+        CaptureBoundedChildOutput(State);
+        const FString ResultsJson = MakeOwnedChildResultsJson(State, ExitCode);
+        TSharedPtr<FJsonObject> Results;
+        FJsonSerializer::Deserialize(TJsonReaderFactory<>::Create(ResultsJson), Results);
+        double FailedCount = 1.0;
+        if (Results.IsValid()) Results->TryGetNumberField(TEXT("failed_count"), FailedCount);
+        FHaybaMCPJobRegistry::Get().SetDone(
+            State->JobId, FMath::Max(ExitCode, FMath::RoundToInt(FailedCount)), ResultsJson);
+        State->bFinalized = true;
+        State->LeaseGuard.Reset();
+        GetActiveOwnedChildState().Reset();
+    }
+
+    static bool OwnedChildPump(
+        float /*Dt*/,
+        TSharedRef<FOwnedAutomationChildState> State)
+    {
+        CaptureBoundedChildOutput(State);
+        if (FPlatformProcess::IsProcRunning(State->Process))
+        {
+            if (State->bCancelRequested)
+            {
+                FPlatformProcess::TerminateProc(State->Process, true);
+            }
+            else if (FPlatformTime::Seconds() - State->StartedAtSeconds > State->TimeoutSeconds)
+            {
+                State->bTimedOut = true;
+                FPlatformProcess::TerminateProc(State->Process, true);
+            }
+            return true;
+        }
+
+        int32 ExitCode = -1;
+        FPlatformProcess::GetProcReturnCode(State->Process, &ExitCode);
+        FinalizeOwnedChild(State, ExitCode);
+        return false;
     }
 
     struct FTestRunState
@@ -430,6 +837,155 @@ namespace
         return true;
     }
 
+    static FHaybaHandlerResult StartOwnedChildRun(
+        TArray<FString> Names,
+        double TimeoutSeconds,
+        const FString& FilterPattern,
+        const FString& CategoryFilter,
+        bool bSmokeOnly)
+    {
+        FHaybaMCPTestRunLease& Lease = GetTestRunLease();
+        TSharedRef<FOwnedAutomationChildState> State =
+            MakeShared<FOwnedAutomationChildState>();
+        State->JobId = FHaybaMCPJobRegistry::Get().AllocateJob(TEXT("test_run"));
+        State->OwnershipToken = FGuid::NewGuid().ToString(EGuidFormats::Digits);
+        State->Names = MoveTemp(Names);
+        State->TimeoutSeconds = FMath::Clamp(
+            TimeoutSeconds, 1.0, GAutomationChildMaximumTimeoutSeconds);
+        State->StartedAtSeconds = FPlatformTime::Seconds();
+        State->StartedAtUtc = FDateTime::UtcNow();
+        State->ReportDirectory = FPaths::ProjectSavedDir()
+            / TEXT("HaybaMCP/TestRuns") / State->OwnershipToken;
+
+        if (!Lease.TryAcquire(State->JobId))
+        {
+            FHaybaMCPJobRegistry::Get().SetDone(
+                State->JobId, -1,
+                MakeOwnedChildNeverStartedResultsJson(
+                    State, TEXT("failed to acquire test-run lease")));
+            State->bFinalized = true;
+            return FHaybaHandlerResult::Err(TEXT("failed to acquire test-run lease"));
+        }
+        State->LeaseGuard = MakeUnique<FHaybaMCPTestRunLeaseGuard>(Lease, State->JobId);
+
+        if (!IFileManager::Get().MakeDirectory(*State->ReportDirectory, true)
+            || !FPlatformProcess::CreatePipe(State->ReadPipe, State->WritePipe))
+        {
+            FHaybaMCPJobRegistry::Get().SetDone(
+                State->JobId, -1,
+                MakeOwnedChildNeverStartedResultsJson(
+                    State, TEXT("owned automation child setup failed")));
+            State->bFinalized = true;
+            State->LeaseGuard.Reset();
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("owned automation child setup failed; job %s completed as failed"),
+                *State->JobId));
+        }
+
+        const FString Editor = FPaths::ConvertRelativePathToFull(
+            FPaths::EngineDir() / TEXT("Binaries/Win64/UnrealEditor-Cmd.exe"));
+        if (!FPaths::FileExists(Editor))
+        {
+            FHaybaMCPJobRegistry::Get().SetDone(
+                State->JobId, -1,
+                MakeOwnedChildNeverStartedResultsJson(
+                    State, TEXT("UnrealEditor-Cmd is unavailable")));
+            State->bFinalized = true;
+            State->LeaseGuard.Reset();
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("UnrealEditor-Cmd is unavailable; job %s completed as failed"),
+                *State->JobId));
+        }
+
+        for (const FString& Name : State->Names)
+        {
+            if (Name.Contains(TEXT("+")) || Name.Contains(TEXT(";"))
+                || Name.Contains(TEXT("\"")) || Name.Contains(TEXT("\r"))
+                || Name.Contains(TEXT("\n")))
+            {
+                FHaybaMCPJobRegistry::Get().SetDone(
+                    State->JobId, -1,
+                    MakeOwnedChildNeverStartedResultsJson(
+                        State, TEXT("test name cannot be represented safely on the child command line")));
+                State->bFinalized = true;
+                State->LeaseGuard.Reset();
+                return FHaybaHandlerResult::Err(TEXT("unsafe automation test name rejected"));
+            }
+        }
+
+        const FString ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath());
+        const FString TestExpression = FString::Join(State->Names, TEXT("+"));
+        const FString Args = FString::Printf(
+            TEXT("\"%s\" -unattended -nop4 -nullrhi -nosplash -nosound -stdout "
+                 "-FullStdOutLogOutput -ReportExportPath=\"%s\" "
+                 "-HaybaAutomationChild=%s "
+                 "-ExecCmds=\"Automation RunTests %s;Quit\" "
+                 "-TestExit=\"Automation Test Queue Empty\""),
+            *ProjectPath,
+            *State->ReportDirectory,
+            *State->OwnershipToken,
+            *TestExpression);
+
+        State->Process = FPlatformProcess::CreateProc(
+            *Editor,
+            *Args,
+            false,
+            true,
+            true,
+            &State->ProcessId,
+            0,
+            nullptr,
+            State->WritePipe,
+            nullptr);
+        if (!State->Process.IsValid())
+        {
+            FHaybaMCPJobRegistry::Get().SetDone(
+                State->JobId, -1,
+                MakeOwnedChildNeverStartedResultsJson(
+                    State, TEXT("UnrealEditor-Cmd child did not start")));
+            State->bFinalized = true;
+            State->LeaseGuard.Reset();
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("UnrealEditor-Cmd child did not start; job %s completed as failed"),
+                *State->JobId));
+        }
+
+        State->TickHandle = FTSTicker::GetCoreTicker().AddTicker(
+            FTickerDelegate::CreateLambda(
+                [State](float Dt){ return OwnedChildPump(Dt, State); }));
+        if (!State->TickHandle.IsValid())
+        {
+            FPlatformProcess::TerminateProc(State->Process, true);
+            FHaybaMCPJobRegistry::Get().SetDone(
+                State->JobId, -1,
+                MakeOwnedChildNeverStartedResultsJson(
+                    State, TEXT("owned child monitor did not start")));
+            State->bFinalized = true;
+            State->LeaseGuard.Reset();
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("owned child monitor did not start; job %s completed as failed"),
+                *State->JobId));
+        }
+        GetActiveOwnedChildState() = State;
+
+        auto Out = MakeShared<FJsonObject>();
+        Out->SetStringField(TEXT("command"), TEXT("test_run"));
+        Out->SetStringField(TEXT("job_id"), State->JobId);
+        Out->SetStringField(TEXT("status"), TEXT("running"));
+        Out->SetStringField(TEXT("execution_mode"), TEXT("owned_child"));
+        Out->SetStringField(TEXT("ownership_token"), State->OwnershipToken);
+        Out->SetNumberField(TEXT("child_pid"), State->ProcessId);
+        Out->SetNumberField(TEXT("total"), State->Names.Num());
+        Out->SetNumberField(TEXT("timeout_seconds"), State->TimeoutSeconds);
+        Out->SetBoolField(TEXT("ok"), true);
+        if (!FilterPattern.IsEmpty()) Out->SetStringField(TEXT("filter"), FilterPattern);
+        if (!CategoryFilter.IsEmpty()) Out->SetStringField(TEXT("category"), CategoryFilter);
+        Out->SetBoolField(TEXT("smoke_only"), bSmokeOnly);
+        Out->SetStringField(TEXT("note"),
+            TEXT("Tests are running in a tagged owned UnrealEditor-Cmd child. Poll build_status { job_id }; use test_cancel { job_id } to terminate only that child."));
+        return FHaybaHandlerResult::Ok(Out);
+    }
+
     static FHaybaHandlerResult Cmd_TestRun(const TSharedPtr<FJsonObject>& Params)
     {
         if (!Params.IsValid())
@@ -561,14 +1117,22 @@ namespace
         for (const FString& RequestedName : RequestedNames)
         {
             const FString RegisteredName = ResolveRegisteredTestName(RequestedName, Discovered);
+            const FString CanonicalName = ResolveCanonicalTestPath(RequestedName, Discovered);
+            if (CanonicalName.IsEmpty())
+            {
+                return FHaybaHandlerResult::Err(FString::Printf(
+                    TEXT("test_run could not resolve '%s' to a currently registered test; use test_list and retry"),
+                    *RequestedName));
+            }
             if (SeenRegisteredNames.Contains(RegisteredName)) continue;
             SeenRegisteredNames.Add(RegisteredName);
-            UniqueNames.Add(RequestedName);
+            UniqueNames.Add(CanonicalName);
             RegisteredNames.Add(RegisteredName);
         }
         RequestedNames = MoveTemp(UniqueNames);
 
-        // Per-run timeout from params (seconds), default 120 per test.
+        // In-process runs interpret this per test. Owned-child runs interpret
+        // it as a total process deadline and clamp it to a hard maximum.
         double PerTestTimeoutSec = 120.0;
         Params->TryGetNumberField(TEXT("timeout_seconds"), PerTestTimeoutSec);
         if (PerTestTimeoutSec <= 0.0) PerTestTimeoutSec = 120.0;
@@ -577,6 +1141,13 @@ namespace
         // abnormal ticker teardown can otherwise leave process-static state
         // behind while the job registry no longer contains that job.
         FHaybaMCPTestRunLease& Lease = GetTestRunLease();
+        if (const TSharedPtr<FOwnedAutomationChildState> ActiveChild =
+                GetActiveOwnedChildState().Pin())
+        {
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("a test_run job %s owns UnrealEditor-Cmd PID %u; poll build_status { job_id: '%s' } or cancel it with test_cancel"),
+                *ActiveChild->JobId, ActiveChild->ProcessId, *ActiveChild->JobId));
+        }
         if (const TSharedPtr<FTestRunState> ActiveState = GetActiveTestRunState().Pin())
         {
             // A live state owns a ticker (the lambda holds the strong ref), so
@@ -626,6 +1197,26 @@ namespace
                 *ActiveJobId);
         }
 
+        bool bRequiresOwnedChild = false;
+        for (const FString& Name : RequestedNames)
+        {
+            if (HaybaAutomationIsolation::Classify(Name)
+                == HaybaAutomationIsolation::EExecutionMode::OwnedChild)
+            {
+                bRequiresOwnedChild = true;
+                break;
+            }
+        }
+        if (bRequiresOwnedChild)
+        {
+            const double ChildTimeout = PerTestTimeoutSec == 120.0
+                ? GAutomationChildDefaultTimeoutSeconds
+                : PerTestTimeoutSec;
+            return StartOwnedChildRun(
+                MoveTemp(RequestedNames), ChildTimeout,
+                FilterPattern, CategoryFilter, bSmokeOnly);
+        }
+
         // Long-running: drive the run on the game-thread core ticker (fires
         // OUTSIDE task-graph task execution, so latent commands that pump the
         // task graph / async loads are safe — same reason TcpServer drains
@@ -670,6 +1261,7 @@ namespace
         Out->SetStringField(TEXT("command"), TEXT("test_run"));
         Out->SetStringField(TEXT("job_id"), S->JobId);
         Out->SetStringField(TEXT("status"), TEXT("running"));
+        Out->SetStringField(TEXT("execution_mode"), TEXT("in_process_allowlisted"));
         Out->SetNumberField(TEXT("total"), S->Names.Num());
         Out->SetBoolField(TEXT("ok"), true);
         if (!FilterPattern.IsEmpty()) Out->SetStringField(TEXT("filter"), FilterPattern);
@@ -677,6 +1269,43 @@ namespace
         Out->SetBoolField(TEXT("smoke_only"), bSmokeOnly);
         Out->SetStringField(TEXT("note"),
             TEXT("Tests started asynchronously. Poll build_status { job_id } for {passed, failed, skipped, elapsed_seconds, total}, or test_get_log for the last run's detailed entries."));
+        return FHaybaHandlerResult::Ok(Out);
+    }
+
+    static FHaybaHandlerResult Cmd_TestCancel(const TSharedPtr<FJsonObject>& Params)
+    {
+        FString JobId;
+        if (!Params.IsValid()
+            || !Params->TryGetStringField(TEXT("job_id"), JobId)
+            || JobId.IsEmpty())
+        {
+            return FHaybaHandlerResult::Err(TEXT("test_cancel requires { job_id: string }"));
+        }
+
+        const TSharedPtr<FOwnedAutomationChildState> State =
+            GetActiveOwnedChildState().Pin();
+        if (!State.IsValid() || State->JobId != JobId)
+        {
+            return FHaybaHandlerResult::Err(FString::Printf(
+                TEXT("job %s is not the active owned automation child; no process was terminated"),
+                *JobId));
+        }
+
+        State->bCancelRequested = true;
+        if (State->Process.IsValid() && FPlatformProcess::IsProcRunning(State->Process))
+        {
+            FPlatformProcess::TerminateProc(State->Process, true);
+        }
+
+        auto Out = MakeShared<FJsonObject>();
+        Out->SetStringField(TEXT("job_id"), State->JobId);
+        Out->SetStringField(TEXT("status"), TEXT("cancelling"));
+        Out->SetStringField(TEXT("execution_mode"), TEXT("owned_child"));
+        Out->SetStringField(TEXT("ownership_token"), State->OwnershipToken);
+        Out->SetNumberField(TEXT("child_pid"), State->ProcessId);
+        Out->SetBoolField(TEXT("cancel_requested"), true);
+        Out->SetStringField(TEXT("note"),
+            TEXT("Only the tagged child owned by this job was terminated; poll build_status for terminal evidence."));
         return FHaybaHandlerResult::Ok(Out);
     }
 
@@ -723,6 +1352,7 @@ TArray<FString> FHaybaMCPTestHandler::GetCommands() const
     return {
         TEXT("test_list"),
         TEXT("test_run"),
+        TEXT("test_cancel"),
         TEXT("test_get_log")
     };
 }
@@ -732,6 +1362,7 @@ FHaybaHandlerResult FHaybaMCPTestHandler::Handle(const FString& Cmd, const TShar
 #if WITH_EDITOR
     if (Cmd == TEXT("test_list"))    return Cmd_TestList(Params);
     if (Cmd == TEXT("test_run"))     return Cmd_TestRun(Params);
+    if (Cmd == TEXT("test_cancel"))  return Cmd_TestCancel(Params);
     if (Cmd == TEXT("test_get_log")) return Cmd_TestGetLog(Params);
     return FHaybaHandlerResult::Err(FString::Printf(TEXT("Unknown test command: %s"), *Cmd));
 #else
@@ -746,6 +1377,30 @@ FHaybaHandlerResult FHaybaMCPTestHandler::Handle(const FString& Cmd, const TShar
 void FHaybaMCPTestHandler::ShutdownActiveRun()
 {
 #if WITH_EDITOR
+    if (const TSharedPtr<FOwnedAutomationChildState> Child =
+            GetActiveOwnedChildState().Pin())
+    {
+        GetActiveOwnedChildState().Reset();
+        if (Child->TickHandle.IsValid())
+        {
+            FTSTicker::GetCoreTicker().RemoveTicker(Child->TickHandle);
+            Child->TickHandle.Reset();
+        }
+        Child->bCancelRequested = true;
+        if (Child->Process.IsValid() && FPlatformProcess::IsProcRunning(Child->Process))
+        {
+            // This handle was created by this job and carries its unique token.
+            // Never enumerate or terminate an unrelated UnrealEditor process.
+            FPlatformProcess::TerminateProc(Child->Process, true);
+        }
+        FHaybaMCPJobRegistry::Get().SetDone(
+            Child->JobId,
+            1,
+            MakeOwnedChildResultsJson(Child.ToSharedRef(), -1));
+        Child->bFinalized = true;
+        Child->LeaseGuard.Reset();
+    }
+
     const TSharedPtr<FTestRunState> ActiveState = GetActiveTestRunState().Pin();
     GetActiveTestRunState().Reset();
     if (!ActiveState.IsValid())


### PR DESCRIPTION
## Summary

References #407. This PR intentionally does **not** close the issue until tagged runtime acceptance evidence exists.

- defaults every unknown project, engine, plugin, and future Hayba automation test to a tagged, owned `UnrealEditor-Cmd` child
- keeps only an exact lifecycle-audited allowlist of pure Hayba contracts in the serving editor
- monitors owned children asynchronously from the core ticker with a 300s default / 900s hard cap, bounded output, single-flight ownership, exact-handle cancellation, and shutdown cleanup
- reports structured pass/fail/skip totals plus child PID/token, process exit, report validity, timeout, cancellation, crash, output truncation, and token-attributed crash-artifact count without returning private paths, stacks, payloads, or crash IDs
- prevents disposable children from starting Hayba TCP or chat sidecar services, preserving the serving editor listener/heartbeat

## Verification reached

- `npx tsc --noEmit` — exit 0
- `npm test` — 205 files passed; 2,298 passed / 1 skipped
- `node scripts/check-legacy-wrappers.mjs` — OK (22 C++ commands, 155 sidecar entries)
- standalone MSVC policy contract — exit 0
- mutation: changed the default branch from `OwnedChild` to `InProcess`; the standalone contract failed with three static assertions, then returned green after revert

## Native compile status

A normal Aphrosia build reached the new files and found two #407 type errors; both were fixed in this branch. The same run also exposed pre-existing, unrelated `HaybaMCPUIHandler.cpp` format-string errors. Per operator instruction, Aphrosia was restored and no further project build/editor launch was attempted. This PR therefore does not claim a clean full native compile or runtime acceptance.

## Runtime acceptance still required

Keep #407 / HCR-AUTO-001 open until a tagged disposable-editor run records all of:

- deliberately asserting/ensuring/crashing project fixture runs in the owned child while the original serving PID/listener answers a fresh nonce ping
- token-attributed child crash evidence with no private crash material in the MCP response
- timeout kills only the owned child and leaves no orphan
- `test_cancel` kills only the matching owned child and leaves no orphan
- valid isolated passing run returns a fresh matching report and truthful counts
- exact allowlisted Hayba contract remains asynchronous in-process without game-thread busy-wait