### PR TITLE
fix(python): align native policy precedence

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/guards/known-crashers.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/guards/known-crashers.test.ts
@@ -89,4 +89,17 @@ describe('known-crashers', () => {
     expect(scanPythonForCrashers('input("blocks")')?.code).toBe('HCR-BLOCK-001');
     expect(scanPythonForCrashers('compile(source, "<x>", "exec")')?.code).toBe('HCR-DYNAMIC-001');
   });
+
+  it('keeps specific blocking and deadline classifications ahead of broad dynamic guards', () => {
+    expect(scanPythonForCrashers('builtins.input("blocks")')?.code).toBe('HCR-BLOCK-001');
+    expect(
+      scanPythonForCrashers(
+        "import inspect\ninspect.currentframe().f_back.f_locals['_hb_deadline'] = 999999999",
+      )?.code,
+    ).toBe('HCR-TIME-001');
+  });
+
+  it('does not classify policy vocabulary inside inert string literals', () => {
+    expect(scanPythonForCrashers("module_name = 'importlib.util'; similarly_named_inspector = 1")).toBeNull();
+  });
 });

--- a/mcp-tools/hayba-mcp/src/tools/guards/known-crashers.ts
+++ b/mcp-tools/hayba-mcp/src/tools/guards/known-crashers.ts
@@ -235,6 +235,43 @@ export function compactPythonPolicySource(script: string): string {
     .replace(/[\t\f\v ]+/g, '');
 }
 
