### PR TITLE
fix(ui): retire replacement staging objects before GUID reconciliation

### DIFF
--- a/mcp-tools/hayba-mcp/src/tools/ui-guid-invariant-contract.test.ts
+++ b/mcp-tools/hayba-mcp/src/tools/ui-guid-invariant-contract.test.ts
@@ -19,6 +19,22 @@ const handlerPath = join(
   'HaybaMCPUIHandler.cpp',
 );
 const source = readFileSync(handlerPath, 'utf8');
+const opsSource = readFileSync(
+  join(
+    here,
+    '..',
+    '..',
+    '..',
+    '..',
+    'unreal',
+    'HaybaMCPToolkit',
+    'Source',
+    'HaybaMCPToolkit',
+    'Private',
+    'HaybaUIOps.cpp',
+  ),
+  'utf8',
+);
 
 function bodyOf(signature: string, nextSignature: string): string {
   const start = source.indexOf(signature);
@@ -77,6 +93,43 @@ describe('UMG GUID invariant crash boundary (#406)', () => {
     ]) {
       expect(source, marker).toContain(marker);
     }
+  });
+
+  it('retires discarded widget objects out of the WidgetTree source population', () => {
+    const retire = bodyOf(
+      'bool RetireWidgetTreeObject(',
+      '/** Remove every object allocated for a staged operation',
+    );
+    expect(retire).toContain('GetTransientPackage()');
+    expect(retire).toContain('Widget->Rename(');
+
+    const discard = bodyOf(
+      'bool DiscardStagedWidgets(',
+      '/** Copy every property the two widgets share',
+    );
+    expect(discard).toContain('RetireWidgetTreeObject(WBP, Widget)');
+  });
+
+  it('retires the outgoing replacement subtree before final GUID reconciliation', () => {
+    const replace = bodyOf(
+      'else if (Operation == TEXT("replace"))',
+      'FHaybaHandlerResult FHaybaMCPUIHandler::HandleCompile(',
+    );
+    const retire = replace.indexOf('RetireWidgetTreeObject(WBP, Widget)');
+    const finalize = replace.indexOf(
+      'FinalizeWidgetTreeMutation(WBP, TEXT("ui_mutate_tree replace")',
+    );
+    expect(retire).toBeGreaterThanOrEqual(0);
+    expect(finalize).toBeGreaterThan(retire);
+  });
+
+  it('keeps missing and stale GUID repair behavior pinned in the pure planner', () => {
+    expect(opsSource).toMatch(
+      /if \(!ExistingGuid\)[\s\S]{0,300}Missing\.Add\(Name\)[\s\S]{0,300}FreshGuid\(Name, Used\)[\s\S]{0,300}Reconciled\.Add\(Name, NewGuid\)/,
+    );
+    expect(opsSource).toMatch(
+      /for \(const TPair<FName, FGuid>& Pair : Existing\)[\s\S]{0,200}!LiveNames\.Contains\(Pair\.Key\)[\s\S]{0,100}Stale\.Add\(Pair\.Key\)/,
+    );
   });
 
   it('keeps rollback diagnostics compatible with UE checked format strings', () => {

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPUIHandlerTest.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/Tests/HaybaMCPUIHandlerTest.cpp
@@ -263,6 +263,27 @@ bool FHaybaMCPUIReplacePreservesChildrenTest::RunTest(const FString& Parameters)
     TestEqual(TEXT("nested Font.LetterSpacing lands on FSlateFontInfo"), TrackingText->GetFont().LetterSpacing, 125);
     TestEqual(TEXT("partial font patch preserves existing size"), TrackingText->GetFont().Size, 37.0f);
 
+    int32 ScratchSourceCount = 0;
+    int32 MissingSourceGuidCount = 0;
+    WBP->ForEachSourceWidget([&](UWidget* SourceWidget)
+    {
+        if (!SourceWidget) return;
+        const FString SourceName = SourceWidget->GetName();
+        if (SourceName.StartsWith(TEXT("HaybaMCP_ReplacementStaging"))
+            || SourceName.StartsWith(TEXT("HaybaMCP_RetiredWidget")))
+        {
+            ++ScratchSourceCount;
+        }
+        const FGuid* Guid = WBP->WidgetVariableNameToGuidMap.Find(SourceWidget->GetFName());
+        if (!Guid || !Guid->IsValid()) ++MissingSourceGuidCount;
+    });
+    TestEqual(TEXT("replacement leaves no staging/retired object in the compiler source population"),
+        ScratchSourceCount, 0);
+    TestEqual(TEXT("property preflight repairs every newly attached source GUID before compile"),
+        MissingSourceGuidCount, 0);
+    TestTrue(TEXT("TrackingText receives a compiler GUID"),
+        WBP->WidgetVariableNameToGuidMap.FindRef(TEXT("TrackingText")).IsValid());
+
     FKismetEditorUtilities::CompileBlueprint(WBP);
     TestEqual(TEXT("widget blueprint compiles after safe and destructive replacements"), WBP->Status, BS_UpToDate);
 

--- a/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
+++ b/unreal/HaybaMCPToolkit/Source/HaybaMCPToolkit/Private/handlers/HaybaMCPUIHandler.cpp
@@ -402,6 +402,24 @@ namespace
         }
     }
 
