### PR TITLE
fix(native): align NullRHI boundary contracts

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/native-nullrhi-boundary-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/native-nullrhi-boundary-contract.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(import.meta.dirname, '../../../..');
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+
+const command = read('unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/HaybaMCPCommandHandler.cpp');
+const advisoryTest = read('unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPAdvisoryBoundaryTest.cpp');
+const params = read('unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPParams.h');
+const paramsTest = read('unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPParamsTest.cpp');
+const renderTest = read('unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPRenderSafetyTest.cpp');
+
+describe('native regressions observed in the 2026-08-28 Aphrosia NullRHI run', () => {
+  it('exercises advisory shaping with the registered destructive actor command', () => {
+    expect(command).toContain('TEXT("actor_set_transform")');
+    expect(advisoryTest).toContain('MakeOkResponse(\n                TEXT("2c"), MakeShared<FJsonObject>(), TEXT("actor_set_transform"))');
+    expect(advisoryTest).not.toContain('TEXT("actor_transform")');
+  });
+
+  it('checks JSON kinds before Unreal scalar accessors can coerce them', () => {
+    expect(params.match(/HasJsonKind\(Key, EJson::String\)/g)).toHaveLength(2);
+    expect(params.match(/HasJsonKind\(Key, EJson::Boolean\)/g)).toHaveLength(1);
+    expect(paramsTest).toContain('wrong required string is rejected');
+  });
+
+  it('accepts either truthful pre-allocation NullRHI refusal path', () => {
+    expect(renderTest).toContain('LeaseError.Contains(TEXT("without render capability"))');
+    expect(renderTest).toContain('LeaseError.Contains(TEXT("real initialized RHI"))');
+  });
+});

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPAdvisoryBoundaryTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPAdvisoryBoundaryTest.cpp
@@ -122,7 +122,7 @@ bool FHaybaMCPAdvisoryBoundaryTest::RunTest(const FString&)
     {
         const TSharedPtr<FJsonObject> Envelope = ParseEnvelope(
             FHaybaMCPCommandHandler::MakeOkResponse(
-                TEXT("2c"), MakeShared<FJsonObject>(), TEXT("actor_transform")));
+                TEXT("2c"), MakeShared<FJsonObject>(), TEXT("actor_set_transform")));
         TestEqual(TEXT("unverified mutation warns by default"),
             Envelope->GetObjectField(TEXT("advisory"))->GetStringField(TEXT("state")),
             FString(TEXT("success_needs_verification")));
@@ -130,7 +130,7 @@ bool FHaybaMCPAdvisoryBoundaryTest::RunTest(const FString&)
         TSharedPtr<FJsonObject> VerifiedData = MakeShared<FJsonObject>();
         VerifiedData->SetBoolField(TEXT("readback_verified"), true);
         const TSharedPtr<FJsonObject> VerifiedEnvelope = ParseEnvelope(
-            FHaybaMCPCommandHandler::MakeOkResponse(TEXT("2d"), VerifiedData, TEXT("actor_transform")));
+            FHaybaMCPCommandHandler::MakeOkResponse(TEXT("2d"), VerifiedData, TEXT("actor_set_transform")));
         TestFalse(TEXT("verified mutation does not emit optional warning noise"),
             VerifiedEnvelope->HasField(TEXT("advisory")));
     }

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPParamsTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPParamsTest.cpp
@@ -274,6 +274,7 @@ bool FHaybaMCPParamReaderTest::RunTest(const FString& Parameters)
         TSharedPtr<FJsonObject> P = MakeShared<FJsonObject>();
         P->SetNumberField(TEXT("maybe_string"), 1.0);
         P->SetStringField(TEXT("maybe_bool"), TEXT("true"));
+        P->SetBoolField(TEXT("required_string"), true);
         P->SetStringField(TEXT("maybe_array"), TEXT("not-an-array"));
         P->SetArrayField(TEXT("maybe_object"), {});
         P->SetStringField(TEXT("maybe_vec"), TEXT("1,2,3"));
@@ -302,6 +303,8 @@ bool FHaybaMCPParamReaderTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("wrong optional string uses default"),
             R.OptionalString(TEXT("maybe_string"), TEXT("fallback")), FString(TEXT("fallback")));
         TestTrue(TEXT("wrong optional bool uses default"), R.OptionalBool(TEXT("maybe_bool"), true));
+        TestEqual(TEXT("wrong required string is rejected"),
+            R.RequiredString(TEXT("required_string")), FString());
         TestNull(TEXT("wrong optional array is unset"), R.OptionalArray(TEXT("maybe_array")));
         TestFalse(TEXT("wrong optional object is unset"), R.OptionalObject(TEXT("maybe_object")).IsValid());
         TestFalse(TEXT("wrong optional vector is unset"), R.OptionalVec3(TEXT("maybe_vec")).IsSet());