+/** Remove inert comments and quoted string bodies while retaining executable
+ * punctuation and identifiers. This is intentionally a small lexical pass,
+ * not a Python parser; it exists for rules whose vocabulary is otherwise
+ * indistinguishable from harmless documentation strings. */
+function executablePythonPolicySource(script: string): string {
+  let result = '';
+  let index = 0;
+  while (index < script.length) {
+    const ch = script[index];
+    if (ch === '#') {
+      while (index < script.length && script[index] !== '\n' && script[index] !== '\r') index += 1;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      const triple = script.slice(index, index + 3) === quote.repeat(3);
+      index += triple ? 3 : 1;
+      while (index < script.length) {
+        if (script[index] === '\\') {
+          index += 2;
+          continue;
+        }
+        if (triple ? script.slice(index, index + 3) === quote.repeat(3) : script[index] === quote) {
+          index += triple ? 3 : 1;
+          break;
+        }
+        index += 1;
+      }
+      result += "''";
+      continue;
+    }
+    result += ch;
+    index += 1;
+  }
+  return result;
+}
+
 /** Bare call patterns must begin at a token boundary. Without this,
  * `set_input()` matches `input(` and `.recompile()` matches `compile(`. */
 function compactContainsPolicyPattern(compact: string, pattern: string): boolean {
@@ -253,6 +290,7 @@ function compactContainsPolicyPattern(compact: string, pattern: string): boolean
 /** Return the first fatal policy match, or null for a script safe to forward. */
 export function scanPythonForCrashers(script: string): CrashGuardHit | null {
   const compact = compactPythonPolicySource(script);
+  const executableCompact = compactPythonPolicySource(executablePythonPolicySource(script));
   // Wildcard imports erase the callable spellings that both policy boundaries
   // rely on for alias analysis. The native lexer remains authoritative; this
   // is the matching early-feedback refusal for ordinary executable syntax.
@@ -265,9 +303,21 @@ export function scanPythonForCrashers(script: string): CrashGuardHit | null {
       alternative: 'import only the specific policy-visible names required by the request',
     };
   }
+
+  const compactDeadlineFrameWrite = compact.includes(".f_locals['_hb_deadline']");
+  if (executableCompact.includes('_hb_deadline') || compactDeadlineFrameWrite) {
+    return {
+      pattern: '_hb_deadline',
+      code: 'HCR-TIME-001',
+      family: 'deadline_tampering',
+      reason: 'it attempts to access reserved cooperative-deadline state',
+      alternative: 'use application-owned variable names and leave the deadline hook private',
+    };
+  }
   for (const rule of PYTHON_CRASH_RULES) {
     for (const pattern of rule.patterns) {
-      if (compactContainsPolicyPattern(compact, pattern)) {
+      const policySource = pattern === 'importlib.' ? executableCompact : compact;
+      if (compactContainsPolicyPattern(policySource, pattern)) {
         return { ...rule, pattern };
       }
     }

--- a/mcp-tools/hayba-mcp/src/tools/python/python-crash-policy-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/python/python-crash-policy-contract.test.ts
@@ -57,6 +57,30 @@ function cppPairs(): string[] {
 }
 
 describe('python_run native/TS crash policy contract', () => {
+  it('orders effect-specific native classifications before broad runtime guards', () => {
+    const reservedBoundary = cpp.slice(
+      cpp.indexOf('bool FindReservedPythonRuntimeAccess('),
+      cpp.indexOf('bool CompactContainsPolicyPattern('),
+    );
+    expect(reservedBoundary.indexOf(".f_locals['_hb_deadline']")).toBeGreaterThan(-1);
+    expect(reservedBoundary.indexOf(".f_locals['_hb_deadline']")).toBeLessThan(
+      reservedBoundary.indexOf('HighRiskDynamicPythonModules'),
+    );
+    const frameDeadlineBoundary = reservedBoundary.slice(
+      reservedBoundary.indexOf('if (CompactCode.Contains(TEXT(".f_locals'),
+      reservedBoundary.indexOf('// Specific deadline-state access'),
+    );
+    expect(frameDeadlineBoundary).toContain('OutPolicyCode = TEXT("HCR-TIME-001")');
+    const builtinsBoundary = reservedBoundary.slice(reservedBoundary.indexOf('if (Token.Text == TEXT("builtins"))'));
+    expect(builtinsBoundary.indexOf('AliasExpandedCalls.Contains(TEXT("builtins.input("))')).toBeLessThan(
+      builtinsBoundary.indexOf('OutPattern = Token.Text'),
+    );
+
+    const ruleBoundary = cpp.slice(cpp.indexOf('for (const FFatalPythonRule& Rule : FatalPythonRules())'));
+    expect(ruleBoundary).toContain('bLexicalOnlyDynamicImport');
+    expect(ruleBoundary).toContain('!bLexicalOnlyDynamicImport');
+  });
+
   it('keeps every fatal rule and stable code identical at both boundaries', () => {
     expect(cppPairs()).toEqual(tsPairs());
   });

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPythonHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPPythonHandler.cpp
@@ -1021,6 +1021,38 @@ namespace
             return true;
         };
 
+        const FString CompactCode = CompactPythonSource(Code);
+        if (CompactCode.Contains(TEXT(".f_locals['_hb_deadline']")))
+        {
+            OutPattern = TEXT("f_locals['_hb_deadline']");
+            OutPolicyCode = TEXT("HCR-TIME-001");
+            OutReason = TEXT("attempts to mutate reserved cooperative-deadline state through a private frame");
+            OutAlternative = TEXT("use application-owned variable names and leave private wrapper frames inaccessible");
+            return true;
+        }
+
+        // Specific deadline-state access outranks the broader module used to
+        // reach it. Diagnose the attempted effect, not merely `import inspect`.
+        for (const FPythonPolicyToken& Token : Tokens)
+        {
+            if (Token.Kind != EPythonPolicyTokenKind::Identifier
+                || !Token.Text.StartsWith(TEXT("_hb_")))
+            {
+                continue;
+            }
+            if (Token.Text.Contains(TEXT("deadline"))
+                || Token.Text.Contains(TEXT("trace"))
+                || Token.Text == TEXT("_hb_sys")
+                || Token.Text == TEXT("_hb_time"))
+            {
+                OutPattern = Token.Text;
+                OutPolicyCode = TEXT("HCR-TIME-001");
+                OutReason = TEXT("attempts to access reserved cooperative-deadline state");
+                OutAlternative = TEXT("use application-owned variable names and leave the deadline hook private");
+                return true;
+            }
+        }
+
         // This bounded, incident-driven stdlib list is not a claim that source
         // preflight can make arbitrary in-process Python complete or safe.
         // These modules can recover hidden attributes, load code, or
@@ -1468,32 +1500,6 @@ namespace
             }
         }
 
-        // The wrapper deliberately reserves every _hb_* identifier. These
-        // tokens are checked lexically, rather than in CompactPythonSource, so
-        // documentation such as print("_hb_deadline") and comments remain
-        // harmless. Check deadline identifiers first so an expression such as
-        // __main__._hb_deadline gets the more useful HCR-TIME diagnosis.
-        for (const FPythonPolicyToken& Token : Tokens)
-        {
-            if (Token.Kind != EPythonPolicyTokenKind::Identifier
-                || !Token.Text.StartsWith(TEXT("_hb_")))
-            {
-                continue;
-            }
-
-            if (Token.Text.Contains(TEXT("deadline"))
-                || Token.Text.Contains(TEXT("trace"))
-                || Token.Text == TEXT("_hb_sys")
-                || Token.Text == TEXT("_hb_time"))
-            {
-                OutPattern = Token.Text;
-                OutPolicyCode = TEXT("HCR-TIME-001");
-                OutReason = TEXT("attempts to access reserved cooperative-deadline state");
-                OutAlternative = TEXT("use application-owned variable names and leave the deadline hook private");
-                return true;
-            }
-        }
-
         for (const FPythonPolicyToken& Token : Tokens)
         {
             if (Token.Kind != EPythonPolicyTokenKind::Identifier) continue;
@@ -1515,6 +1521,14 @@ namespace
             }
             if (Token.Text == TEXT("builtins"))
             {
+                if (AliasExpandedCalls.Contains(TEXT("builtins.input(")))
+                {
+                    OutPattern = TEXT("builtins.input(");
+                    OutPolicyCode = TEXT("HCR-BLOCK-001");
+                    OutReason = TEXT("waits for stdin that an unattended editor cannot provide");
+                    OutAlternative = TEXT("request input through the MCP user-prompt tool before python_run");
+                    return true;
+                }
                 OutPattern = Token.Text;
                 OutPolicyCode = TEXT("HCR-DYNAMIC-001");
                 OutReason = TEXT("can mutate process-global Python helpers used after the request");
@@ -1684,7 +1698,9 @@ namespace
             // using it here would reject print("sys.settrace(None)") even
             // though no instrumentation access is executable.
             const bool bDeadlineRule = FCString::Strcmp(Rule.PolicyCode, TEXT("HCR-TIME-001")) == 0;
-            if ((!bDeadlineRule && CompactContainsPolicyPattern(Compact, Rule.Pattern))
+            const bool bLexicalOnlyDynamicImport = FCString::Strcmp(Rule.Pattern, TEXT("importlib.")) == 0;
+            if ((!bDeadlineRule && !bLexicalOnlyDynamicImport
+                    && CompactContainsPolicyPattern(Compact, Rule.Pattern))
                 || CompactContainsPolicyPattern(AliasExpandedCalls, Rule.Pattern))
             {
                 OutPattern = Rule.Pattern;


### PR DESCRIPTION
## Root cause

`FindReservedPythonRuntimeAccess` classified broad module/runtime access before the specific operation:

- `builtins.input(` hit the broad `builtins` mutation guard before the blocking-input rule.
- `inspect.currentframe()...f_locals['_hb_deadline']` hit the broad high-risk `inspect` import guard before deadline tampering.
- `importlib.` was still checked against `CompactPythonSource`, which retains strings, so inert policy vocabulary looked executable even though native import/alias handling is lexical.

## Fix

- Prioritize private-frame deadline writes before broad import classification.
- Preserve `HCR-BLOCK-001` for `builtins.input(` before the generic builtins guard.
- Make `importlib.` lexical-only at the native boundary.
- Mirror executable-vs-inert source handling and deadline vocabulary in the TS early-feedback guard.
- Add focused behavioral and native source-contract regressions.

## Verification

- `npm run typecheck`
- Focused policy suite: 2 files, 28 tests passed
- Full suite after rebasing onto current `origin/docs/redesign-dossier`: 206 files, 2313 passed, 1 skipped
- `npm run lint:legacy-wrappers`: 22 C++ commands, 155 sidecar entries, no violations
- `npm run build:server`

Mutation checks went RED and were restored GREEN for:

1. Deadline/frame classification changed from `HCR-TIME-001` to `HCR-DYNAMIC-001`.
2. `importlib.` changed back to the string-retaining compact stream.
3. Native lexical-only importlib predicate inverted.

## Native verification still required

Per task constraints, Unreal was not launched or built and Aphrosia was not modified. A disposable native runner must still compile the plugin and rerun:

- `Hayba.MCP.Python.FatalPolicy`
- `Hayba.MCP.Python.PolicyBoundary`

Expected repaired assertions are `builtins.input(` → `HCR-BLOCK-001`, private-frame `_hb_deadline` mutation → `HCR-TIME-001`, and inert `'importlib.util'` text → no policy match.