+    /** Remove an editor-only staging/discard object from the compiler's source
+     *  population. UBaseWidgetBlueprint::ForEachSourceWidget enumerates every
+     *  direct UObject outer of WidgetTree, not merely the attached hierarchy;
+     *  UWidgetTree::RemoveWidget therefore is not sufficient on its own. */
+    bool RetireWidgetTreeObject(UWidgetBlueprint* WBP, UWidget* Widget)
+    {
+        if (!WBP || !WBP->WidgetTree || !Widget) return false;
+        if (Widget->GetOuter() != WBP->WidgetTree) return true;
+
+        UObject* const RetiredOuter = GetTransientPackage();
+        const FName RetiredName = MakeUniqueObjectName(
+            RetiredOuter, Widget->GetClass(), TEXT("HaybaMCP_RetiredWidget"));
+        return Widget->Rename(
+                *RetiredName.ToString(), RetiredOuter,
+                REN_DontCreateRedirectors | REN_DoNotDirty)
+            && Widget->GetOuter() == RetiredOuter;
+    }
+
     /** Remove every object allocated for a staged operation and prove none is
      *  still a source widget. Returning false means the caller must report an
      *  unknown recovery state, never claim the original tree was restored. */
@@ -409,12 +427,14 @@ namespace
     {
         if (!WBP || !WBP->WidgetTree) return false;
 
+        bool bAllRetired = true;
         for (int32 Index = Staged.Num() - 1; Index >= 0; --Index)
         {
             UWidget* Widget = Staged[Index];
             if (!Widget) continue;
             if (UPanelWidget* Parent = Widget->GetParent()) Parent->RemoveChild(Widget);
             WBP->WidgetTree->RemoveWidget(Widget);
+            bAllRetired = RetireWidgetTreeObject(WBP, Widget) && bAllRetired;
         }
 
         bool bAnyRemain = false;
@@ -422,7 +442,7 @@ namespace
         {
             if (Staged.Contains(Widget)) bAnyRemain = true;
         });
