### PR TITLE
fix(native): align DataAsset and MetaSound boundaries with UE 5.8

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/metasound-handler-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/metasound-handler-contract.test.ts
@@ -155,6 +155,11 @@ describe('editor-safe MetaSound handler contract', () => {
     expect(handler).toContain('type must be a string');
     expect(handler).toContain('node_id must be a valid GUID when supplied');
     expect(handler).toContain('save must be a boolean');
+    expect(handler).toContain('SaveValue->Type != EJson::Boolean');
+    expect(handler).toMatch(
+      /SaveValue->Type != EJson::Boolean[\s\S]*LoadMetaSound\(P, Path, Error/,
+    );
+    expect(handler).not.toContain('TryGetBoolField(TEXT("save"), bSave)');
     expect(handler).toContain('path_prefix must be a string');
     expect(handler).toMatch(/bool bSave = true;[\s\S]*LoadMetaSound\(P, Path, Error/);
   });

--- a/mcp-tools/hayba-mcp/src/tools/mutation-atomicity-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/mutation-atomicity-contract.test.ts
@@ -191,6 +191,24 @@ describe('stateful handler atomicity contracts (#369)', () => {
     expect(dataAsset).toContain('GetIndexByNameString');
     expect(dataAsset).toContain('GetValueByIndex');
     expect(dataAsset).toContain('Tokens.Num() > 1 && !Enum->HasAnyEnumFlags(EEnumFlags::Flags)');
+    const enumNativeTest = readFileSync(
+      join(
+        root,
+        'unreal',
+        'HaybaMCPToolkit',
+        'Source',
+        'HaybaMCPToolkit',
+        'Private',
+        'Tests',
+        'HaybaMCPDataAssetPreflightTest.cpp',
+      ),
+      'utf8',
+    );
+    expect(enumNativeTest).toContain('SignedEnum->GetName() + TEXT("::MinusOne")');
+    expect(enumNativeTest).toContain('FlagsEnum->GetName() + TEXT("::First")');
+    expect(enumNativeTest).toContain('FlagsEnum->GetName() + TEXT("::Second")');
+    expect(enumNativeTest).not.toContain('EHaybaSignedProbe::MinusOne');
+    expect(enumNativeTest).not.toContain('EHaybaFlagsProbe::First');
     expect(dataAsset).toContain('CPF_SkipSerialization');
     expect(dataAsset).toContain('has a native getter or setter; raw storage would bypass its semantics');
     expect(set.match(/ValidateMutationPropertyGraph\(/g)).toHaveLength(2);

--- a/unreal/HaybaMCPMetaSound/Source/HaybaMCPMetaSound/Private/HaybaMCPMetaSoundHandler.cpp
+++ b/unreal/HaybaMCPMetaSound/Source/HaybaMCPMetaSound/Private/HaybaMCPMetaSoundHandler.cpp
@@ -492,8 +492,16 @@ static FHaybaHandlerResult MSInspect(const TSharedPtr<FJsonObject>& P)
 static FHaybaHandlerResult MSCompile(const TSharedPtr<FJsonObject>& P)
 {
     bool bSave = true;
-    if (P.IsValid() && P->HasField(TEXT("save")) && !P->TryGetBoolField(TEXT("save"), bSave))
-        return FHaybaHandlerResult::Err(TEXT("metasound_compile: save must be a boolean"));
+    if (P.IsValid() && P->HasField(TEXT("save")))
+    {
+        const TSharedPtr<FJsonValue> SaveValue = P->TryGetField(TEXT("save"));
+        // UE 5.8's FJsonValueString::TryGetBool coercively succeeds for every
+        // string. Check the JSON kind explicitly so malformed input is refused
+        // before LoadMetaSound can perform asset-registry or loading work.
+        if (!SaveValue.IsValid() || SaveValue->Type != EJson::Boolean)
+            return FHaybaHandlerResult::Err(TEXT("metasound_compile: save must be a boolean"));
+        bSave = SaveValue->AsBool();
+    }
     FString Path, Error; UObject* Asset = LoadMetaSound(P, Path, Error, /*bRequireGameContent=*/true); if (!Asset) return FHaybaHandlerResult::Err(TEXT("metasound_compile: ") + Error);
     UMetaSoundBuilderBase* Builder=AttachBuilder(*Asset); if (!Builder) return FHaybaHandlerResult::Err(TEXT("metasound_compile: builder unavailable"));
     const FMetaSoundFrontendDocumentBuilder& DocBuilder = Builder->GetConstBuilder();

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPDataAssetPreflightTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPDataAssetPreflightTest.cpp
@@ -565,8 +565,8 @@ bool FHaybaMCPDataAssetReadWritePreflightTest::RunTest(const FString& Parameters
         if (SignedEnum)
         {
             TArray<TPair<FName, int64>> Names = {
-                { FName(TEXT("EHaybaSignedProbe::MinusOne")), -1 },
-                { FName(TEXT("EHaybaSignedProbe::Zero")), 0 },
+                { FName(*(SignedEnum->GetName() + TEXT("::MinusOne"))), -1 },
+                { FName(*(SignedEnum->GetName() + TEXT("::Zero"))), 0 },
             };
             TestTrue(TEXT("signed enum resolver fixture was initialized"),
                 SignedEnum->SetEnums(
@@ -586,8 +586,8 @@ bool FHaybaMCPDataAssetReadWritePreflightTest::RunTest(const FString& Parameters
         if (FlagsEnum)
         {
             TArray<TPair<FName, int64>> Names = {
-                { FName(TEXT("EHaybaFlagsProbe::First")), 1 },
-                { FName(TEXT("EHaybaFlagsProbe::Second")), 2 },
+                { FName(*(FlagsEnum->GetName() + TEXT("::First"))), 1 },
+                { FName(*(FlagsEnum->GetName() + TEXT("::Second"))), 2 },
             };
             TestTrue(TEXT("enum flags resolver fixture was initialized"),
                 FlagsEnum->SetEnums(


### PR DESCRIPTION
## Summary
- correct the transient UEnum test fixtures so enum-class scopes match the actual UEnum object name under UE 5.8
- preserve the production resolver's index-based handling of legal enum value -1 and authored flag lists
- reject non-boolean MetaSound compile save values by exact JSON kind before any asset load
- pin both regressions with static TypeScript contracts

## Diagnosis
- DataAsset assertions were wrong: GetAuthoredNameStringByIndex returns the short token, while GetIndexByNameString reconstructs enum-class scope from the UEnum object's actual name. The fixtures used unrelated hard-coded scopes.
- MetaSound implementation was wrong: UE 5.8 FJsonValueString::TryGetBool coercively returns true, so TryGetBoolField accepted string values and allowed loading to begin.

## Verification
- standalone UE 5.8 engine-source policy check: passed
- focused contracts: 32/32 passed
- mutation: inverted strict MetaSound JSON-kind check -> RED, restored -> GREEN
- mutation: restored hard-coded DataAsset enum scope -> RED, restored -> GREEN
- npm run typecheck: passed
- npm test: 205 files, 2,298 passed, 1 skipped
- npm run build:server: passed
- npm run lint:legacy-wrappers: passed (22 C++ commands, 154 sidecar entries)

## Native verification remaining
Per task constraints, this branch did not touch Aphrosia and did not launch or build Unreal. A UE 5.8 native build and rerun of Hayba.MCP.DataAsset.ReadWritePreflight and Hayba.MCP.MetaSound.InputBoundary remain required before merge/closure.