@@ -323,7 +326,8 @@ bool FHaybaMCPParamReaderTest::RunTest(const FString& Parameters)
         TestTrue(TEXT("all malformed present optionals are errors"), R.HasErrors());
         const FString Msg = R.ErrorMessage();
         for (const TCHAR* Field : {
-            TEXT("maybe_string"), TEXT("maybe_bool"), TEXT("maybe_array"), TEXT("maybe_object"),
+            TEXT("maybe_string"), TEXT("maybe_bool"), TEXT("required_string"),
+            TEXT("maybe_array"), TEXT("maybe_object"),
             TEXT("maybe_vec"), TEXT("bounded_string"), TEXT("bounded_array"), TEXT("bounded_object"),
             TEXT("four_vector"), TEXT("radius"), TEXT("steps"), TEXT("required_range"),
             TEXT("required_integer"), TEXT("required_vector") })

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPRenderSafetyTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPRenderSafetyTest.cpp
@@ -127,7 +127,8 @@ bool FHaybaMCPRenderSafetyPolicyTest::RunTest(const FString& Parameters)
         TestFalse(TEXT("NullRHI is refused before any allocation"),
             FLease::TryAcquire(TEXT("policy_test"), 5, LeaseError).IsValid());
         TestTrue(TEXT("NullRHI refusal explains the evidence boundary"),
-            LeaseError.Contains(TEXT("real initialized RHI")));
+            LeaseError.Contains(TEXT("without render capability"))
+            || LeaseError.Contains(TEXT("real initialized RHI")));
     }
     else
     {

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPParams.h
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Public/HaybaMCPParams.h
@@ -99,7 +99,8 @@ public:
         {
             Missing(Key, TEXT("string"));
         }
-        else if (!bParamsMissing && !Params->TryGetStringField(Key, Out))
+        else if (!bParamsMissing && (!HasJsonKind(Key, EJson::String)
+            || !Params->TryGetStringField(Key, Out)))
         {
             WrongKind(Key, TEXT("string"));
         }
@@ -174,7 +175,7 @@ public:
     {
         FString Out;
         if (bParamsMissing || !Params->HasField(Key)) return Default;
-        if (!Params->TryGetStringField(Key, Out))
+        if (!HasJsonKind(Key, EJson::String) || !Params->TryGetStringField(Key, Out))
         {
             WrongKind(Key, TEXT("string"));
             return Default;
@@ -224,7 +225,7 @@ public:
     {
         bool Out = false;
         if (bParamsMissing || !Params->HasField(Key)) return Default;
-        if (!Params->TryGetBoolField(Key, Out))
+        if (!HasJsonKind(Key, EJson::Boolean) || !Params->TryGetBoolField(Key, Out))
         {
             WrongKind(Key, TEXT("boolean"));
             return Default;
@@ -597,6 +598,13 @@ public:
     }
 
 private:
+    bool HasJsonKind(const TCHAR* Key, EJson Expected) const
+    {
+        const TSharedPtr<FJsonValue> Value = Params.IsValid()
+            ? Params->TryGetField(Key) : nullptr;
+        return Value.IsValid() && Value->Type == Expected;
+    }
+
     static FString JsonKind(const TSharedPtr<FJsonValue>& Value)
     {
         if (!Value.IsValid()) return TEXT("invalid/null value");


### PR DESCRIPTION
## Summary

Diagnoses and fixes the three requested failures from the 2026-08-28 Aphrosia NullRHI report without touching Aphrosia or launching Unreal.

- `Hayba.MCP.Advisory.ResponseBoundary`: stale test command `actor_transform` replaced with registered destructive command `actor_set_transform`.
- `Hayba.MCP.Params.Reader`: production bug fixed by checking exact `EJson` kinds before Unreal scalar accessors can coerce numbers/bools/strings; required and optional string paths plus optional bool are pinned.
- `Hayba.MCP.RenderSafety.Policy`: stale assertion now accepts both truthful pre-allocation refusal paths emitted by commandlet/NullRHI startup.

## Evidence

- RED first: all three static regression checks failed against the original tree.
- GREEN: targeted NullRHI/native contracts pass (8/8).
- Full TS suite: 206 files passed; 2,301 passed, 1 skipped (`--maxWorkers=4`).
- Typecheck passed.
- Server build passed.
- Legacy-wrapper lint passed (22 C++ commands, 154 sidecar entries).
- Three deliberate mutations independently produced RED, then GREEN after restoration.

One unconstrained full-suite run hit a pre-existing 5-second timeout in `secure-archive.test.ts`; the same test passed alone in 47 ms, and the bounded-worker full rerun passed.

## Remaining native verification

Per task constraints, no Unreal build/editor/native automation was run. A fresh native build and `-NullRHI` run must confirm:

- `Hayba.MCP.Advisory.ResponseBoundary`
- `Hayba.MCP.Params.Reader`
- `Hayba.MCP.RenderSafety.Policy`

against the rebuilt DLL.