-        return !bAnyRemain;
+        return bAllRetired && !bAnyRemain;
     }
 
     /** Copy every property the two widgets share by name and type. Used by
@@ -2584,7 +2604,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
                     if (!Entry.Key) { bRestored = false; continue; }
                     if (Entry.Key->GetFName() == Entry.Value) continue;
                     bRestored = Entry.Key->Rename(
-                        *Entry.Value.ToString(), Entry.Key->GetOuter(),
+                        *Entry.Value.ToString(), WBP->WidgetTree,
                         REN_DontCreateRedirectors | REN_DoNotDirty)
                         && Entry.Key->GetFName() == Entry.Value
                         && bRestored;
@@ -2612,7 +2632,7 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
                 const bool bDiscardedNamesRestored = RestoreDiscardedNames();
                 const bool bOriginalNameRestored = Widget->GetFName() == OriginalName
                     || (Widget->Rename(
-                            *OriginalName.ToString(), Widget->GetOuter(),
+                            *OriginalName.ToString(), WBP->WidgetTree,
                             REN_DontCreateRedirectors | REN_DoNotDirty)
                         && Widget->GetFName() == OriginalName);
 
@@ -2785,6 +2805,22 @@ FHaybaHandlerResult FHaybaMCPUIHandler::HandleMutateTree(const TSharedPtr<FJsonO
                         *MakeUniqueObjectName(Descendant->GetOuter(), Descendant->GetClass(), TEXT("HaybaMCP_Discarded")).ToString(),
                         Descendant->GetOuter(), REN_DontCreateRedirectors | REN_DoNotDirty);
                 }
+            }
+
+            bool bOutgoingRetired = true;
+            for (const TPair<UWidget*, FName>& Entry : DiscardedDescendants)
+            {
+                bOutgoingRetired = Entry.Key
+                    && RetireWidgetTreeObject(WBP, Entry.Key)
+                    && bOutgoingRetired;
+            }
+            bOutgoingRetired = RetireWidgetTreeObject(WBP, Widget) && bOutgoingRetired;
+            if (!bOutgoingRetired)
+            {
+                const bool bRecovered = RestoreOriginal();
+                return FHaybaHandlerResult::Err(bRecovered
+                    ? TEXT("ui_mutate_tree replace: outgoing widget retirement failed; original state restored and no compile attempted")
+                    : TEXT("ui_mutate_tree replace: outgoing widget retirement failed and recovery is unknown; reload the asset before any further UI command"));
             }
 
             if (!FinalizeWidgetTreeMutation(WBP, TEXT("ui_mutate_tree replace"), InvariantError))


### PR DESCRIPTION
## Root cause

`UBaseWidgetBlueprint::ForEachSourceWidget` enumerates every direct UObject outer of `WidgetTree`. `UWidgetTree::RemoveWidget` only detaches hierarchy membership; replacement staging/discard objects therefore remained compiler-visible. Final GUID reconciliation correctly refused the leaked `HaybaMCP_ReplacementStaging*` source, rollback left `HaybaMCP_ReplacementStagingRollback_0` visible, and later property preflight could not repair `TrackingText` because the scratch-source blocker made the plan non-applicable.

## Fix

- Re-outer discarded/staging widget objects to the transient package before GUID reconciliation.
- Re-adopt original widgets and destructive descendants into `WidgetTree` during rollback.
- Retire every outgoing replacement object before structural finalization.
- Extend the native regression to assert zero staging/retired source objects and valid GUIDs for every compiler-visible widget.
- Add static contracts for replacement retirement ordering and missing/stale GUID planner behavior.

## TDD and mutation evidence

- RED first: focused contract failed because `RetireWidgetTreeObject` and pre-finalization retirement were absent.
- GREEN after lifecycle fix.
- Mutation 1: inverted missing-GUID detection -> focused contract RED -> reverted.
- Mutation 2: inverted stale-GUID detection -> focused contract RED -> reverted.
- Mutation 3: retired back into `WidgetTree` instead of the transient package -> focused contract RED -> reverted.

## Verification

- `npm test`: 205 files passed; 2301 passed, 1 skipped.
- `npm run typecheck`: passed.
- `npm run build`: passed.
- `node scripts/check-legacy-wrappers.mjs`: passed (22 C++ commands, 154 sidecar entries).
- `git diff --check`: passed.

## Native verification still required

Per task constraints, this branch was not built or run in Unreal and Aphrosia was never touched. Before closing #406, build the plugin in a disposable project and rerun `Hayba.MCP.UI.Replace.PreservesChildrenAndRollsBackCollision`; verify no `WidgetVariableNameToGuidMap` ensures, all replacement assertions pass, compile status is `BS_UpToDate`, and temporary assets/crash artifacts are clean.

Refs #406